### PR TITLE
Error checking on timestore set when it originates from a string

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -31,7 +31,7 @@ IS_LOCAL = window.location.port is '8000' or window.__karma__
 delay = (ms, fn) -> setTimeout(fn, ms)
 
 setNow = (jqXhr) ->
-  TimeActions.setNow(new Date(jqXhr.getResponseHeader('Date')))
+  TimeActions.setFromString(jqXhr.getResponseHeader('Date'))
 
 apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker) ->
   listenAction.addListener 'trigger', (args...) ->

--- a/src/flux/time.coffee
+++ b/src/flux/time.coffee
@@ -11,6 +11,14 @@ TimeConfig =
     # called by API
     @_shiftMs = now.getTime() - localNow.getTime()
 
+  setFromString: (txtDate, localNow = new Date()) ->
+    return unless txtDate
+    date = new Date(txtDate)
+    if isNaN(date.getTime()) # "Invalid Date"
+      console?.warn?("Attempted to set invalid date #{txtDate} on TimeStore")
+    else
+      @setNow(date, localNow)
+
   exports:
     getNow: (localNow = new Date()) ->
       shift = @_shiftMs or 0

--- a/test/time.spec.coffee
+++ b/test/time.spec.coffee
@@ -12,3 +12,14 @@ describe 'Server Time', ->
     time = TimeStore.getNow(LOCAL_TIME)
     # Use strings so millisecs do not matter
     expect("#{time}").to.equal("#{SERVER_TIME}")
+
+  it 'prevents invalid dates from being set', ->
+    today = TimeStore.getNow().toDateString()
+    TimeActions.setFromString("an invalid date")
+    expect(TimeStore.getNow().toDateString()).to.equal(today)
+
+  it 'can be set from string', ->
+    now = new Date()
+    TimeActions.setFromString('Thu Nov 10 2011 18:00:00 GMT-0600 (CST)', now)
+    time = TimeStore.getNow(now)
+    expect(time.toDateString()).to.equal('Thu Nov 10 2011')

--- a/test/time.spec.coffee
+++ b/test/time.spec.coffee
@@ -20,6 +20,7 @@ describe 'Server Time', ->
 
   it 'can be set from string', ->
     now = new Date()
-    TimeActions.setFromString('Thu Nov 10 2011 18:00:00 GMT-0600 (CST)', now)
+    iso_string = 'Fri Nov 11 2011 00:00:00 GMT+0000 (UTC)'
+    TimeActions.setFromString(iso_string, now)
     time = TimeStore.getNow(now)
-    expect(time.toDateString()).to.equal('Thu Nov 10 2011')
+    expect( new Date(iso_string).toDateString() ).to.equal( time.toDateString() )


### PR DESCRIPTION
Fix for cases where the server returns 500 or other error which also means it sends a null server time.