### PR TITLE
Move actions from TaskStore to TaskStepStore

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -9,6 +9,7 @@ $ = require 'jquery'
 _ = require 'underscore'
 {CurrentUserActions, CurrentUserStore} = require './flux/current-user'
 {TaskActions} = require './flux/task'
+{TaskStepActions} = require './flux/task-step'
 {TaskPlanActions, TaskPlanStore} = require './flux/task-plan'
 {TocActions} = require './flux/toc'
 {TeacherTaskPlanActions, TeacherTaskPlanStore} = require './flux/teacher-task-plan'
@@ -46,10 +47,14 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker) ->
       resolved = (results) -> successAction(results, args...) # Include listenAction for faking
       rejected = (jqXhr, statusMessage, err) ->
         statusCode = jqXhr.status
-        if statusCode is 400
+        if statusCode is 200
+          # HACK For PUT returning nothing (actually, it returns HTML for some reason)
+          successAction(args...)
+
+        else if statusCode is 400
           CurrentUserActions.logout()
         else if statusMessage is 'parsererror' and statusCode is 200 and IS_LOCAL
-          if httpMethod is 'PUT'
+          if httpMethod is 'PUT' or httpMethod is 'PATCH'
             # HACK for PUT
             successAction(null, args...)
           else
@@ -59,7 +64,10 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker) ->
           Actions.FAILED(statusCode, 'ERROR_NOTFOUND', args...)
         else
           # Parse the error message and fail
-          msg = JSON.parse(jqXhr.responseText)
+          try
+            msg = JSON.parse(jqXhr.responseText)
+          catch e
+            msg = jqXhr.responseText
           Actions.FAILED(statusCode, msg, args...)
 
 
@@ -108,21 +116,17 @@ start = ->
   apiHelper TocActions, TocActions.load, TocActions.loaded, 'GET', () ->
     url: "/api/courses/#{courseId}/readings"
 
-  reloadAfterCompletion = (empty, task, step) ->
-    TaskActions.load(task.id)
 
-  apiHelper TaskActions, TaskActions.completeStep, reloadAfterCompletion, 'PUT', (task, step) ->
-    console.warn('TODO: Refactor to use the TaskStep store directly')
-    url: "/api/steps/#{step.id}/completed"
+  # Go from complete to load so we fetch the new JSON
+  apiHelper TaskStepActions, TaskStepActions.complete, TaskStepActions.load, 'PUT', (id) ->
+    url: "/api/steps/#{id}/completed"
 
-  apiHelper TaskActions, TaskActions.setFreeResponseAnswer, TaskActions.saved, 'PATCH', (task, step, free_response) ->
-    console.warn('TODO: Refactor to use the TaskStep store directly')
-    url: "/api/steps/#{step.id}"
+  apiHelper TaskStepActions, TaskStepActions.setFreeResponseAnswer, TaskStepActions.saved, 'PATCH', (id, free_response) ->
+    url: "/api/steps/#{id}"
     payload: {free_response}
 
-  apiHelper TaskActions, TaskActions.setAnswerId, TaskActions.saved, 'PATCH', (task, step, answer_id) ->
-    console.warn('TODO: Refactor to use the TaskStep store directly')
-    url: "/api/steps/#{step.id}"
+  apiHelper TaskStepActions, TaskStepActions.setAnswerId, TaskActions.saved, 'PATCH', (id, answer_id) ->
+    url: "/api/steps/#{id}"
     payload: {answer_id}
 
 

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -117,6 +117,9 @@ start = ->
     url: "/api/courses/#{courseId}/readings"
 
 
+  apiHelper TaskStepActions, TaskStepActions.load, TaskStepActions.loaded, 'GET', (id) ->
+    url: "/api/steps/#{id}"
+
   # Go from complete to load so we fetch the new JSON
   apiHelper TaskStepActions, TaskStepActions.complete, TaskStepActions.load, 'PUT', (id) ->
     url: "/api/steps/#{id}/completed"

--- a/src/components/index.cjsx
+++ b/src/components/index.cjsx
@@ -50,15 +50,18 @@ SingleTask = React.createClass
 TaskResult = React.createClass
   mixins: [Router.Navigation]
   render: ->
-    {id} = @props.model
-    actionTitle = 'Work Now'
-    title = @props.model.title or err('BUG: Task without a title')
+    {id} = @props
+    task = TaskStore.get(id)
+    steps = TaskStore.getSteps(id)
 
