### PR TITLE
Reload task after complete

### DIFF
--- a/api/tasks/4
+++ b/api/tasks/4
@@ -1,5 +1,5 @@
 { "id": 4,
-  "LOCAL_STEP_COMPLETION_HACK": true,
+  "HACK_LOCAL_STEP_COMPLETION": true,
   "title": "Assignment",
   "steps": [
     { "id": "step-id-4-1",

--- a/api/tasks/4
+++ b/api/tasks/4
@@ -1,4 +1,5 @@
 { "id": 4,
+  "LOCAL_STEP_COMPLETION_HACK": true,
   "title": "Assignment",
   "steps": [
     { "id": "step-id-4-1",

--- a/api/user/tasks
+++ b/api/user/tasks
@@ -44,6 +44,7 @@
       }]
     },
     { "id": 4,
+      "HACK_LOCAL_STEP_COMPLETION": true,
       "title": "Assignment",
       "steps": [
         { "id": "step-id-4-1",

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -57,7 +57,10 @@ start = ->
   #   url: "/api/tasks/#{id}"
   #   payload: obj
 
-  apiHelper TaskActions, TaskActions.completeStep, TaskActions.completed, 'PUT', (task, step) ->
+  reloadAfterCompletion = (empty, task, step) ->
+    TaskActions.load(task.id)
+
+  apiHelper TaskActions, TaskActions.completeStep, reloadAfterCompletion, 'PUT', (task, step) ->
     url: "/api/tasks/#{task.id}/steps/#{step.id}/completed"
 
   apiHelper TaskActions, TaskActions.setFreeResponseAnswer, TaskActions.saved, 'PATCH', (task, step, free_response) ->

--- a/src/components/index.cjsx
+++ b/src/components/index.cjsx
@@ -76,18 +76,7 @@ SingleTask = React.createClass
 
   render: ->
     id = @props.params.id
-    switch TaskStore.getAsyncStatus(id)
-      when 'loaded'
-        return @transferPropsTo(<Task id={id} />)
-
-      when 'failed'
-        <div>Error. Please refresh</div>
-
-      when 'loading'
-        <div>Loading...</div>
-
-      else
-        <div>Starting loading</div>
+    @transferPropsTo(<Task key={id} id={id} />)
 
 
 TaskResult = React.createClass

--- a/src/components/task.cjsx
+++ b/src/components/task.cjsx
@@ -18,11 +18,12 @@ module.exports = React.createClass
   getInitialState: ->
     currentStep = 0
     model = TaskStore.get(@props.id)
-    # Determine the first uncompleted step
-    for step, i in model.steps
-      unless step.is_completed
-        currentStep = i
-        break
+    if model
+      # Determine the first uncompleted step
+      for step, i in model.steps
+        unless step.is_completed
+          currentStep = i
+          break
 
     {currentStep}
 
@@ -47,6 +48,22 @@ module.exports = React.createClass
     @setState({})
 
   render: ->
+    {id} = @props
+    switch TaskStore.getAsyncStatus(id)
+      when 'loaded'
+        @renderBody()
+      when 'failed'
+        <div>Error. Please refresh</div>
+      when 'loading'
+        # If reloading then do not replace the entire DOM (and lose currentStep state)
+        if TaskStore.get(id)
+          @renderBody()
+        else
+          <div>Loading...</div>
+      else
+        <div>Starting loading</div>
+
+  renderBody: ->
     {id} = @props
     model = TaskStore.get(id)
     steps = model.steps

--- a/src/flux/helpers.coffee
+++ b/src/flux/helpers.coffee
@@ -34,7 +34,18 @@ CrudConfig =
   loaded: (obj, id) ->
     # id = obj.id
     @_asyncStatus[id] = LOADED
-    @_local[id] = obj
+    # HACK When working locally a step completion triggers a reload but the is_completed field on the TaskStep
+    # is discarded. so, if is_completed is set on the local object but not on the returned JSON
+    # Tack on a dummy correct_answer_id
+    if @_local[id] and obj.LOCAL_STEP_COMPLETION_HACK
+      for step in @_local[id].steps
+        # HACK: Tack on a fake correct_answer and feedback to all completed steps that have an exercise but no correct_answer_id
+        if step.is_completed and step.content?.questions?[0]?.answers[0]? and not step.correct_answer_id
+          step.correct_answer_id = step.content.questions[0].answers[0].id
+          step.feedback_html = 'Some <em>FAKE</em> feedback'
+
+    else
+      @_local[id] = obj
     # If the specific type needs to do something else to the object:
     @_loaded?(obj, id)
     @emitChange()

--- a/src/flux/helpers.coffee
+++ b/src/flux/helpers.coffee
@@ -37,7 +37,7 @@ CrudConfig =
     # HACK When working locally a step completion triggers a reload but the is_completed field on the TaskStep
     # is discarded. so, if is_completed is set on the local object but not on the returned JSON
     # Tack on a dummy correct_answer_id
-    if @_local[id] and obj.LOCAL_STEP_COMPLETION_HACK
+    if @_local[id] and obj.HACK_LOCAL_STEP_COMPLETION
       for step in @_local[id].steps
         # HACK: Tack on a fake correct_answer and feedback to all completed steps that have an exercise but no correct_answer_id
         if step.is_completed and step.content?.questions?[0]?.answers[0]? and not step.correct_answer_id

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -22,16 +22,6 @@ TaskConfig =
 
   completed: (empty, task, step) ->
     # First arg is null and ignored because it was a PUT ./completed
-    # @load(task.id)
-
-    # Only mark the step complete once
-    step = @_getStep(task.id, step.id)
-    step.is_completed = true
-    # HACK: Tack on a fake correct_answer and feedback
-    if step.content?.questions?[0]?.answers[0]?
-      step.correct_answer_id = step.content.questions[0].answers[0].id
-      step.feedback_html = 'Some <em>FAKE</em> feedback'
-    @emitChange()
 
   setAnswerId: (task, step, answerId) ->
     step = @_getStep(task.id, step.id)
@@ -43,15 +33,6 @@ TaskConfig =
     step = @_getStep(task.id, step.id)
     step.free_response = freeResponse
     @emitChange()
-
-  _loaded: (obj, id) ->
-    # Add a .url field to both the task and each step so API can patch the answer and completion info
-    obj.url ?= "/api/tasks/#{id}"
-    for step, i in obj.steps
-      throw new Error('Bug! No Step ID Provided!') unless step.id
-      step.url ?= "/api/tasks/#{id}/steps/#{step.id}"
-
-  _saved: (obj, id) -> @_loaded(obj, id)
 
   exports:
     isStepAnswered: (taskId, stepId) ->


### PR DESCRIPTION
No UI changes.

The completing an exercise requires 2 calls to the backend (for now):

1. `PUT /tasks/123/steps/234/completed`
2. `GET /tasks/123` (TaskStep now contains the `correct_answer_id` and optional `feedback_html`)

Ideally, it would be a single `PATCH /tasks/123/steps/234` with `{is_completed: true}` which would return the `correct_answer_id` and optional `feedback_html` inside the JSON.

To get the mockup data to work correctly I added an additional `HACK_LOCAL_STEP_COMPLETION` to know tutor-js is fetching mock data and should "emulate" the TaskStep completion.