### PR TITLE
downgrade flux-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cjsxify": "0.2.6",
     "coffee-script": "~1.9.1",
     "del": "~1.1.1",
-    "flux-react": "~2.6.4",
+    "flux-react": "~2.4.2",
     "font-awesome": "~4.3.0",
     "gulp": "~3.8.8",
     "gulp-flatten": "~0.0.4",

--- a/src/components/task/breadcrumbs.cjsx
+++ b/src/components/task/breadcrumbs.cjsx
@@ -9,6 +9,8 @@ module.exports = React.createClass
   componentWillMount:   -> TaskStore.addChangeListener(@update)
   componentWillUnmount: -> TaskStore.removeChangeListener(@update)
 
+  # TODO: flux-react 2.5 and 2.6 both remove the change listener but still fire @update
+  # after a component is unmounted.
   update: -> @setState({})
 
   render: ->


### PR DESCRIPTION
No UI changes.

flux-react 2.5 and 2.6 both remove the listener but still fire (bug in their code)