### PR TITLE
Try Another / Refresh my Memory / Move On question review buttons

### DIFF
--- a/api/tasks/4.json
+++ b/api/tasks/4.json
@@ -29,6 +29,7 @@
     },
     { "id": "step-id-4-2",
       "type": "exercise",
+      "has_recovery": true,
       "content": {
         "stimulus_html": "Stimulus for Second Exercise",
         "questions":[

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "browserify-shim": "~3.8.3",
     "chai": "~2.1.1",
     "cjsxify": "0.2.6",
+    "classnames": "^1.2.0",
     "coffee-script": "~1.9.1",
     "cors": "^2.5.3",
     "del": "~1.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "browserify-shim": "~3.8.3",
     "chai": "~2.1.1",
     "cjsxify": "0.2.6",
-    "classnames": "^1.2.0",
     "coffee-script": "~1.9.1",
     "cors": "^2.5.3",
     "del": "~1.1.1",

--- a/src/components/question.cjsx
+++ b/src/components/question.cjsx
@@ -11,6 +11,7 @@ module.exports = React.createClass
     answer_id: React.PropTypes.string
     correct_answer_id: React.PropTypes.string
     feedback_html: React.PropTypes.string
+    onChange: React.PropTypes.func
 
   getInitialState: ->
     answer: null

--- a/src/components/task-step/exercise-multiple-choice.cjsx
+++ b/src/components/task-step/exercise-multiple-choice.cjsx
@@ -7,7 +7,7 @@ ArbitraryHtmlAndMath = require '../html'
 StepMixin = require './step-mixin'
 Question = require '../question'
 BS = require 'react-bootstrap'
-classNames = require 'classnames'
+
 
 ExerciseFreeResponse = React.createClass
   displayName: 'ExerciseFreeResponse'
@@ -134,9 +134,11 @@ ExerciseReview = React.createClass
     return step.has_recovery and step.correct_answer_id isnt step.answer_id
 
   renderFooterButtons: ->
-    continueBtnClasses = classNames('-continue', {disabled: !@isContinueEnabled()})
+    # TODO: switch to using classnames library
+    buttonClasses = '-continue'
+    buttonClasses += 'disabled' unless @isContinueEnabled()
     continueButton =
-      <BS.Button bsStyle="primary" className={continueBtnClasses} onClick={@onContinue}>
+      <BS.Button bsStyle="primary" className={buttonClasses} onClick={@onContinue}>
         { if @canTryAnother() then "Move On" else "Continue" }
       </BS.Button>
     if @canTryAnother()

--- a/src/components/task-step/exercise-multiple-choice.cjsx
+++ b/src/components/task-step/exercise-multiple-choice.cjsx
@@ -7,7 +7,7 @@ ArbitraryHtmlAndMath = require '../html'
 StepMixin = require './step-mixin'
 Question = require '../question'
 BS = require 'react-bootstrap'
-
+classNames = require 'classnames'
 
 ExerciseFreeResponse = React.createClass
   displayName: 'ExerciseFreeResponse'
@@ -140,11 +140,9 @@ ExerciseReview = React.createClass
     return step.has_recovery and step.correct_answer_id isnt step.answer_id
 
   renderFooterButtons: ->
-    # TODO switch to using React.addons.classSet for classname
-    buttonClasses = '-continue'
-    buttonClasses += 'disabled' unless @isContinueEnabled()
+    continueBtnClasses = classNames('-continue', {disabled: !@isContinueEnabled()})
     continueButton =
-      <BS.Button bsStyle="primary" className={buttonClasses} onClick={@onContinue}>
+      <BS.Button bsStyle="primary" className={continueBtnClasses} onClick={@onContinue}>
         { if @canTryAnother() then "Move On" else "Continue" }
       </BS.Button>
     if @canTryAnother()

--- a/src/components/task-step/exercise-multiple-choice.cjsx
+++ b/src/components/task-step/exercise-multiple-choice.cjsx
@@ -141,10 +141,10 @@ ExerciseReview = React.createClass
       </BS.Button>
     if @canTryAnother()
       extraButtons = [
-        <BS.Button bsStyle="primary" onClick={@tryAnother}>
+        <BS.Button bsStyle="primary" className="-try-another" onClick={@tryAnother}>
           Try Another
         </BS.Button>
-        <BS.Button bsStyle="primary" onClick={@refreshMemory}>
+        <BS.Button bsStyle="primary" className="-refresh-memory" onClick={@refreshMemory}>
           Refresh My Memory
         </BS.Button>
       ]

--- a/src/components/task-step/exercise-multiple-choice.cjsx
+++ b/src/components/task-step/exercise-multiple-choice.cjsx
@@ -123,16 +123,10 @@ ExerciseReview = React.createClass
     TaskActions.load(task_id)
 
   refreshMemory: ->
-    {id} = @props
-    steps = TaskStore.getSteps(TaskStepStore.getTaskId(id))
-    currentStepIndex = _.findIndex(steps, (step) -> step.id == id )
-    return if -1 == currentStepIndex # should never happen
-    # Find the last reading that we saw by starting at the
-    # current step and moving backwards in the list
-    for i in [currentStepIndex..0] by -1
-      if "reading" == steps[i].type
-        # goToStep returns an function with the step index in closure scope.
-        @props.goToStep(i)()
+    {index} = TaskStore.getReadingForTaskId(@props.id)
+    throw new Error('BUG: No reading found for task') unless index
+    # goToStep returns an function with the step index in closure scope
+    @props.goToStep(index)()
 
   canTryAnother: ->
     {id} = @props

--- a/src/components/task-step/exercise-multiple-choice.cjsx
+++ b/src/components/task-step/exercise-multiple-choice.cjsx
@@ -2,7 +2,7 @@ _ = require 'underscore'
 React = require 'react'
 katex = require 'katex'
 {TaskStepActions, TaskStepStore} = require '../../flux/task-step'
-{TaskActions} = require '../../flux/task'
+{TaskActions,TaskStore} = require '../../flux/task'
 ArbitraryHtmlAndMath = require '../html'
 StepMixin = require './step-mixin'
 Question = require '../question'
@@ -11,6 +11,9 @@ BS = require 'react-bootstrap'
 
 ExerciseFreeResponse = React.createClass
   displayName: 'ExerciseFreeResponse'
+  propTypes:
+    id: React.PropTypes.number.isRequired
+
   mixins: [StepMixin]
 
   getInitialState: ->
@@ -55,6 +58,9 @@ ExerciseFreeResponse = React.createClass
 ExerciseMultiChoice = React.createClass
   displayName: 'ExerciseMultiChoice'
   mixins: [StepMixin]
+  propTypes:
+    id: React.PropTypes.string.isRequired
+    onStepCompleted: React.PropTypes.func.isRequired
 
   renderBody: ->
     {id} = @props
@@ -85,6 +91,10 @@ ExerciseMultiChoice = React.createClass
 ExerciseReview = React.createClass
   displayName: 'ExerciseReview'
   mixins: [StepMixin]
+  propTypes:
+    id: React.PropTypes.string.isRequired
+    onStepCompleted: React.PropTypes.func.isRequired
+    goToStep: React.PropTypes.func.isRequired
 
   renderBody: ->
     {id} = @props
@@ -94,7 +104,7 @@ ExerciseReview = React.createClass
     question = content.questions[0]
     FreeResponse = if TaskStepStore.hasFreeResponse(id) then <div className="free-response">{free_response}</div> else ''
 
-    <Question model={question} answer_id={answer_id} correct_answer_id={correct_answer_id} feedback_html={feedback_html} onChange={@onAnswerChanged}>
+    <Question model={question} answer_id={answer_id} correct_answer_id={correct_answer_id} feedback_html={feedback_html}>
       {FreeResponse}
     </Question>
 
@@ -112,6 +122,18 @@ ExerciseReview = React.createClass
     TaskStepActions.loadRecovery(id)
     TaskActions.load(task_id)
 
+  refreshMemory: ->
+    {id} = @props
+    steps = TaskStore.getSteps(TaskStepStore.getTaskId(id))
+    currentStepIndex = _.findIndex(steps, (step) -> step.id == id )
+    return if -1 == currentStepIndex # should never happen
+    # Find the last reading that we saw by starting at the
+    # current step and moving backwards in the list
+    for i in [currentStepIndex..0] by -1
+      if "reading" == steps[i].type
+        # goToStep returns an function with the step index in closure scope.
+        @props.goToStep(i)()
+
   canTryAnother: ->
     {id} = @props
     step = TaskStepStore.get(id)
@@ -121,16 +143,32 @@ ExerciseReview = React.createClass
     # TODO switch to using React.addons.classSet for classname
     buttonClasses = '-continue'
     buttonClasses += 'disabled' unless @isContinueEnabled()
-    continueButton = <BS.Button bsStyle="primary" className={buttonClasses} onClick={@onContinue}>Continue</BS.Button>
-    tryAnotherButton = <BS.Button bsStyle="primary" onClick={@tryAnother}>Try Another</BS.Button> if @canTryAnother()
-    <div className="-footer-buttons">
-      {tryAnotherButton}
+    continueButton =
+      <BS.Button bsStyle="primary" className={buttonClasses} onClick={@onContinue}>
+        { if @canTryAnother() then "Move On" else "Continue" }
+      </BS.Button>
+    if @canTryAnother()
+      extraButtons = [
+        <BS.Button bsStyle="primary" onClick={@tryAnother}>
+          Try Another
+        </BS.Button>
+        <BS.Button bsStyle="primary" onClick={@refreshMemory}>
+          Refresh My Memory
+        </BS.Button>
+      ]
+    <div className="footer-buttons">
+      {extraButtons}
       {continueButton}
     </div>
 
 
 module.exports = React.createClass
   displayName: 'Exercise'
+  propTypes:
+    id: React.PropTypes.number.isRequired
+    onStepCompleted: React.PropTypes.func.isRequired
+    goToStep: React.PropTypes.func.isRequired
+    onNextStep: React.PropTypes.func.isRequired
 
   render: ->
     {id} = @props
@@ -155,6 +193,7 @@ module.exports = React.createClass
       <ExerciseReview
         id={id}
         onNextStep={@props.onNextStep}
+        goToStep={@props.goToStep}
         onStepCompleted={@props.onStepCompleted}
       />
     else if free_response or not hasFreeResponse

--- a/src/components/task-step/index.cjsx
+++ b/src/components/task-step/index.cjsx
@@ -27,16 +27,18 @@ TaskStepLoaded = React.createClass
   propTypes:
     id: React.PropTypes.any.isRequired
     onNextStep: React.PropTypes.func.isRequired
+    goToStep: React.PropTypes.func.isRequired
     onStepCompleted: React.PropTypes.func.isRequired
 
   render: ->
-    {id, onNextStep, onStepCompleted} = @props
+    {id, goToStep, onNextStep, onStepCompleted} = @props
     {type} = TaskStepStore.get(id)
     Type = getStepType(type)
 
     <Type
       id={id}
       onNextStep={onNextStep}
+      goToStep={goToStep}
       onStepCompleted={onStepCompleted}
     />
 
@@ -48,11 +50,17 @@ module.exports = React.createClass
     TaskStepActions.complete(id)
 
   render: ->
-    {id, onNextStep, onStepCompleted} = @props
+    {id, onNextStep, goToStep, onStepCompleted} = @props
 
     <LoadableItem
       id={id}
       store={TaskStepStore}
       actions={TaskStepActions}
-      renderItem={=> <TaskStepLoaded id={id} onNextStep={onNextStep} onStepCompleted={@onStepCompleted}/>}
+      renderItem={=>
+        <TaskStepLoaded id={id}
+          onNextStep={onNextStep}
+          goToStep={goToStep}
+          onStepCompleted={@onStepCompleted}
+        />
+      }
     />

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -86,6 +86,7 @@ module.exports = React.createClass
 
       panel = <TaskStep
                 id={stepConfig.id}
+                goToStep={@goToStep}
                 onNextStep={@onNextStep}
               />
 

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -76,6 +76,19 @@ TaskConfig =
       # Determine the first uncompleted step
       getCurrentStepIndex(steps)
 
+    # Returns the reading and it's step index for a given task's ID
+    getReadingForTaskId: (taskId)->
+      steps = getSteps(@_steps[taskId])
+      taskStepIndex = _.findIndex(steps, (step) -> step.id == id )
+      # should never happen if the taskId was valid
+      throw new Error('BUG: Invalid taskId.  Unable to find index') if taskStepIndex is -1
+      # Find the reading that appears before the given task
+      for i in [taskStepIndex..0] by -1
+        if "reading" == steps[i].type
+          return {reading: steps[i], index:i}
+      return {}
+
+
     getDefaultStepIndex: (taskId) ->
       steps = getSteps(@_steps[taskId])
 

--- a/style/task-step.less
+++ b/style/task-step.less
@@ -5,6 +5,12 @@
 @answer-hover-color: #e6f9fc;
 @answer-select-color: #def4f7; // darker than hover
 
+.task-step {
+  .footer-buttons {
+    text-align: center;
+  }
+}
+
 .task-step .exercise,
 .question {
   font-size: 2.1rem;

--- a/style/tutor.less
+++ b/style/tutor.less
@@ -8,6 +8,7 @@
 @import './typography';
 @import './reading';
 @import './question';
+@import './task-step';
 @import './homework';
 @import './learning-guide';
 

--- a/style/tutor.less
+++ b/style/tutor.less
@@ -7,7 +7,6 @@
 @import './buttons';
 @import './typography';
 @import './reading';
-@import './question';
 @import './task-step';
 @import './homework';
 @import './learning-guide';

--- a/test/components/helpers/task/checks.coffee
+++ b/test/components/helpers/task/checks.coffee
@@ -87,6 +87,11 @@ checks =
     expect(div.querySelector('.question-feedback').innerHTML).to.equal(feedback_html)
     {div, component, stepId, taskId, state, router, history, correct_answer, feedback_html}
 
+  _checkRecoveryRefreshChoice: ({div, component, stepId, taskId, state, router, history}) ->
+    expect(div.querySelector('.footer-buttons').children.length).to.equal(3)
+    titles = _.pluck(div.querySelector('.footer-buttons').children, 'textContent')
+    expect(titles).to.deep.equal(['Try Another', 'Refresh My Memory', 'Move On'])
+
   _checkIsNextStep: ({div, component, stepId, taskId, state, router, history}) ->
     stepIndex = TaskStore.getCurrentStepIndex(taskId)
     steps = TaskStore.getStepsIds(taskId)

--- a/test/components/helpers/task/checks.coffee
+++ b/test/components/helpers/task/checks.coffee
@@ -89,8 +89,10 @@ checks =
 
   _checkRecoveryRefreshChoice: ({div, component, stepId, taskId, state, router, history}) ->
     expect(div.querySelector('.footer-buttons').children.length).to.equal(3)
-    titles = _.pluck(div.querySelector('.footer-buttons').children, 'textContent')
-    expect(titles).to.deep.equal(['Try Another', 'Refresh My Memory', 'Move On'])
+    classes = _.pluck(div.querySelector('.footer-buttons').children, 'className')
+    expect(classes).to.deep.equal([
+      '-try-another btn btn-primary','-refresh-memory btn btn-primary','-continue btn btn-primary'
+    ])
 
   _checkIsNextStep: ({div, component, stepId, taskId, state, router, history}) ->
     stepIndex = TaskStore.getCurrentStepIndex(taskId)
@@ -111,6 +113,7 @@ checks =
   _checkIsCompletePage: ({div, component, stepId, taskId, state, router, history}) ->
     {type} = TaskStore.get(taskId)
     type ?= 'task'
+    debugger
     expect(div.querySelector(".-#{type}-completed")).to.not.be.null
 
     {div, component, stepId, taskId, state, router, history}

--- a/test/components/helpers/task/index.coffee
+++ b/test/components/helpers/task/index.coffee
@@ -20,18 +20,19 @@ tests =
     React.unmountComponentAtNode(@container)
     @container = document.createElement('div')
 
-  _renderTaskStep: (stepId, taskId, onNextStep) ->
+  _renderTaskStep: (stepId, taskId, onNextStep, goToStep) ->
     div = @container
-    componentStub._render(div, <TaskStep id={stepId} onNextStep={onNextStep}/>, {stepId, taskId})
+    componentStub._render(div, <TaskStep id={stepId} goToStep={goToStep} onNextStep={onNextStep}/>, {stepId, taskId})
 
   renderStep: (taskId) ->
     {id} = TaskStore.getCurrentStep(taskId)
     taskTests = @
 
+    # TODO Do something for these handlers
     onNextStep = ->
-      # TODO Do something for next step.
+    goToStep = (num)-> =>
 
-    @_renderTaskStep(id, taskId, onNextStep)
+    @_renderTaskStep(id, taskId, onNextStep, goToStep)
 
   goToTask: (route, taskId) ->
     div = @container

--- a/test/components/task.spec.coffee
+++ b/test/components/task.spec.coffee
@@ -175,3 +175,9 @@ describe 'Task Widget', ->
       .then(taskActions.clickDetails)
       .then(taskChecks.checkIsPopoverOpen)
       .then(_.delay(done, taskTests.delay)).catch(done)
+
+  it 'should allow recovery when available and answer is incorrect', (done) ->
+    taskTests
+      .submitMultipleChoice(taskId)
+      .then(taskChecks.checkRecoveryRefreshChoice)
+      .then(_.delay(done, taskTests.delay)).catch(done)


### PR DESCRIPTION
![screen shot 2015-04-17 at 3 15 56 pm](https://cloud.githubusercontent.com/assets/79566/7212110/2cca4688-e528-11e4-9c5f-c55e93bd43dd.png)


This adds a "Refresh My Memory" button to the question review screen.  If the button is selected it displays the last reading that was shown prior to the question so that the student can review the source material.

In order to hook up the button to navigate to the prior reading, I needed the "goToStep" callback from the main Task view, which is how the breadcrumbs navigate.  Unfortunately, this change rippled out through various panels before it could get to ExerciseReview.  It would seem to be more React like if we had a "navigation state" data structure that could be shared, and each would render appropriately based on it.

If there's agreement on that, I'll rework to use that method.