### PR TITLE
add store for getting current server time

### DIFF
--- a/src/flux/time.coffee
+++ b/src/flux/time.coffee
@@ -7,15 +7,13 @@ flux = require 'flux-react'
 
 TimeConfig =
 
-  setNow: (now) ->
+  setNow: (now, localNow=new Date()) ->
     # called by API
-    localNow = new Date()
     @_shiftMs = now.getTime() - localNow.getTime()
 
   exports:
-    getNow: ->
+    getNow: (localNow=new Date())->
       shift = @_shiftMs or 0
-      localNow = new Date()
       new Date(localNow.getTime() + shift)
 
 {actions, store} = makeSimpleStore(TimeConfig)

--- a/src/flux/time.coffee
+++ b/src/flux/time.coffee
@@ -1,0 +1,22 @@
+# Store for getting the current server time.
+# Defaults to browser time if a server request has not been made yet.
+
+flux = require 'flux-react'
+
+{makeSimpleStore} = require './helpers'
+
+TimeConfig =
+
+  setNow: (now) ->
+    # called by API
+    localNow = new Date()
+    @_shiftMs = now.getTime() - localNow.getTime()
+
+  exports:
+    getNow: ->
+      shift = @_shiftMs or 0
+      localNow = new Date()
+      new Date(localNow.getTime() + shift)
+
+{actions, store} = makeSimpleStore(TimeConfig)
+module.exports = {TimeActions:actions, TimeStore:store}

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -11,6 +11,7 @@ require './crud-store.spec'
 require './task-store.spec'
 require './loadable.spec'
 require './teacher-task-plan-store.spec'
+require './time.spec'
 
 # This should be done **last** because it starts up the whole app
 require './router.spec'

--- a/test/time.spec.coffee
+++ b/test/time.spec.coffee
@@ -1,0 +1,14 @@
+{expect} = require 'chai'
+
+{TimeActions, TimeStore} = require '../src/flux/time'
+
+SERVER_TIME = new Date('2000-02-02')
+LOCAL_TIME = new Date('2011-11-11')
+
+describe 'Server Time', ->
+
+  it 'returns the server time', ->
+    TimeActions.setNow(SERVER_TIME, LOCAL_TIME)
+    time = TimeStore.getNow(LOCAL_TIME)
+    # Use strings so millisecs do not matter
+    expect("#{time}").to.equal("#{SERVER_TIME}")


### PR DESCRIPTION
No UI changes.

adds a `TimeStore.getNow()` which returns a `Date` representing the current **server** time.