### PR TITLE
catch Katex parser errors

### DIFF
--- a/src/components/katex-mixin.coffee
+++ b/src/components/katex-mixin.coffee
@@ -13,8 +13,11 @@ module.exports =
       if isBlock
         formula = "\\displaystyle {#{formula}}"
 
-      katex.render(formula, node)
-      node.classList.add('loaded')
+      try
+        katex.render(formula, node)
+        node.classList.add('loaded')
+      catch e
+        console.error(e)
 
   sanitizeKatexHtml: (html) ->
     # Clean up the katex that was added


### PR DESCRIPTION
No UI Changes.

Allows the exercise builder to still work when there are katex parser errors