### PR TITLE
Fix random orange color appearing on dashboard

### DIFF
--- a/resources/styles/components/student-dashboard/dashboard.less
+++ b/resources/styles/components/student-dashboard/dashboard.less
@@ -55,7 +55,7 @@
   }
 
   .nav-tabs {
-    background: inherit;
+    background: none;
     li {
       #fonts .sans(2.4rem, 2.4rem);
       width: 210px;

--- a/resources/styles/global/navbar.less
+++ b/resources/styles/global/navbar.less
@@ -9,20 +9,6 @@
   &.navbar.navbar{
     border-bottom: 1px solid @border-color;
     background-color: @tutor-white;
-    .dropdown-menu {
-      a:hover {
-        color: @tutor-neutral-darker;
-        background-color: @tutor-neutral-lighter;
-      }
-      .active a {
-        color: @tutor-neutral-darker;
-        background-color: @tutor-neutral-light;
-        &:hover {
-          background-color: @tutor-neutral-light;
-          cursor: default;
-        }
-      }
-    }
   }
 
   .container-fluid { padding: 0 @tutor-navbar-padding-horizontal; }

--- a/resources/styles/global/navbar.less
+++ b/resources/styles/global/navbar.less
@@ -9,6 +9,20 @@
   &.navbar.navbar{
     border-bottom: 1px solid @border-color;
     background-color: @tutor-white;
+    .dropdown-menu {
+      a:hover {
+        color: @tutor-neutral-darker;
+        background-color: @tutor-neutral-lighter;
+      }
+      .active a {
+        color: @tutor-neutral-darker;
+        background-color: @tutor-neutral-light;
+        &:hover {
+          background-color: @tutor-neutral-light;
+          cursor: default;
+        }
+      }
+    }
   }
 
   .container-fluid { padding: 0 @tutor-navbar-padding-horizontal; }
@@ -19,4 +33,5 @@
     width: 217px;
     .tutor-background-image('logo-brand.svg');
   }
+
 }

--- a/resources/styles/global/tutor-material.less
+++ b/resources/styles/global/tutor-material.less
@@ -54,17 +54,17 @@ legend {
     position: relative;
     a:hover {
       background-color: transparent;
-      color: @primary;
+      color: @tutor-neutral-darker;
     }
   }
-  .variations(~" li a:hover", color, @primary);
+  .variations(~" li a:hover", color, @tutor-neutral-darker);
 }
 
 // Active state
 .dropdown-menu {
-  .variations(~" > .active > a", background-color, @primary);
-  .variations(~" > .active > a:hover", background-color, @primary);
-  .variations(~" > .active > a:focus", background-color, @primary);
+  .variations(~" > .active > a", background-color, @tutor-neutral-light);
+  .variations(~" > .active > a:hover", background-color, @tutor-neutral-darker);
+  .variations(~" > .active > a:focus", background-color, @tutor-neutral-lighter);
 }
 
 // Alerts

--- a/resources/styles/global/tutor-material.less
+++ b/resources/styles/global/tutor-material.less
@@ -44,7 +44,7 @@ legend {
 @import "@{material-path}/_navbar";
 
 .dropdown-menu {
-  border: 0;
+  border: 0; 
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
   .divider {
     background-color: rgba(229, 229, 229, 0.12);
@@ -52,19 +52,20 @@ legend {
   li {
     overflow: hidden;
     position: relative;
-    a:hover {
-      background-color: transparent;
-      color: @tutor-neutral-darker;
-    }
+    // a:hover {
+    //   color: @tutor-neutral-darker;
+    //   background-color: @tutor-neutral-light;
+    // }
   }
   .variations(~" li a:hover", color, @tutor-neutral-darker);
-}
+  .variations(~" li a:hover", background-color, @tutor-neutral-bright);
 
-// Active state
-.dropdown-menu {
+  // Active state
+  .variations(~" > .active > a", color, @tutor-neutral-darker);
   .variations(~" > .active > a", background-color, @tutor-neutral-light);
-  .variations(~" > .active > a:hover", background-color, @tutor-neutral-darker);
-  .variations(~" > .active > a:focus", background-color, @tutor-neutral-lighter);
+  .variations(~" > .active > a:hover", background-color, @tutor-neutral-light);
+  .variations(~" > .active > a:hover", color, @tutor-neutral-darker);
+  .variations(~" > .active > a:hover", cursor, default);
 }
 
 // Alerts

--- a/resources/styles/global/tutor-material.less
+++ b/resources/styles/global/tutor-material.less
@@ -47,15 +47,11 @@ legend {
   border: 0; 
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
   .divider {
-    background-color: rgba(229, 229, 229, 0.12);
+    background-color: @tutor-neutral-light;
   }
   li {
     overflow: hidden;
     position: relative;
-    // a:hover {
-    //   color: @tutor-neutral-darker;
-    //   background-color: @tutor-neutral-light;
-    // }
   }
   .variations(~" li a:hover", color, @tutor-neutral-darker);
   .variations(~" li a:hover", background-color, @tutor-neutral-bright);


### PR DESCRIPTION
On screenshots, pointer is hovering on Learning Guide.

Before:
![screen shot 2015-05-20 at 2 16 17 pm](https://cloud.githubusercontent.com/assets/79566/7734333/e2b2e1c6-fefa-11e4-9d52-955a60e663b5.png)
![screen shot 2015-05-21 at 3 14 51 pm](https://cloud.githubusercontent.com/assets/79566/7758020/2505cee0-ffcc-11e4-9c22-4a49f0d664cd.png)


I think this should also correct the orange background from showing on the testing site, but's hard to be sure since we can't replicate locally. 
