### PR TITLE
fix calendar add task popover

### DIFF
--- a/src/components/course-calendar/month.cjsx
+++ b/src/components/course-calendar/month.cjsx
@@ -74,7 +74,7 @@ CourseMonth = React.createClass
       @hideAddOnDay(componentName, dayMoment, mouseEvent)
 
   undoActives: (componentName, dayMoment, mouseEvent) ->
-    unless dayMoment? and dayMoment.isSame(@refs.addOnDay.state.date, 'day')
+    unless dayMoment? and dayMoment.isSame(@refs.addOnDay.state.addDate, 'day')
       @hideAddOnDay(componentName, dayMoment, mouseEvent)
 
   hideAddOnDay: (componentName, dayMoment, mouseEvent) ->


### PR DESCRIPTION
It wasn't sticking because it was not checking the dropdown's addDate state

### Before
Closing as soon as we mouse enter into the box for the selected date.

### After
Stays open because it's checking the actual addDate that the dropdown has set with the date of the box that got mouse enteredededed

![screen shot 2015-05-20 at 7 33 40 pm](https://cloud.githubusercontent.com/assets/2483873/7739477/2845a9ea-ff27-11e4-87d7-c7735868711d.png)
