### PR TITLE
WIP keep track of unsaved changes in the stores

### DIFF
--- a/Gulpfile.coffee
+++ b/Gulpfile.coffee
@@ -70,7 +70,7 @@ buildTests = (isWatching) ->
   buildBrowserify(srcPath, destDir, destFile, isWatching)
 
 
-gulp.task 'test', ['build'], (done) ->
+gulp.task 'test', ['buildJS'], (done) ->
   buildTests(false)
   .on 'end', ->
     config =

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -77,11 +77,12 @@ start = ->
     url: "/api/courses/1/plans/#{id}/publish"
 
   saveHelper = (id) ->
-    obj = TaskPlanStore.get(id)
+    {id} = TaskPlanStore.get(id) # Could be a local id
     # Use the obj.id because id could be the local id if freshly created
-    throw new Error('BUG: Failed to POST first') unless obj.id
+    throw new Error('BUG: Failed to POST first') unless id
+    obj = TaskPlanStore.getChanged(id)
 
-    url: "/api/courses/1/plans/#{obj.id}"
+    url: "/api/courses/1/plans/#{id}"
     payload: obj
 
   apiHelper TaskPlanActions, TaskPlanActions.updateTitle, TaskPlanActions.saved, 'PATCH', saveHelper

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -88,7 +88,9 @@ ReadingPlan = React.createClass
 
   getInitialState: ->
     id = @getParams().id
-    unless id
+    if id
+      TaskPlanActions.load(id)
+    else
       id = TaskPlanStore.freshLocalId()
       TaskPlanActions.create(id, due_at: new Date())
     {id}
@@ -116,55 +118,55 @@ ReadingPlan = React.createClass
 
   render: ->
     id = @getParams().id
+    id = @state.id unless id
 
-    if id
-      plan = TaskPlanStore.get(id)    
+    if TaskPlanStore.isLoaded(id)
+
+      plan = TaskPlanStore.get(id)
+
+      isEnabled = plan.title and plan.due_at and plan.settings.page_ids.length > 0
+
+      classes = []
+      classes.push('disabled') unless isEnabled
+      classes = classes.join(' ')
+
+      footer = <BS.Button bsStyle="primary" className={classes} onClick={@publish}>Publish</BS.Button>
+      headerText = if id then 'Edit Reading' else 'Add Reading'
+      dueDate = if @state.due_at then @state.due_at else @props.due_at
+      topics = TaskPlanStore.getTopics(@state.id)
+
+
+      selectedReadingList =
+        <ul className="selected-reading-list">
+          <li><strong>Currently selected sections in this reading</strong></li>
+          {_.map(topics, @renderTopics)}
+        </ul> if topics?.length
+
+      <BS.Panel bsStyle="default" className="create-reading" footer={footer}>
+        <h1>{headerText}</h1>
+        <div>
+          <label htmlFor="title">Name</label>
+          <input ref="title" id="title" type="text" onChange={@setTitle} value={@props.title}/>
+        </div>
+        <div>
+          <label htmlFor="due-date">Due Date</label>
+          <DateTimePicker
+            id="due-date"
+            format="MMM dd, yyyy"
+            time={false}
+            calendar={true}
+            readOnly={false}
+            onChange={@setDueAt}
+            value={dueDate}/>
+        </div>
+        <p>
+          <label>Select Readings</label>
+          <SelectTopics planId={@state.id} selected={topics}/>
+        </p>
+        {selectedReadingList}
+      </BS.Panel>
+
     else
