### PR TITLE
Student dashboard fixes

### DIFF
--- a/src/components/student-dashboard/dont-forget-panel.cjsx
+++ b/src/components/student-dashboard/dont-forget-panel.cjsx
@@ -41,7 +41,7 @@ module.exports = React.createClass
     </BS.Col>
 
   render: ->
-    events  = StudentDashboardStore.pastDueEvents(@props.courseId)
+    events  = _.last(StudentDashboardStore.pastDueEvents(@props.courseId),4)
     if events.length
       <BS.Panel className="dont-forget" header="Don't Forget">
         {_.map(events, @renderBlock)}

--- a/src/components/student-dashboard/homework-row.cjsx
+++ b/src/components/student-dashboard/homework-row.cjsx
@@ -36,8 +36,9 @@ module.exports = React.createClass
       "#{event.complete_exercise_count}/#{event.exercise_count} complete"
     # In the future, the backend will signal whether the event has recovery
     # and feedback available and whether or not the student has already
-    # accessed it.  For now we assume if the event's compete it can be recovered
-    recoverable = event.complete
+    # accessed it.
+    # For now we assume if the event's compete and it's not on the current week it can be recovered
+    recoverable = event.complete and moment(event.due_at).startOf('isoweek').add(1,'week').isBefore(TimeStore.getNow())
     <EventRow {...@props} feedback={feedback} className="homework">
         {event.title}{@actionLinks() if recoverable}
     </EventRow>

--- a/src/components/student-dashboard/upcoming-panel.cjsx
+++ b/src/components/student-dashboard/upcoming-panel.cjsx
@@ -12,7 +12,8 @@ module.exports = React.createClass
     courseId: React.PropTypes.any.isRequired
 
   render: ->
-    events  = StudentDashboardStore.upcomingEvents(@props.courseId)
+    startAt = moment(TimeStore.getNow()).startOf('isoweek').add(1,'week')
+    events  = StudentDashboardStore.upcomingEvents(@props.courseId, startAt)
     if events.length
       <EventsPanel
         className="-upcoming"

--- a/src/flux/student-dashboard.coffee
+++ b/src/flux/student-dashboard.coffee
@@ -53,25 +53,18 @@ StudentDashboardConfig = {
             # other types (homework) must be incomplete and not past due
             (not event.complete and moment(event.due_at).isAfter(TimeStore.getNow())))
 
-    upcomingEvents: (courseId) ->
-      now = TimeStore.getNow()
-      _.filter @_get(courseId)?.tasks, (event) -> new Date(event.due_at) > now
-
-    # Return a few events that are past due
-    # Options:
-    #   limit: How many records to return, defaults to 4
-    #   startAt: Events older than this will be returned, default to TimeStore.getNow()
-    pastDueEvents: (courseId, options = {}) ->
-      _.defaults options,
-        limit: 4
-        startAt: TimeStore.getNow()
-
+    # Returns events who's due date has not passed
+    upcomingEvents: (courseId, now = TimeStore.getNow()) ->
       _.chain(@_get(courseId)?.tasks or [])
-        .filter( (event) ->
-          new Date(event.due_at) < options.startAt
-        )
+        .filter( (event) -> new Date(event.due_at) > now )
         .sortBy('due_at')
-        .last(options.limit)
+        .value()
+
+    # Returns events who's due date is in the past
+    pastDueEvents: (courseId, now = TimeStore.getNow()) ->
+      _.chain(@_get(courseId)?.tasks or [])
+        .filter( (event) -> new Date(event.due_at) < now )
+        .sortBy('due_at')
         .value()
 }
 


### PR DESCRIPTION
No UI changes other than how tasks are selected for which panel

Fixes for: 
 * Only Homeworks that are due on past weeks can be recovered/feedback viewed
 * Simplify store pastDueEvents method to remove the "options" hash, add upcomingEvents method
 * Upcoming events panel should start at next week, use the new upcomingEvents method on the store.