### PR TITLE
fix calendar reloading when returning from screen

### DIFF
--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -16,12 +16,17 @@ CourseDuration = React.createClass
   getInitialState: ->
     groupedDurations: []
 
-  componentWillReceiveProps: (nextProps) ->
-    {durations, viewingDuration, groupingDurations} = nextProps
+  updateGroupedDurations: (props) ->
+    {durations, viewingDuration, groupingDurations} = props
 
     groupedDurations = @groupDurations(durations, viewingDuration, groupingDurations)
 
     @setState({groupedDurations})
+
+  componentWillMount: ->
+    @updateGroupedDurations(@props)
+  componentWillReceiveProps: (nextProps) ->
+    @updateGroupedDurations(nextProps)
 
   groupDurations: (durations, viewingDuration, groupingDurations) ->
     durationsInView = _.chain(durations)


### PR DESCRIPTION
When returning from HW or iReading builder the calendar would be blank:

![image](https://cloud.githubusercontent.com/assets/253202/7505858/b6eb86d6-f425-11e4-8e7e-29e3d69608c5.png)