-      plan = TaskPlanStore.get(@state.id)
-
-    console.log('getParams().id: '+id)
-    console.log('@state.id: '+@state.id)
-     
-    isEnabled = plan.title and plan.due_at and plan.settings.page_ids.length > 0
-
-    classes = []
-    classes.push('disabled') unless isEnabled
-    classes = classes.join(' ')
-
-    footer = <BS.Button bsStyle="primary" className={classes} onClick={@publish}>Publish</BS.Button>
-    headerText = if id then 'Edit Reading' else 'Add Reading'
-    dueDate = if @state.due_at then @state.due_at else @props.due_at
-    topics = TaskPlanStore.getTopics(@state.id)
-    
-
-    selectedReadingList =
-      <ul className="selected-reading-list">
-        <li><strong>Currently selected sections in this reading</strong></li>
-        {_.map(topics, @renderTopics)}
-      </ul> if topics?.length
-
-    <BS.Panel bsStyle="default" className="create-reading" footer={footer}>
-      <h1>{headerText}</h1>
-      <div>
-        <label htmlFor="title">Name</label>
-        <input ref="title" id="title" type="text" onChange={@setTitle} value={@props.title}/>
-      </div>
-      <div>
-        <label htmlFor="due-date">Due Date</label>
-        <DateTimePicker
-          id="due-date"
-          format="MMM dd, yyyy"
-          time={false}
-          calendar={true}
-          readOnly={false}
-          onChange={@setDueAt}
-          value={dueDate}/>
-      </div>
-      <p>
-        <label>Select Readings</label>
-        <SelectTopics planId={@state.id} selected={topics}/>
-      </p>
-      {selectedReadingList}
-    </BS.Panel>
+      <div className="loading">Loading...</div>
 
 module.exports = ReadingPlan

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -13,26 +13,29 @@ TaskPlanConfig =
   FAILED: ->
 
   updateTitle: (id, title) ->
-    plan = @_getPlan(id)
-    _.extend(plan, {title})
-    @emitChange()
+    @_change(id, {title})
 
   updateDueAt: (id, due_at=new Date()) ->
-    plan = @_getPlan(id)
-    _.extend(plan, {due_at: due_at.toISOString()})
-    @emitChange()
+    @_change(id, {due_at: due_at.toISOString()})
 
   addTopic: (id, topicId) ->
     plan = @_getPlan(id)
-    plan.settings.page_ids.push(topicId) unless plan.settings.page_ids.indexOf(topicId) >= 0
-    @emitChange()
+    {page_ids} = plan.settings
+    page_ids = page_ids[..] # Copy the page_ids so we can reset it back if clearChanged() is called
+
+    page_ids.push(topicId) unless plan.settings.page_ids.indexOf(topicId) >= 0
+
+    @_change(id, {settings: page_ids})
 
   removeTopic: (id, topicId) ->
     plan = @_getPlan(id)
+    {page_ids} = plan.settings
+    page_ids = page_ids[..] # Copy the page_ids so we can reset it back if clearChanged() is called
 
     index = plan.settings.page_ids?.indexOf(topicId)
     plan.settings.page_ids?.splice(index, 1)
-    @emitChange()
+
+    @_change(id, {settings: page_ids})
 
   publish: (id) ->
 

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -6,7 +6,7 @@ flux = require 'flux-react'
 TaskConfig =
   _getStep: (taskId, stepId) ->
     task = @_local[taskId]
-    step = _.find task.steps, (s) -> s.id is stepId
+    step = _.find(task.steps, (s) -> s.id is stepId)
     step
 
   updateStep: (id, stepId, updateObj) ->

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -1,5 +1,6 @@
 {expect} = require 'chai'
 
+require './crud-store.spec'
 require './task-store.spec'
 
 # This should be done **last** because it starts up the whole app

