### PR TITLE
Exercise Card Styles and Tag Display

### DIFF
--- a/resources/styles/components/task-plan/homework/exercises.less
+++ b/resources/styles/components/task-plan/homework/exercises.less
@@ -40,10 +40,6 @@ table.exercise-table {
     text-align: center;
   }
 
-  .chapter-section {
-    color: @tutor-secondary;
-  }
-
   td.ellipses {
     white-space: nowrap;
     overflow: hidden;
@@ -58,10 +54,6 @@ table.exercise-table {
 
 label.exercises-section-label {
   font-size: 2.8rem;
-
-  .chapter-section {
-    color: @tutor-secondary;
-  }
 }
 
 .exercise.card {
@@ -79,7 +71,7 @@ label.exercises-section-label {
     bottom: 0;
     left: 0;
     display: none;
-    background-color: fade(@tutor-neutral-lighter, 35%);
+    background-color: fade(@tutor-neutral-lighter, 0%);
     border: none;
 
     .btn.btn-primary {
@@ -90,13 +82,13 @@ label.exercises-section-label {
       width: 100px;
       margin-top: -50px;
       margin-left: -50px;
-      background-color: @tutor-white;
+      background-color: fade(@tutor-white, 75%);
       border: 1px solid @tutor-neutral-lighter;
       border-radius: 100px;
       color: @tutor-black;
 
       &:hover {
-        background-color: white;
+        background-color: fade(@tutor-white, 100%);
         border: 1px solid @tutor-neutral-lighter;
       }
     }
@@ -151,9 +143,30 @@ label.exercises-section-label {
 }
 
 .card-list.exercises {
+  .panel-heading {
+    background:@tutor-neutral-bright;
+    height: 50px;
+    padding: 10px;
+    border-bottom: 1px solid @tutor-neutral-light;
+    display: block;
+    .exercise-number {
+      color: @tutor-primary;
+    }
+  }
+
+  .card-actions button.btn-default {
+    .homework-circle-btn(25px);
+    padding: 0;
+    margin:0 15px 0 0;
+    color: @tutor-neutral-darker;
+    background: white;
+  }
+
   > .exercise > .panel-body {
     .stem {
       margin-top: 3rem;
     }
   }
 }
+
+

--- a/src/components/task-plan/homework/exercises.cjsx
+++ b/src/components/task-plan/homework/exercises.cjsx
@@ -20,13 +20,14 @@ ExerciseCardMixin =
     </div>
 
   renderTags: (tag) ->
-    <span className="exercise-tag">{tag}</span>
+    tagContent = if tag.name then tag.name else tag.id
+    <span className="exercise-tag">{tagContent}</span>
 
   renderExercise: ->
     content = @props.exercise.content
     question = content.questions[0]
     renderedAnswers = _.map(question.answers, @renderAnswers)
-    renderedTags = _.map(content.tags, @renderTags)
+    renderedTags = _.map(@props.exercise.tags, @renderTags)
 
     header = @renderHeader()
     panelStyle = @getPanelStyle()


### PR DESCRIPTION
![screen shot 2015-05-19 at 11 49 03 am](https://cloud.githubusercontent.com/assets/6434717/7695112/2b643890-fe1d-11e4-9d1a-d3a88b732055.png)
![screen shot 2015-05-19 at 11 48 25 am](https://cloud.githubusercontent.com/assets/6434717/7695113/2b668a28-fe1d-11e4-99d5-ed3812a10283.png)
![screen shot 2015-05-19 at 11 48 39 am](https://cloud.githubusercontent.com/assets/6434717/7695114/2b697cd8-fe1d-11e4-9070-00cc825b92f0.png)

- [x] Get rid of semi-transparent overlay when hovering over card
- [x] Add Button should be semitransparent when hovering over exercises, and opaque when hovering over button
- [x] Show LO text instead of id
- [x] Fix review exercise heading and button styles