### PR TITLE
suffix JSON keys containing HTML with _html

### DIFF
--- a/api/tasks/3
+++ b/api/tasks/3
@@ -3,19 +3,19 @@
   "steps": [{
     "type": "exercise",
     "content": {
-      "stimulus":"The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s",
+      "stimulus_html":"The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s",
       "questions":[
         {
           "id": "123",
           "format": "short-answer",
-          "stem":"What is the rest mass in kg?"
+          "stem_html":"What is the rest mass in kg?"
         },{
           "id": "234",
           "format": "multiple-choice",
-          "stem":"What is the force if it slams into a wall?",
+          "stem_html":"What is the force if it slams into a wall?",
           "answers":[
-            {"id":"id1","content":"10 N"},
-            {"id":"id2","content":"1 N"}
+            {"id":"id1","content_html":"10 N"},
+            {"id":"id2","content_html":"1 N"}
           ]
         }
       ]

--- a/api/tasks/4
+++ b/api/tasks/4
@@ -3,27 +3,27 @@
   "steps": [
     { "type": "exercise",
       "content": {
-        "stimulus": "First Exercise",
+        "stimulus_html": "First Exercise",
         "questions":[
           {
             "id": "987",
             "format": "short-answer",
-            "stem":"What is your favorite color?"
+            "stem_html":"What is your favorite color?"
           }
         ]
       }
     },
     { "type": "exercise",
       "content": {
-        "stimulus": "Second Exercise",
+        "stimulus_html": "Second Exercise",
         "questions":[
           {
             "id": "876",
             "format": "multiple-choice",
-            "stem":"Is the glass half full or half empty?",
+            "stem_html":"Is the glass half full or half empty?",
             "answers":[
-              {"id":"id3","content":"Half Full"},
-              {"id":"id4","content":"Half Empty"}
+              {"id":"id3","content_html":"Half Full"},
+              {"id":"id4","content_html":"Half Empty"}
             ]
           }
         ]
@@ -31,19 +31,19 @@
     },
     { "type": "exercise",
       "content": {
-        "stimulus":"The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s",
+        "stimulus_html":"The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s",
         "questions":[
           {
             "id": "123",
             "format": "short-answer",
-            "stem":"What is the rest mass in kg?"
+            "stem_html":"What is the rest mass in kg?"
           },{
             "id": "234",
             "format": "multiple-choice",
-            "stem":"What is the force if it slams into a wall?",
+            "stem_html":"What is the force if it slams into a wall?",
             "answers":[
-              {"id":"id1","content":"10 N"},
-              {"id":"id2","content":"1 N"}
+              {"id":"id1","content_html":"10 N"},
+              {"id":"id2","content_html":"1 N"}
             ]
           }
         ]

--- a/api/user/tasks
+++ b/api/user/tasks
@@ -19,19 +19,19 @@
       "steps": [{
         "type": "exercise",
         "content": {
-          "stimulus":"The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s",
+          "stimulus_html":"The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s",
           "questions":[
             {
               "id": "123",
               "format": "short-answer",
-              "stem":"What is the rest mass in kg?"
+              "stem_html":"What is the rest mass in kg?"
             },{
               "id": "234",
               "format": "multiple-choice",
-              "stem":"What is the force if it slams into a wall?",
+              "stem_html":"What is the force if it slams into a wall?",
               "answers":[
-                {"id":"id1","content":"10 N"},
-                {"id":"id2","content":"1 N"}
+                {"id":"id1","content_html":"10 N"},
+                {"id":"id2","content_html":"1 N"}
               ]
             }
           ]
@@ -44,27 +44,27 @@
       "steps": [
         { "type": "exercise",
           "content": {
-            "stimulus": "First Exercise",
+            "stimulus_html": "First Exercise",
             "questions":[
               {
                 "id": "987",
                 "format": "short-answer",
-                "stem":"What is your favorite color?"
+                "stem_html":"What is your favorite color?"
               }
             ]
           }
         },
         { "type": "exercise",
           "content": {
-            "stimulus": "Second Exercise",
+            "stimulus_html": "Second Exercise",
             "questions":[
               {
                 "id": "876",
                 "format": "multiple-choice",
-                "stem":"Is the glass half full or half empty?",
+                "stem_html":"Is the glass half full or half empty?",
                 "answers":[
-                  {"id":"id3","content":"Half Full"},
-                  {"id":"id4","content":"Half Empty"}
+                  {"id":"id3","content_html":"Half Full"},
+                  {"id":"id4","content_html":"Half Empty"}
                 ]
               }
             ]
@@ -72,19 +72,19 @@
         },
         { "type": "exercise",
           "content": {
-            "stimulus":"The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s",
+            "stimulus_html":"The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s",
             "questions":[
               {
                 "id": "123",
                 "format": "short-answer",
-                "stem":"What is the rest mass in kg?"
+                "stem_html":"What is the rest mass in kg?"
               },{
                 "id": "234",
                 "format": "multiple-choice",
-                "stem":"What is the force if it slams into a wall?",
+                "stem_html":"What is the force if it slams into a wall?",
                 "answers":[
-                  {"id":"id1","content":"10 N"},
-                  {"id":"id2","content":"1 N"}
+                  {"id":"id1","content_html":"10 N"},
+                  {"id":"id2","content_html":"1 N"}
                 ]
               }
             ]

--- a/src/components/exercise.cjsx
+++ b/src/components/exercise.cjsx
@@ -49,10 +49,10 @@ BlankQuestion = React.createClass
     {stem} = config
     isAnswered = !!config.answer
 
-    if config.stimulus
+    if config.stimulus_html
       stimulus =
         <div className="stimulus">
-          <ArbitraryHtmlAndMath block=true className="stimulus" html={config.stimulus} />
+          <ArbitraryHtmlAndMath block=true className="stimulus" html={config.stimulus_html} />
         </div>
 
     if isAnswered
@@ -93,22 +93,22 @@ SimpleQuestion = React.createClass
     isAnswered = !!config.answer
     answer = AnswerStore.getAnswer(config)
 
-    if config.stimulus
+    if config.stimulus_html
       stimulus =
         <div className="stimulus">
-          <ArbitraryHtmlAndMath block=true className="stimulus" html={config.stimulus} />
+          <ArbitraryHtmlAndMath block=true className="stimulus" html={config.stimulus_html} />
         </div>
 
     if isAnswered
       <div className="question simple">
         {stimulus}
-        <div className="stem">{config.stem}</div>
+        <div className="stem">{config.stem_html}</div>
         Your answer: <strong>{answer}</strong>
       </div>
     else
       <div className="question simple">
         {stimulus}
-        <div className="stem">{config.stem}</div>
+        <div className="stem">{config.stem_html}</div>
         <input type="text" placeholder={config.short_stem} ref="prompt" onChange=@onChange value={answer or ''}/>
       </div>
 
@@ -125,7 +125,7 @@ SimpleMultipleChoiceOption = React.createClass
   render: ->
     {config, questionId, index} = @props
     id = config.id
-    <ArbitraryHtmlAndMath className="stem" html={config.content or config.value} />
+    <ArbitraryHtmlAndMath className="stem" html={config.content_html} />
 
 MultiMultipleChoiceOption = React.createClass
   displayName: 'MultiMultipleChoiceOption'
@@ -233,7 +233,7 @@ MultipleChoiceQuestion = React.createClass
     classes.push('answered') if isAnswered
 
     <div key={questionId} className={classes.join(' ')}>
-      <ArbitraryHtmlAndMath block=true className="stem" html={config.stem} />
+      <ArbitraryHtmlAndMath block=true className="stem" html={config.stem_html} />
       <ul className="options">{options}</ul>
     </div>
 
@@ -319,15 +319,15 @@ MultiSelectQuestion = React.createClass
     classes = ['question']
     classes.push('answered') if isAnswered
 
-    if config.stimulus
+    if config.stimulus_html
       stimulus =
         <div className="stimulus">
-          <ArbitraryHtmlAndMath block=true className="stimulus" html={config.stimulus} />
+          <ArbitraryHtmlAndMath block=true className="stimulus" html={config.stimulus_html} />
         </div>
 
     <div key={questionId} className={classes.join(' ')}>
       {stimulus}
-      <ArbitraryHtmlAndMath block=true className="stem" html={config.stem} />
+      <ArbitraryHtmlAndMath block=true className="stem" html={config.stem_html} />
       <div>Select all that apply:</div>
       <ul className="options">{options}</ul>
     </div>
@@ -355,10 +355,10 @@ TrueFalseQuestion = React.createClass
     idTrue = "#{questionId}-true"
     idFalse = "#{questionId}-false"
 
-    if config.stimulus
+    if config.stimulus_html
       stimulus =
         <div className='stimulus'>
-          <ArbitraryHtmlAndMath block=true className="stimulus" html={config.stimulus} />
+          <ArbitraryHtmlAndMath block=true className="stimulus" html={config.stimulus_html} />
         </div>
 
     if isAnswered
@@ -379,7 +379,7 @@ TrueFalseQuestion = React.createClass
 
       <div className="question answered true-false">
         {stimulus}
-        <ArbitraryHtmlAndMath block=true className="stem" html={config.stem} />
+        <ArbitraryHtmlAndMath block=true className="stem" html={config.stem_html} />
         <ul className="options">
           <li className={trueClasses.join(' ')}>
             <span>True</span>
@@ -394,7 +394,7 @@ TrueFalseQuestion = React.createClass
     else
       <div className="question true-false">
         {stimulus}
-        <ArbitraryHtmlAndMath block=true className="stem" html={config.stem} />
+        <ArbitraryHtmlAndMath block=true className="stem" html={config.stem_html} />
         <ul className="options">
           <li className="option">
             <label>
@@ -428,21 +428,21 @@ MatchingQuestion = React.createClass
         </td>
         <td className="spacer"></td>
         <td className="answer">
-          <ArbitraryHtmlAndMath className="stem" html={answer.content or answer.value} />
+          <ArbitraryHtmlAndMath className="stem" html={answer.content_html} />
         </td>
       </tr>
 
-    if config.stimulus
+    if config.stimulus_html
       stimulus =
         <div className='stimulus'>
-          <ArbitraryHtmlAndMath block=true className="stimulus" html={config.stimulus} />
+          <ArbitraryHtmlAndMath block=true className="stimulus" html={config.stimulus_html} />
         </div>
 
     <div className="question matching">
       {stimulus}
       <table>
         <caption>
-          <ArbitraryHtmlAndMath className="stem" html={config.stem} />
+          <ArbitraryHtmlAndMath className="stem" html={config.stem_html} />
         </caption>
         {rows}
       </table>
@@ -475,7 +475,7 @@ Exercise = React.createClass
 
 
     <div className="exercise">
-      <ArbitraryHtmlAndMath className="stimulus" html={config.content.stimulus} />
+      <ArbitraryHtmlAndMath className="stimulus" html={config.content.stimulus_html} />
       {questions}
     </div>
 

--- a/test/components/task/exercise.spec.cjsx
+++ b/test/components/task/exercise.spec.cjsx
@@ -11,7 +11,7 @@ describe 'Exercise Task', ->
   it 'should render an Exercise with 0 questions', ->
     config =
       content:
-        stimulus: 'EXERCISE_TEXT'
+        stimulus_html: 'EXERCISE_TEXT'
         questions: []
 
     html = React.renderComponentToString(<Exercise config={config} />)
@@ -28,13 +28,13 @@ describe 'Exercise Task', ->
     it 'should render an Exercise with a short-answer question', ->
       config =
         content:
-          stimulus: 'EXERCISE_TEXT'
+          stimulus_html: 'EXERCISE_TEXT'
           questions: [
             {
               id: '123'
               format: 'short-answer'
-              stimulus: 'QUESTION_STIMULUS'
-              stem: 'QUESTION_STEM'
+              stimulus_html: 'QUESTION_STIMULUS'
+              stem_html: 'QUESTION_STEM'
             }
           ]
 
@@ -60,7 +60,7 @@ describe 'Question Types', ->
       config =
         id: '123'
         format: 'short-answer'
-        stem: 'QUESTION_STEM'
+        stem_html: 'QUESTION_STEM'
 
       Type = getQuestionType('short-answer')
       html = React.renderComponentToString(<Type config={config} />)
@@ -74,7 +74,7 @@ describe 'Question Types', ->
       config =
         id: '123'
         format: 'short-answer'
-        stem: 'QUESTION_STEM'
+        stem_html: 'QUESTION_STEM'
 
       Type = getQuestionType('short-answer')
       $node = $("<div id='wrapper'></div>")
@@ -94,10 +94,10 @@ describe 'Question Types', ->
       config =
         id: '123'
         format: 'multiple-choice'
-        stem: 'QUESTION_STEM'
+        stem_html: 'QUESTION_STEM'
         answers: [
-          {id:'id1',content:'OPTION_1'}
-          {id:'id2',content:'OPTION_2'}
+          {id:'id1',content_html:'OPTION_1'}
+          {id:'id2',content_html:'OPTION_2'}
         ]
 
       Type = getQuestionType('multiple-choice')
@@ -116,10 +116,10 @@ describe 'Question Types', ->
       config =
         id: '123'
         format: 'multiple-choice'
-        stem: 'QUESTION_STEM'
+        stem_html: 'QUESTION_STEM'
         answers: [
-          {id:'OPTION_1_ID',content:'OPTION_1'}
-          {id:'OPTION_2_ID',content:'OPTION_2'}
+          {id:'OPTION_1_ID',content_html:'OPTION_1'}
+          {id:'OPTION_2_ID',content_html:'OPTION_2'}
         ]
 
       Type = getQuestionType('multiple-choice')
@@ -142,7 +142,7 @@ describe 'Question Types', ->
         config =
           content:
             id: '123'
-            stimulus: INLINE_MATH
+            stimulus_html: INLINE_MATH
             questions: []
 
         $node = $("<div id='wrapper'></div>")
@@ -153,7 +153,7 @@ describe 'Question Types', ->
       it 'should render Math in the true-false.stem', ->
         config =
           type: 'true-false'
-          stem: INLINE_MATH
+          stem_html: INLINE_MATH
 
         $node = $("<div id='wrapper'></div>")
         Type = getQuestionType(config.type)
@@ -164,7 +164,7 @@ describe 'Question Types', ->
       it 'should render Math in the multiple-choice.stem', ->
         config =
           type: 'multiple-choice'
-          stem: INLINE_MATH
+          stem_html: INLINE_MATH
           answers: []
 
         $node = $("<div id='wrapper'></div>")
@@ -175,10 +175,10 @@ describe 'Question Types', ->
       it 'should render Math in the multiple-choice.answer', ->
         config =
           type: 'multiple-choice'
-          stem: ''
+          stem_html: ''
           answers: [{
             id: 'answer1'
-            content: INLINE_MATH
+            content_html: INLINE_MATH
           }]
 
         $node = $("<div id='wrapper'></div>")


### PR DESCRIPTION
**DO NOT MERGE** until Tutor and Exercises have been updated.

This came out of a discussion on which fields are just text (like a title) and which fields may contain markup (like math)

An exercise would become:

```json
{
  "stimulus_html":"The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s",
  "questions":[
    {
      "id": "123",
      "format": "short-answer",
      "stem_html":"What is the rest mass in kg?"
    },{
      "id": "234",
      "format": "multiple-choice",
      "stem_html":"What is the force if it slams into a wall?",
      "answers":[
        {"id":"id1","content_html":"10 N"},
        {"id":"id2","content_html":"1 N"}
      ]
    }
  ]
}
```