### PR TITLE
print package versions after failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ node_js:
 before_install:
   - npm install -g gulp bower
   - bower install
+after_failure:
+  - npm list

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 # `sudo:false` for faster builds.
 sudo: false
-cache:
-  directories:
-    - node_modules
-    - bower_components
 language: node_js
 node_js:
   - "0.10"


### PR DESCRIPTION
No UI Changes.

Also, don't have travis cache `node_modules` since that seemed to be causing problems with PRs. Maybe we should pin all the packages and just periodically update them.