### PR TITLE
add unit tests for ReadingPlan

### DIFF
--- a/Gulpfile.coffee
+++ b/Gulpfile.coffee
@@ -82,7 +82,7 @@ gulp.task 'test', ['buildJS'], (done) ->
 
   return # Since this is async
 
-gulp.task 'tdd', ['build'],  (done) ->
+gulp.task 'tdd', ['buildJS'],  (done) ->
   buildTests(true)
   .on 'end', ->
     config =

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -34,7 +34,7 @@ SectionTopic = React.createClass
 SelectTopics = React.createClass
   mixins: [BS.OverlayMixin]
   getInitialState: ->
-    TocActions.load()
+    TocActions.load() unless TocStore.isLoaded()
     { isModalOpen: false }
 
   componentWillMount:   -> TocStore.addChangeListener(@update)
@@ -139,16 +139,16 @@ ReadingFooter = React.createClass
     saveable = valid and TaskPlanStore.isChanged(id)
     deleteable = not TaskPlanStore.isNew(id)
 
-    classes = []
+    classes = ['-publish']
     classes.push('disabled') unless publishable
     classes = classes.join(' ')
 
     publishButton = <BS.Button bsStyle="link" className={classes} onClick={@onPublish}>Publish</BS.Button>
 
     if deleteable
-      deleteLink = <BS.Button bsStyle="link" onClick={@onDelete}>Delete</BS.Button>
+      deleteLink = <BS.Button bsStyle="link" className="-delete" onClick={@onDelete}>Delete</BS.Button>
 
-    classes = []
+    classes = ['-save']
     classes.push('disabled') unless saveable
     classes = classes.join(' ')
 
@@ -163,48 +163,23 @@ ReadingFooter = React.createClass
 
 
 ReadingPlan = React.createClass
-  mixins: [Router.State, Router.Navigation, LoadableMixin, ConfirmLeaveMixin]
-
-  getInitialState: ->
-    {courseId, id} = @getParams()
-    if (id)
-      TaskPlanActions.load(id)
-    else
-      id = TaskPlanStore.freshLocalId()
-      TaskPlanActions.create(id, {_HACK_courseId: courseId})
-    {id}
-
-  getId: -> @getParams().id or @state.id
-  getFlux: ->
-    store: TaskPlanStore
-    actions: TaskPlanActions
-
-  # If, as a result of a save creating a new object (and providing an id)
-  # then transition to editing the object
-  update: ->
-    id = @getId()
-    if TaskPlanStore.isNew(id) and TaskPlanStore.get(id).id
-      {id} = TaskPlanStore.get(id)
-      {courseId} = @getParams()
-      delay => @transitionTo('editReading', {courseId, id})
-    else
-      @setState({})
+  mixins: [Router.Navigation, ConfirmLeaveMixin]
 
   setOpensAt: (value) ->
-    id = @getId()
+    {id} = @props
     TaskPlanActions.updateOpensAt(id, value)
 
   setDueAt: (value) ->
-    id = @getId()
+    {id} = @props
     TaskPlanActions.updateDueAt(id, value)
 
   setTitle: ->
-    id = @getId()
+    {id} = @props
     value = @refs.title.getDOMNode().value
     TaskPlanActions.updateTitle(id, value)
 
-  renderLoaded: ->
-    id = @getId()
+  render: ->
+    {id} = @props
     plan = TaskPlanStore.get(id)
 
     headerText = if TaskPlanStore.isNew(id) then 'Add Reading' else 'Edit Reading'
@@ -258,4 +233,37 @@ ReadingPlan = React.createClass
       <SelectTopics planId={id} selected={topics}/>
     </BS.Panel>
 
-module.exports = ReadingPlan
+
+ReadingShell = React.createClass
+  mixins: [Router.State, LoadableMixin]
+
+  getInitialState: ->
+    {courseId, id} = @getParams()
+    if (id)
+      TaskPlanActions.load(id)
+    else
+      id = TaskPlanStore.freshLocalId()
+      TaskPlanActions.create(id, {_HACK_courseId: courseId})
+    {id}
+
+  getId: -> @getParams().id or @state.id
+  getFlux: ->
+    store: TaskPlanStore
+    actions: TaskPlanActions
+
+  # If, as a result of a save creating a new object (and providing an id)
+  # then transition to editing the object
+  update: ->
+    id = @getId()
+    if TaskPlanStore.isNew(id) and TaskPlanStore.get(id).id
+      {id} = TaskPlanStore.get(id)
+      {courseId} = @getParams()
+      delay => @transitionTo('editReading', {courseId, id})
+    else
+      @setState({})
+
+  renderLoaded: ->
+    id = @getId()
+    <ReadingPlan id={id} />
+
+module.exports = {ReadingShell, ReadingPlan}

--- a/src/flux/toc.coffee
+++ b/src/flux/toc.coffee
@@ -8,6 +8,10 @@ TocConfig =
 
   FAILED: -> console.error("BUG: could not load readings")
 
