### PR TITLE
Plan Footer - Cancel button and homework logic

### DIFF
--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -28,6 +28,12 @@ PlanFooter = React.createClass
       TaskPlanActions.delete(id)
       @context.router.transitionTo('dashboard')
 
+  onCancel: ->
+    {id} = @props
+    if confirm('Are you sure you want to cancel?')
+      TaskPlanActions.reset(id)
+      @context.router.transitionTo('dashboard')
+
   onViewStats: ->
     {id, courseId} = @props
     @context.router.transitionTo('viewStats', {courseId, id, type: 'homework'})
@@ -49,7 +55,9 @@ PlanFooter = React.createClass
     if deleteable
       deleteLink = <BS.Button bsStyle='link' className='-delete' onClick={@onDelete}>Delete</BS.Button>
 
-    if TaskPlanStore.isHomework(id) and not TaskPlanStore.isPublished(id)
+    hasExercises = TaskPlanStore.getExercises(id)?.length
+    if TaskPlanStore.isHomework(id) and not TaskPlanStore.isPublished(id) and not hasExercises
+      publishButton = null
       selectProblems = <BS.Button 
         bsStyle='primary' 
         className='-select-problems'
@@ -60,6 +68,7 @@ PlanFooter = React.createClass
       {selectProblems}
       {publishButton}
       {deleteLink}
+      <BS.Button aria-role='close' onClick={@onCancel}>Cancel</BS.Button>
     </span>
 
 module.exports = PlanFooter

--- a/test/components/homework/homework-plan.spec.coffee
+++ b/test/components/homework/homework-plan.spec.coffee
@@ -43,7 +43,6 @@ describe 'Homework Builder', ->
     tests = ({div}) ->
       expect(div.querySelector('#homework-title').value).to.equal(VALID_MODEL.title)
       expect(div.querySelector('#homework-due-date')).to.be.not.null
-      expect(div.querySelector('.-select-problems')).to.be.not.null
       expect(div.querySelectorAll('.card.exercise').length).to.equal(VALID_MODEL.settings.exercise_ids.length)
       done()
 


### PR DESCRIPTION
![screen shot 2015-05-19 at 11 42 15 am](https://cloud.githubusercontent.com/assets/6434717/7695047/5df55ede-fe1c-11e4-8052-e9cabd9bba62.png)
![screen shot 2015-05-19 at 11 38 15 am](https://cloud.githubusercontent.com/assets/6434717/7695048/5df70eaa-fe1c-11e4-90f9-c99a725bd8e4.png)
![screen shot 2015-05-19 at 11 42 41 am](https://cloud.githubusercontent.com/assets/6434717/7695049/5df98252-fe1c-11e4-8dac-31201348663b.png)

- [x] Add cancel button for ireadings and homeworks
- [x] Hide publish button if no exercises are selected
- [x] Hide Select Problems button if exercises are selected