### PR TITLE
previous attempt info is optional

### DIFF
--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -49,10 +49,6 @@ Stats = React.createClass
       correct = <BS.ProgressBar className="reading-progress-bar" bsStyle="success" label="%(percent)s%" now={@percent(data.correct_count,data.correct_count+data.incorrect_count)} key={1} />
     else
       correct = ' '
-    if data.incorrect_count > 0
-      incorrect = <BS.ProgressBar className="reading-progress-bar" bsStyle="warning" label="%(percent)s%" now={@percent(data.incorrect_count,data.correct_count+data.incorrect_count)} key={2} />
-    else
-      incorrect = ' '
     <div>
       <div className="reading-progress-heading">
         {data.page.number} - {data.page.title}
@@ -60,7 +56,6 @@ Stats = React.createClass
       <div className="reading-progress-container">
         <BS.ProgressBar className="reading-progress-group">
           {correct}
-          {incorrect}
         </BS.ProgressBar>
 
       </div>

--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -31,7 +31,7 @@ Stats = React.createClass
       op = '-'
     op + ' ' + Math.round((change / b) * 100)
 
- 
+
   renderCourseBar: (data) ->
     <div className="reading-progress-container">
       <div className="reading-progress-heading">
@@ -42,7 +42,7 @@ Stats = React.createClass
         <BS.ProgressBar className="reading-progress-bar" bsStyle="warning" label="%(now)s" now={data.partially_complete_count} key={2} />
         <BS.ProgressBar className="reading-progress-bar" bsStyle="danger" label="%(now)s" now={data.total_count - (data.complete_count + data.partially_complete_count)} key={3} />
       </BS.ProgressBar>
-    </div> 
+    </div>
 
   renderChapterBars: (data, i) ->
     if data.correct_count > 0
@@ -62,12 +62,14 @@ Stats = React.createClass
           {correct}
           {incorrect}
         </BS.ProgressBar>
-        
+
       </div>
-      
+
     </div>
 
   renderPracticeBars: (data, i) ->
+    if data.previous_attempt
+      previous = <div className="reading-progress-delta">{@percentDelta(data.correct_count,data.previous_attempt.correct_count)}% change</div>
     <div>
       <div className="reading-progress-heading">
         {data.page.number} - {data.page.title}
@@ -76,14 +78,14 @@ Stats = React.createClass
         <BS.ProgressBar className="reading-progress-group">
           <BS.ProgressBar className="reading-progress-bar" bsStyle="success" label="%(now)s%" now={@percent(data.correct_count,data.correct_count+data.incorrect_count)} key={1} />
         </BS.ProgressBar>
-        <div className="reading-progress-delta">{@percentDelta(data.correct_count,data.previous_attempt.correct_count)}% change</div>
+        {previous}
       </div>
     </div>
 
   renderLoaded: ->
 
     id = @getId()
-    
+
 
     if TaskPlanStore.isLoaded(id)
 
@@ -92,7 +94,7 @@ Stats = React.createClass
       chapters = _.map(plan.stats.course.current_pages, @renderChapterBars)
       practice = _.map(plan.stats.course.spaced_pages, @renderPracticeBars)
 
-    
+
     <BS.Panel className="reading-stats-container">
       <label>course:</label>
       {course}

--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -57,9 +57,7 @@ Stats = React.createClass
         <BS.ProgressBar className="reading-progress-group">
           {correct}
         </BS.ProgressBar>
-
       </div>
-
     </div>
 
   renderPracticeBars: (data, i) ->

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -115,6 +115,7 @@ SelectTopics = React.createClass
     </BS.Modal>
 
 ReadingFooter = React.createClass
+  mixins: [Router.Navigation]
 
   onSave: ->
     {id} = @props
@@ -130,8 +131,12 @@ ReadingFooter = React.createClass
       TaskPlanActions.delete(id)
       @transitionTo('dashboard')
 
+  onViewStats: ->
+    {id, courseId} = @props
+    @transitionTo('viewStats', {courseId, id})
+
   render: ->
-    {id} = @props
+    {id, courseId} = @props
     plan = TaskPlanStore.get(id)
 
     valid = TaskPlanStore.isValid(id)
@@ -154,10 +159,13 @@ ReadingFooter = React.createClass
 
     saveLink = <BS.Button bsStyle="primary" className={classes} onClick={@onSave}>Save as Draft</BS.Button>
 
