### PR TITLE
Fix display of single teacher's name

### DIFF
--- a/src/flux/student-dashboard.coffee
+++ b/src/flux/student-dashboard.coffee
@@ -9,7 +9,10 @@ addEvents = (hash, events) ->
     week.push(event)
 
 arrayToSentence = (arry) ->
-  arry.slice(0, arry.length - 1).join(', ') + " & " + arry.slice(-1)
+  if arry.length > 1
+    arry.slice(0, arry.length - 1).join(', ') + " & " + arry.slice(-1)
+  else
+    arry[0]
 
 StudentDashboardConfig = {
 

--- a/test/components/student-dashboard.spec.coffee
+++ b/test/components/student-dashboard.spec.coffee
@@ -29,10 +29,18 @@ describe 'Student Dashboard Component', ->
     StudentDashboardActions.loaded(DATA, COURSE_ID)
     done()
 
-  it 'displays the course title', ->
+  it 'displays the course title with teacher names combined', ->
     renderDashBoard().then (state) ->
       expect(state.div.querySelector('.course-title').innerText)
         .equal("Physics - Many Plan | Andrew Garcia & Bob Newhart")
+
+      newData = _.clone(DATA)
+      newData.course.teacher_names=["Teacher Jill"]
+      StudentDashboardActions.loaded(newData, COURSE_ID)
+      state.dashboard.setState(courseId: COURSE_ID) # triggers re-rendering
+      expect(state.div.querySelector('.course-title').innerText)
+        .equal("Physics - Many Plan | Teacher Jill")
+
 
   it 'renders this week panel',  ->
     TimeActions.setNow(NOW)


### PR DESCRIPTION
Correct a bug that I introduced where the "&" symbol would prepended to the teacher names even if there was only one teacher.  I had the extra lines in the code, but must have somehow rebased over or otherwise discarded them somewhere along the line :(

Before:
![screen shot 2015-04-28 at 1 59 22 pm](https://cloud.githubusercontent.com/assets/79566/7377879/cb97d1fc-edae-11e4-9d07-b3c0aa3d4173.png)


After:
![screen shot 2015-04-28 at 1 57 57 pm](https://cloud.githubusercontent.com/assets/79566/7377855/9caa8434-edae-11e4-9c6c-722f97292274.png)