### PR TITLE
Fix colors and sign out option on navbar menu

### DIFF
--- a/resources/styles/global/navbar.less
+++ b/resources/styles/global/navbar.less
@@ -20,4 +20,12 @@
     .tutor-background-image('logo-brand.svg');
   }
 
+  .dropdown-menu .signout {
+    button {
+      #fonts .sans(1.4rem, 1.4rem);
+      margin: 0;
+      padding-left: 0;
+      &:hover { text-decoration: initial; }
+    }
+  }
 }

--- a/resources/styles/global/tutor-material.less
+++ b/resources/styles/global/tutor-material.less
@@ -43,6 +43,8 @@ legend {
 // Navbar
 @import "@{material-path}/_navbar";
 
+.navbar.navbar .dropdown-menu,
+.navbar-default.navbar .dropdown-menu,
 .dropdown-menu {
   border: 0; 
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);

--- a/src/components/navbar/index.cjsx
+++ b/src/components/navbar/index.cjsx
@@ -102,6 +102,7 @@ module.exports = React.createClass
             ref='navDropDown'>
             {menuItems}
             <BS.MenuItem
+              className="signout"
               eventKey={4}
               key='dropdown-item-logout'>
                 <SignOut className='btn btn-link btn-xs'>Sign Out!</SignOut>


### PR DESCRIPTION
Looks like the material design added some default styling that overrode our defaults

Before:
![screen shot 2015-05-26 at 12 47 31 pm](https://cloud.githubusercontent.com/assets/79566/7819141/6565733c-03a5-11e5-8587-de68b06bbbdf.png)

After:
![screen shot 2015-05-26 at 12 47 09 pm](https://cloud.githubusercontent.com/assets/79566/7819144/690794ca-03a5-11e5-8a61-2382ce8984e9.png)

