### PR TITLE
Auto detect the host & port for loading resources

### DIFF
--- a/src/components/learning-guide-chart.coffee
+++ b/src/components/learning-guide-chart.coffee
@@ -1,14 +1,14 @@
 _ = require 'underscore'
 d3 = require 'd3'
+{AppConfigStore} = require '../flux/app-config'
 
-CLOUD_PATH = '/style/resources/learning-guide/cloud.svg'
-PLANE_PATH = '/style/resources/learning-guide/openstax-plane.svg'
-CITYSCAPE_PATH = '/style/resources/learning-guide/houston-skyline.svg'
-
-FLAG_BLUE = '/style/resources/learning-guide/flag-blue.svg'
-FLAG_GREEN = '/style/resources/learning-guide/flag-green.svg'
-FLAG_YELLOW = '/style/resources/learning-guide/flag-yellow.svg'
-FLAG_GREY = '/style/resources/learning-guide/flag-grey.svg'
+CITYSCAPE_PATH = 'learning-guide/houston-skyline.svg'
+CLOUD_PATH     = 'learning-guide/cloud.svg'
+PLANE_PATH     = 'learning-guide/openstax-plane.svg'
+FLAG_BLUE      = 'learning-guide/flag-blue.svg'
+FLAG_GREEN     = 'learning-guide/flag-green.svg'
+FLAG_YELLOW    = 'learning-guide/flag-yellow.svg'
+FLAG_GREY      = 'learning-guide/flag-grey.svg'
 
 # SVG is vector so width/height don't really matter.  100 is just a convenient # to multiple by
 WIDTH = 160
@@ -30,7 +30,7 @@ module.exports = class LearningGuideChart
       .attr('y', options.y)
       .attr('width', options.width   or 10)
       .attr('height', options.height or 10)
-      .attr('xlink:href', url)
+      .attr('xlink:href', AppConfigStore.urlForResource(url))
       .attr('class', className)
 
   drawChart: (guide, showAll) ->
@@ -84,7 +84,7 @@ module.exports = class LearningGuideChart
 
     @drawTitle(container, guide)
 
-    
+
 
 
   drawTitle: (container, guide) ->
@@ -173,7 +173,7 @@ module.exports = class LearningGuideChart
       .attr('class', 'y-desc')
       .attr('transform', "rotate(-90, 8, #{ypos})")
       .text(text)
-      
+
   drawYLabel: (container, ypos, text) ->
     wrap = container.append('g')
       .append("svg:text")
@@ -262,6 +262,7 @@ module.exports = class LearningGuideChart
 
 
   drawStaticImages: (container, points) ->
+
     @addImage(CITYSCAPE_PATH, width:109.7, height:12, x:32, y:32.5)
 
     @addImage(FLAG_BLUE, width:10, height:2.5, x:13.2, y:6.3)
@@ -274,7 +275,7 @@ module.exports = class LearningGuideChart
     @addImage(CLOUD_PATH, width:15, height:15, x:30, y:2, 'cloud cloud-opacity-40')
     @addImage(CLOUD_PATH, width:20, height:10, x:38, y:7, 'cloud cloud-opacity-70')
     @addImage(CLOUD_PATH, width:20, height:15, x:135, y:2, 'cloud cloud-opacity-50')
-    
+
 
   drawCircles: (container, fields, points) ->
     wrap = container.append('g')

--- a/src/flux/app-config.coffee
+++ b/src/flux/app-config.coffee
@@ -1,0 +1,31 @@
+# Store for getting information about the application's configuration
+
+flux = require 'flux-react'
+
+{makeSimpleStore} = require './helpers'
+
+AppConfig =
+
+  setAssetsHost: (host) ->
+    @_assetsHost = host
+
+  exports:
+    getAssetsHost: ->
+      return @_assetsHost if @_assetsHost?
+      # http://caniuse.com/#feat=css-sel3 (substring selector is IE 8+)
+      tutorStyle = document.head.querySelector('link[href$="tutor.css"]')
+      # if we didn't find the styling css, use "/" string.
+      # That'll cause the anchor test below to be a relative link and use the document's scheme/host/port
+      href = if tutorStyle then tutorStyle.getAttribute('href') else "/"
+      # By using this method we can easily support http, https, as well as protocol agnostic schemes
+      # without using a huge nasty regex.
+      # It's a bit more expensive (don't use in a loop), but we're caching the results
+      a = document.createElement('a')
+      a.href = href
+      @_assetsHost = "#{a.protocol}//#{a.host}"
+
+    urlForResource: (path) ->
+      this.exports.getAssetsHost.call(this) + "/style/resources/#{path}"
+
+{actions, store} = makeSimpleStore(AppConfig)
+module.exports = {AppConfigActions:actions, AppConfigStore:store}

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -18,6 +18,7 @@ require './loadable.spec'
 require './teacher-task-plan-store.spec'
 require './step-panel-policy.spec'
 require './time.spec'
+require './app-configuration.spec'
 
 # This should be done **last** because it starts up the whole app
 require './router.spec'

--- a/test/app-configuration.spec.coffee
+++ b/test/app-configuration.spec.coffee
@@ -1,0 +1,15 @@
+{expect} = require 'chai'
+
+{AppConfigActions, AppConfigStore} = require '../src/flux/app-config'
+
+describe 'App Configuration', ->
+
+  it 'gets and sets the assets host', ->
+    # Karma runs it's specs on localhost using a random port
+    expect( AppConfigStore.getAssetsHost() ).to.match(/localhost:\d+/)
+    AppConfigActions.setAssetsHost("https://crazy-bobs-cheap-servers.testing/")
+    expect( AppConfigStore.getAssetsHost() ).to.equal("https://crazy-bobs-cheap-servers.testing/")
+
+  it 'calculates resource links', ->
+    expect(AppConfigStore.urlForResource("a-pretty-image.svg"))
+      .to.include("/style/resources/a-pretty-image.svg")


### PR DESCRIPTION
No UI changes

Created a new AppConfigStore that has a `getAssetsHost` and `urlForResource` methods and configures the learning-guide to load it's assets using it.

Feedback welcomed on how `getAssetsHost` auto-detects the host and if that's a good idea or not.  We could also set it explicitly as when the app's loaded in the index.html files as part of a "Bootstrap" type call.