### PR TITLE
Make the large icons a bit larger, add an xlg size for the "don't forget" panel

### DIFF
--- a/src/components/student-dashboard/dont-forget-panel.cjsx
+++ b/src/components/student-dashboard/dont-forget-panel.cjsx
@@ -18,6 +18,7 @@ module.exports = React.createClass
   recoverData: (event) ->
     name: 'Recovery'
     summary: "#{event.exercise_count} available"
+    icon: 'recover'
     clickHandler: @viewRecovery
 
   feedbackData: (event) ->
@@ -25,14 +26,14 @@ module.exports = React.createClass
       "#{event.correct_exercise_count}/#{event.exercise_count} correct"
     else
       "#{event.complete_exercise_count}/#{event.exercise_count} complete"
-    { name: 'Feedback', summary: summary, clickHandler: @viewFeedback }
+    { name: 'Feedback', summary: summary, icon: 'feedback', clickHandler: @viewFeedback }
 
   renderBlock: (event, i, all) ->
     feedback = "#{event.complete_exercise_count}/#{event.exercise_count} complete"
     data = if i % 2 then @feedbackData(event) else @recoverData(event)
-    <BS.Col key={event.id} className={data.name.toLowerCase()} xs={12 / all.length}>
+    <BS.Col key={event.id} xs={12 / all.length}>
       <div>
-        <i onClick={_.partial(data.clickHandler, event.id)}/>
+        <i className="icon-xlg icon-#{data.icon}" onClick={_.partial(data.clickHandler, event.id)}/>
         <h3 className="heading">View {data.name}</h3>
         <div className="title">{event.title}</div>
         <div className="summary">{data.summary}</div>

--- a/style/icons/all.less
+++ b/style/icons/all.less
@@ -4,9 +4,10 @@
 @icon-size-xlg: @icon-size-sm * 6;
 
 // # Overview
-// There are 2 ways of including the icons:
+//
 // - add `<i class="icon-homework icon-sm" />` tag in the HTML
-// - use the `#icon>.sm(homework);` in the CSS
+//   - Similar to font-awesome icons
+// - use `<span class="icon-stack icon-lg">` for stacking icons
 
 
 // # Local mixins
@@ -47,14 +48,10 @@
   text-align: center;
 }
 
-// # Method 1
-//
-// Similar to font-awesome icons:
-//
-// add `<i class="icon-homework icon-sm"></i>` in the HTML
+// # Icon Classes
 
-.icon-sm { .x-icon-size(@icon-size-sm); }
-.icon-lg { .x-icon-size(@icon-size-lg); }
+.icon-sm  { .x-icon-size(@icon-size-sm); }
+.icon-lg  { .x-icon-size(@icon-size-lg); }
 .icon-xlg { .x-icon-size(@icon-size-xlg); }
 
 // Note: Use tokens instead of strings to be able to do LESS compile-time validation
@@ -66,27 +63,3 @@
 // The following are usually overlays on other icons
 .icon-correct  { .x-icon-bg(correct); }
 .icon-incorrect { .x-icon-bg(incorrect); }
-
-
-// # Method 2
-//
-// Call the namespaced mixin to inject the correct CSS
-//
-// Example:
-//
-// ```less
-//
-// .list .item.homework .icon { #icon>.sm(homework); }
-//
-// ```
-#icon {
-  .sm(@name) {
-    .x-icon-size(@icon-size-sm);
-    .x-icon-bg(@name);
-  }
-
-  .lg(@name) {
-    .x-icon-size(@icon-size-lg);
-    .x-icon-bg(@name);
-  }
-}

--- a/style/icons/all.less
+++ b/style/icons/all.less
@@ -1,6 +1,7 @@
 @icon-path: '.';
 @icon-size-sm: 1rem;
-@icon-size-lg: @icon-size-sm * 2;
+@icon-size-lg: @icon-size-sm * 4;
+@icon-size-xlg: @icon-size-sm * 6;
 
 // # Overview
 // There are 2 ways of including the icons:
@@ -54,6 +55,7 @@
 
 .icon-sm { .x-icon-size(@icon-size-sm); }
 .icon-lg { .x-icon-size(@icon-size-lg); }
+.icon-xlg { .x-icon-size(@icon-size-xlg); }
 
 // Note: Use tokens instead of strings to be able to do LESS compile-time validation
 .icon-feedback { .x-icon-bg(feedback); }

--- a/style/student-dashboard.less
+++ b/style/student-dashboard.less
@@ -102,17 +102,6 @@
 
   .dont-forget {
     .panel-body { text-align: center; }
-    i {
-      height: 5rem;
-      width: 100%;
-      display: block;
-      background-size: 5rem;
-      background-repeat: no-repeat;
-      background-position: center;
-      cursor: pointer;
-    }
-    .recovery i { .x-icon-bg(recover); }
-    .feedback i { .x-icon-bg(feedback); }
     .heading {
       font-family: 'Lato-Black', 'Lato Black', 'Lato';
       font-weight: 900;


### PR DESCRIPTION
This is closer to what the mockup shows.  I also discovered that the "Don't Forget" panel was still using it's own css vs the new icon based methods and corrected it with the new xlg size

Before:
![screen shot 2015-04-28 at 12 59 30 pm](https://cloud.githubusercontent.com/assets/79566/7376618/88d26722-eda6-11e4-8daa-e6659d78f4a7.png)

After:
![screen shot 2015-04-28 at 12 57 43 pm](https://cloud.githubusercontent.com/assets/79566/7376620/8d589d2a-eda6-11e4-9bc0-70ee7ab89930.png)