-    if @props.model.steps.length is 1
-      mainType = @props.model.steps[0].type
+    actionTitle = 'Work Now'
+    title = task.title or err('BUG: Task without a title')
+
+    if steps.length is 1
+      mainType = steps[0].type
     else
       mainType = ''
-      stepsInfo = <small className='details'>({@props.model.steps.length} steps)</small>
+      stepsInfo = <small className='details'>({steps.length} steps)</small>
 
     <BS.Panel bsStyle="default" onClick={@onClick}>
       <Router.Link to="viewTask" params={{courseId, id}}><i className="fa fa-fw #{mainType}"></i> {title}</Router.Link>
@@ -69,7 +72,7 @@ TaskResult = React.createClass
     </BS.Panel>
 
   onClick: ->
-    {id} = @props.model
+    {id} = @props
     @transitionTo('viewTask', {courseId, id})
 
 
@@ -90,7 +93,7 @@ Tasks = React.createClass
         <div className='ui-task-list ui-empty'>No Tasks</div>
       else
         tasks = for task in allTasks
-          <TaskResult model={task} />
+          <TaskResult id={task.id} />
 
         <div className='ui-task-list'>
           <h3>Current Tasks ({allTasks.length})</h3>

--- a/src/components/task-step/all-steps.cjsx
+++ b/src/components/task-step/all-steps.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 
 api = require '../../api'
+{TaskStepStore} = require '../../flux/task-step'
 ArbitraryHtmlAndMath = require '../html'
 Exercise = require './exercise-multiple-choice'
 StepMixin = require './step-mixin'
@@ -18,7 +19,8 @@ Reading = React.createClass
     @props.onStepCompleted()
     @props.onNextStep()
   renderBody: ->
-    {content_html} = @props.model
+    {id} = @props
+    {content_html} = TaskStepStore.get(id)
     <ArbitraryHtmlAndMath className="reading-step" html={content_html} />
 
 Interactive = React.createClass
@@ -28,6 +30,8 @@ Interactive = React.createClass
     @props.onStepCompleted()
     @props.onNextStep()
   renderBody: ->
-    <iframe src={@props.model.content_url} />
+    {id} = @props
+    {content_url} = TaskStepStore.get(id)
+    <iframe src={content_url} />
 
 module.exports = {Reading, Interactive, Exercise}

--- a/src/components/task-step/index.cjsx
+++ b/src/components/task-step/index.cjsx
@@ -1,7 +1,8 @@
 React = require 'react'
 
 {TaskStore} = require '../../flux/task'
-{TaskStepStore} = require '../../flux/task-step'
+{TaskStepActions, TaskStepStore} = require '../../flux/task-step'
+LoadableMixin = require '../loadable-mixin'
 {Reading, Interactive, Exercise} = require './all-steps'
 
 # React swallows thrown errors so log them first
@@ -22,15 +23,18 @@ getStepType = (typeName) ->
 module.exports = React.createClass
   displayName: 'TaskStep'
 
+  mixins: [LoadableMixin]
+
   propTypes:
     id: React.PropTypes.string.isRequired
 
-  componentWillMount: -> TaskStepStore.addChangeListener(@update)
-  componentWillUnmount: -> TaskStepStore.removeChangeListener(@update)
+  getId: -> @props.id
 
-  update: -> @setState({})
+  getFlux: ->
+    store: TaskStepStore
+    actions: TaskStepActions
 
-  render: ->
+  renderLoaded: ->
     {id} = @props
     {type} = TaskStepStore.get(id)
     Type = getStepType(type)

--- a/src/components/task-step/index.cjsx
+++ b/src/components/task-step/index.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 
 {TaskStore} = require '../../flux/task'
+{TaskStepStore} = require '../../flux/task-step'
 {Reading, Interactive, Exercise} = require './all-steps'
 
 # React swallows thrown errors so log them first
@@ -22,17 +23,20 @@ module.exports = React.createClass
   displayName: 'TaskStep'
 
   propTypes:
-    model: React.PropTypes.object.isRequired
-    task: React.PropTypes.object.isRequired
+    id: React.PropTypes.string.isRequired
+
+  componentWillMount: -> TaskStepStore.addChangeListener(@update)
+  componentWillUnmount: -> TaskStepStore.removeChangeListener(@update)
+
+  update: -> @setState({})
 
   render: ->
-    {model} = @props
-    {type} = model
+    {id} = @props
+    {type} = TaskStepStore.get(id)
     Type = getStepType(type)
 
     <Type
