### PR TITLE
Continue task behavior

### DIFF
--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -105,4 +105,4 @@ module.exports = React.createClass
 
   onNextStep: ->
     {id} = @props
-    @setState({currentStep: @getDefaultCurrentStep()})
+    @setState({currentStep: @state.currentStep + 1})


### PR DESCRIPTION
* Clicking continue should go to next step, as opposed to first incomplete step.

This change is especially apparent if you go to step 3 for example, and try to continue.

Previously, the continue would take you to the first incomplete step, which may be step 1 or step 6.
* Step 1 if you're in a homework and skipped to step 3 without completing step 1
* Step 6 if you're in a reading and you have completed up to step 5 but are going back to step 3 to review.

Now, it should take you to step 4.


There is currently a problem with the backend where it doesn't expect us to complete exercise more than once (i.e. when we change an answer and then click continue).  I am discussion with @Dantemss about this and other edge cases around this.