### PR TITLE
Exercise states

### DIFF
--- a/api/tasks/4
+++ b/api/tasks/4
@@ -2,27 +2,37 @@
   "title": "Assignment",
   "steps": [
     { "type": "exercise",
+      "is_completed": true,
+      "correct_answer_id": "id2",
+      "answer_id": "id1",
+      "free_response": "four",
+      "feedback_html": "Two apples and then two more apples is <strong>four</strong>",
       "content": {
+        "stimulus_html": "Addition is fun",
         "questions":[
           {
             "id": "987",
-            "format": "short-answer",
-            "stem":"What is your favorite color?"
+            "format": "multiple-choice",
+            "stem_html":"What is 2+2?",
+            "answers":[
+              {"id":"id1","content_html":"22"},
+              {"id":"id2","content_html":"4"}
+            ]
           }
         ]
       }
     },
     { "type": "exercise",
       "content": {
-        "stimulus": "Stimulus for Second Exercise",
+        "stimulus_html": "Stimulus for Second Exercise",
         "questions":[
           {
             "id": "876",
             "format": "multiple-choice",
-            "stem":"Is the glass half full or half empty?",
+            "stem_html":"Is the glass half full or half empty?",
             "answers":[
-              {"id":"id3","content":"Half Full"},
-              {"id":"id4","content":"Half Empty"}
+              {"id":"id3","content_html":"Half Full"},
+              {"id":"id4","content_html":"Half Empty"}
             ]
           }
         ]
@@ -39,19 +49,14 @@
     },
     { "type": "exercise",
       "content": {
-        "stimulus":"The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s",
         "questions":[
           {
-            "id": "123",
-            "format": "short-answer",
-            "stem":"What is the rest mass in kg?"
-          },{
             "id": "234",
             "format": "multiple-choice",
-            "stem":"What is the force if it slams into a wall?",
+            "stem_html":"<p>The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s</p><p>What is the force if it slams into a wall?</p>",
             "answers":[
-              {"id":"id1","content":"10 N"},
-              {"id":"id2","content":"1 N"}
+              {"id":"id1","content_html":"10 N"},
+              {"id":"id2","content_html":"1 N"}
             ]
           }
         ]

--- a/api/user/tasks
+++ b/api/user/tasks
@@ -44,27 +44,37 @@
       "title": "Assignment",
       "steps": [
         { "type": "exercise",
+          "is_completed": true,
+          "correct_answer_id": "id2",
+          "answer_id": "id1",
+          "free_response": "four",
+          "feedback_html": "Two apples and then two more apples is <strong>four</strong>",
           "content": {
+            "stimulus_html": "Addition is fun",
             "questions":[
               {
                 "id": "987",
-                "format": "short-answer",
-                "stem":"What is your favorite color?"
+                "format": "multiple-choice",
+                "stem_html":"What is 2+2?",
+                "answers":[
+                  {"id":"id1","content_html":"22"},
+                  {"id":"id2","content_html":"4"}
+                ]
               }
             ]
           }
         },
         { "type": "exercise",
           "content": {
-            "stimulus": "Stimulus for Second Exercise",
+            "stimulus_html": "Stimulus for Second Exercise",
             "questions":[
               {
                 "id": "876",
                 "format": "multiple-choice",
-                "stem":"Is the glass half full or half empty?",
+                "stem_html":"Is the glass half full or half empty?",
                 "answers":[
-                  {"id":"id3","content":"Half Full"},
-                  {"id":"id4","content":"Half Empty"}
+                  {"id":"id3","content_html":"Half Full"},
+                  {"id":"id4","content_html":"Half Empty"}
                 ]
               }
             ]
@@ -81,19 +91,14 @@
         },
         { "type": "exercise",
           "content": {
-            "stimulus":"The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s",
             "questions":[
               {
-                "id": "123",
-                "format": "short-answer",
-                "stem":"What is the rest mass in kg?"
-              },{
                 "id": "234",
                 "format": "multiple-choice",
-                "stem":"What is the force if it slams into a wall?",
+                "stem_html":"<p>The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s</p><p>What is the force if it slams into a wall?</p>",
                 "answers":[
-                  {"id":"id1","content":"10 N"},
-                  {"id":"id2","content":"1 N"}
+                  {"id":"id1","content_html":"10 N"},
+                  {"id":"id2","content_html":"1 N"}
                 ]
               }
             ]

--- a/src/components/all-steps.cjsx
+++ b/src/components/all-steps.cjsx
@@ -14,17 +14,20 @@ err = (msgs...) ->
 
 Reading = React.createClass
   mixins: [StepMixin]
-  isEnabled: -> true
-  onSaveAndContinue: -> @props.onComplete()
+  isContinueEnabled: -> true
+  onContinue: ->
+    @props.onStepCompleted()
+    @props.onNextStep()
   renderBody: ->
     {content_html} = @props.model
     <ArbitraryHtmlAndMath html={content_html} />
 
 Interactive = React.createClass
   mixins: [StepMixin]
-  isEnabled: -> true
-  onSaveAndContinue: -> @props.onComplete()
-
+  isContinueEnabled: -> true
+  onContinue: ->
+    @props.onStepCompleted()
+    @props.onNextStep()
   renderBody: ->
     <iframe src={@props.model.content_url} />
 

--- a/src/components/all-steps.cjsx
+++ b/src/components/all-steps.cjsx
@@ -2,8 +2,9 @@ $ = require 'jquery'
 React = require 'react'
 
 api = require '../api'
-{Exercise} = require './exercise'
+Exercise = require './exercise-multiple-choice'
 ArbitraryHtmlAndMath = require './html'
+StepMixin = require './step-mixin'
 
 # React swallows thrown errors so log them first
 err = (msgs...) ->
@@ -12,12 +13,19 @@ err = (msgs...) ->
 
 
 Reading = React.createClass
-  render: ->
+  mixins: [StepMixin]
+  isEnabled: -> true
+  onSaveAndContinue: -> @props.onComplete()
+  renderBody: ->
     {content_html} = @props.model
     <ArbitraryHtmlAndMath html={content_html} />
 
 Interactive = React.createClass
-  render: ->
+  mixins: [StepMixin]
+  isEnabled: -> true
+  onSaveAndContinue: -> @props.onComplete()
+
+  renderBody: ->
     <iframe src={@props.model.content_url} />
 
 module.exports = {Reading, Interactive, Exercise}

--- a/src/components/all-steps.cjsx
+++ b/src/components/all-steps.cjsx
@@ -3,7 +3,7 @@ React = require 'react'
 
 api = require '../api'
 {Exercise} = require './exercise'
-
+ArbitraryHtmlAndMath = require './html'
 
 # React swallows thrown errors so log them first
 err = (msgs...) ->
@@ -13,20 +13,11 @@ err = (msgs...) ->
 
 Reading = React.createClass
   render: ->
-    content_html = @props.model.content_html or @state?.content_html
-    if content_html
-      <div className='arbitrary-html' dangerouslySetInnerHTML={{__html: content_html}} />
-
-    else if @state?.content_html_error
-      <div>Error loading Reading Step. Please reload the page and try again</div>
-
-    else
-      <div>Loading...</div>
-
+    {content_html} = @props.model
+    <ArbitraryHtmlAndMath html={content_html} />
 
 Interactive = React.createClass
   render: ->
     <iframe src={@props.model.content_url} />
-
 
 module.exports = {Reading, Interactive, Exercise}

--- a/src/components/breadcrumbs.cjsx
+++ b/src/components/breadcrumbs.cjsx
@@ -13,10 +13,12 @@ module.exports = React.createClass
   render: ->
     steps = @props.model.steps
 
-    unansweredStepCount = 0
+    # Make sure the 1st incomplete step is displayed.
+    # Useful when the student clicks back to review a previous step
+    # (ie the reading step)
+    showedFirstIncompleteStep = false
+
     stepButtons = for step, i in steps
-      unless step.is_completed
-        unansweredStepCount += 1
 
       classes = ['btn step']
       classes.push(step.type)
@@ -35,9 +37,11 @@ module.exports = React.createClass
         # classes.push('disabled')
         title ?= "Step Completed (#{step.type}). Click to review"
 
+      else if showedFirstIncompleteStep
+        continue
       else
-        classes.push('btn-default')
-        title ?= "Click to view #{step.type}"
+        showedFirstIncompleteStep = true
+
 
       <button type='button' className={classes.join(' ')} title={title} onClick={@props.goToStep(i)}><i className="fa fa-fw #{step.type}"></i></button>
 

--- a/src/components/exercise-multiple-choice.cjsx
+++ b/src/components/exercise-multiple-choice.cjsx
@@ -6,174 +6,14 @@ ArbitraryHtmlAndMath = require './html'
 StepMixin = require './step-mixin'
 Question = require './question'
 
-# Converts an index to `a-z` for question answers
-AnswerLabeler = React.createClass
-  displayName: 'AnswerLabeler'
-  render: ->
-    {index, before, after} = @props
-    letter = String.fromCharCode(index + 97) # For uppercase use 65
-    <span className='answer-char'>{before}{letter}{after}</span>
 
-
-QuestionMixin =
-  # renderBody: ->
-  # renderStem: ->
-  render: ->
-    {model} = @props
-    isAnswered = !!model.answer
-
-    if model.stimulus?
-      stimulus = <ArbitraryHtmlAndMath block=true className='stimulus' html={model.stimulus} />
-    classes = ['question', model.format]
-    classes.push('answered') if isAnswered
-
-    if @renderStem?
-      stem = @renderStem()
-    else
-      stem = <ArbitraryHtmlAndMath block=true className='stem' html={model.stem} />
-
-    <div className={classes.join(' ')} data-format={model.type}>
-      {stimulus}
-      {stem}
-      {@renderBody()}
-    </div>
-
-
-SimpleMultipleChoiceOption = React.createClass
-  displayName: 'SimpleMultipleChoiceOption'
-  render: ->
-    {model, questionId, index} = @props
-    id = model.id
-    <ArbitraryHtmlAndMath className='stem' html={model.content or model.value} />
-
-MultiMultipleChoiceOption = React.createClass
-  displayName: 'MultiMultipleChoiceOption'
-  render: ->
-    {model, idIndices} = @props
-    vals = []
-    for id, i in idIndices
-      unless model.value.indexOf(id) < 0
-        index = model.value.indexOf(id)
-        vals.push <AnswerLabeler key={index} before='(' after=')' index={index}/>
-    <span className='multi'>{vals}</span>
-
-
-MultipleChoiceOptionMixin =
-  render: ->
-    {inputType, model, questionId, index, isAnswered} = @props
-
-    # For radio boxes there is only 1 value, the id/value but
-    # for checkboxes the answer is an array of ids/values
-    option = if Array.isArray(model.value)
-      @props.idIndices = for id in model.value
-        id
-      MultiMultipleChoiceOption(@props)
-    else
-      SimpleMultipleChoiceOption(@props)
-
-    id = "#{questionId}-#{model.id}"
-
-    inputType = 'hidden' if isAnswered
-
-    classes = ['option']
-    # null (unanswered), 'correct', 'incorrect', 'missed'
-    classes.push(@props.answerState) if @props.answerState
-
-    optionIdent = @props.model.id or @props.model.value
-    if Array.isArray(@props.answer)
-      isChecked = @props.answer.indexOf(optionIdent) >= 0
-    else
-      isChecked = @props.answer is optionIdent
-
-    contents = [
-      <span key='letter' className='letter'><AnswerLabeler after=')' index={index}/> </span>
-      <span key='answer' className='answer'>{option}</span>
-    ]
-
-
-    unless isAnswered
-      contents =
-        <label>
-          <input type={inputType}
-            ref='input'
-            name={questionId}
-            value={JSON.stringify(model.value)}
-            onChange=@onChange
-            defaultChecked={isChecked}
-          />
-          {contents}
-        </label>
-
-    <li key={id} className={classes.join(' ')}>
-      {contents}
-    </li>
-
-
-
-MultipleChoiceOption = React.createClass
-  displayName: 'MultipleChoiceOption'
-  getDefaultProps: -> {inputType:'radio'}
-  mixins: [MultipleChoiceOptionMixin]
-
-  onChange: ->
-    @props.onChange(@props.model)
-
-
-MultipleChoiceQuestion = React.createClass
-  displayName: 'MultipleChoiceQuestion'
-
-  render: ->
-    {model} = @props
-    isAnswered = !!model.answer
-
-    questionId = model.id
-    options = for option, index in model.answers
-      answerState = null
-      if model.answer is option.id # if my answer is this option
-        if model.correct is model.answer
-          answerState = 'correct'
-        else
-          answerState = 'incorrect'
-      else if model.correct is option.id and model.answers.length > 2
-        answerState = 'missed'
-
-      optionProps = {
-        model: option
-        answer: AnswerStore.getAnswer(model)
-        questionId
-        index
-        isAnswered
-        answerState
-        @onChange
-      }
-      MultipleChoiceOption(optionProps)
-
-    classes = ['question']
-    classes.push('answered') if isAnswered
-
-    <div key={questionId} className={classes.join(' ')}>
-      <ul className='options'>{options}</ul>
-    </div>
-
-  onChange: (answer) ->
-    AnswerActions.setAnswer(@props.model, answer.id or answer.value)
-
-
-QUESTION_TYPES =
-  'multiple-choice'   : MultipleChoiceQuestion
-
-getQuestionType = (format) ->
-  QUESTION_TYPES[format] or throw new Error("Unsupported format type '#{format}'")
-
-
-
-Exercise1 = React.createClass
+ExerciseFreeResponse = React.createClass
   mixins: [StepMixin]
 
   getInitialState: ->
     freeResponse: @props.model.free_response
 
-  isEnabled: ->
+  isContinueEnabled: ->
     !! (@props.model.free_response or @state.freeResponse)
 
   renderBody: ->
@@ -199,16 +39,16 @@ Exercise1 = React.createClass
     freeResponse = @refs.freeResponse.getDOMNode().value
     @setState {freeResponse}
 
-  onSaveAndContinue: ->
+  onContinue: ->
     {freeResponse} = @state
-    AnswerActions.setFreeResponseAnswer(@props.model.content.questions[0], freeResponse)
+    question = @props.model.content.questions[0]
+    AnswerActions.setFreeResponseAnswer(question, freeResponse)
 
 
-Exercise2 = React.createClass
+ExerciseMultiChoice = React.createClass
   mixins: [StepMixin]
 
-  getInitialState: ->
-    isEnabled: !! @props.model.answer
+  _getQuestion: -> @props.model.content.questions[0]
 
   renderBody: ->
     {content, free_response, correct_answer_id, feedback_html} = @props.model
@@ -217,30 +57,56 @@ Exercise2 = React.createClass
     answer_id = @props.model.answer_id or AnswerStore.getAnswer(question)?.id
     free_response ?= AnswerStore.getFreeResponseAnswer(question)
 
-    Type = getQuestionType(question.format)
-
     <Question model={question} answer_id={answer_id} correct_answer_id={correct_answer_id} feedback_html={feedback_html} onChange={@onAnswerChanged}>
       <div className="free-response">{free_response}</div>
       <div>Choose the best answer from the following:</div>
     </Question>
 
   onAnswerChanged: (answer) ->
-    AnswerActions.setAnswer(@props.model.content.questions[0], answer)
+    question = @_getQuestion()
+    AnswerActions.setAnswer(question, answer)
 
-  isEnabled: -> !! AnswerStore.getAnswer(@props.model.content.questions[0])
+  isContinueEnabled: ->
+    question = @_getQuestion()
+    !! (@props.model.answer_id or AnswerStore.getAnswer(question))
 
-  onSaveAndContinue: ->
-    # {freeResponse} = @state
-    # AnswerActions.setFreeResponseAnswer(@props.model.content.questions[0], freeResponse)
-    @props.onComplete()
+  onContinue: ->
+    @props.onStepCompleted()
 
+
+ExerciseReview = React.createClass
+  mixins: [StepMixin]
+
+  _getQuestion: -> @props.model.content.questions[0]
+
+  renderBody: ->
+    {content, free_response, correct_answer_id, feedback_html} = @props.model
+    # TODO: Assumes 1 question.
+    question = content.questions[0]
+    answer_id = @props.model.answer_id or AnswerStore.getAnswer(question)?.id
+    free_response ?= AnswerStore.getFreeResponseAnswer(question)
+
+    <Question model={question} answer_id={answer_id} correct_answer_id={correct_answer_id} feedback_html={feedback_html} onChange={@onAnswerChanged}>
+      <div className="free-response">{free_response}</div>
+    </Question>
+
+  onAnswerChanged: (answer) ->
+    question = @_getQuestion()
+    AnswerActions.setAnswer(question, answer)
+
+  isContinueEnabled: ->
+    question = @_getQuestion()
+    !! (@props.model.answer_id or AnswerStore.getAnswer(question))
+
+  onContinue: ->
+    @props.onNextStep()
 
 
 module.exports = React.createClass
   displayName: 'Exercise'
 
   render: ->
-    {content, free_response, answer, correct_answer, feedback} = @props.model
+    {content, free_response, answer, correct_answer, is_completed} = @props.model
     # TODO: Assumes 1 question.
     question = content.questions[0]
 
@@ -248,22 +114,25 @@ module.exports = React.createClass
 
     # This should handle the 4 different states an Exercise can be in:
     # 1. `not(free_response)`: Show the question stem and a text area
-    # 2. `free_response and not(answer_id)`: Show stem, your free_response, and the multiple choice options
+    # 2. `free_response and not(is_completed)`: Show stem, your free_response, and the multiple choice options
     # 3. `correct_answer`: review how you did and show feedback (if any)
     # 4. `task.is_completed and answer` show your answer choice but no option to change it
 
-    if correct_answer
+    if is_completed
       # 3. `correct_answer`: review how you did and show feedback (if any)
-      <Exercise2 model={@props.model} onComplete={@props.onComplete} />
-    else if free_response
-      # 2. `free_response and not(answer_id)`: Show stem, your free_response, and the multiple choice options
-      <Exercise2
+      <ExerciseReview
         model={@props.model}
-        onComplete={@props.onComplete}
+        onNextStep={@props.onNextStep}
+        onStepCompleted={@props.onStepCompleted}
+      />
+    else if free_response
+      # 2. `free_response and not(is_completed)`: Show stem, your free_response, and the multiple choice options
+      <ExerciseMultiChoice
+        model={@props.model}
+        onStepCompleted={@props.onStepCompleted}
       />
     else
       # 1. `not(free_response)`: Show the question stem and a text area
-      <Exercise1
+      <ExerciseFreeResponse
         model={@props.model}
-        onComplete={@props.onComplete}
       />

--- a/src/components/exercise-multiple-choice.cjsx
+++ b/src/components/exercise-multiple-choice.cjsx
@@ -1,0 +1,269 @@
+_ = require 'underscore'
+React = require 'react'
+katex = require 'katex'
+{AnswerActions, AnswerStore} = require '../flux/answer'
+ArbitraryHtmlAndMath = require './html'
+StepMixin = require './step-mixin'
+Question = require './question'
+
+# Converts an index to `a-z` for question answers
+AnswerLabeler = React.createClass
+  displayName: 'AnswerLabeler'
+  render: ->
+    {index, before, after} = @props
+    letter = String.fromCharCode(index + 97) # For uppercase use 65
+    <span className='answer-char'>{before}{letter}{after}</span>
+
+
+QuestionMixin =
+  # renderBody: ->
+  # renderStem: ->
+  render: ->
+    {model} = @props
+    isAnswered = !!model.answer
+
+    if model.stimulus?
+      stimulus = <ArbitraryHtmlAndMath block=true className='stimulus' html={model.stimulus} />
+    classes = ['question', model.format]
+    classes.push('answered') if isAnswered
+
+    if @renderStem?
+      stem = @renderStem()
+    else
+      stem = <ArbitraryHtmlAndMath block=true className='stem' html={model.stem} />
+
+    <div className={classes.join(' ')} data-format={model.type}>
+      {stimulus}
+      {stem}
+      {@renderBody()}
+    </div>
+
+
+SimpleMultipleChoiceOption = React.createClass
+  displayName: 'SimpleMultipleChoiceOption'
+  render: ->
+    {model, questionId, index} = @props
+    id = model.id
+    <ArbitraryHtmlAndMath className='stem' html={model.content or model.value} />
+
+MultiMultipleChoiceOption = React.createClass
+  displayName: 'MultiMultipleChoiceOption'
+  render: ->
+    {model, idIndices} = @props
+    vals = []
+    for id, i in idIndices
+      unless model.value.indexOf(id) < 0
+        index = model.value.indexOf(id)
+        vals.push <AnswerLabeler key={index} before='(' after=')' index={index}/>
+    <span className='multi'>{vals}</span>
+
+
+MultipleChoiceOptionMixin =
+  render: ->
+    {inputType, model, questionId, index, isAnswered} = @props
+
+    # For radio boxes there is only 1 value, the id/value but
+    # for checkboxes the answer is an array of ids/values
+    option = if Array.isArray(model.value)
+      @props.idIndices = for id in model.value
+        id
+      MultiMultipleChoiceOption(@props)
+    else
+      SimpleMultipleChoiceOption(@props)
+
+    id = "#{questionId}-#{model.id}"
+
+    inputType = 'hidden' if isAnswered
+
+    classes = ['option']
+    # null (unanswered), 'correct', 'incorrect', 'missed'
+    classes.push(@props.answerState) if @props.answerState
+
+    optionIdent = @props.model.id or @props.model.value
+    if Array.isArray(@props.answer)
+      isChecked = @props.answer.indexOf(optionIdent) >= 0
+    else
+      isChecked = @props.answer is optionIdent
+
+    contents = [
+      <span key='letter' className='letter'><AnswerLabeler after=')' index={index}/> </span>
+      <span key='answer' className='answer'>{option}</span>
+    ]
+
+
+    unless isAnswered
+      contents =
+        <label>
+          <input type={inputType}
+            ref='input'
+            name={questionId}
+            value={JSON.stringify(model.value)}
+            onChange=@onChange
+            defaultChecked={isChecked}
+          />
+          {contents}
+        </label>
+
+    <li key={id} className={classes.join(' ')}>
+      {contents}
+    </li>
+
+
+
+MultipleChoiceOption = React.createClass
+  displayName: 'MultipleChoiceOption'
+  getDefaultProps: -> {inputType:'radio'}
+  mixins: [MultipleChoiceOptionMixin]
+
+  onChange: ->
+    @props.onChange(@props.model)
+
+
+MultipleChoiceQuestion = React.createClass
+  displayName: 'MultipleChoiceQuestion'
+
+  render: ->
+    {model} = @props
+    isAnswered = !!model.answer
+
+    questionId = model.id
+    options = for option, index in model.answers
+      answerState = null
+      if model.answer is option.id # if my answer is this option
+        if model.correct is model.answer
+          answerState = 'correct'
+        else
+          answerState = 'incorrect'
+      else if model.correct is option.id and model.answers.length > 2
+        answerState = 'missed'
+
+      optionProps = {
+        model: option
+        answer: AnswerStore.getAnswer(model)
+        questionId
+        index
+        isAnswered
+        answerState
+        @onChange
+      }
+      MultipleChoiceOption(optionProps)
+
+    classes = ['question']
+    classes.push('answered') if isAnswered
+
+    <div key={questionId} className={classes.join(' ')}>
+      <ul className='options'>{options}</ul>
+    </div>
+
+  onChange: (answer) ->
+    AnswerActions.setAnswer(@props.model, answer.id or answer.value)
+
+
+QUESTION_TYPES =
+  'multiple-choice'   : MultipleChoiceQuestion
+
+getQuestionType = (format) ->
+  QUESTION_TYPES[format] or throw new Error("Unsupported format type '#{format}'")
+
+
+
+Exercise1 = React.createClass
+  mixins: [StepMixin]
+
+  getInitialState: ->
+    freeResponse: @props.model.free_response
+
+  isEnabled: ->
+    !! (@props.model.free_response or @state.freeResponse)
+
+  renderBody: ->
+    {content} = @props.model
+    # TODO: Assumes 1 question.
+    question = content.questions[0]
+
+    <div className="exercise">
+      <ArbitraryHtmlAndMath className="stimulus" block={true} html={content.stimulus_html} />
+      <ArbitraryHtmlAndMath className="stem" block={true} html={question.stem_html} />
+      <textarea
+        className="form-control"
+        ref="freeResponse"
+        placeholder="Enter your response"
+        value={@state.freeResponse or ''}
+        onChange={@onFreeResponseChange}
+        />
+    </div>
+
+  componentDidMount: -> @refs.freeResponse.getDOMNode().focus()
+
+  onFreeResponseChange: ->
+    freeResponse = @refs.freeResponse.getDOMNode().value
+    @setState {freeResponse}
+
+  onSaveAndContinue: ->
+    {freeResponse} = @state
+    AnswerActions.setFreeResponseAnswer(@props.model.content.questions[0], freeResponse)
+
+
+Exercise2 = React.createClass
+  mixins: [StepMixin]
+
+  getInitialState: ->
+    isEnabled: !! @props.model.answer
+
+  renderBody: ->
+    {content, free_response, correct_answer_id, feedback_html} = @props.model
+    # TODO: Assumes 1 question.
+    question = content.questions[0]
+    answer_id = @props.model.answer_id or AnswerStore.getAnswer(question)?.id
+    free_response ?= AnswerStore.getFreeResponseAnswer(question)
+
+    Type = getQuestionType(question.format)
+
+    <Question model={question} answer_id={answer_id} correct_answer_id={correct_answer_id} feedback_html={feedback_html} onChange={@onAnswerChanged}>
+      <div className="free-response">{free_response}</div>
+      <div>Choose the best answer from the following:</div>
+    </Question>
+
+  onAnswerChanged: (answer) ->
+    AnswerActions.setAnswer(@props.model.content.questions[0], answer)
+
+  isEnabled: -> !! AnswerStore.getAnswer(@props.model.content.questions[0])
+
+  onSaveAndContinue: ->
+    # {freeResponse} = @state
+    # AnswerActions.setFreeResponseAnswer(@props.model.content.questions[0], freeResponse)
+    @props.onComplete()
+
+
+
+module.exports = React.createClass
+  displayName: 'Exercise'
+
+  render: ->
+    {content, free_response, answer, correct_answer, feedback} = @props.model
+    # TODO: Assumes 1 question.
+    question = content.questions[0]
+
+    free_response ?= AnswerStore.getFreeResponseAnswer(question)
+
+    # This should handle the 4 different states an Exercise can be in:
+    # 1. `not(free_response)`: Show the question stem and a text area
+    # 2. `free_response and not(answer_id)`: Show stem, your free_response, and the multiple choice options
+    # 3. `correct_answer`: review how you did and show feedback (if any)
+    # 4. `task.is_completed and answer` show your answer choice but no option to change it
+
+    if correct_answer
+      # 3. `correct_answer`: review how you did and show feedback (if any)
+      <Exercise2 model={@props.model} onComplete={@props.onComplete} />
+    else if free_response
+      # 2. `free_response and not(answer_id)`: Show stem, your free_response, and the multiple choice options
+      <Exercise2
+        model={@props.model}
+        onComplete={@props.onComplete}
+      />
+    else
+      # 1. `not(free_response)`: Show the question stem and a text area
+      <Exercise1
+        model={@props.model}
+        onComplete={@props.onComplete}
+      />

--- a/src/components/exercise.cjsx
+++ b/src/components/exercise.cjsx
@@ -2,7 +2,7 @@ _ = require 'underscore'
 React = require 'react'
 katex = require 'katex'
 {AnswerActions, AnswerStore} = require '../flux/answer'
-
+ArbitraryHtmlAndMath = require './html'
 
 # Converts an index to `a-z` for question answers
 AnswerLabeler = React.createClass
@@ -11,35 +11,6 @@ AnswerLabeler = React.createClass
     {index, before, after} = @props
     letter = String.fromCharCode(index + 97) # For uppercase use 65
     <span className='answer-char'>{before}{letter}{after}</span>
-
-
-ArbitraryHtmlAndMath = React.createClass
-  displayName: 'ArbitraryHtmlAndMath'
-  render: ->
-    classes = ['arbitrary-html-and-math']
-    classes.push(@props.className) if @props.className
-
-    if @props.block
-      <div className={classes.join(' ')} dangerouslySetInnerHTML={__html:@props.html} />
-    else
-      <span className={classes.join(' ')} dangerouslySetInnerHTML={__html:@props.html} />
-
-  renderMath: ->
-    for node in @getDOMNode().querySelectorAll('[data-math]:not(.loaded)')
-      $node = $(node)
-      formula = $node.attr('data-math')
-
-      # Divs with data-math should be rendered as a block
-      isBlock = node.tagName.toLowerCase() in ['div']
-
-      if isBlock
-        formula = "\\displaystyle {#{formula}}"
-
-      katex.render(formula, $node[0])
-      $node.addClass('loaded')
-
-  componentDidMount:  -> @renderMath()
-  componentDidUpdate: -> @renderMath()
 
 
 QuestionMixin =

--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -1,0 +1,29 @@
+React = require 'react'
+katex = require 'katex'
+
+module.exports = React.createClass
+  displayName: 'ArbitraryHtmlAndMath'
+  render: ->
+    classes = ['arbitrary-html-and-math']
+    classes.push(@props.className) if @props.className
+
+    if @props.block
+      <div className={classes.join(' ')} dangerouslySetInnerHTML={__html:@props.html} />
+    else
+      <span className={classes.join(' ')} dangerouslySetInnerHTML={__html:@props.html} />
+
+  renderMath: ->
+    for node in @getDOMNode().querySelectorAll('[data-math]:not(.loaded)')
+      formula = node.getAttribute('data-math')
+
+      # Divs with data-math should be rendered as a block
+      isBlock = node.tagName.toLowerCase() in ['div']
+
+      if isBlock
+        formula = "\\displaystyle {#{formula}}"
+
+      katex.render(formula, node)
+      node.classList.add('loaded')
+
+  componentDidMount:  -> @renderMath()
+  componentDidUpdate: -> @renderMath()

--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -1,29 +1,14 @@
 React = require 'react'
-katex = require 'katex'
+KatexMixin = require './katex-mixin'
 
 module.exports = React.createClass
   displayName: 'ArbitraryHtmlAndMath'
+  mixins: [KatexMixin]
   render: ->
-    classes = ['arbitrary-html-and-math']
+    classes = ['has-html']
     classes.push(@props.className) if @props.className
 
     if @props.block
       <div className={classes.join(' ')} dangerouslySetInnerHTML={__html:@props.html} />
     else
       <span className={classes.join(' ')} dangerouslySetInnerHTML={__html:@props.html} />
-
-  renderMath: ->
-    for node in @getDOMNode().querySelectorAll('[data-math]:not(.loaded)')
-      formula = node.getAttribute('data-math')
-
-      # Divs with data-math should be rendered as a block
-      isBlock = node.tagName.toLowerCase() in ['div']
-
-      if isBlock
-        formula = "\\displaystyle {#{formula}}"
-
-      katex.render(formula, node)
-      node.classList.add('loaded')
-
-  componentDidMount:  -> @renderMath()
-  componentDidUpdate: -> @renderMath()

--- a/src/components/katex-mixin.coffee
+++ b/src/components/katex-mixin.coffee
@@ -1,0 +1,38 @@
+katex = require 'katex'
+
+DOM_HELPER = document.createElement('div')
+
+module.exports =
+  renderMath: ->
+    for node in @getDOMNode().querySelectorAll('[data-math]:not(.loaded)')
+      formula = node.getAttribute('data-math')
+
+      # Divs with data-math should be rendered as a block
+      isBlock = node.tagName.toLowerCase() in ['div']
+
+      if isBlock
+        formula = "\\displaystyle {#{formula}}"
+
+      katex.render(formula, node)
+      node.classList.add('loaded')
+
+  sanitizeKatexHtml: (html) ->
+    # Clean up the katex that was added
+    DOM_HELPER.innerHTML = html.trim() # Useful later in the func for unwrapping
+    for node in DOM_HELPER.querySelectorAll('[data-math]')
+      formula = node.getAttribute('data-math')
+      node.classList.remove('loaded')
+      # Put the formula in the innerHTML because browsers like to remove empty span tags
+      node.innerHTML = formula
+
+    # if there is only 1 <div> child element then unwrap it instead.
+    # That way we don't have a bunch of <div>123</div> answers
+    if DOM_HELPER.childElementCount is 1 and DOM_HELPER.firstChild.tagName.toLowerCase() is 'div'
+      html = DOM_HELPER.firstChild.innerHTML
+    else
+      html = DOM_HELPER.innerHTML
+    DOM_HELPER.innerHTML = '' # for memory
+    html
+
+  componentDidMount:  -> @renderMath()
+  componentDidUpdate: -> @renderMath()

--- a/src/components/question.cjsx
+++ b/src/components/question.cjsx
@@ -1,0 +1,68 @@
+_ = require 'underscore'
+React = require 'react'
+ArbitraryHtml = require './html'
+StepMixin = require './step-mixin'
+
+idCounter = 0
+
+
+# props:
+#   model
+#   answer
+#   correct_answer
+#   feedback_html
+
+module.exports = React.createClass
+
+  getInitialState: ->
+    answer: null
+
+  # Curried function to remember the answer
+  onChangeAnswer: (answer) -> =>
+    @setState {answer_id:answer.id}
+    @props.onChange(answer)
+
+  render: ->
+    html = @props.model.stem_html
+    qid = @props.model.id or "auto-#{idCounter++}"
+
+    if @props.feedback_html
+      feedback = <ArbitraryHtml className="question-feedback has-html" html={@props.feedback_html} />
+
+    answers = _.map @props.model.answers, (answer, i) =>
+      isChecked = answer.id in [@props.answer_id, @state.answer_id]
+      isCorrect = answer.id is @props.correct_answer_id
+
+      classes = ['answers-answer']
+      classes.push('answer-checked') if isChecked
+      classes.push('answer-correct') if isCorrect
+      classes = classes.join(' ')
+
+      <div className={classes}>
+        <input
+          type="radio"
+          className="answer-input-box"
+          checked={isChecked}
+          id="#{qid}-option-#{i}"
+          name="#{qid}-options"
+          onChange={@onChangeAnswer(answer)}
+        />
+        <label htmlFor="#{qid}-option-#{i}" className="answer-label">
+          <div className="answer-letter" />
+          <ArbitraryHtml className="answer-content" html={answer.content_html} />
+        </label>
+      </div>
+
+    hasCorrectAnswer = !! @props.correct_answer_id
+    classes = ['question']
+    classes.push('has-correct-answer') if hasCorrectAnswer
+    classes = classes.join(' ')
+
+    <div className={classes}>
+      <ArbitraryHtml className="question-stem" block={true} html={html} />
+      {@props.children}
+      <div className="answers-table">
+        {answers}
+      </div>
+      {feedback}
+    </div>

--- a/src/components/step-mixin.cjsx
+++ b/src/components/step-mixin.cjsx
@@ -2,13 +2,13 @@ React = require 'react'
 
 module.exports =
   render: ->
-    isDisabledClass = 'disabled' unless @isEnabled()
+    isDisabledClass = 'disabled' unless @isContinueEnabled()
 
     <div className="task-step panel panel-default">
       <div className="panel-body">
         {@renderBody()}
       </div>
       <div className="panel-footer">
-        <button className="btn btn-primary #{isDisabledClass}" onClick={@onSaveAndContinue}>Continue</button>
+        <button className="btn btn-primary #{isDisabledClass}" onClick={@onContinue}>Continue</button>
       </div>
     </div>

--- a/src/components/step-mixin.cjsx
+++ b/src/components/step-mixin.cjsx
@@ -1,0 +1,14 @@
+React = require 'react'
+
+module.exports =
+  render: ->
+    isDisabledClass = 'disabled' unless @isEnabled()
+
+    <div className="task-step panel panel-default">
+      <div className="panel-body">
+        {@renderBody()}
+      </div>
+      <div className="panel-footer">
+        <button className="btn btn-primary #{isDisabledClass}" onClick={@onSaveAndContinue}>Continue</button>
+      </div>
+    </div>

--- a/src/components/task-step.cjsx
+++ b/src/components/task-step.cjsx
@@ -32,5 +32,6 @@ module.exports = React.createClass
 
     <Type
       model={@props.model}
-      onComplete={@props.onComplete}
+      onNextStep={@props.onNextStep}
+      onStepCompleted={@props.onStepCompleted}
     />

--- a/src/components/task-step.cjsx
+++ b/src/components/task-step.cjsx
@@ -32,4 +32,5 @@ module.exports = React.createClass
 
     <Type
       model={@props.model}
+      onComplete={@props.onComplete}
     />

--- a/src/components/task.cjsx
+++ b/src/components/task.cjsx
@@ -46,27 +46,12 @@ module.exports = React.createClass
         break
     currentStep
 
-
   goToStep: (num) -> () =>
     # Curried for React
     @setState({currentStep: num})
 
   update: ->
     @setState({})
-
-  areAllStepsCompleted: (stepConfig) ->
-    isUnanswered = false
-
-    # TODO: Each step should have a boolean "completed" flag so we do not have to special-case in this code
-    switch stepConfig.type
-      when 'exercise'
-        for question in stepConfig.content.questions
-          unless AnswerStore.getAnswer(question)?
-            isUnanswered = true
-      else
-        isUnanswered = true
-
-    !isUnanswered
 
   render: ->
     {id} = @props
@@ -83,18 +68,11 @@ module.exports = React.createClass
     if TaskStore.isStepAnswered(id, @state.currentStep)
       isDisabledClass = ''
     else
-      isDisabledClass = ' disabled'
+      isDisabledClass = 'disabled'
 
     <div className="task">
       {breadcrumbs}
-      <div className="task-step panel panel-default">
-        <div className="panel-body">
-          <TaskStep taskId={id} id={@state.currentStep} model={stepConfig} onComplete={@onStepComplete} />
-        </div>
-        <div className="panel-footer">
-          <button className="btn btn-primary #{isDisabledClass}" onClick={@onStepComplete}>Continue</button>
-        </div>
-      </div>
+      <TaskStep taskId={id} id={@state.currentStep} model={stepConfig} onComplete={@onStepComplete} />
     </div>
 
   onStepComplete: ->

--- a/src/components/task.cjsx
+++ b/src/components/task.cjsx
@@ -17,19 +17,13 @@ err = (msgs...) ->
 module.exports = React.createClass
   displayName: 'Task'
   getInitialState: ->
-    # Grab the currentStep from the URL from SingleTask
-    if @props.params.currentStep?
-      try
-        currentStep = parseInt(@props.params.currentStep) - 1
-      catch e
-        currentStep = 0
-    else
-      model = TaskStore.get(@props.id)
-      # Determine the first uncompleted step
-      for step, i in model.steps
-        unless step.is_completed
-          currentStep = i
-          break
+    currentStep = 0
+    model = TaskStore.get(@props.id)
+    # Determine the first uncompleted step
+    for step, i in model.steps
+      unless step.is_completed
+        currentStep = i
+        break
 
     {currentStep}
 
@@ -65,18 +59,21 @@ module.exports = React.createClass
           <Breadcrumbs model={model} goToStep={@goToStep} currentStep={@state.currentStep} />
         </div>
 
-    if TaskStore.isStepAnswered(id, @state.currentStep)
-      isDisabledClass = ''
-    else
-      isDisabledClass = 'disabled'
-
     <div className="task">
       {breadcrumbs}
-      <TaskStep taskId={id} id={@state.currentStep} model={stepConfig} onComplete={@onStepComplete} />
+      <TaskStep
+        taskId={id}
+        id={@state.currentStep}
+        model={stepConfig}
+        onStepCompleted={@onStepCompleted}
+        onNextStep={@onNextStep}
+      />
     </div>
 
-  onStepComplete: ->
+  onStepCompleted: ->
     {id} = @props
     stepId = @state.currentStep
     TaskActions.completeStep(id, stepId)
+
+  onNextStep: ->
     @setState({currentStep: @getDefaultCurrentStep()})

--- a/src/flux/answer.coffee
+++ b/src/flux/answer.coffee
@@ -3,17 +3,24 @@ flux = require 'flux-react'
 
 AnswerActions = flux.createActions [
   'reset'     # () ->
+  'setFreeResponseAnswer' # (question, freeResponse) ->
   'setAnswer' # (question, answer) ->
 ]
 
 
 AnswerStore = flux.createStore
-  actions: [AnswerActions.reset, AnswerActions.setAnswer]
+  actions: [AnswerActions.reset, AnswerActions.setAnswer, AnswerActions.setFreeResponseAnswer]
 
   _answers: {}
+  _freeResponseAnswers: {}
 
   reset: ->
     @_answers = {}
+    @_freeResponseAnswers = {}
+    @emitChange()
+
+  setFreeResponseAnswer: (question, freeResponse) ->
+    @_freeResponseAnswers[question.id] = freeResponse
     @emitChange()
 
   setAnswer: (question, answer) ->
@@ -24,6 +31,10 @@ AnswerStore = flux.createStore
     getAnswer: (question) ->
       id = question.id
       @_answers[id] or question.answer
+    getFreeResponseAnswer: (question) ->
+      id = question.id
+      @_freeResponseAnswers[id] or question.free_response
+
     getAllAnswers: -> @_answers
 
 module.exports = {AnswerActions, AnswerStore}

--- a/src/flux/helpers.coffee
+++ b/src/flux/helpers.coffee
@@ -1,0 +1,79 @@
+_ = require 'underscore'
+flux = require 'flux-react'
+
+LOADING = 'loading'
+LOADED  = 'loaded'
+FAILED  = 'failed'
+SAVING  = 'saving'
+
+CrudConfig =
+  _asyncStatus: {}
+  _local: {}
+  _errors: {}
+  _unsaved: {}
+
+  reset: ->
+    @_asyncStatus = {}
+    @_local = {}
+    @_errors = {}
+    @_unsaved = {}
+    @emitChange()
+
+  FAILED: (status, msg, id) ->
+    @_asyncStatus[id] = FAILED
+    delete @_local[id]
+    @_errors[id] = msg
+    @emitChange()
+
+  load: (id) ->
+    @_asyncStatus[id] = LOADING
+    @emitChange()
+
+  loaded: (obj, id) ->
+    # id = obj.id
+    @_asyncStatus[id] = LOADED
+    @_local[id] = obj
+    @emitChange()
+
+  save: (id, obj) ->
+    @_asyncStatus[id] = SAVING
+    @emitChange()
+
+  saved: (result, id) ->
+    # id = result.id
+    @_asyncStatus[id] = LOADED # TODO: Maybe make this SAVED
+    @_local[id] = result
+    delete @_unsaved[id]
+    delete @_errors[id]
+    @emitChange()
+
+  exports:
+    isUnknown: (id) -> !@_asyncStatus[id]
+    isLoading: (id) -> @_asyncStatus[id] is LOADING
+    isLoaded: (id) -> @_asyncStatus[id] is LOADED
+    isFailed: (id) -> @_asyncStatus[id] is FAILED
+    getAsyncStatus: (id) -> @_asyncStatus[id]
+    get: (id) -> @_local[id]
+
+
+# Helper for creating a simple store for actions
+makeSimpleStore = (storeConfig) ->
+
+  actionsConfig = _.omit storeConfig, (value, key) ->
+    typeof value isnt 'function' or key is 'exports'
+
+  actionsConfig = _.keys(actionsConfig)
+  actions = flux.createActions(actionsConfig)
+  storeConfig.actions = _.values(actions)
+  store = flux.createStore(storeConfig)
+  {actions, store}
+
+
+extendConfig = (newConfig, origConfig) ->
+  newConfig.exports ?= {}
+  _.defaults(newConfig, origConfig)
+  _.defaults(newConfig.exports, origConfig.exports)
+  newConfig
+
+
+module.exports = {CrudConfig, makeSimpleStore, extendConfig}

--- a/src/flux/task-step.coffee
+++ b/src/flux/task-step.coffee
@@ -1,0 +1,15 @@
+_ = require 'underscore'
+flux = require 'flux-react'
+
+{CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
+
+TaskStepConfig =
+
+  complete: (id) ->
+    @edit(id, {is_completed: true})
+    @save(id)
+
+
+extendConfig(TaskConfig, CrudConfig)
+{actions, store} = makeSimpleStore(TaskConfig)
+module.exports = {TaskActions:actions, TaskStore:store}

--- a/style/question.less
+++ b/style/question.less
@@ -1,0 +1,126 @@
+.question {
+    counter-reset: answer 0;
+
+    &.has-correct-answer {
+      .answer-input-box { display: none; }
+
+      .answer-correct .answer-label { background-color: #0f0; }
+      .answer-checked:not(.answer-correct) .answer-label { background-color: #f00; }
+    }
+
+    .answers-table {
+      display: table;
+      border-collapse: collapse;
+
+      border-top: 1px dotted #ccc;
+      margin-top: 1rem;
+
+      .answers-answer {
+        counter-increment: answer 1;
+        display: table-row;
+
+        .answer-letter {
+          display: table-cell;
+          width: 2rem;
+          padding-left: .5rem;
+          &:after { content: counter(answer, lower-latin) ')'; }
+        }
+
+        .answer-content {
+          display: table-cell;
+          padding: .5rem 0;
+          width: 100%;
+          padding-left: 1rem;
+          padding-right: .5rem;
+        }
+      }
+    }
+
+
+
+    // The Row
+    .answers-answer,
+    .answers-add {
+      display: table-row;
+      // transition: background-color .3s ease;
+    }
+    // .answers-answer:hover { background-color: #efefef; }
+    .answer-letter,
+    .answer-actions {
+      display: table-cell;
+      width: 2rem;
+    }
+    .answer-letter { cursor: default; }
+
+
+
+
+
+
+
+  // &.mode-view,
+  // &.mode-preview {
+    // &:before {
+    //   font-size: 3rem;
+    //   position: absolute;
+    //   content: counter(question);
+    //
+    //   margin-left: 3rem-1rem; // From materialize .card-content (-1rem for double-digit numbers)
+    //   margin-top: 1.7rem; // From materialize .card-content
+    // }
+    .card-content {
+      margin-left: 4rem; // Enough room for double-digit question numbers
+
+      .question-stem {
+        font-size: 1.2rem;
+        margin-top: 1.5rem;
+        min-height: 2rem; // center with the 3rem question number
+      }
+
+      .answers-table .answer-letter {
+        font-weight: bold;
+      }
+    }
+  // }
+
+
+
+  // &.mode-preview {
+    .answer-input-box { display: table-cell; }
+
+&:not(.has-correct-answer) {
+
+    .answer-input-box:checked + label.answer-label,
+    .answer-input-box:checked + label.answer-label:hover {
+      background-color: #9e9e9e; // darker than hover
+    }
+
+}
+
+    .answers-table {
+      width: 100%;
+
+      label.answer-label {
+        display: table-cell;
+        transition: background-color .2s ease-in;
+        &:hover { background-color: #e0e0e0; }
+
+        //Materialize hack
+        color: inherit;
+        font-weight: inherit;
+        font-size: inherit;
+        padding-left: 0;
+        height: inherit;
+        line-height: inherit;
+        //Materialize hack
+        //[type="radio"]:not(:checked) + label:before
+        &:before,
+        &:after { display: none; }
+
+      }
+    }
+  // }
+
+
+
+}

--- a/style/tutor.less
+++ b/style/tutor.less
@@ -2,6 +2,7 @@
 @import '../bower_components/bootstrap-material-design/less/material-wfont.less';
 @import '../node_modules/font-awesome/less/font-awesome.less';
 @import '../bower_components/katex/static/katex.less';
+@import './question.less';
 
 // Override the default path to the font-awesome fonts
 @fa-font-path: '../node_modules/font-awesome/fonts';

--- a/test/task-store.spec.coffee
+++ b/test/task-store.spec.coffee
@@ -9,7 +9,7 @@ describe 'Task Store', ->
   it 'should clear the store', ->
     id = 0
     expect(TaskStore.isUnknown(id)).to.be.true
-    TaskActions.loaded(id, {hello:'foo'})
+    TaskActions.loaded({hello:'foo'}, id)
     expect(TaskStore.isUnknown(id)).to.be.false
     TaskActions.reset()
     expect(TaskStore.isUnknown(id)).to.be.true
@@ -38,7 +38,7 @@ describe 'Task Store', ->
     expect(TaskStore.isLoading(id)).to.be.true
     expect(TaskStore.isFailed(id)).to.be.false
 
-    TaskActions.loaded(id, {hello:'bar'})
+    TaskActions.loaded({hello:'bar'}, id)
 
     expect(TaskStore.isUnknown(id)).to.be.false
     expect(TaskStore.isLoaded(id)).to.be.true
@@ -62,51 +62,12 @@ describe 'Task Store', ->
     expect(TaskStore.isLoading(id)).to.be.true
     expect(TaskStore.isFailed(id)).to.be.false
 
-    TaskActions.FAILED(id, {err:'message'})
+    TaskActions.FAILED(404, {err:'message'}, id)
 
     expect(TaskStore.isUnknown(id)).to.be.false
     expect(TaskStore.isLoaded(id)).to.be.false
     expect(TaskStore.isLoading(id)).to.be.false
     expect(TaskStore.isFailed(id)).to.be.true
-
-
-  it 'should remember what was changed', (done) ->
-    id = 0
-    calledSynchronously = 0
-    TaskStore.addChangeListener ->
-      calledSynchronously += 1
-      calledSynchronously is 3 and done()
-
-    TaskActions.loaded(id, {hello:'world'})
-    expect(TaskStore.get(id).hello).to.equal('world')
-
-    # Add a new attribute
-    TaskActions.edit(id, {bar:'baz'})
-    expect(TaskStore.get(id)).to.deep.equal({hello:'world', bar:'baz'})
-    expect(TaskStore.getUnsaved(id)).to.deep.equal({bar:'baz'})
-
-    TaskActions.edit(id, {hello:'foo'})
-    expect(TaskStore.get(id)).to.deep.equal({hello:'foo', bar:'baz'})
-    expect(TaskStore.getUnsaved(id)).to.deep.equal({hello:'foo', bar:'baz'})
-
-
-
-  it 'should reset the unsaved set when save completes', (done) ->
-    id = 0
-    calledSynchronously = 0
-    TaskStore.addChangeListener ->
-      calledSynchronously += 1
-      calledSynchronously is 3 and done()
-
-    TaskActions.loaded(id, {hello:'world'})
-
-    # Add a new attribute
-    TaskActions.edit(id, {hello:'foo'})
-    TaskActions.saved(id, {hello:'baz'})
-
-    expect(TaskStore.get(id)).to.deep.equal({hello:'baz'})
-    expect(TaskStore.getUnsaved(id)).to.be.undefined
-
 
 
   it 'should mark the task as complete', (done) ->


### PR DESCRIPTION
This should handle the 4 different states an Exercise can be in:

1. `not(free_response)`: Show the question stem and a text area
2. `free_response and not(answer_id)`: Show stem, your free_response, and the multiple choice options
3. `correct_answer_id`: review how you did and show feedback (if any)
4. `task.is_completed and answer` show your answer choice but no option to change it

Student is presented with a free response:
![image](https://cloud.githubusercontent.com/assets/253202/6133846/dd44e004-b12a-11e4-84c9-63313c7112e7.png)

clicks "Continue" and is shown their answer plus Multiple choice options:

![image](https://cloud.githubusercontent.com/assets/253202/6133856/f49112dc-b12a-11e4-8e23-61bbb3245489.png)

Clicks "Continue" and is shown a review for the question:

![image](https://cloud.githubusercontent.com/assets/253202/6133865/03de64e2-b12b-11e4-9b76-f95c92efa3bd.png)

Clicks "Continue" and is sent to the next Step:
![image](https://cloud.githubusercontent.com/assets/253202/6133871/135f9760-b12b-11e4-9b4b-0af158d40214.png)

Clicks a completed step and sees the review page:
![image](https://cloud.githubusercontent.com/assets/253202/6133865/03de64e2-b12b-11e4-9b76-f95c92efa3bd.png)