+  reset: ->
+    @_toc = null
+    @_sections = {}
+
   load: ->
   loaded: (obj) ->
     @_toc = obj

--- a/src/router.coffee
+++ b/src/router.coffee
@@ -3,7 +3,7 @@ React = require 'react'
 Router = require 'react-router'
 {Route, Redirect, NotFoundRoute} = Router
 {App, Dashboard, Tasks, SingleTask, Invalid} = require './components'
-ReadingPlan = require './components/task-plan/reading'
+{ReadingShell} = require './components/task-plan/reading'
 TeacherTaskPlans = require './components/task-plan/teacher-task-plans-listing'
 
 Stats = require './components/task-plan/reading-stats'
@@ -17,8 +17,8 @@ routes = (
     <Route path='courses/:courseId/tasks/?' name='listTasks' handler={Tasks} />
     <Route path='courses/:courseId/tasks/:id/?' name='viewTask' handler={SingleTask} />
     <Route path='courses/:courseId/readings/?' name='taskplans' handler={TeacherTaskPlans} />
-    <Route path='courses/:courseId/readings/new/?' name='createReading' handler={ReadingPlan} />
-    <Route path='courses/:courseId/readings/:id/?' name='editReading' handler={ReadingPlan} />
+    <Route path='courses/:courseId/readings/new/?' name='createReading' handler={ReadingShell} />
+    <Route path='courses/:courseId/readings/:id/?' name='editReading' handler={ReadingShell} />
     <Route path='courses/:courseId/readings/:id/stats/?' name='viewStats' handler={Stats} />
     <Route path='sandbox/?' name='sandbox' handler={Sandbox} />
     <NotFoundRoute handler={Invalid} />

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -1,5 +1,7 @@
 {expect} = require 'chai'
 
+require './components/reading-plan.spec'
+
 require './crud-store.spec'
 require './task-store.spec'
 require './loadable.spec'

--- a/test/components/reading-plan.spec.coffee
+++ b/test/components/reading-plan.spec.coffee
@@ -1,0 +1,81 @@
+{expect} = require 'chai'
+
+React = require 'react'
+
+{TaskPlanActions, TaskPlanStore} = require '../../src/flux/task-plan'
+{TocActions} = require '../../src/flux/toc'
+{ReadingPlan} = require '../../src/components/task-plan/reading'
+
+TEST_TOC = [
+  {
+    id: 2
+    title: 'Chapter title'
+    type: 'part'
+    children: [
+      {id: 1, type: 'page', title: 'Introduction'}
+    ]
+  }
+]
+
+VALID_MODEL =
+  type: 'reading'
+  id: 111
+  title: 'Test Title'
+  opens_at: '2015-03-19'
+  due_at: '2015-03-20'
+  settings:
+    page_ids: [1]
+
+
+helper = (model, doChangeTitle) ->
+  {id} = model
+  # Load the plan into the store
+  TaskPlanActions.loaded(model, id)
+  if doChangeTitle
+    TaskPlanActions.updateTitle(id, 'Some other title')
+  html = React.renderToString(<ReadingPlan id={id} />)
+  div = document.createElement('div')
+  div.innerHTML = html
+  div
+
+
+describe 'Reading Plan', ->
+  beforeEach ->
+    TaskPlanActions.reset()
+    TocActions.reset()
+    TocActions.loaded(TEST_TOC)
+
+  it 'should not allow save/publish when empty', ->
+    model =
+      type: 'reading'
+      id: 0
+
+    node = helper(model, false)
+    expect(node.querySelector('.-save.disabled')).to.not.be.null
+    expect(node.querySelector('.-publish.disabled')).to.not.be.null
+    expect(node.querySelector('.-delete')).to.not.be.null
+
+  it 'should have the right buttons when valid but not changed', ->
+    node = helper(VALID_MODEL, false)
+    expect(node.querySelector('.-save.disabled')).to.not.be.null
+    expect(node.querySelector('.-publish.disabled')).to.be.null
+    expect(node.querySelector('.-delete')).to.not.be.null
+
+  it 'should allow save when the title is changed', ->
+    node = helper(VALID_MODEL, true)
+    expect(node.querySelector('.-save.disabled')).to.be.null
+    expect(node.querySelector('.-publish.disabled')).to.not.be.null
+    expect(node.querySelector('.-delete')).to.not.be.null
+
+
+  it 'should not allow delete when the plan does not exist in the backend', ->
+    id = TaskPlanStore.freshLocalId()
+    model =
+      type: 'reading'
+      id: id
+
+    TaskPlanActions.created(model, id)
+    node = helper(model, true)
+    expect(node.querySelector('.-delete')).to.be.null
+
+  # TODO: Add unit tests to verify API calls


### PR DESCRIPTION
No UI changes.

This adds a couple unit tests for a ReadingPlan. Should be useful for making more unit tests

**Notes:**

- To test a Component I needed to refactor out part of it that used the `Router.State` mixin
- had to add classes to buttons to test if they were disabled