### PR TITLE
Fixes for reading overlay

### DIFF
--- a/resources/styles/components/task-step/reading/book-content/index.less
+++ b/resources/styles/components/task-step/reading/book-content/index.less
@@ -104,7 +104,7 @@ div[data-type="document-title"] ~ p {padding: 0 140px;}
     position: relative;
     background-color: rgba(0, 0, 0, 0.6);
     color: @tutor-white;
-    top: -100px;
+    margin-top: -100px;
     font-size: 3rem;
     line-height: 100px;
     height: 100px;

--- a/src/components/task-step/all-steps.cjsx
+++ b/src/components/task-step/all-steps.cjsx
@@ -32,6 +32,8 @@ Reading = React.createClass
     {title} = TaskStepStore.get(@props.id)
     for img in root.querySelectorAll('.splash img')
       overlay = document.createElement('div')
+      # don't apply overlay twice or if cnx content already includes it
+      continue if img.parentElement.querySelector('.ui-overlay')
       # Prefix the class to distinguish it from a class in the original HTML content
       overlay.className = 'ui-overlay'
       overlay.innerHTML = title


### PR DESCRIPTION
I discovered that the overlay was leaving a blank area where it should have been due to the use of relative positioning adjustment.

Also put a check in to make sure the ui-overlay element isn't generated more than once.

Before:
![screen shot 2015-05-14 at 9 50 58 am](https://cloud.githubusercontent.com/assets/79566/7634287/8cd9699e-fa1f-11e4-9bf0-2960a1d6ebdd.png)

After:
![screen shot 2015-05-14 at 9 51 23 am](https://cloud.githubusercontent.com/assets/79566/7634290/9448f2e4-fa1f-11e4-9a95-1dae9212cfee.png)
