### PR TITLE
Refactor create code to handle multiple creations and types

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -78,7 +78,10 @@ start = ->
 
   saveHelper = (id) ->
     obj = TaskPlanStore.get(id)
-    url: "/api/courses/1/plans/#{id}"
+    # Use the obj.id because id could be the local id if freshly created
+    throw new Error('BUG: Failed to POST first') unless obj.id
+
+    url: "/api/courses/1/plans/#{obj.id}"
     payload: obj
 
   apiHelper TaskPlanActions, TaskPlanActions.updateTitle, TaskPlanActions.saved, 'PATCH', saveHelper

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -87,25 +87,16 @@ ReadingPlan = React.createClass
   mixins: [Router.State, Router.Navigation]
 
   getInitialState: ->
-    if (@getParams().id)
-      return {id: @getParams().id}
-    else
-      TaskPlanActions.create()
-      return {id: TaskPlanStore.getCreateKey()}
+    id = @getParams().id
+    unless id
+      id = TaskPlanStore.freshLocalId()
+      TaskPlanActions.create(id, due_at: new Date())
+    {id}
 
   componentWillMount: -> TaskPlanStore.addChangeListener(@update)
   componentWillUnmount: -> TaskPlanStore.removeChangeListener(@update)
 
-  update: ->
-    if @state.id is 'CREATING'
-      id = TaskPlanStore.get('CREATING')
-    else
-      id = @state.id
-
-    @setState({
-      id: id,
-      topics: TaskPlanStore.getTopics(id)
-    })
+  update: -> @setState {}
 
   setDueAt: (value) ->
     TaskPlanActions.updateDueAt(@state.id, value)
@@ -115,8 +106,9 @@ ReadingPlan = React.createClass
     TaskPlanActions.updateTitle(@state.id, value)
 
   publish: ->
-    TaskPlanActions.publish(@state.id)
-    @transitionTo('editReading', {id: @state.id})
+    {id} = TaskPlanStore.get(@state.id)
+    TaskPlanActions.publish(id)
+    @transitionTo('editReading', {id})
 
   renderTopics: (topicId) ->
     topic = TocStore.getSectionInfo(topicId)

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -1,7 +1,6 @@
 _ = require 'underscore'
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
 
-CREATE_KEY = "CREATING"
 
 TaskPlanConfig =
   _getPlan: (planId) ->
@@ -37,21 +36,10 @@ TaskPlanConfig =
 
   publish: (id) ->
 
-  create: (due_at = new Date()) ->
-    @_local[CREATE_KEY] = {
-      due_at: due_at
-    }
-
-  created: (result, id) ->
-    @_local[CREATE_KEY] = result.id # HACK to give react component the id
-    @_local[result.id] = result
-    @emitChange()
-
   exports:
     hasTopic: (id, topicId) ->
       plan = @_getPlan(id)
       plan?.settings.page_ids?.indexOf(topicId) >= 0
-    getCreateKey: -> CREATE_KEY
     getTopics: (id) ->
       plan = @_getPlan(id)
       plan?.settings.page_ids


### PR DESCRIPTION
No UI changes.

- [x] clean up unused code
- [x] move creation code into CRUD helper
- [x] allow creating multiple types of objects

For another PR:
- save should handle new and existing objects
- API should check `Store.isNew` and decide on POST vs PATCH (like Backbone does)
- refactor `freshLocalId()`