### PR TITLE
Add fonts directory to production build in correct directory

### DIFF
--- a/Gulpfile.coffee
+++ b/Gulpfile.coffee
@@ -128,7 +128,6 @@ gulp.task '_copyFonts', ['_cleanFonts'], ->
       'node_modules/**/*.{eot,svg,png,jpg,ttf,woff,woff2}',
       'resources/fonts/**/*'
     ])
-    .pipe(flatten())
     .pipe(gulp.dest(destDirFonts))
 
 gulp.task '_cleanFonts', (done) ->

--- a/Gulpfile.coffee
+++ b/Gulpfile.coffee
@@ -128,6 +128,7 @@ gulp.task '_copyFonts', ['_cleanFonts'], ->
       'node_modules/**/*.{eot,svg,png,jpg,ttf,woff,woff2}',
       'resources/fonts/**/*'
     ])
+    .pipe(flatten())
     .pipe(gulp.dest(destDirFonts))
 
 gulp.task '_cleanFonts', (done) ->
@@ -179,7 +180,7 @@ gulp.task '_archive', ['_cleanArchive', '_build', '_min', '_rev'], ->
     './dist/tutor.min-*.js',
     './dist/tutor.min-*.css',
     './dist/fonts/*',
-    './dist/**/*.{svg,png,jpg}'])
+    './dist/**/*.{svg,png,jpg}'], base: './dist')
     .pipe(tar('archive.tar'))
     .pipe(gzip())
     .pipe(gulp.dest('./dist/'))


### PR DESCRIPTION
Fonts are being stored in the main dist directory on production but the css is loading them from dist/fonts

WIP until I can verify on vagrant