### PR TITLE
Some objectives lack .ost-learning-objective-def

### DIFF
--- a/resources/styles/components/task-step/reading/book-content/index.less
+++ b/resources/styles/components/task-step/reading/book-content/index.less
@@ -46,11 +46,9 @@ cnx-pi { display: none; }
     margin: 0 0;
     padding: 0 15px 0 30px;
     border-left: 1px solid rgba(255,255,255,.4);
-    ul {
-      display: flex;
-      flex-direction: column;
-    }
-    .ost-learning-objective-def {
+    display: flex;
+    flex-direction: column;
+    li {
       font-weight: 300;
       font-size: 1.5rem;
       line-height: 3rem;
@@ -59,6 +57,9 @@ cnx-pi { display: none; }
       display: flex;
       justify-content: center;
       flex-direction: column;
+      .MathJax {
+        margin-left: 2rem;
+      }
     }
   }
 

--- a/resources/styles/components/task-step/reading/book-content/index.less
+++ b/resources/styles/components/task-step/reading/book-content/index.less
@@ -48,7 +48,7 @@ cnx-pi { display: none; }
     border-left: 1px solid rgba(255,255,255,.4);
     display: flex;
     flex-direction: column;
-    li {
+    .ost-learning-objective-def {
       font-weight: 300;
       font-size: 1.5rem;
       line-height: 3rem;


### PR DESCRIPTION
And are not styled.  This gives up identifiying them by class
and assumes that all li elements inside a .learning-objectives
are objectives.

Also add 2rem of indentation to MathJax so it looks neater.  The MathJax styling conflicts with the flex alignment on the list, causing it to be moved to a new line.  Since flex box is the only way to get the list to vertically space the elements equally I think that's the best we can do.

Before:
![screen shot 2015-05-14 at 10 01 00 am](https://cloud.githubusercontent.com/assets/79566/7634525/136b6808-fa21-11e4-923e-698efbe91a07.png)


After:
![screen shot 2015-05-14 at 10 03 50 am](https://cloud.githubusercontent.com/assets/79566/7634521/09543318-fa21-11e4-9c0d-3087d6dcc411.png)