### PR TITLE
Don't delete cached data when no reply is received

### DIFF
--- a/src/flux/helpers.coffee
+++ b/src/flux/helpers.coffee
@@ -35,9 +35,10 @@ CrudConfig = ->
 
     FAILED: (status, msg, id) ->
       @_asyncStatus[id] = FAILED
-      delete @_local[id]
       @_errors[id] = msg
-      @emitChange()
+      unless status is 0 # indicates network failure
+        delete @_local[id]
+        @emitChange()
 
     load: (id) ->
       # Add a shortcut for unit testing


### PR DESCRIPTION
When the network times out or is otherwise interrupted the status is 0, indicating "no status".

http://stackoverflow.com/questions/3825581/does-an-http-status-code-of-0-have-any-meaning/26451773#26451773

This is the root cause of the task-steps becoming un-navigable  after a network timeout.  To test, you can load up the task steps, shut down the server, and then attempt to click on a breadcrumb.