### PR TITLE
Remove ranges from the calendar

### DIFF
--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -69,12 +69,18 @@ CourseDuration = React.createClass
   # can be reused for units, for example
   setDuration: (duration) ->
     (plan) ->
-      if plan.opens_at and plan.due_at
-        plan.duration = moment(plan.opens_at).startOf('day').twix(moment(plan.due_at).endOf('day').add(1, 'day'), {allDay: true})
-      else if plan.opens_at
-        plan.duration = moment(plan.opens_at).startOf('day').twix(moment(plan.opens_at).endOf('day'), {allDay: true})
-      else if plan.due_at
+      # TODO: Commented_because_in_alpha_plans_in_the_calendar_do_not_have_ranges
+      # if plan.opens_at and plan.due_at
+      #   plan.duration = moment(plan.opens_at).startOf('day').twix(moment(plan.due_at).endOf('day').add(1, 'day'), {allDay: true})
+      # else if plan.opens_at
+      #   plan.duration = moment(plan.opens_at).startOf('day').twix(moment(plan.opens_at).endOf('day'), {allDay: true})
+      # else if plan.due_at
+      if plan.due_at
         plan.duration = moment(plan.due_at).startOf('day').twix(moment(plan.due_at).endOf('day'), {allDay: true})
+      else if plan.opens_at # HACK. some plans don't have a due_at
+        plan.duration = moment(plan.opens_at).startOf('day').twix(moment(plan.opens_at).endOf('day'), {allDay: true})
+      else
+        throw new Error('BUG! All Plans should have a due_at')
 
   isInDuration: (duration) ->
     (plan) ->

--- a/test/components/course-calendar.spec.coffee
+++ b/test/components/course-calendar.spec.coffee
@@ -70,16 +70,17 @@ describe 'Course Calendar', ->
         done()
       ).catch(done)
 
-  it 'should render plans when month with plans is rendered', (done) ->
-    calendarActions
-      # TODO make work with goToMonthWithPlans instead
-      # .goToMonthWithPlans(@result)
-      .clickPrevious(@result)
-      .then(calendarChecks.checkIsLabelPreviousMonth)
-      .then(calendarChecks.checkDoesViewHavePlans)
-      .then((result) ->
-        done()
-      ).catch(done)
+  # TODO: Commented_because_in_alpha_plans_in_the_calendar_do_not_have_ranges
+  # it 'should render plans when month with plans is rendered', (done) ->
+  #   calendarActions
+  #     # TODO make work with goToMonthWithPlans instead
+  #     # .goToMonthWithPlans(@result)
+  #     .clickPrevious(@result)
+  #     .then(calendarChecks.checkIsLabelPreviousMonth)
+  #     .then(calendarChecks.checkDoesViewHavePlans)
+  #     .then((result) ->
+  #       done()
+  #     ).catch(done)
 
   it 'should show plan details when plan is clicked', (done) ->
     calendarActions


### PR DESCRIPTION
Ranges are meant to be for block scheduling.

This unfortunately hides some fancy (and tested!) code showing calendar ranges.

![image](https://cloud.githubusercontent.com/assets/253202/7382385/380541da-eddc-11e4-9b5f-56d6bf7fb656.png)

I commented the code in case there is a better way to turn it off for now