-      model={@props.model}
-      task={@props.task}
+      id={id}
       onNextStep={@props.onNextStep}
       onStepCompleted={@props.onStepCompleted}
     />

--- a/src/components/task-step/step-mixin.cjsx
+++ b/src/components/task-step/step-mixin.cjsx
@@ -2,15 +2,19 @@ React = require 'react'
 BS = require 'react-bootstrap'
 
 {TaskStepStore} = require '../../flux/task-step'
+{TaskStepActions, TaskStepStore} = require '../../flux/task-step'
+LoadableMixin = require '../loadable-mixin'
 
 module.exports =
 
-  componentWillMount: -> TaskStepStore.addChangeListener(@update)
-  componentWillUnmount: -> TaskStepStore.removeChangeListener(@update)
+  mixins: [LoadableMixin]
 
-  update: -> @setState({})
+  getId: -> @props.id
+  getFlux: ->
+    store: TaskStepStore
+    actions: TaskStepActions
 
-  render: ->
+  renderLoaded: ->
     isDisabledClass = 'disabled' unless @isContinueEnabled()
 
     footer = <BS.Button bsStyle="primary" className={isDisabledClass} onClick={@onContinue}>Continue</BS.Button>

--- a/src/components/task-step/step-mixin.cjsx
+++ b/src/components/task-step/step-mixin.cjsx
@@ -1,7 +1,15 @@
 React = require 'react'
 BS = require 'react-bootstrap'
 
+{TaskStepStore} = require '../../flux/task-step'
+
 module.exports =
+
+  componentWillMount: -> TaskStepStore.addChangeListener(@update)
+  componentWillUnmount: -> TaskStepStore.removeChangeListener(@update)
+
+  update: -> @setState({})
+
   render: ->
     isDisabledClass = 'disabled' unless @isContinueEnabled()
 

--- a/src/components/task/breadcrumbs.cjsx
+++ b/src/components/task/breadcrumbs.cjsx
@@ -14,7 +14,8 @@ module.exports = React.createClass
   update: -> @setState({})
 
   render: ->
-    steps = @props.model.steps
+    {id} = @props
+    steps = TaskStore.getSteps(id)
 
     # Make sure the 1st incomplete step is displayed.
     # Useful when the student clicks back to review a previous step

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -3,7 +3,9 @@ BS = require 'react-bootstrap'
 Router = require 'react-router'
 
 api = require '../../api'
-{TaskStore, TaskActions} = require '../../flux/task'
+{TaskStore} = require '../../flux/task'
+{TaskStepActions} = require '../../flux/task-step'
+
 TaskStep = require '../task-step'
 Breadcrumbs = require './breadcrumbs'
 Time = require '../time'
@@ -91,9 +93,7 @@ module.exports = React.createClass
       <div className="task">
         {breadcrumbs}
         <TaskStep
-          id={@state.currentStep}
-          model={stepConfig}
-          task={model}
+          id={stepConfig.id}
           onStepCompleted={@onStepCompleted}
           onNextStep={@onNextStep}
         />
@@ -102,9 +102,10 @@ module.exports = React.createClass
 
   onStepCompleted: ->
     {id} = @props
+    # TODO: Operate on just the corrent step
     model = TaskStore.get(id)
     step = model.steps[@state.currentStep]
-    TaskActions.completeStep(model, step)
+    TaskStepActions.complete(step.id)
 
   onNextStep: ->
     @setState({currentStep: @getDefaultCurrentStep()})

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -4,24 +4,19 @@ Router = require 'react-router'
 
 api = require '../../api'
 {TaskStore} = require '../../flux/task'
-{TaskStepActions} = require '../../flux/task-step'
+{TaskStepActions, TaskStepStore} = require '../../flux/task-step'
 
 TaskStep = require '../task-step'
 Breadcrumbs = require './breadcrumbs'
 Time = require '../time'
 
-# React swallows thrown errors so log them first
-err = (msgs...) ->
-  console.error(msgs...)
-  throw new Error(JSON.stringify(msgs...))
-
-
 module.exports = React.createClass
   displayName: 'ReadingTask'
 
   getInitialState: ->
-    model = TaskStore.get(@props.id)
-    if model? and model.steps.length is 1
+    {id} = @props
+    steps = TaskStore.getSteps(id)
+    if steps.length is 1
       # For non-reading tasks that are simple (1 step) just skip the overview page
       currentStep = 0
     else
@@ -31,10 +26,11 @@ module.exports = React.createClass
     {currentStep}
 
   getDefaultCurrentStep: ->
