### PR TITLE
Align text labels, move "Correct Answer" inside card

### DIFF
--- a/resources/styles/components/question.less
+++ b/resources/styles/components/question.less
@@ -49,7 +49,7 @@
 
     &:before {
       content: "My Answer:";
-      margin-left: -145px;
+      margin-left: -130px;
       .answer-label();
     }
   }
@@ -64,7 +64,7 @@
 
     &:before {
       content: "Why?";
-      margin-left: -56px;
+      margin-left: -50px;
       .answer-label();
     }
   }
@@ -152,9 +152,9 @@
         display: none;
       }
 
-      .answer-correct:not(.answer-checked):before {
+      .answer-correct:not(.answer-checked) .answer-letter:before {
         content: "Correct Answer:";
-        margin-left: -145px;
+        margin-left: -170px;
         .answer-label();
         line-height: @answer-height;
       }


### PR DESCRIPTION
Before:
![screen shot 2015-05-15 at 10 47 18 am](https://cloud.githubusercontent.com/assets/79566/7657902/7297a50a-fafb-11e4-882d-9ebcb37a3163.png)
After:
![screen shot 2015-05-15 at 12 10 46 pm](https://cloud.githubusercontent.com/assets/79566/7657905/754c927e-fafb-11e4-987b-26cc3acbbd5f.png)

The main cause turned out to be that the :before element was attached to the incorrect element, which also caused the vertical alignment to be off.
