### PR TITLE
change lint warnings to errors

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -5,45 +5,45 @@
     ]
   },
   "indentation": {
-    "level": "warn",
+    "level": "error",
     "value": 2
   },
   "line_endings": {
     "value": "unix",
-    "level": "warn"
+    "level": "error"
   },
   "arrow_spacing": {
-    "level": "warn"
+    "level": "error"
   },
   "no_empty_functions": {
-    "level": "warn"
+    "level": "error"
   },
   "no_empty_param_list": {
-    "level": "warn"
+    "level": "error"
   },
   "no_interpolation_in_single_quotes": {
-    "level": "warn"
+    "level": "error"
   },
   "no_throwing_strings": {
-    "level": "warn"
+    "level": "error"
   },
   "no_unnecessary_double_quotes": {
     "level": "ignore"
   },
   "no_unnecessary_fat_arrows": {
-    "level": "warn"
+    "level": "error"
   },
   "prefer_english_operator": {
-    "level": "warn"
+    "level": "error"
   },
   "space_operators": {
-    "level": "warn"
+    "level": "error"
   },
   "spacing_after_comma": {
-    "level": "warn"
+    "level": "error"
   },
   "max_line_length": {
     "value": 135,
-    "level": "warn"
+    "level": "error"
   }
 }


### PR DESCRIPTION
No UI Changes.

Lint errors will now cause Travis to cry.

And now I need to go through and fix `no_unnecessary_double_quotes`