### PR TITLE
Remove border from dashboard panel headings

### DIFF
--- a/resources/styles/components/student-dashboard/dashboard.less
+++ b/resources/styles/components/student-dashboard/dashboard.less
@@ -78,5 +78,5 @@
     }
   }
 
-
+  .panel-heading { border: none; }
 }


### PR DESCRIPTION
In dff52431d24dc0449fb9e8f090dab8d76bfe5593, `.panel > .panel-heading` gained a `border: 2px solid @tutor-secondary-light` rule, causing the dashboard to look like:

![screen shot 2015-05-15 at 12 14 50 pm](https://cloud.githubusercontent.com/assets/79566/7658034/5a1c1776-fafc-11e4-81d2-32e0aab0a3f1.png)

This removes it