### PR TITLE
tweaks around scroll and pinning behaviour

### DIFF
--- a/src/components/pinned-header-footer-card/index.cjsx
+++ b/src/components/pinned-header-footer-card/index.cjsx
@@ -14,7 +14,7 @@ module.exports = React.createClass
 
   getDefaultProps: ->
     buffer: 60
-    scrollSpeedBuffer: 10
+    scrollSpeedBuffer: 20
 
   getInitialState: ->
     pinned: false
@@ -40,17 +40,30 @@ module.exports = React.createClass
   isScrollingDown: (prevScrollTop, currentScrollTop) ->
     currentScrollTop > prevScrollTop
 
+  isScrollPassBuffer: (prevScrollTop, currentScrollTop) ->
+    currentScrollTop > @props.buffer
+
   shouldPinHeader: (prevScrollTop, currentScrollTop) ->
-    if @isScrollingDown(prevScrollTop, currentScrollTop)
-      # on down scroll, check if the scroll position is past buffer
-      shouldPinHeader = (currentScrollTop > @props.buffer)
-    # if upscrolling is slow
-    else if @isScrollingSlowed(prevScrollTop, currentScrollTop)
-      # keep as current pinned state
-      shouldPinHeader = @state.pinned
-    else if @isScrollingUp(prevScrollTop, currentScrollTop)
-      # unpinned on upscroll
+    # should not pin regardless of scroll direction if the scroll top is above buffer
+    unless @isScrollPassBuffer(prevScrollTop, currentScrollTop)
       shouldPinHeader = false
+
+    # otherwise, when scroll top is below buffer
+    # and on down scroll
+    else if @isScrollingDown(prevScrollTop, currentScrollTop)
+      # header should pin
+      shouldPinHeader = true
+
+    # or when up scrolling is slow
+    else if @isScrollingSlowed(prevScrollTop, currentScrollTop)
+      # leave the pinning as is
+      shouldPinHeader = @state.pinned
+
+    # else, the only case left is if up scrolling is fast
+    else
+      # unpin on fast up scroll
+      shouldPinHeader = false
+
 
     shouldPinHeader
 


### PR DESCRIPTION
## Default
### unpinned
![screen shot 2015-05-15 at 3 21 57 pm](https://cloud.githubusercontent.com/assets/2483873/7661230/4f870716-fb16-11e4-8aae-0b63c0cb1460.png)

## Down scroll past buffer point
### pinned
![screen shot 2015-05-15 at 3 22 10 pm](https://cloud.githubusercontent.com/assets/2483873/7661221/47739aa8-fb16-11e4-8d23-98d83822a77e.png)

## Slow up scroll
### pinned
![screen shot 2015-05-15 at 3 22 24 pm](https://cloud.githubusercontent.com/assets/2483873/7661223/4775af82-fb16-11e4-9637-844fae641605.png)

## Slow up scroll passing above buffer point
### unpinned
![screen shot 2015-05-15 at 3 22 39 pm](https://cloud.githubusercontent.com/assets/2483873/7661220/4772ce34-fb16-11e4-8cc1-c7823813f7ae.png)

## Fast up scroll, when past buffer point
### unpinned
![screen shot 2015-05-15 at 3 22 46 pm](https://cloud.githubusercontent.com/assets/2483873/7661222/47757e40-fb16-11e4-849b-86aac67b4639.png)
