### PR TITLE
Move mixins out of ReadingComponent

### DIFF
--- a/src/components/confirm-leave-mixin.cjsx
+++ b/src/components/confirm-leave-mixin.cjsx
@@ -1,10 +1,10 @@
 module.exports =
   # getFlux: -> {store, actions}
-  # getId: -> id 
+  # getId: -> id
   componentDidMount: ->
-    window.addEventListener 'beforeunload', @confirmLeave
+    window.addEventListener('beforeunload', @confirmLeave)
   componentWillUnmount: ->
-    window.removeEventListener "beforeunload", @confirmLeave
+    window.removeEventListener('beforeunload', @confirmLeave)
 
     {store, actions} = @getFlux()
     # TODO add isValid() to the CrudConfig so we can save

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -163,7 +163,6 @@ ReadingFooter = React.createClass
 
 
 ReadingPlan = React.createClass
-  mixins: [Router.Navigation, ConfirmLeaveMixin]
 
   setOpensAt: (value) ->
     {id} = @props
@@ -235,7 +234,7 @@ ReadingPlan = React.createClass
 
 
 ReadingShell = React.createClass
-  mixins: [Router.State, LoadableMixin]
+  mixins: [Router.State, Router.Navigation, LoadableMixin, ConfirmLeaveMixin]
 
   getInitialState: ->
     {courseId, id} = @getParams()


### PR DESCRIPTION
No UI Changes.

When refactoring to add unit tests I failed to manually test the reading to make sure transitions still worked.