-    model = TaskStore.get(@props.id)
+    {id} = @props
+    steps = TaskStore.getSteps(id)
     # Determine the first uncompleted step
     currentStep = -1
-    for step, i in model.steps
+    for step, i in steps
       unless step.is_completed
         currentStep = i
         break
@@ -48,18 +44,18 @@ module.exports = React.createClass
   render: ->
     {id} = @props
     model = TaskStore.get(id)
-    steps = model.steps
+    steps = TaskStore.getSteps(id)
     stepConfig = steps[@state.currentStep]
 
     allStepsCompleted = true
-    for step in model.steps
+    for step in steps
       unless step.is_completed
         allStepsCompleted = false
 
     if steps.length > 1
       breadcrumbs =
         <div className="panel-header">
-          <Breadcrumbs model={model} goToStep={@goToStep} currentStep={@state.currentStep} />
+          <Breadcrumbs id={id} goToStep={@goToStep} currentStep={@state.currentStep} />
         </div>
 
     if @state.currentStep > steps.length
@@ -103,8 +99,8 @@ module.exports = React.createClass
   onStepCompleted: ->
     {id} = @props
     # TODO: Operate on just the corrent step
-    model = TaskStore.get(id)
-    step = model.steps[@state.currentStep]
+    steps = TaskStore.getSteps(id)
+    step = steps[@state.currentStep]
     TaskStepActions.complete(step.id)
 
   onNextStep: ->

--- a/src/flux/helpers.coffee
+++ b/src/flux/helpers.coffee
@@ -54,10 +54,12 @@ CrudConfig = ->
             step.correct_answer_id = step.content.questions[0].answers[0].id
             step.feedback_html = 'Some <em>FAKE</em> feedback'
 
-      else
+      else if obj
         @_local[id] = obj
-      # If the specific type needs to do something else to the object:
-      @_loaded?(obj, id)
+
+      if obj
+        # If the specific type needs to do something else to the object:
+        @_loaded?(obj, id)
       @emitChange()
 
     save: (id, obj) ->
@@ -68,13 +70,12 @@ CrudConfig = ->
     saved: (result, id) ->
       # id = result.id
       @_asyncStatus[id] = LOADED # TODO: Maybe make this SAVED
-      unless result
-        console.error('API ERROR: Server did not return JSON after saving')
       if result
-        @_local[id] = result # Sometimes the POST/PATCH does not return anything
+        @_local[id] = result
         @_local[result.id] = result
         delete @_changed[result.id]
       else
+        console.warn('API WARN: Server did not return JSON after saving. Patching locally')
         # Merge all the local changes into the new local object
         @_local[id] = _.extend(@_local[id], @_changed[id])
       delete @_changed[id]
@@ -112,15 +113,18 @@ CrudConfig = ->
     clearChanged: (id) ->
       delete @_changed[id]
 
+    # Keep this here so other exports method have access to it
+    _get: (id) ->
+      return null unless @_asyncStatus[id] is LOADED or @_asyncStatus[id] is SAVING
+      _.extend({}, @_local[id], @_changed[id])
+
     exports:
       isUnknown: (id) -> !@_asyncStatus[id]
       isLoading: (id) -> @_asyncStatus[id] is LOADING
       isLoaded: (id) -> @_asyncStatus[id] is LOADED
       isFailed: (id) -> @_asyncStatus[id] is FAILED
       getAsyncStatus: (id) -> @_asyncStatus[id]
-      get: (id) ->
-        return null unless @_asyncStatus[id] is LOADED or @_asyncStatus[id] is SAVING
-        _.extend({}, @_local[id], @_changed[id])
+      get: (id) -> @_get(id)
       isChanged: (id) -> !_.isEmpty(@_changed[id])
       getChanged: (id) -> @_changed[id] or {}
       freshLocalId: -> CREATE_KEY()

--- a/src/flux/task-step.coffee
+++ b/src/flux/task-step.coffee
@@ -6,10 +6,37 @@ flux = require 'flux-react'
 TaskStepConfig =
 
   complete: (id) ->
