### PR TITLE
Allow navigation through homework questions by showing all breadcrumbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,3 @@
 /bower_components
 /.tmp
 /dist
-
-.DS_Store
-*.sublime-project
-*.sublime-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /dist
 
 .DS_Store
+*.sublime-project
+*.sublime-workspace

--- a/src/components/task-step/ends.cjsx
+++ b/src/components/task-step/ends.cjsx
@@ -32,8 +32,7 @@ HomeworkEnd = React.createClass
     <div className="task task-completed">
       {@props.breadcrumbs}
       <BS.Panel bsStyle="default" footer={footer} className='-homework-completed'>
-        <h1>Turn in your homework.</h1>
-        <h3>Great Job!</h3>
+        <h3>Your homework will be automatically turned in at the due date.</h3>
       </BS.Panel>
     </div>
 

--- a/src/components/task/breadcrumbs.cjsx
+++ b/src/components/task/breadcrumbs.cjsx
@@ -6,6 +6,15 @@ BS = require 'react-bootstrap'
 module.exports = React.createClass
   displayName: 'Breadcrumbs'
 
+  propTypes:
+    id: React.PropTypes.any.isRequired
+    currentStep: React.PropTypes.number.isRequired
+    goToStep: React.PropTypes.func.isRequired
+    allowSeeAhead: React.PropTypes.bool.isRequired
+
+  getDefaultProps: ->
+    allowSeeAhead: false
+
   componentWillMount:   -> TaskStore.addChangeListener(@update)
   componentWillUnmount: -> TaskStore.removeChangeListener(@update)
 
@@ -14,7 +23,7 @@ module.exports = React.createClass
   update: -> @setState({})
 
   render: ->
-    {id} = @props
+    {id, allowSeeAhead} = @props
     steps = TaskStore.getSteps(id)
 
     # Make sure the 1st incomplete step is displayed.
@@ -49,7 +58,8 @@ module.exports = React.createClass
         title ?= "Step Completed (#{step.type}). Click to review"
 
       else if showedFirstIncompleteStep
-        continue
+        unless allowSeeAhead
+          continue
       else
         showedFirstIncompleteStep = true
 

--- a/src/components/task/breadcrumbs.cjsx
+++ b/src/components/task/breadcrumbs.cjsx
@@ -53,7 +53,6 @@ module.exports = React.createClass
 
       <BS.Button bsStyle={bsStyle} className={classes} title={title} onClick={@props.goToStep(crumb.key)} key="step-#{crumb.key}">
         <i className="fa fa-fw #{crumbType}"></i>
-        <span className="step-problem-number">{index + 1}</span>
       </BS.Button>
 
     <BS.ButtonGroup className='steps'>

--- a/src/components/task/crumb-mixin.cjsx
+++ b/src/components/task/crumb-mixin.cjsx
@@ -32,7 +32,6 @@ module.exports =
 
     # The following pushing of objects onto crumbs could be abstracted some more.
     # That would come in handy for any further case/task specific configuration needed for crumbs
-    # 
     # Intro
     crumbs.push
       key: -1

