### PR TITLE
Clean up stray elements created by MathJax

### DIFF
--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -25,11 +25,28 @@ module.exports = React.createClass
     if html
       __html: html
 
-  componentDidMount: ->
+  componentDidMount:  -> @updateDOMNode()
+  componentDidUpdate: -> @updateDOMNode()
+
+  # Perform manipulation on HTML contained inside the components node.
+  updateDOMNode: ->
     # External links should open in a new window
     root = @getDOMNode()
     links = root.querySelectorAll('a')
     _.each links, (link) ->
       link.setAttribute('target', '_blank') unless link.getAttribute('href')?[0] is '#'
+
     # MathML should be rendered by MathJax (if available)
     window.MathJax?.Hub.Queue(['Typeset', MathJax.Hub, root])
+    # Once MathML finishes processing, manually cleanup after it to prevent
+    # React "Invariant Violation" exceptions.
+    # MathJax calls Queued events in order, so this should always execute after typesetting
+    window.MathJax?.Hub.Queue([ ->
+      for nodeId in ['MathJax_Message', 'MathJax_Hidden', 'MathJax_Font_Test']
+        el = document.getElementById(nodeId)
+        break unless el # the elements won't exist if MathJax didn't do anything
+        # Some of the elements are wrapped by divs without selectors under body
+        # Select the parentElement unless it's already directly under body.
+        el = el.parentElement unless el.parentElement is document.body
+        el.parentElement.removeChild(el)
+    ])


### PR DESCRIPTION
As pointed out by the awesome @pandafulmanda - MathJax creates multiple elements outside the container that it's working on.

If we remove them after MathJax does it's thing, the "Invariant Violation" exceptions no longer occur.