### PR TITLE
Connect student dashboard "view feedback" links

### DIFF
--- a/src/components/student-dashboard/homework-row.cjsx
+++ b/src/components/student-dashboard/homework-row.cjsx
@@ -14,8 +14,12 @@ module.exports = React.createClass
     event: React.PropTypes.object.isRequired
     courseId: React.PropTypes.any.isRequired
 
+  contextTypes:
+    router: React.PropTypes.func
+
   viewFeedback: (e) ->
-    alert "TODO: View feedback for task ID: #{@props.event.id} in course ID: #{@props.courseId}"
+    @context.router.transitionTo 'viewTask',
+      {courseId:@props.courseId, id: @props.event.id}
     e.preventDefault() # needed to stop event from propagating the click up to the event click handler
 
   viewRecovery: (e) ->

--- a/src/components/student-dashboard/homework-row.cjsx
+++ b/src/components/student-dashboard/homework-row.cjsx
@@ -20,11 +20,11 @@ module.exports = React.createClass
   viewFeedback: (e) ->
     @context.router.transitionTo 'viewTask',
       {courseId:@props.courseId, id: @props.event.id}
-    e.preventDefault() # needed to stop event from propagating the click up to the event click handler
+    e.stopPropagation() # needed to stop event from propagating the click up to the event click handler
 
   viewRecovery: (e) ->
     alert "TODO: View recovery for task ID: #{@props.event.id} in course ID: #{@props.courseId}"
-    e.preventDefault() # needed to stop event from propagating the click up to the event click handler
+    e.stopPropagation() # needed to stop event from propagating the click up to the event click handler
 
   actionLinks: ->
     <span className="-actions"> | <a

--- a/src/components/student-dashboard/reading-row.cjsx
+++ b/src/components/student-dashboard/reading-row.cjsx
@@ -14,7 +14,7 @@ module.exports = React.createClass
 
   viewReference: (e) ->
     alert "TODO: View Reference for task ID: #{@props.event.id} in course ID: #{@props.courseId}"
-    e.preventDefault() # needed to stop event from propagating the click up to the event click handler
+    e.stopPropagation() # needed to stop event from propagating the click up to the event click handler
 
   render: ->
     feedback = switch


### PR DESCRIPTION
No UI changes.

This connects the "View Feedback" link to the tasks, where the feedback will be shown since the task is past due.

I also discovered and fixed a bug where I'd used preventDefault instead of stopPropagation on the links.  No idea why I did that, and am not sure why/how preventDefault was even working, but stopPropagation is the behavior we want on them.