--- a/src/components/task/crumb-mixin.cjsx
+++ b/src/components/task/crumb-mixin.cjsx
@@ -1,0 +1,73 @@
+# For handling steps logic outside of breadcrumb and task step rendering.
+# Specifically, it returns psuedo steps `intro` and `end` in sequence with real task steps.
+_ = require 'underscore'
+
+{TaskActions, TaskStore} = require '../../flux/task'
+{TaskStepActions, TaskStepStore} = require '../../flux/task-step'
+
+module.exports =
+  # Nice little alias that will return unique values for intro and end as step indexes.
+  # This logic need not be buried with render logic anymore, yay!
+  getDefaultCurrentStep: ->
+    {id} = @props
+    defaultIndex = TaskStore.getDefaultStepIndex(id)
+    steps = TaskStore.getSteps id
+
+    if defaultIndex is -1 and TaskStore.isTaskCompleted(id)
+      defaultIndex = steps.length
+
+    defaultIndex
+
+  shouldStepCrumb: (index) ->
+    {id} = @props
+    latestIndex = @getDefaultCurrentStep()
+    # doesAllowSeeAhead is currently true for if task type is homework.
+    doesAllowSeeAhead = TaskStore.doesAllowSeeAhead id
+
+    doesAllowSeeAhead or index <= latestIndex
+
+  _generateCrumbsFromSteps: (task, steps) ->
+    crumbs = []
+    task.is_completed = TaskStore.isTaskCompleted(task.id)
+
+    # The following pushing of objects onto crumbs could be abstracted some more.
+    # That would come in handy for any further case/task specific configuration needed for crumbs
+    # 
+    # Intro
+    crumbs.push
+      key: -1
+      data: task
+      crumb: false
+      type: 'intro'
+
+    # Step crumbs
+    _.each steps, (step, index) =>
+      crumbs.push
+        key: index
+        data: step
+        crumb: @shouldStepCrumb index
+        type: 'step'
+
+    # Completion
+    crumbs.push
+      key: steps.length
+      data: task
+      crumb: @shouldStepCrumb steps.length
+      type: 'end'
+
+    crumbs
+
+  _generateCrumbs: (id) ->
+    task = TaskStore.get(id)
+    steps = TaskStore.getSteps id
+    @_generateCrumbsFromSteps task, steps
+
+  generateCrumbs: ->
+    {id} = @props
+    @_generateCrumbs id
+
+  getCrumableCrumbs: ->
+    # only return crumbables for breadcrumbs to render through
+    allCrumbs = @generateCrumbs()
+    crumbableCrumbs = _.where allCrumbs,
+      crumb: true

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -53,12 +53,15 @@ module.exports = React.createClass
 
     taskClasses = 'task'
     taskClasses += ' task-completed' if allStepsCompleted
+    taskClasses += " task-#{model.type}"
 
     unless TaskStore.isSingleStepped(id)
+      allowSeeAhead = TaskStore.doesAllowSeeAhead(id)
+
       breadcrumbs =
         <div className="panel-header">
           <Details task={model} />
-          <Breadcrumbs id={id} goToStep={@goToStep} currentStep={@state.currentStep} />
+          <Breadcrumbs id={id} goToStep={@goToStep} currentStep={@state.currentStep} allowSeeAhead={allowSeeAhead}/>
         </div>
 
     if @state.currentStep < -1

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -88,7 +88,6 @@ TaskConfig =
           return {reading: steps[i], index:i}
       return {}
 
-
     getDefaultStepIndex: (taskId) ->
       steps = getSteps(@_steps[taskId])
 

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -118,6 +118,9 @@ TaskConfig =
     isSingleStepped: (taskId) ->
       @_steps[taskId].length is 1
 
+    doesAllowSeeAhead: (taskId) ->
+      if @_get(taskId).type is 'homework' then true else false
+
 extendConfig(TaskConfig, new CrudConfig())
 {actions, store} = makeSimpleStore(TaskConfig)
 module.exports = {TaskActions:actions, TaskStore:store}

--- a/style/calendar.less
+++ b/style/calendar.less
@@ -1,16 +1,9 @@
-
-@import '../node_modules/bootstrap/less/bootstrap.less';
-@import '../bower_components/bootstrap-material-design/less/material-wfont.less';
-
-// Sample bootstrap theme for react-calendar
-// @import '../node_modules/react-calendar/less/bootstrap-theme.less';
-
-
 // TODO make this a mixin for flexible calendaringggg
 
 @calendar-cell-width: 14.28%;
 @calendar-cell-height: 10rem;
 
+// TODO look into putting things like this in a tutor-variable.less file.
 @reading-color: @brand-success;
 @homework-color: @primary;
 @exercise-color: @brand-info;

