### PR TITLE
Set minimum height for p elements with drop caps

### DIFF
--- a/resources/styles/components/task-step/reading/book-content/index.less
+++ b/resources/styles/components/task-step/reading/book-content/index.less
@@ -58,6 +58,9 @@
     color: @tutor-secondary;
     margin: 0 4px 0 -6px;
   }
+  // ensure that the p is heigh enough for the drop cap
+  // to fit beside it, otherwise it will overlay on top of the next element
+  min-height: 8rem;
 }
 
 // Hide CNX Processing instructions


### PR DESCRIPTION
Ensures a para that has drop-caps effect applied is tall enough so that the drop-caps don't descend into it's sibling elements.

Before:
![screen shot 2015-05-18 at 9 20 45 pm](https://cloud.githubusercontent.com/assets/79566/7694430/d5a40d1c-fda5-11e4-8c30-b457a164295c.png)

After:
![screen shot 2015-05-18 at 9 37 03 pm](https://cloud.githubusercontent.com/assets/79566/7694455/2fea7996-fda6-11e4-87ef-8fa818dd01b2.png)
