### PR TITLE
Read CSRF token from meta tag, send with requests

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -7,7 +7,6 @@
 
 $ = require 'jquery'
 _ = require 'underscore'
-CSRF_Token = document.head.querySelector('meta[name=csrf-token]')?.getAttribute("content")
 {TimeActions} = require './flux/time'
 {CurrentUserActions, CurrentUserStore} = require './flux/current-user'
 {CourseActions} = require './flux/course'
@@ -27,6 +26,11 @@ CSRF_Token = document.head.querySelector('meta[name=csrf-token]')?.getAttribute(
 #   - otherwise there would be a file named `plans` and a directory named `plans`
 # - do not error when a PUT occurs
 IS_LOCAL = window.location.port is '8000' or window.__karma__
+
+# Read the CSRF token from document's meta tag.  If not found, log a warning but proceed
+# on the assumption that the server knows what it's doing.
+CSRF_Token = document.head.querySelector('meta[name=csrf-token]')?.getAttribute("content")
+console?.warn?("CSRF token was not found, proceeding without CSRF protection") unless CSRF_Token
 
 # Make sure API calls occur **after** all local Action listeners complete
 delay = (ms, fn) -> setTimeout(fn, ms)

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -7,6 +7,7 @@
 
 $ = require 'jquery'
 _ = require 'underscore'
+CSRF_Token = $('meta[name=csrf-token]').attr('content')
 
 {TimeActions} = require './flux/time'
 {CurrentUserActions, CurrentUserStore} = require './flux/current-user'
@@ -44,6 +45,7 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker) ->
         method: httpMethod or httpMethodOverride
         dataType: 'json'
         headers:
+          'X-CSRF-Token': CSRF_Token,
           token: CurrentUserStore.getToken()
       if payload?
         opts.data = JSON.stringify(payload)

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -7,8 +7,7 @@
 
 $ = require 'jquery'
 _ = require 'underscore'
-CSRF_Token = $('meta[name=csrf-token]').attr('content')
-
+CSRF_Token = document.head.querySelector('meta[name=csrf-token]')?.getAttribute("content")
 {TimeActions} = require './flux/time'
 {CurrentUserActions, CurrentUserStore} = require './flux/current-user'
 {CourseActions} = require './flux/course'


### PR DESCRIPTION
The simplest thing that could possibly work.  I'm also a fan of making a `Tutor.boot()` method that could initialize this.

![screen shot 2015-05-20 at 3 24 40 pm](https://cloud.githubusercontent.com/assets/79566/7735743/ae3993c2-ff04-11e4-8d2d-108dcefef8da.png)
