### PR TITLE
reading stats - adjusted progress bars, added spaced practice

### DIFF
--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -4,27 +4,17 @@ BS = require 'react-bootstrap'
 Router = require 'react-router'
 
 {TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
+LoadableMixin = require '../loadable-mixin'
 
 Stats = React.createClass
-  mixins: [Router.State, Router.Navigation]
+  mixins: [Router.State, Router.Navigation, LoadableMixin]
 
-  getInitialState: ->
-    id = @getParams().id
-    if (id)
-      TaskPlanActions.load(id)
-    else
-      id = TaskPlanStore.freshLocalId()
-      plan = TaskPlanActions.create(id, due_at: new Date())
+  getFlux: ->
+    store: TaskPlanStore
+    actions: TaskPlanActions
 
-    {id}
+  getId: -> @getParams().id
 
-  componentWillMount: -> TaskPlanStore.addChangeListener(@update)
-  componentWillUnmount: -> TaskPlanStore.removeChangeListener(@update)
-
-  getPlanId: () ->
-    @getParams().id or @state.id
-
-  update: -> @setState {}
 
   percent: (num,total) ->
     Math.round((num/total) * 100)
@@ -41,18 +31,16 @@ Stats = React.createClass
       op = '-'
     op + ' ' + Math.round((change / b) * 100)
 
-    
-  
+ 
   renderCourseBar: (data) ->
-    max = data.complete_count + data.partially_complete_count + (data.total_count - (data.complete_count + data.partially_complete_count))
     <div className="reading-progress-container">
       <div className="reading-progress-heading">
         complete / in progress / not started
       </div>
       <BS.ProgressBar className="reading-progress-group">
-        <BS.ProgressBar className="reading-progress-bar" bsStyle="success" label="%(now)s" max={max} now={data.complete_count} key={1} />
-        <BS.ProgressBar className="reading-progress-bar" bsStyle="warning" label="%(now)s" max={max} now={data.partially_complete_count} key={2} />
-        <BS.ProgressBar className="reading-progress-bar" bsStyle="danger" label="%(now)s" max={max} now={data.total_count - (data.complete_count + data.partially_complete_count)} key={3} />
+        <BS.ProgressBar className="reading-progress-bar" bsStyle="success" label="%(now)s" now={data.complete_count} key={1} />
+        <BS.ProgressBar className="reading-progress-bar" bsStyle="warning" label="%(now)s" now={data.partially_complete_count} key={2} />
+        <BS.ProgressBar className="reading-progress-bar" bsStyle="danger" label="%(now)s" now={data.total_count - (data.complete_count + data.partially_complete_count)} key={3} />
       </BS.ProgressBar>
     </div> 
 
@@ -92,8 +80,10 @@ Stats = React.createClass
       </div>
     </div>
 
-  render: ->
-    id = @getPlanId()
+  renderLoaded: ->
+
+    id = @getId()
+    
 
     if TaskPlanStore.isLoaded(id)
 

--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -1,0 +1,117 @@
+React = require 'react'
+_ = require 'underscore'
+BS = require 'react-bootstrap'
+Router = require 'react-router'
+
+{TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
+
+Stats = React.createClass
+  mixins: [Router.State, Router.Navigation]
+
+  getInitialState: ->
+    id = @getParams().id
+    if (id)
+      TaskPlanActions.load(id)
+    else
+      id = TaskPlanStore.freshLocalId()
+      plan = TaskPlanActions.create(id, due_at: new Date())
+
+    {id}
+
+  componentWillMount: -> TaskPlanStore.addChangeListener(@update)
+  componentWillUnmount: -> TaskPlanStore.removeChangeListener(@update)
+
+  getPlanId: () ->
+    @getParams().id or @state.id
+
+  update: -> @setState {}
+
+  percent: (num,total) ->
+    Math.round((num/total) * 100)
+
+  percentDelta: (a,b) ->
+    if a > b
+      change = a - b
+      op = '+'
+    else if a == b
+      change = 0
+      op = ''
+    else
+      change = b - a
+      op = '-'
+    op + ' ' + Math.round((change / b) * 100)
+
+    
+  
+  renderCourseBar: (data) ->
+    max = data.complete_count + data.partially_complete_count + (data.total_count - (data.complete_count + data.partially_complete_count))
+    <div className="reading-progress-container">
+      <div className="reading-progress-heading">
+        complete / in progress / not started
+      </div>
+      <BS.ProgressBar className="reading-progress-group">
+        <BS.ProgressBar className="reading-progress-bar" bsStyle="success" label="%(now)s" max={max} now={data.complete_count} key={1} />
+        <BS.ProgressBar className="reading-progress-bar" bsStyle="warning" label="%(now)s" max={max} now={data.partially_complete_count} key={2} />
+        <BS.ProgressBar className="reading-progress-bar" bsStyle="danger" label="%(now)s" max={max} now={data.total_count - (data.complete_count + data.partially_complete_count)} key={3} />
+      </BS.ProgressBar>
+    </div> 
+
+  renderChapterBars: (data, i) ->
+    if data.correct_count > 0
+      correct = <BS.ProgressBar className="reading-progress-bar" bsStyle="success" label="%(percent)s%" now={@percent(data.correct_count,data.correct_count+data.incorrect_count)} key={1} />
+    else
+      correct = ' '
+    if data.incorrect_count > 0
+      incorrect = <BS.ProgressBar className="reading-progress-bar" bsStyle="warning" label="%(percent)s%" now={@percent(data.incorrect_count,data.correct_count+data.incorrect_count)} key={2} />
+    else
+      incorrect = ' '
+    <div>
+      <div className="reading-progress-heading">
+        {data.page.number} - {data.page.title}
+      </div>
+      <div className="reading-progress-container">
+        <BS.ProgressBar className="reading-progress-group">
+          {correct}
+          {incorrect}
+        </BS.ProgressBar>
+        
+      </div>
+      
+    </div>
+
+  renderPracticeBars: (data, i) ->
+    <div>
+      <div className="reading-progress-heading">
+        {data.page.number} - {data.page.title}
+      </div>
+      <div className="reading-progress-container">
+        <BS.ProgressBar className="reading-progress-group">
+          <BS.ProgressBar className="reading-progress-bar" bsStyle="success" label="%(now)s%" now={@percent(data.correct_count,data.correct_count+data.incorrect_count)} key={1} />
+        </BS.ProgressBar>
+        <div className="reading-progress-delta">{@percentDelta(data.correct_count,data.previous_attempt.correct_count)}% change</div>
+      </div>
+    </div>
+
+  render: ->
+    id = @getPlanId()
+
+    if TaskPlanStore.isLoaded(id)
+
+      plan = TaskPlanStore.get(id)
+      course = @renderCourseBar(plan.stats.course)
+      chapters = _.map(plan.stats.course.current_pages, @renderChapterBars)
+      practice = _.map(plan.stats.course.spaced_pages, @renderPracticeBars)
+
+    
+    <BS.Panel className="reading-stats-container">
+      <label>course:</label>
+      {course}
+      <label>chapters:</label>
+      {chapters}
+      <label>practice:</label>
+      {practice}
+    </BS.Panel>
+
+
+
+module.exports = Stats

--- a/src/router.coffee
+++ b/src/router.coffee
@@ -6,6 +6,7 @@ Router = require 'react-router'
 ReadingPlan = require './components/task-plan/reading'
 TeacherTaskPlans = require './components/task-plan/teacher-task-plans-listing'
 
+Stats = require './components/task-plan/reading-stats'
 
 Sandbox = require './sandbox'
 
@@ -18,6 +19,7 @@ routes = (
     <Route path='courses/:courseId/readings/?' name='taskplans' handler={TeacherTaskPlans} />
     <Route path='courses/:courseId/readings/new/?' name='createReading' handler={ReadingPlan} />
     <Route path='courses/:courseId/readings/:id/?' name='editReading' handler={ReadingPlan} />
+    <Route path='courses/:courseId/readings/:id/stats/?' name='viewStats' handler={Stats} />
     <Route path='sandbox/?' name='sandbox' handler={Sandbox} />
     <NotFoundRoute handler={Invalid} />
   </Route>

--- a/style/reading-stats.less
+++ b/style/reading-stats.less
@@ -1,0 +1,42 @@
+.reading-stats-container{
+  min-width:550px;
+}
+
+.reading-progress-container{
+  width: 450px;
+  //border: 1px solid blue;
+  position: relative;
+}
+
+.reading-progress-group{
+  width:300px;
+  height:20px;
+  .reading-progress-bar{
+
+  }
+}
+
+.reading-progress-delta{
+  right:0px;
+  top:0px;
+  height:20px;
+  line-height: 1rem;
+  position:absolute;
+  color:red;
+}
+
+
+
+
+// debug:
+
+.progress{
+  overflow:visible;
+}
+
+.progress-bar {
+    // overflow-x:visible;
+    // white-space:nowrap;
+    // display: inline-block;
+    min-width:20px;
+}

--- a/style/reading-stats.less
+++ b/style/reading-stats.less
@@ -4,14 +4,16 @@
 
 .reading-progress-container{
   width: 450px;
-  //border: 1px solid blue;
   position: relative;
 }
 
 .reading-progress-group{
   width:300px;
   height:20px;
+  overflow:visible;
+
   .reading-progress-bar{
+    min-width:15px;
 
   }
 }
@@ -25,18 +27,3 @@
   color:red;
 }
 
-
-
-
-// debug:
-
-.progress{
-  overflow:visible;
-}
-
-.progress-bar {
-    // overflow-x:visible;
-    // white-space:nowrap;
-    // display: inline-block;
-    min-width:20px;
-}

--- a/style/tutor.less
+++ b/style/tutor.less
@@ -170,4 +170,5 @@ ul.selected-reading-list {
 }
 
 @import 'reading';
+@import 'reading-stats';
 @import 'sandbox';


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/954569/6737782/34d530ae-ce44-11e4-849e-91ca0c033564.png)

This PR renders progress bars for course overall, current_pages and spaced_pages.  It is currently not rendering periods.  Percent change is calculated on spaced_pages based on previous_attempt.

current issues:

1) the way either bootstrap progressbar or react-bootstrap calculates percentage width is causing smaller segments to overflow:

![image](https://cloud.githubusercontent.com/assets/954569/6737926/233afa1c-ce45-11e4-8919-ae1a972c65eb.png)


2) the overall course stats needs stat: 'not started' and/or an accurate total_count to render the progress bar properly.
