### PR TITLE
update the expected JSON format for the list of plans

### DIFF
--- a/api/courses/1/plans.json
+++ b/api/courses/1/plans.json
@@ -1,30 +1,32 @@
-[
-  {
-      "id": 1,
-      "type": "reading",
-      "title": "Read Pages 9-11",
-      "opens_at": "2015-03-04T16:40:23.796Z",
-      "due_at": "2015-03-10T04:00:00.000Z",
-      "settings": {
-          "page_ids": [3, 2, 1]
-      }
-  },{
-      "id": 2,
-      "type": "exercise",
-      "title": "Complete exercise 12A on pg 12",
-      "opens_at": "2015-03-04T11:40:23.796Z",
-      "due_at": "2015-03-18T04:00:00.000Z",
-      "settings": {
-          "exercise_id": [11]
-      }
-  },{
-      "id": 13,
-      "type": "essay",
-      "title": "Write short essay on the rise and fall of the Roman Empire",
-      "opens_at": "2015-10-04T16:40:23.796Z",
-      "due_at": "2015-10-14T04:00:00.000Z",
-      "settings": {
-          "min_words": [300]
-      }
-  }
-]
+{
+  "items": [
+    {
+        "id": 1,
+        "type": "reading",
+        "title": "Read Pages 9-11",
+        "opens_at": "2015-03-04T16:40:23.796Z",
+        "due_at": "2015-03-10T04:00:00.000Z",
+        "settings": {
+            "page_ids": [3, 2, 1]
+        }
+    },{
+        "id": 2,
+        "type": "exercise",
+        "title": "Complete exercise 12A on pg 12",
+        "opens_at": "2015-03-04T11:40:23.796Z",
+        "due_at": "2015-03-18T04:00:00.000Z",
+        "settings": {
+            "exercise_id": [11]
+        }
+    },{
+        "id": 13,
+        "type": "essay",
+        "title": "Write short essay on the rise and fall of the Roman Empire",
+        "opens_at": "2015-10-04T16:40:23.796Z",
+        "due_at": "2015-10-14T04:00:00.000Z",
+        "settings": {
+            "min_words": [300]
+        }
+    }
+  ]
+}

--- a/src/flux/teacher-task-plan.coffee
+++ b/src/flux/teacher-task-plan.coffee
@@ -2,6 +2,13 @@ _ = require 'underscore'
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
 
 TeacherTaskPlanConfig =
+
+  # The load returns a JSON containing `{total_count: 0, items: [...]}`.
+  # Unwrap the JSON and store the items.
+  _loaded: (obj, id) ->
+    {items} = obj
+    @_local[id] = items
+
   exports:
     getCoursePlans: (id)->
         @_local[id] || []

--- a/test/teacher-task-plan-store.spec.coffee
+++ b/test/teacher-task-plan-store.spec.coffee
@@ -11,5 +11,6 @@ describe 'Teacher Task Plan Store', ->
     TeacherTaskPlanStore.addChangeListener ->
       calledSynchronously = true
       calledSynchronously and done()
-    TeacherTaskPlanActions.loaded({hello:'world', steps:[]}, 123)
-    expect(TeacherTaskPlanStore.get(123).hello).to.equal('world')
+    TeacherTaskPlanActions.loaded({items:[{hello:'world', steps:[]}]}, 123)
+    # Verify the taskPlanLoader unwraps the returned JSON and stores the items
+    expect(TeacherTaskPlanStore.get(123)[0].hello).to.equal('world')


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/253202/6787585/2c8a30c4-d16a-11e4-9ead-075989868bef.png)

Used to be an empty reading list when using `tutor-server` because the JSON format was different.