+    statsLink = <BS.Button bsStyle="link" className="-stats" onClick={@onViewStats}>Stats</BS.Button>
+
     <span className="-footer-buttons">
       {saveLink}
       {publishButton}
       {deleteLink}
+      {statsLink}
     </span>
 
 
@@ -178,7 +186,7 @@ ReadingPlan = React.createClass
     TaskPlanActions.updateTitle(id, value)
 
   render: ->
-    {id} = @props
+    {id, courseId} = @props
     plan = TaskPlanStore.get(id)
 
     headerText = if TaskPlanStore.isNew(id) then 'Add Reading' else 'Edit Reading'
@@ -191,7 +199,7 @@ ReadingPlan = React.createClass
     if plan?.due_at
       dueAt = new Date(plan.due_at)
 
-    footer= <ReadingFooter id={id} />
+    footer= <ReadingFooter id={id} courseId={courseId} />
 
     <BS.Panel bsStyle="default" className="create-reading" footer={footer}>
       <h1>{headerText}</h1>
@@ -263,6 +271,8 @@ ReadingShell = React.createClass
 
   renderLoaded: ->
     id = @getId()
-    <ReadingPlan id={id} />
+    {courseId} = @getParams()
+
+    <ReadingPlan id={id} courseId={courseId} />
 
 module.exports = {ReadingShell, ReadingPlan}

--- a/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -19,15 +19,23 @@ TaskPlan = React.createClass
     {id} = @props.plan
     @transitionTo('editReading', {courseId, id})
 
+  onViewStats: ->
+    {courseId} = @props
+    {id} = @props.plan
+    @transitionTo('viewStats', {courseId, id})
+
   render: ->
     {plan} = @props
     start  = moment(plan.opens_at)
     ending = moment(plan.due_at)
     duration = moment.duration( ending.diff(start) ).humanize()
 
-    <BS.ListGroupItem header={plan.title} onClick={@onEditPlan}>
-      {start.fromNow()} ({duration})
-    </BS.ListGroupItem>
+    <div className="-list-item">
+      <BS.ListGroupItem header={plan.title} onClick={@onEditPlan}>
+        {start.fromNow()} ({duration})
+      </BS.ListGroupItem>
+      <BS.Button bsStyle="link" className="-tasks-list-stats-button" onClick={@onViewStats}>View Stats</BS.Button>
+    </div>
 
 
 TeacherTaskPlanListing = React.createClass

--- a/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -19,18 +19,14 @@ TaskPlan = React.createClass
     {id} = @props.plan
     @transitionTo('editReading', {courseId, id})
 
-  onViewStats: ->
-    {courseId} = @props
-    {id} = @props.plan
-    @transitionTo('viewStats', {courseId, id})  
-
   render: ->
-    start  = moment(@props.plan.opens_at)
-    ending = moment(@props.plan.due_at)
+    {plan} = @props
+    start  = moment(plan.opens_at)
+    ending = moment(plan.due_at)
     duration = moment.duration( ending.diff(start) ).humanize()
-    statsLink = <BS.Button bsStyle="small" onClick={@onViewStats}>View Stats</BS.Button>
-    <BS.ListGroupItem header={@props.plan.title} onClick={@onEditPlan}>
-      {start.fromNow()} ({duration}) {statsLink}
+
+    <BS.ListGroupItem header={plan.title} onClick={@onEditPlan}>
+      {start.fromNow()} ({duration})
     </BS.ListGroupItem>
 
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/253202/6814342/216f062a-d254-11e4-8073-50b7bc26326b.png)

<!-- ![image](https://cloud.githubusercontent.com/assets/253202/6814000/f68828a4-d250-11e4-8c9e-8ef8ac812bd5.png) -->

Backend is not returning previous attempt data (%changed since last attempted this question) so making it optional.

Also, removed the 2nd progress bar which was occasionally being wrapped

# Readings now have a view stats button on them

![image](https://cloud.githubusercontent.com/assets/253202/6814751/df43401e-d257-11e4-9ad8-000cce106e0c.png)

# Plan listing with stats

![image](https://cloud.githubusercontent.com/assets/253202/6815204/1ac2f972-d25d-11e4-90af-addcbab6750f.png)
