### PR TITLE
temporarily pin react exactly for peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
     "katex": "~0.2.0",
     "markdown-it": "^4.1.1",
     "moment": "^2.9.0",
-    "react": "~0.13.1",
+    "react": "0.13.1",
     "react-bootstrap": "~0.18.0",
     "react-calendar": "^0.4.0",
     "react-router": "~0.13.2",
     "react-widgets": "^2.2.6",
     "twix": "^0.6.3",
-    "underscore": "~1.8.2"    
+    "underscore": "~1.8.2"
   },
   "devDependencies": {
     "browserify": "~9.0.3",


### PR DESCRIPTION
No UI Changes.

One of the packages requiring react is complaining