### PR TITLE
Improvements on homework review page

### DIFF
--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -12,23 +12,6 @@
   
 }
 
-.task-chapter_practice {
-  .completed-message {
-    .tutor-completed-message();
-  }
-}
-
-.task-homework {
-  .completed-message {
-    .size-exercise-card();
-  }
-}
-
-.task-step {
-  .placeholder-step {
-    .size-exercise-card();
-  }
-}
-
 @import './reading';
 @import './video';
+@import './ends';

--- a/resources/styles/components/task-step/ends.less
+++ b/resources/styles/components/task-step/ends.less
@@ -1,0 +1,27 @@
+.task-chapter_practice {
+  .completed-message {
+    .tutor-completed-message();
+  }
+}
+
+.task-homework {
+  .completed-message {
+    .size-exercise-card();
+  }
+}
+
+.task-step {
+  .placeholder-step {
+    .size-exercise-card();
+  }
+}
+
+.homework-review-problem-leave {
+  max-height: 800px;
+  overflow: hidden;
+  .transition(max-height 0.5s);
+}
+
+.homework-review-problem-leave-active {
+  max-height: 0;
+}

--- a/resources/styles/components/task-step/ends.less
+++ b/resources/styles/components/task-step/ends.less
@@ -19,7 +19,7 @@
 .homework-review-problem-leave {
   max-height: 800px;
   overflow: hidden;
-  .transition(max-height 0.5s);
+  .transition(max-height 0.3s);
 }
 
 .homework-review-problem-leave-active {

--- a/src/components/task-step/all-steps.cjsx
+++ b/src/components/task-step/all-steps.cjsx
@@ -91,9 +91,9 @@ Video = React.createClass
 Placeholder = React.createClass
   displayName: "Placeholder"
   mixins: [StepMixin]
-  isContinueEnabled: -> 
+  isContinueEnabled: ->
     {review} = @props
-    not review
+    not review?.length
   onContinue: ->
     @props.onNextStep()
   renderBody: ->

--- a/src/components/task-step/all-steps.cjsx
+++ b/src/components/task-step/all-steps.cjsx
@@ -91,7 +91,9 @@ Video = React.createClass
 Placeholder = React.createClass
   displayName: "Placeholder"
   mixins: [StepMixin]
-  isContinueEnabled: -> true
+  isContinueEnabled: -> 
+    {review} = @props
+    not review
   onContinue: ->
     @props.onNextStep()
   renderBody: ->

--- a/src/components/task-step/ends.cjsx
+++ b/src/components/task-step/ends.cjsx
@@ -92,15 +92,18 @@ HomeworkEnd = React.createClass
     completedSteps = TaskStore.getCompletedSteps taskId
     incompleteSteps = TaskStore.getIncompleteSteps taskId
     totalSteps = TaskStore.getTotalStepsCount taskId
+    completedLabel = null
+    todoLabel = null
 
     if completedSteps.length
       completedLabel = <h1>Problems Review</h1>
-      completedReview = @renderReviewSteps(taskId, completedSteps, completedLabel, 'completed')
 
     if incompleteSteps.length
       todoLabel =
         <h1>Problems To Do <small>{incompleteSteps.length} remaining</small></h1>
-      todoReview = @renderReviewSteps(taskId, incompleteSteps, todoLabel, 'todo')
+
+    completedReview = @renderReviewSteps(taskId, completedSteps, completedLabel, 'completed')
+    todoReview = @renderReviewSteps(taskId, incompleteSteps, todoLabel, 'todo')
 
     <div className='task-review -homework-completed'>
       {todoReview}

--- a/src/components/task-step/ends.cjsx
+++ b/src/components/task-step/ends.cjsx
@@ -1,6 +1,6 @@
 # coffeelint: disable=no_empty_functions
 
-React = require 'react'
+React = require 'react/addons'
 BS = require 'react-bootstrap'
 Router = require 'react-router'
 _ = require 'underscore'
@@ -12,6 +12,8 @@ TaskStep = require './index'
 {TaskStore} = require '../../flux/task'
 {TaskStepStore} = require '../../flux/task-step'
 {CardBody, PinnableFooter} = require '../pinned-header-footer-card/sections'
+
+ReactCSSTransitionGroup = React.addons.CSSTransitionGroup
 
 PracticeEnd = React.createClass
   displayName: 'PracticeEnd'
@@ -75,7 +77,9 @@ HomeworkEnd = React.createClass
     stepsReview =
       <div className="task task-review-#{type}">
         {label}
-        {stepsList}
+        <ReactCSSTransitionGroup transitionName="homework-review-problem">
+          {stepsList}
+        </ReactCSSTransitionGroup>
         <PinnableFooter>
           <Router.Link
             to='viewStudentDashboard'

--- a/src/components/task-step/ends.cjsx
+++ b/src/components/task-step/ends.cjsx
@@ -48,20 +48,13 @@ PracticeEnd = React.createClass
 
 HomeworkEnd = React.createClass
   displayName: 'HomeworkEnd'
-
-  mixins: [BindStoreMixin]
-  bindStore: TaskStepStore
-  bindEvent: 'step.completed'
-  bindUpdate: ->
-    # update on complete
-    @setState({})
-
   propTypes:
     courseId: React.PropTypes.string.isRequired
     taskId: React.PropTypes.string.isRequired
 
   goToStep: ->
   onNextStep: ->
+    @setState({})
 
   renderReviewSteps: (taskId, steps, label, type) ->
     {courseId} = @props
@@ -74,7 +67,7 @@ HomeworkEnd = React.createClass
         key="task-review-#{step.id}"
         # focus on first problem
         focus={index is 0}
-        review={true}
+        review={type}
         pinned={false}
         taskId={taskId}
       />

--- a/src/components/task-step/ends.cjsx
+++ b/src/components/task-step/ends.cjsx
@@ -63,7 +63,7 @@ HomeworkEnd = React.createClass
   goToStep: ->
   onNextStep: ->
 
-  renderReviewSteps: (steps, label, type) ->
+  renderReviewSteps: (taskId, steps, label, type) ->
     {courseId} = @props
 
     stepsList = _.map steps, (step, index) =>
@@ -76,6 +76,7 @@ HomeworkEnd = React.createClass
         focus={index is 0}
         review={true}
         pinned={false}
+        taskId={taskId}
       />
 
     stepsReview =
@@ -97,12 +98,12 @@ HomeworkEnd = React.createClass
 
     if completedSteps.length
       completedLabel = <h1>Problems Review</h1>
-      completedReview = @renderReviewSteps(completedSteps, completedLabel, 'completed')
+      completedReview = @renderReviewSteps(taskId, completedSteps, completedLabel, 'completed')
 
     if incompleteSteps.length
       todoLabel =
         <h1>Problems To Do <small>{incompleteSteps.length} remaining</small></h1>
-      todoReview = @renderReviewSteps(incompleteSteps, todoLabel, 'todo')
+      todoReview = @renderReviewSteps(taskId, incompleteSteps, todoLabel, 'todo')
 
     <div className='task-review -homework-completed'>
       {todoReview}

--- a/src/components/task-step/exercise/index.cjsx
+++ b/src/components/task-step/exercise/index.cjsx
@@ -15,11 +15,11 @@ module.exports = React.createClass
     goToStep: React.PropTypes.func.isRequired
     onNextStep: React.PropTypes.func.isRequired
     focus: React.PropTypes.bool.isRequired
-    review: React.PropTypes.bool.isRequired
+    review: React.PropTypes.string.isRequired
 
   getDefaultProps: ->
     focus: true
-    review: false
+    review: ''
     pinned: true
 
   renderReview: (id) ->

--- a/src/components/task-step/exercise/modes.cjsx
+++ b/src/components/task-step/exercise/modes.cjsx
@@ -187,7 +187,7 @@ ExerciseReview = React.createClass
     buttonClasses = '-continue'
     buttonClasses += 'disabled' unless @isContinueEnabled()
 
-    unless review
+    unless review is 'completed'
       continueButton =
         <BS.Button bsStyle='primary' className={buttonClasses} onClick={@onContinue}>
           { if @canTryAnother() then 'Move On' else 'Continue' }

--- a/src/components/task/breadcrumb.cjsx
+++ b/src/components/task/breadcrumb.cjsx
@@ -10,11 +10,16 @@ module.exports = React.createClass
   componentWillMount: ->
     {crumb} = @props
 
+    TaskStepStore.setMaxListeners(20)
+    TaskStepStore.on('step.completed', @update)
+
     if crumb.type is 'step' and TaskStepStore.isPlaceholder(crumb.data.id)
       TaskStepStore.on('step.completed', @checkPlaceholder)
       TaskStepStore.on('step.loaded', @update)
 
   removeListeners: ->
+    TaskStepStore.setMaxListeners(10)
+    TaskStepStore.off('step.completed', @update)
     TaskStepStore.off('step.completed', @checkPlaceholder)
     TaskStepStore.off('step.loaded', @update)
 
@@ -29,9 +34,8 @@ module.exports = React.createClass
   update: (id) ->
     {crumb} = @props
 
-    if (crumb.data.id is id) and not TaskStepStore.isPlaceholder(crumb.data.id)
+    if (crumb.data.id is id)
       @setState({})
-      @removeListeners()
 
   propTypes:
     crumb: React.PropTypes.object.isRequired


### PR DESCRIPTION
- [X] breadcrumbs update as you work homework problems on review page
  - try it, it's pretty kewl!
- [x] smooth out transition when problem completed
- [x] fix remaining questions needed for placeholder personalized question
- [x] disable continue for placeholder personalized question

- first problem leave may jump if you are not scrolled past a certain point :disappointed:


## Placeholder on Review

### Before
![screen shot 2015-05-19 at 2 25 10 pm](https://cloud.githubusercontent.com/assets/2483873/7711917/7ded2412-fe33-11e4-8b2b-71fab9963a27.png)

### After
![screen shot 2015-05-19 at 6 33 43 pm](https://cloud.githubusercontent.com/assets/2483873/7716254/b5724648-fe55-11e4-91f4-ee0bf6846e57.png)



## Working a problem

### Before
Abruptly continues to next problem
![screen shot 2015-05-19 at 6 53 20 pm](https://cloud.githubusercontent.com/assets/2483873/7716503/8aea22ee-fe58-11e4-8263-f8fe8f45d74e.png)
![screen shot 2015-05-19 at 6 53 30 pm](https://cloud.githubusercontent.com/assets/2483873/7716504/8aea4ad0-fe58-11e4-9928-7b2c1ff93b83.png)


### After
shows review screen for completed problem until user clicks continue
![screen shot 2015-05-19 at 6 53 20 pm](https://cloud.githubusercontent.com/assets/2483873/7716503/8aea22ee-fe58-11e4-8263-f8fe8f45d74e.png)
![screen shot 2015-05-19 at 6 53 26 pm](https://cloud.githubusercontent.com/assets/2483873/7716502/8ae9fbde-fe58-11e4-8b22-3b69cd40a2cf.png)
![screen shot 2015-05-19 at 6 53 30 pm](https://cloud.githubusercontent.com/assets/2483873/7716504/8aea4ad0-fe58-11e4-9928-7b2c1ff93b83.png)