--- a/style/task-step.less
+++ b/style/task-step.less
@@ -8,17 +8,19 @@
 // WHOA. This is sneaky. And hilarious. Am I allowed?!
 // http://caniuse.com/#search=counter
 .task-homework{
-  .steps {
-    counter-reset: step;
-  }
-  .step {
-    &:before {
-      content: counter(step);
-      counter-increment: step;
+  .step:not(.end) {
+    .step-problem-number {
+      display: block;
     }
     i {
       display: none;
     }
+  }
+}
+
+.step {
+  .step-problem-number {
+    display: none;
   }
 }
 

--- a/style/task-step.less
+++ b/style/task-step.less
@@ -5,12 +5,15 @@
 @answer-hover-color: #e6f9fc;
 @answer-select-color: #def4f7; // darker than hover
 
-// WHOA. This is sneaky. And hilarious. Am I allowed?!
 // http://caniuse.com/#search=counter
 .task-homework{
+  .steps {
+    counter-reset: step;
+  }
   .step:not(.end) {
-    .step-problem-number {
-      display: block;
+    &:before {
+      content: counter(step);
+      counter-increment: step;
     }
     i {
       display: none;
@@ -18,11 +21,7 @@
   }
 }
 
-.step {
-  .step-problem-number {
-    display: none;
-  }
-}
+
 
 .task-step {
   .footer-buttons {

--- a/style/task-step.less
+++ b/style/task-step.less
@@ -5,6 +5,23 @@
 @answer-hover-color: #e6f9fc;
 @answer-select-color: #def4f7; // darker than hover
 
+// WHOA. This is sneaky. And hilarious. Am I allowed?!
+// http://caniuse.com/#search=counter
+.task-homework{
+  .steps {
+    counter-reset: step;
+  }
+  .step {
+    &:before {
+      content: counter(step);
+      counter-increment: step;
+    }
+    i {
+      display: none;
+    }
+  }
+}
+
 .task-step {
   .footer-buttons {
     text-align: center;

--- a/style/tutor.less
+++ b/style/tutor.less
@@ -25,6 +25,7 @@ i.fa {
   &.reading::before     { content: @fa-var-newspaper-o; } // or fa-var-file-text-o
   &.interactive::before { content: @fa-var-desktop; }
   &.exercise::before    { content: @fa-var-question; } // or fa-var-mortar-board
+  &.end::before    { content: @fa-var-star; }
 }
 
 .ui-task-list {

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -2,6 +2,7 @@
 
 require './components/reading-plan.spec'
 require './components/task.spec'
+require './components/task-homework.spec'
 require './components/practice.spec'
 require './components/learning-guide.spec'
 require './components/course-calendar.spec'

--- a/test/components/helpers/task/actions.coffee
+++ b/test/components/helpers/task/actions.coffee
@@ -25,8 +25,10 @@ actions =
 
     commonActions.click(breadcrumbs[breadcrumbButtonIndex])
     steps = TaskStore.getStepsIds(taskId)
-    # change step
-    stepId = steps[breadcrumbButtonIndex].id
+
+    unless breadcrumbButtonIndex is steps.length
+      # change step
+      stepId = steps[breadcrumbButtonIndex].id
 
     {div, component, stepId, taskId, state, router, history}
 

--- a/test/components/helpers/task/actions.coffee
+++ b/test/components/helpers/task/actions.coffee
@@ -20,10 +20,10 @@ actions =
   clickDetails: commonActions.focusMatch('.task-details')
 
   _clickBreadcrumb: (breadcrumbButtonIndex, {div, component, stepId, taskId, state, router, history}) ->
-    completedBreadcrumbs = div.querySelectorAll('button.step.completed')
-    completedBreadcrumbs = Array.prototype.slice.call(completedBreadcrumbs)
+    breadcrumbs = div.querySelectorAll('button.step')
+    breadcrumbs = Array.prototype.slice.call(breadcrumbs)
 
-    commonActions.click(completedBreadcrumbs[breadcrumbButtonIndex])
+    commonActions.click(breadcrumbs[breadcrumbButtonIndex])
     steps = TaskStore.getStepsIds(taskId)
     # change step
     stepId = steps[breadcrumbButtonIndex].id

--- a/test/components/helpers/task/checks.coffee
+++ b/test/components/helpers/task/checks.coffee
@@ -135,22 +135,6 @@ checks =
 
     {div, component, stepId, taskId, state, router, history}
 
-  _checkIsProblemNumberShowing: ({div, component, stepId, taskId, state, router, history}) ->
-    steps = TaskStore.getStepsIds(taskId)
-    stepComponents = React.addons.TestUtils.scryRenderedDOMComponentsWithClass(component, 'step')
-
-    _.each stepComponents, (step, index) ->
-      stepNode = step.getDOMNode()
-      renderedStepNumber = stepNode.innerText
-      # Not the best, but will work for now.
-      problemNode = stepNode.childNodes[1]
-
-      unless stepNode.classList.contains 'end'
-        expect(renderedStepNumber).to.equal((index + 1).toString())
-        expect(problemNode.style.display).to.not.equal('none')
-
-    {div, component, stepId, taskId, state, router, history}
-
 # promisify for chainability in specs
 _.each(checks, (check, checkName) ->
   # rename without _ in front

--- a/test/components/helpers/task/checks.coffee
+++ b/test/components/helpers/task/checks.coffee
@@ -1,6 +1,7 @@
 {expect} = require 'chai'
 {Promise} = require 'es6-promise'
 _ = require 'underscore'
+React = require 'react/addons'
 
 {TaskStepActions, TaskStepStore} = require '../../../../src/flux/task-step'
 {TaskActions, TaskStore} = require '../../../../src/flux/task'
@@ -33,14 +34,6 @@ checks =
       expect(componentStepId).to.equal(targetStepId)
 
     {div, component, state, router, history}
-
-  _checkIsDefaultStep: ({div, component, stepId, taskId, state, router, history}) ->
-    stepIndex = TaskStore.getCurrentStepIndex(taskId)
-    steps = TaskStore.getStepsIds(taskId)
-    targetStepId = steps[stepIndex].id
-
-    checks._checkIsTargetStepId(targetStepId, {div, component, stepId, taskId, state, router, history})
-    {div, component, stepId, taskId, state, router, history}
 
   _checkRenderFreeResponse: ({div, component, stepId, taskId, state, router, history}) ->
     continueButton = div.querySelector('.-continue')
@@ -118,6 +111,18 @@ checks =
 
     {div, component, stepId, taskId, state, router, history}
 
+  _checkIsDefaultStep: ({div, component, stepId, taskId, state, router, history}) ->
+    stepIndex = TaskStore.getCurrentStepIndex(taskId)
+    steps = TaskStore.getStepsIds(taskId)
+
+    return checks._checkIsIntroScreen({div, component, stepId, taskId, state, router, history}) if stepIndex is -1
+    return checks._checkIsCompletePage({div, component, stepId, taskId, state, router, history}) if stepIndex is steps.length
+
+    targetStepId = steps[stepIndex].id
+
+    checks._checkIsTargetStepId(targetStepId, {div, component, stepId, taskId, state, router, history})
+    {div, component, stepId, taskId, state, router, history}
+
   _checkIsPopoverOpen: ({div, component, stepId, taskId, state, router, history}) ->
     expect(document.querySelector('.task-details-popover h1')).to.not.be.null
 
@@ -127,7 +132,23 @@ checks =
     steps = TaskStore.getStepsIds(taskId)
     stepNodes = div.querySelectorAll('.step')
 
-    expect(stepNodes.length).to.equal(steps.length)
+    expect(stepNodes.length).to.equal(steps.length + 1)
+
+    {div, component, stepId, taskId, state, router, history}
+
+  _checkIsProblemNumberShowing: ({div, component, stepId, taskId, state, router, history}) ->
+    steps = TaskStore.getStepsIds(taskId)
+    stepComponents = React.addons.TestUtils.scryRenderedDOMComponentsWithClass(component, 'step')
+
+    _.each stepComponents, (step, index) ->
+      stepNode = step.getDOMNode()
+      renderedStepNumber = stepNode.innerText
+      # Not the best, but will work for now.
+      problemNode = stepNode.childNodes[1]
+
+      unless stepNode.classList.contains 'end'
+        expect(renderedStepNumber).to.equal((index + 1).toString())
+        expect(problemNode.style.display).to.not.equal('none')
 
     {div, component, stepId, taskId, state, router, history}
 

--- a/test/components/helpers/task/checks.coffee
+++ b/test/components/helpers/task/checks.coffee
@@ -123,6 +123,14 @@ checks =
 
     {div, component, stepId, taskId, state, router, history}
 
+  _checkAreAllStepsShowing: ({div, component, stepId, taskId, state, router, history}) ->
+    steps = TaskStore.getStepsIds(taskId)
+    stepNodes = div.querySelectorAll('.step')
+
+    expect(stepNodes.length).to.equal(steps.length)
+
+    {div, component, stepId, taskId, state, router, history}
+
 # promisify for chainability in specs
 _.each(checks, (check, checkName) ->
   # rename without _ in front

--- a/test/components/task-homework.spec.coffee
+++ b/test/components/task-homework.spec.coffee
@@ -41,7 +41,6 @@ describe 'Task Widget, homework specific things', ->
       .then(taskChecks.checkAllowContinue)
       .then(_.delay(done, taskTests.delay)).catch(done)
 
-
   it 'should render next screen when Continue is clicked', (done) ->
     # Using homework because this one has no completed steps
     # and therefore actually has an intro screen
@@ -51,14 +50,12 @@ describe 'Task Widget, homework specific things', ->
       .then(taskChecks.heckIsDefaultStep)
       .then(_.delay(done, taskTests.delay)).catch(done)
 
-
   it 'should be able to work through a step in homework', (done) ->
     # run a full step through and check each step
     taskTests
       .renderStep(homeworkTaskId)
       .then(taskTests.workExerciseAndCheck)
       .then(_.delay(done, taskTests.delay)).catch(done)
-
 
   it 'should be able to work through a true-false question', (done) ->
     taskActions
@@ -70,14 +67,12 @@ describe 'Task Widget, homework specific things', ->
       .then(taskChecks.workTrueFalseAndCheck)
       .then(_.delay(done, taskTests.delay)).catch(done)
 
-
   it 'should show homework done page on homework completion', (done) ->
     taskActions
       .clickContinue(@result)
       .then(taskActions.completeSteps)
       .then(taskChecks.checkIsCompletePage)
       .then(_.delay(done, taskTests.delay)).catch(done)
-
 
   it 'should allow review completed steps with breadcrumbs', (done) ->
     taskActions
@@ -92,4 +87,18 @@ describe 'Task Widget, homework specific things', ->
     taskActions
       .clickDetails(@result)
       .then(taskChecks.checkIsPopoverOpen)
+      .then(_.delay(done, taskTests.delay)).catch(done)
+
+  it 'should show breadcrumbs for all steps', (done) ->
+    taskChecks
+      .checkAreAllStepsShowing(@result)
+      .then(_.delay(done, taskTests.delay)).catch(done)
+
+  it 'should show last step when last breadcrumb is clicked', (done) ->
+    steps = TaskStore.getStepsIds(homeworkTaskId)
+    lastStepIndex = steps.length - 1
+
+    taskActions
+      .clickBreadcrumb(lastStepIndex)(@result)
+      .then(taskChecks.checkIsMatchStep(lastStepIndex))
       .then(_.delay(done, taskTests.delay)).catch(done)

--- a/test/components/task-homework.spec.coffee
+++ b/test/components/task-homework.spec.coffee
@@ -46,8 +46,7 @@ describe 'Task Widget, homework specific things', ->
     # and therefore actually has an intro screen
     taskActions
       .clickContinue(@result)
-      .then(taskChecks.checkIsNotIntroScreen)
-      .then(taskChecks.heckIsDefaultStep)
+      .then(taskChecks.checkIsDefaultStep)
       .then(_.delay(done, taskTests.delay)).catch(done)
 
   it 'should be able to work through a step in homework', (done) ->
@@ -94,11 +93,25 @@ describe 'Task Widget, homework specific things', ->
       .checkAreAllStepsShowing(@result)
       .then(_.delay(done, taskTests.delay)).catch(done)
 
-  it 'should show last step when last breadcrumb is clicked', (done) ->
+  it 'should show problem number for homework problems', (done) ->
+    taskChecks
+      .checkIsProblemNumberShowing(@result)
+      .then(_.delay(done, taskTests.delay)).catch(done)
+
+  it 'should show last step when last problem is clicked', (done) ->
     steps = TaskStore.getStepsIds(homeworkTaskId)
     lastStepIndex = steps.length - 1
 
     taskActions
       .clickBreadcrumb(lastStepIndex)(@result)
       .then(taskChecks.checkIsMatchStep(lastStepIndex))
+      .then(_.delay(done, taskTests.delay)).catch(done)
+
+  it 'should show complete page when complete page is clicked', (done) ->
+    steps = TaskStore.getStepsIds(homeworkTaskId)
+    completeStepIndex = steps.length
+
+    taskActions
+      .clickBreadcrumb(completeStepIndex)(@result)
+      .then(taskChecks.checkIsCompletePage)
       .then(_.delay(done, taskTests.delay)).catch(done)

--- a/test/components/task-homework.spec.coffee
+++ b/test/components/task-homework.spec.coffee
@@ -93,11 +93,6 @@ describe 'Task Widget, homework specific things', ->
       .checkAreAllStepsShowing(@result)
       .then(_.delay(done, taskTests.delay)).catch(done)
 
-  it 'should show problem number for homework problems', (done) ->
-    taskChecks
-      .checkIsProblemNumberShowing(@result)
-      .then(_.delay(done, taskTests.delay)).catch(done)
-
   it 'should show last step when last problem is clicked', (done) ->
     steps = TaskStore.getStepsIds(homeworkTaskId)
     lastStepIndex = steps.length - 1

--- a/test/components/task-homework.spec.coffee
+++ b/test/components/task-homework.spec.coffee
@@ -1,0 +1,95 @@
+# Tests for homework specific tasks
+
+{expect} = require 'chai'
+_ = require 'underscore'
+
+{taskActions, taskTests, taskChecks} = require './helpers/task'
+
+{CourseActions, CourseStore} = require '../../src/flux/course'
+{TaskActions, TaskStore} = require '../../src/flux/task'
+{TaskStepActions, TaskStepStore} = require '../../src/flux/task-step'
+
+courseId = 1
+homeworkTaskId = 5
+targetStepIndex = 1
+homework_model = require '../../api/tasks/5.json'
+
+describe 'Task Widget, homework specific things', ->
+  beforeEach (done) ->
+    TaskActions.loaded(homework_model, homeworkTaskId)
+
+    taskTests
+      .goToTask("/courses/#{courseId}/tasks/#{homeworkTaskId}", homeworkTaskId)
+      .then((result) =>
+        @result = result
+        done()
+      )
+      .catch(done)
+
+  afterEach ->
+    taskTests.unmount()
+
+    CourseActions.reset()
+    TaskActions.reset()
+    TaskStepActions.reset()
+
+  it 'should allow students to continue tasks', (done) ->
+    # Using homework because this one has no completed steps
+    # and therefore actually has an intro screen
+    taskChecks
+      .checkIsIntroScreen(@result)
+      .then(taskChecks.checkAllowContinue)
+      .then(_.delay(done, taskTests.delay)).catch(done)
+
+
+  it 'should render next screen when Continue is clicked', (done) ->
+    # Using homework because this one has no completed steps
+    # and therefore actually has an intro screen
+    taskActions
+      .clickContinue(@result)
+      .then(taskChecks.checkIsNotIntroScreen)
+      .then(taskChecks.heckIsDefaultStep)
+      .then(_.delay(done, taskTests.delay)).catch(done)
+
+
+  it 'should be able to work through a step in homework', (done) ->
+    # run a full step through and check each step
+    taskTests
+      .renderStep(homeworkTaskId)
+      .then(taskTests.workExerciseAndCheck)
+      .then(_.delay(done, taskTests.delay)).catch(done)
+
+
+  it 'should be able to work through a true-false question', (done) ->
+    taskActions
+      .clickContinue(@result)
+      .then(taskTests.workExercise)
+      .then(taskActions.clickContinue)
+      .then(taskTests.workExercise)
+      .then(taskActions.clickContinue)
+      .then(taskChecks.workTrueFalseAndCheck)
+      .then(_.delay(done, taskTests.delay)).catch(done)
+
+
+  it 'should show homework done page on homework completion', (done) ->
+    taskActions
+      .clickContinue(@result)
+      .then(taskActions.completeSteps)
+      .then(taskChecks.checkIsCompletePage)
+      .then(_.delay(done, taskTests.delay)).catch(done)
+
+
+  it 'should allow review completed steps with breadcrumbs', (done) ->
+    taskActions
+      .clickContinue(@result)
+      .then(taskActions.completeSteps)
+      .then(taskActions.clickBreadcrumb(targetStepIndex))
+      .then(taskChecks.checkIsMatchStep(targetStepIndex))
+      .then(taskChecks.checkIsNotCompletePage)
+      .then(_.delay(done, taskTests.delay)).catch(done)
+
+  it 'should format the details page using markdown (for now)', (done) ->
+    taskActions
+      .clickDetails(@result)
+      .then(taskChecks.checkIsPopoverOpen)
+      .then(_.delay(done, taskTests.delay)).catch(done)

--- a/test/components/task.spec.coffee
+++ b/test/components/task.spec.coffee
@@ -13,7 +13,6 @@ courseId = 1
 taskId = 4
 
 VALID_MODEL = require '../../api/tasks/4.json'
-homework_model = require '../../api/tasks/5.json'
 
 describe 'Task Widget', ->
   beforeEach ->
@@ -25,34 +24,6 @@ describe 'Task Widget', ->
     CourseActions.reset()
     TaskActions.reset()
     TaskStepActions.reset()
-
-  it 'should allow students to continue tasks', (done) ->
-    # Using homework because this one has no completed steps
-    # and therefore actually has an intro screen
-    homeworkTaskId = 5
-    TaskActions.loaded(homework_model, homeworkTaskId)
-
-    taskTests
-      .goToTask("/courses/#{courseId}/tasks/#{homeworkTaskId}", homeworkTaskId)
-      .then(taskChecks.checkIsIntroScreen)
-      .then(taskChecks.checkAllowContinue)
-      .then(_.delay(done, taskTests.delay)).catch(done)
-
-
-  it 'should render next screen when Continue is clicked', (done) ->
-    # Using homework because this one has no completed steps
-    # and therefore actually has an intro screen
-    homeworkTaskId = 5
-    TaskActions.loaded(homework_model, homeworkTaskId)
-
-    taskTests
-      .goToTask("/courses/#{courseId}/tasks/#{homeworkTaskId}", homeworkTaskId)
-      .then(taskActions.clickContinue)
-      .then(taskChecks.checkIsNotIntroScreen)
-      .then(taskChecks.heckIsDefaultStep)
-      .then(_.delay(done, taskTests.delay)).catch(done)
-
-
 
   # _.delay needed to prevent weird problems.
   it 'should render empty free response for unanswered exercise', (done)->
@@ -90,18 +61,6 @@ describe 'Task Widget', ->
       .then(taskChecks.checkSubmitMultipleChoice)
       .then(_.delay(done, taskTests.delay)).catch(done)
 
-
-  it 'should be able to work through a step in homework', (done) ->
-    homeworkTaskId = 5
-    TaskActions.loaded(homework_model, homeworkTaskId)
-
-    # run a full step through and check each step
-    taskTests
-      .renderStep(homeworkTaskId)
-      .then(taskTests.workExerciseAndCheck)
-      .then(_.delay(done, taskTests.delay)).catch(done)
-
-
   it 'should be able to work through a task and load next step from a route', (done) ->
     # run a full step through and check each step
     taskTests
@@ -121,59 +80,6 @@ describe 'Task Widget', ->
       .then(taskActions.clickContinue)
       .then(taskActions.completeSteps)
       .then(taskChecks.checkIsCompletePage)
-      .then(_.delay(done, taskTests.delay)).catch(done)
-
-
-  it 'should be able to work through a true-false question', (done) ->
-    homeworkTaskId = 5
-    TaskActions.loaded(homework_model, homeworkTaskId)
-
-    taskTests
-      .goToTask("/courses/#{courseId}/tasks/#{homeworkTaskId}", homeworkTaskId)
-      .then(taskActions.clickContinue)
-      .then(taskTests.workExercise)
-      .then(taskActions.clickContinue)
-      .then(taskTests.workExercise)
-      .then(taskActions.clickContinue)
-      .then(taskChecks.workTrueFalseAndCheck)
-      .then(_.delay(done, taskTests.delay)).catch(done)
-
-
-  it 'should show homework done page on homework completion', (done) ->
-    homeworkTaskId = 5
-    TaskActions.loaded(homework_model, homeworkTaskId)
-
-    taskTests
-      .goToTask("/courses/#{courseId}/tasks/#{homeworkTaskId}", homeworkTaskId)
-      .then(taskActions.clickContinue)
-      .then(taskActions.completeSteps)
-      .then(taskChecks.checkIsCompletePage)
-      .then(_.delay(done, taskTests.delay)).catch(done)
-
-
-  it 'should allow review completed steps with breadcrumbs', (done) ->
-    homeworkTaskId = 5
-    TaskActions.loaded(homework_model, homeworkTaskId)
-    targetStepIndex = 1
-
-    taskTests
-      .goToTask("/courses/#{courseId}/tasks/#{homeworkTaskId}", homeworkTaskId)
-      .then(taskActions.clickContinue)
-      .then(taskActions.completeSteps)
-      .then(taskActions.clickBreadcrumb(targetStepIndex))
-      .then(taskChecks.checkIsMatchStep(targetStepIndex))
-      .then(taskChecks.checkIsNotCompletePage)
-      .then(_.delay(done, taskTests.delay)).catch(done)
-
-  it 'should format the details page using markdown (for now)', (done) ->
-    homeworkTaskId = 5
-    TaskActions.loaded(homework_model, homeworkTaskId)
-    targetStepIndex = 1
-
-    taskTests
-      .goToTask("/courses/#{courseId}/tasks/#{homeworkTaskId}", homeworkTaskId)
-      .then(taskActions.clickDetails)
-      .then(taskChecks.checkIsPopoverOpen)
       .then(_.delay(done, taskTests.delay)).catch(done)
 
   it 'should allow recovery when available and answer is incorrect', (done) ->

--- a/test/components/task.spec.coffee
+++ b/test/components/task.spec.coffee
@@ -32,7 +32,6 @@ describe 'Task Widget', ->
       .then(taskChecks.checkRenderFreeResponse)
       .then(_.delay(done, taskTests.delay)).catch(done)
 
-
   it 'should update store when free response is submitted', (done) ->
     taskTests
       .answerFreeResponse(taskId)
@@ -40,20 +39,17 @@ describe 'Task Widget', ->
       .then(taskChecks.checkAnswerFreeResponse)
       .then(_.delay(done, taskTests.delay)).catch(done)
 
-
   it 'should render multiple choice after free response', (done) ->
     taskTests
       .submitFreeResponse(taskId)
       .then(taskChecks.checkSubmitFreeResponse)
       .then(_.delay(done, taskTests.delay)).catch(done)
 
-
   it 'should update store when multiple choice answer is chosen', (done) ->
     taskTests
       .answerMultipleChoice(taskId)
       .then(taskChecks.checkAnswerMultipleChoice)
       .then(_.delay(done, taskTests.delay)).catch(done)
-
 
   it 'should render an answer and feedback html for an answered question', (done) ->
     taskTests
@@ -71,7 +67,6 @@ describe 'Task Widget', ->
       .then(taskChecks.checkIsNextStep)
       .then(taskActions.advanceStep)
       .then(_.delay(done, taskTests.delay)).catch(done)
-
 
   it 'should show appropriate done page on completion', (done) ->
     # run a full step through and check each step


### PR DESCRIPTION
# Homework
![screen shot 2015-04-23 at 2 50 34 pm](https://cloud.githubusercontent.com/assets/2483873/7306053/2f6c7af6-e9c8-11e4-95b7-3069d29e57bf.png)
![screen shot 2015-04-23 at 2 50 49 pm](https://cloud.githubusercontent.com/assets/2483873/7306054/315221fe-e9c8-11e4-92c1-6ad4605270a5.png)
![screen shot 2015-04-23 at 6 53 50 pm](https://cloud.githubusercontent.com/assets/2483873/7309926/34707698-e9ea-11e4-9b94-ee3a56f36a4a.png)


# Not Homework
![screen shot 2015-04-23 at 2 50 26 pm](https://cloud.githubusercontent.com/assets/2483873/7306067/44667c2c-e9c8-11e4-8fc4-e9909dfa10fe.png)
![screen shot 2015-04-23 at 2 49 49 pm](https://cloud.githubusercontent.com/assets/2483873/7306063/3cbc45ce-e9c8-11e4-8d07-d4a07e548fed.png)




Using star now but can easily switch for something else.
- [x] tests
  - [x] breadcrumbs show for all steps of homework
  - [x] breadcrumbs are clickable
  - [x] end breadcrumb also clickable and shown

- [x] breadcrumbs are numbered
