### PR TITLE
fix malformed URL when completing a step

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -121,7 +121,7 @@ start = ->
     url: "/api/steps/#{id}"
 
   # Go from complete to load so we fetch the new JSON
-  apiHelper TaskStepActions, TaskStepActions.complete, TaskStepActions.load, 'PUT', (id) ->
+  apiHelper TaskStepActions, TaskStepActions.complete, TaskStepActions.loaded, 'PUT', (id) ->
     url: "/api/steps/#{id}/completed"
 
   apiHelper TaskStepActions, TaskStepActions.setFreeResponseAnswer, TaskStepActions.saved, 'PATCH', (id, free_response) ->


### PR DESCRIPTION
No UI Change (except that UI now works again ; )

fixes the `GET /steps/[Object object]` error @Fredasaurus encountered when backend changed what was returned from `PUT /steps/1/completed`