### PR TITLE
hide MathJax rendered from MathML generated by katex

### DIFF
--- a/style/question.less
+++ b/style/question.less
@@ -11,6 +11,13 @@
   font-weight: 400;
   padding: 0.5em 100px;
 
+  // KaTeX 1.0.2 generates both HTML and MathML
+  // The MathML is then converted by MathJax and causes screen flicker
+  // so for now the MathJax version is hidden.
+  //
+  // TODO: Decide whether to remove KaTeX (involves additional code for MathJax)
+  .has-html .katex > .katex-mathml { display: none; }
+
   textarea {
     margin: 1em 0;
     padding: 5px;


### PR DESCRIPTION
Renders only 1 math formula instead of 2:

New:

![image](https://cloud.githubusercontent.com/assets/253202/7140714/d844ffca-e29a-11e4-9b0c-d591732c4188.png)

Old:

![image](https://cloud.githubusercontent.com/assets/253202/7140626/554b6bb8-e29a-11e4-812c-4958315776e8.png)