-    @edit(id, {is_completed: true})
-    @save(id)
+    @_change(id, {is_completed: true})
+    @emitChange()
+
+  completed: (empty, step) ->
+    # First arg is null and ignored because it was a PUT ./completed
+
+  setAnswerId: (id, answer_id) ->
+    @_change(id, {answer_id})
+    @emitChange()
+
+  setFreeResponseAnswer: (id, free_response) ->
+    @_change(id, {free_response})
+    @emitChange()
+
+  exports:
+    isAnswered: (id) ->
+      step = @_get(id)
+      isAnswered = true
+      if step.type is 'exercise'
+        unless step.answer_id
+          isAnswered = false
+      isAnswered
+
+    getFreeResponse: (id) ->
+      step = @_get(id)
+      step.free_response
+    getAnswerId: (id) ->
+      step = @_get(id)
+      step.answer_id
 
 
-extendConfig(TaskConfig, new CrudConfig())
-{actions, store} = makeSimpleStore(TaskConfig)
-module.exports = {TaskActions:actions, TaskStore:store}
+extendConfig(TaskStepConfig, new CrudConfig())
+{actions, store} = makeSimpleStore(TaskStepConfig)
+module.exports = {TaskStepActions:actions, TaskStepStore:store}

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore'
 flux = require 'flux-react'
+{TaskStepActions} = require './task-step'
 {CurrentUserActions, CurrentUserStore} = require './current-user'
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
 
@@ -9,30 +10,10 @@ TaskConfig =
     step = _.find(task.steps, (s) -> s.id is stepId)
     step
 
-  updateStep: (id, stepId, updateObj) ->
-    step = @_getStep(id, stepId)
-    _.extend(step, updateObj)
-
-  completeStep: (task, step) ->
-    # Only mark the step complete once
-    step = @_getStep(task.id, step.id)
-    unless step.is_completed
-      step.is_completed = true # This is tied to getDefaultCurrentStep in getNextStep and occurs before TaskActions.completed is fired
-      @emitChange()
-
-  completed: (empty, task, step) ->
-    # First arg is null and ignored because it was a PUT ./completed
-
-  setAnswerId: (task, step, answerId) ->
-    step = @_getStep(task.id, step.id)
-    step.answer_id = answerId
-    @emitChange()
-
-  setFreeResponseAnswer: (task, step, freeResponse) ->
-    # Find the local objects for task and step
-    step = @_getStep(task.id, step.id)
-    step.free_response = freeResponse
-    @emitChange()
+  _loaded: (obj, id) ->
+    # Populate all the TaskSteps when a Task is loaded
+    for step in obj.steps
+      TaskStepActions.loaded(step, step.id)
 
   loadUserTasks: ->
     # Used by API
@@ -44,21 +25,6 @@ TaskConfig =
     @emitChange()
 
   exports:
-    isStepAnswered: (taskId, stepId) ->
-      step = @_getStep(taskId, stepId)
-      isAnswered = true
-      if step.type is 'exercise'
-        unless step.answer_id
-          isAnswered = false
-      isAnswered
-
-    getStepFreeResponse: (taskId, stepId) ->
-      step = @_getStep(taskId, stepId)
-      step.free_response
-    getStepAnswerId: (taskId, stepId) ->
-      step = @_getStep(taskId, stepId)
-      step.answer_id
-
     getAll: -> _.values(@_local)
 
 

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -1,6 +1,6 @@
 _ = require 'underscore'
 flux = require 'flux-react'
-{TaskStepActions} = require './task-step'
+{TaskStepActions, TaskStepStore} = require './task-step'
 {CurrentUserActions, CurrentUserStore} = require './current-user'
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
 
@@ -12,7 +12,13 @@ TaskConfig =
 
   _loaded: (obj, id) ->
     # Populate all the TaskSteps when a Task is loaded
-    for step in obj.steps
+    @_steps ?= {}
+    # Remove the steps so Components are forced to use `.getSteps()` to get
+    # the updated step objects
+    steps = obj.steps
+    delete obj.steps
+    @_steps[id] = steps
+    for step in steps
       TaskStepActions.loaded(step, step.id)
 
   loadUserTasks: ->
@@ -25,6 +31,10 @@ TaskConfig =
     @emitChange()
 
   exports:
+    getSteps: (id) ->
+      throw new Error('BUG: Steps not loaded') unless @_steps[id]
+      _.map @_steps[id], ({id}) ->
+        TaskStepStore.get(id)
     getAll: -> _.values(@_local)
 
 


### PR DESCRIPTION
No UI changes.

- moves most of the actions from the TaskStore into the TaskStepStore
  - since TaskSteps no longer need the parent Task id, the methods do not need to be on TaskStore
- cleans up the TaskStep models a bit (but more is needed)

This should make the following stories a little easier:
- defaulting to the correct step when opening a Task
- rendering Practice problems