### PR TITLE
Only render katex nodes with Mathjax

### DIFF
--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -31,3 +31,5 @@ module.exports = React.createClass
     links = root.querySelectorAll('a')
     _.each links, (link) ->
       link.setAttribute('target', '_blank') unless link.getAttribute('href')?[0] is '#'
+    # MathML should be rendered by MathJax (if available)
+    window.MathJax?.Hub.Queue(['Typeset', MathJax.Hub, root])

--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -31,6 +31,3 @@ module.exports = React.createClass
     links = root.querySelectorAll('a')
     _.each links, (link) ->
       link.setAttribute('target', '_blank') unless link.getAttribute('href')?[0] is '#'
-
-    # MathML should be rendered by MathJax (if available)
-    window.MathJax?.Hub.Queue(['Typeset', MathJax.Hub], @getDOMNode())

--- a/src/components/katex-mixin.coffee
+++ b/src/components/katex-mixin.coffee
@@ -15,8 +15,6 @@ module.exports =
 
       katex.render(formula, node)
       node.classList.add('loaded')
-      # MathML should be rendered by MathJax (if available)
-      window.MathJax?.Hub.Queue(['Typeset', MathJax.Hub, node])
 
   sanitizeKatexHtml: (html) ->
     # Clean up the katex that was added

--- a/src/components/katex-mixin.coffee
+++ b/src/components/katex-mixin.coffee
@@ -15,6 +15,8 @@ module.exports =
 
       katex.render(formula, node)
       node.classList.add('loaded')
+      # MathML should be rendered by MathJax (if available)
+      window.MathJax?.Hub.Queue(['Typeset', MathJax.Hub, node])
 
   sanitizeKatexHtml: (html) ->
     # Clean up the katex that was added


### PR DESCRIPTION
I believe the MathJax Typeset call is what's causing the "Invariant Violation" exceptions in the task steps.  If it's disabled, the exceptions no longer occur. 

As part of that investigation, I discovered that the MathJax.Hub.Queue call's arguments were specified incorrectly.  The element should be given as part of the array.  Since it wasn't specified property, Mathjax is actually typsetting the entire document.  http://docs.mathjax.org/en/latest/queues.html#using-queues (*search for Typeset*)

Unfortunately, this does not correct the "Invariant Violation".  Even with this fix, MathJax still causes them.  When I set a breakpoint on the dom tree before the call, I see multiple mutations being performed, but they all appear to be inside the html of the Html component, so React shouldn't care about them.

The Tex component from Khan academy is an interesting implementation of MathJax with React: https://github.com/Khan/react-components/blob/master/js/tex.jsx
