### PR TITLE
Style/teacher analytics panel tweaks

### DIFF
--- a/resources/styles/components/task-plan/reading-stats.less
+++ b/resources/styles/components/task-plan/reading-stats.less
@@ -18,11 +18,14 @@
 
     &:not(:first-child){
       padding-top: 10px;
+
+      &:not(:last-child){
+        padding-bottom: 20px;
+      }
     }
 
     &:not(:last-child) {
       border-bottom: @tutor-teacher-plan-stats-border-style;
-      padding-bottom: 20px;
     }
 
     .reading-progress:last-child {

--- a/resources/styles/components/task-plan/reading-stats.less
+++ b/resources/styles/components/task-plan/reading-stats.less
@@ -17,17 +17,16 @@
     }
 
     &:not(:first-child){
-      padding-top: 1rem;
+      padding-top: 10px;
     }
 
     &:not(:last-child) {
       border-bottom: @tutor-teacher-plan-stats-border-style;
+      padding-bottom: 20px;
     }
 
-    &:last-child {
-      .reading-progress-container {
-        margin-bottom: 0;
-      }
+    .reading-progress:last-child {
+      margin-bottom: 0;
     }
 
   }
@@ -53,9 +52,10 @@
 
 .reading-progress {
 
+  margin-bottom: 20px;
+
   &-container {
     position: relative;
-    margin-bottom: 2rem;
   }
 
   &-group {

--- a/resources/styles/components/task-plan/reading-stats.less
+++ b/resources/styles/components/task-plan/reading-stats.less
@@ -68,14 +68,39 @@
 
   &-bar{
 
+    position: relative;
+
     &.no-progress {
       span {
         display: none;
       }
     }
 
+    span {
+      cursor: default;
+    }
+
     &:not(.no-progress) {
       min-width:15px;
+    }
+
+    &::after {
+      content: attr(type);
+      position: absolute;
+      bottom: -24px;
+      left: 50%;
+      width: 100px;
+      margin-left: -50px;
+      text-align: center;
+      color: @tutor-neutral;
+      .opacity(0);
+      .transition(opacity 1s);
+    }
+
+    &:hover {
+      &::after {
+        .opacity(1);
+      }
     }
   }
 

--- a/src/components/course-calendar/plan-details.cjsx
+++ b/src/components/course-calendar/plan-details.cjsx
@@ -53,11 +53,6 @@ CoursePlanDetails = React.createClass
       <div className='modal-body'>
         <StatsModalShell id={id}/>
       </div>
-      <div className='modal-footer'>
-        <div className='modal-footer-menu'>
-          <BS.Button onClick={@onClickEdit}>Edit {type}</BS.Button>
-        </div>
-      </div>
     </BS.Modal>
 
 

--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -66,7 +66,7 @@ Stats = React.createClass
         ({data.student_count} students)
       </span>
 
-    <div key="#{type}-bar-#{index}">
+    <div key="#{type}-bar-#{index}" className='reading-progress'>
       <div className='reading-progress-heading'>
         <strong>
           <span className='text-success'>

--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -52,7 +52,7 @@ Stats = React.createClass
                 label={label}
                 now={percent}
                 key="page-progress-#{type}-#{data.id}-#{correctOrIncorrect}"
-                title="#{percent}% #{correctOrIncorrect}"
+                type="#{correctOrIncorrect}"
                 alt="#{percent}% #{correctOrIncorrect}"/>
 
   renderPercentBars: (data, type) ->

--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -68,7 +68,11 @@ Stats = React.createClass
 
     <div key="#{type}-bar-#{index}">
       <div className='reading-progress-heading'>
-        {@sectionFormat(data.chapter_section, @state.sectionSeparator)} {data.title} {studentCount}
+        <strong>
+          <span className='text-success'>
+            {@sectionFormat(data.chapter_section, @state.sectionSeparator)}
+          </span> {data.title}
+        </strong> {studentCount}
       </div>
       <div className='reading-progress-container'>
         <BS.ProgressBar className='reading-progress-group'>

--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -140,7 +140,10 @@ Stats = React.createClass
     practice = _.map(plan.stats.course.spaced_pages, @renderPracticeBars)
 
     unless _.isEmpty(chapters)
-      chapters = <section>{chapters}</section>
+      chapters = <section>
+        <label>Current Topics Performance</label>
+        {chapters}
+      </section>
 
     unless _.isEmpty(practice)
       practice = <section>

--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -47,7 +47,9 @@ Stats = React.createClass
                 bsStyle={bsStyles[correctOrIncorrect]}
                 label='%(percent)s%'
                 now={percent}
-                key="page-progress-#{type}-#{data.id}-#{correctOrIncorrect}" />
+                key="page-progress-#{type}-#{data.id}-#{correctOrIncorrect}"
+                title="#{percent}% #{correctOrIncorrect}"
+                alt="#{percent}% #{correctOrIncorrect}"/>
 
   renderPercentBars: (data, type) ->
     percents =

--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -42,10 +42,14 @@ Stats = React.createClass
 
     classes = 'reading-progress-bar'
     classes += ' no-progress' unless percent
+
+    label = "#{percent}%"
+    label = "#{label} #{correctOrIncorrect}" if percent is 100
+
     correct = <BS.ProgressBar
                 className={classes}
                 bsStyle={bsStyles[correctOrIncorrect]}
-                label='%(percent)s%'
+                label={label}
                 now={percent}
                 key="page-progress-#{type}-#{data.id}-#{correctOrIncorrect}"
                 title="#{percent}% #{correctOrIncorrect}"


### PR DESCRIPTION
![screen shot 2015-05-26 at 1 11 42 pm](https://cloud.githubusercontent.com/assets/2483873/7819688/fd32326a-03a8-11e5-9f6b-62515c4cd055.png)


Alt text on hover does not show on screenshot, but it shows.  maybe use a tooltip instead

- [x] "Current Topics Performance" title
- [x] Section numbers in green
- [x] Remove edit buttons
- [x] 100% labels
- [x] alt text on percentage bars


Not sure if this is preferred: 
![screen shot 2015-05-26 at 1 33 33 pm](https://cloud.githubusercontent.com/assets/2483873/7820140/f4134518-03ab-11e5-92cf-4ec9ed6a6902.png)

can easily reset back to using browser's default title text label
