### PR TITLE
added stat page link to task plans list

### DIFF
--- a/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -19,12 +19,18 @@ TaskPlan = React.createClass
     {id} = @props.plan
     @transitionTo('editReading', {courseId, id})
 
+  onViewStats: ->
+    {courseId} = @props
+    {id} = @props.plan
+    @transitionTo('viewStats', {courseId, id})  
+
   render: ->
     start  = moment(@props.plan.opens_at)
     ending = moment(@props.plan.due_at)
     duration = moment.duration( ending.diff(start) ).humanize()
+    statsLink = <BS.Button bsStyle="small" onClick={@onViewStats}>View Stats</BS.Button>
     <BS.ListGroupItem header={@props.plan.title} onClick={@onEditPlan}>
-      {start.fromNow()} ({duration})
+      {start.fromNow()} ({duration}) {statsLink}
     </BS.ListGroupItem>
 
 


### PR DESCRIPTION
this adds a link to the stats page for corresponding readings in list:

![image](https://cloud.githubusercontent.com/assets/954569/6790266/d5e32bc8-d17c-11e4-8b7e-4a2731291b27.png)