--- a/test/crud-store.spec.coffee
+++ b/test/crud-store.spec.coffee
@@ -1,0 +1,113 @@
+{expect} = require 'chai'
+
+{CrudConfig, makeSimpleStore, extendConfig} = require '../src/flux/helpers'
+
+CrudConfig = CrudConfig()
+
+{actions:CrudActions, store:CrudStore} = makeSimpleStore(CrudConfig)
+
+
+describe 'CRUD Store', ->
+  afterEach ->
+    CrudActions.reset()
+
+  it 'should clear the store', ->
+    id = 0
+    expect(CrudStore.isUnknown(id)).to.be.true
+    CrudActions.loaded({hello:'foo', steps:[]}, id)
+    expect(CrudStore.isUnknown(id)).to.be.false
+    CrudActions.reset()
+    expect(CrudStore.isUnknown(id)).to.be.true
+
+
+  it 'should load a task and notify', (done)->
+    calledSynchronously = false
+    CrudStore.addChangeListener ->
+      calledSynchronously = true
+      calledSynchronously and done()
+    CrudActions.loaded({hello:'world', steps:[]}, 123)
+    expect(CrudStore.get(123).hello).to.equal('world')
+
+
+  it 'should load a task through the happy path', ->
+    id = 0
+    expect(CrudStore.isUnknown(id)).to.be.true
+    expect(CrudStore.isLoaded(id)).to.be.false
+    expect(CrudStore.isLoading(id)).to.be.false
+    expect(CrudStore.isFailed(id)).to.be.false
+
+    CrudActions.load(id)
+
+    expect(CrudStore.isUnknown(id)).to.be.false
+    expect(CrudStore.isLoaded(id)).to.be.false
+    expect(CrudStore.isLoading(id)).to.be.true
+    expect(CrudStore.isFailed(id)).to.be.false
+
+    CrudActions.loaded({hello:'bar', steps:[]}, id)
+
+    expect(CrudStore.isUnknown(id)).to.be.false
+    expect(CrudStore.isLoaded(id)).to.be.true
+    expect(CrudStore.isLoading(id)).to.be.false
+    expect(CrudStore.isFailed(id)).to.be.false
+
+    expect(CrudStore.get(id).hello).to.equal('bar')
+
+
+  it 'should note when a load failed', ->
+    id = 0
+    expect(CrudStore.isUnknown(id)).to.be.true
+    expect(CrudStore.isLoaded(id)).to.be.false
+    expect(CrudStore.isLoading(id)).to.be.false
+    expect(CrudStore.isFailed(id)).to.be.false
+
+    CrudActions.load(id)
+
+    expect(CrudStore.isUnknown(id)).to.be.false
+    expect(CrudStore.isLoaded(id)).to.be.false
+    expect(CrudStore.isLoading(id)).to.be.true
+    expect(CrudStore.isFailed(id)).to.be.false
+
+    CrudActions.FAILED(404, {err:'message'}, id)
+
+    expect(CrudStore.isUnknown(id)).to.be.false
+    expect(CrudStore.isLoaded(id)).to.be.false
+    expect(CrudStore.isLoading(id)).to.be.false
+    expect(CrudStore.isFailed(id)).to.be.true
+
+
+  it 'should store changed attributes locally', ->
+    id = 0
+    CrudActions.loaded({hello:'bar'}, id)
+    expect(CrudStore.isChanged(id)).to.be.false
+
+    CrudActions._change(id, {foo: 'baz'})
+    expect(CrudStore.isChanged(id)).to.be.true
+    expect(CrudStore.get(id)).to.deep.equal({hello:'bar', foo:'baz'})
+    expect(CrudStore.getChanged(id)).to.deep.equal({foo:'baz'})
+
+    CrudActions._change(id, {hello: 'bam'})
+    expect(CrudStore.get(id)).to.deep.equal({hello:'bam', foo:'baz'})
+    expect(CrudStore.getChanged(id)).to.deep.equal({foo:'baz', hello:'bam'})
+
+
+  it 'should clear changed attributes when saved', ->
+    id = 0
+    CrudActions.loaded({hello:'bar'}, id)
+    CrudActions._change(id, {foo: 'baz'})
+    CrudActions.saved({afterSave:true}, id)
+    expect(CrudStore.isChanged(id)).to.be.false
+    expect(CrudStore.get(id)).to.deep.equal({afterSave:true})
+
+
+  it 'should clear changed attributes locally when clearChanged()', ->
+    id = 0
+    CrudActions.loaded({hello:'bar'}, id)
+    CrudActions._change(id, {foo: 'baz'})
+    CrudActions.clearChanged(id)
+    expect(CrudStore.get(id)).to.deep.equal({hello:'bar'})
+    expect(CrudStore.getChanged(id)).to.deep.equal({})
+
+  it 'should be loaded when a new item is created', ->
+    id = CrudStore.freshLocalId()
+    CrudActions.create(id, {hello:'bar'})
+    expect(CrudStore.isLoaded(id)).to.be.true


### PR DESCRIPTION
no UI changes.

This is useful for `PATCH` to only send the unsaved changes and for “Cancel” buttons or confirm dialogs when moving away from a page.

Each CRUD Store now has `.isChanged(id)`, `.getChanged(id)` and a `.get(id)` contains a combination of the unchanged fields and the locally changed ones.

Each CRUD Actions set now has an internal `._change(id, obj)`.