### PR TITLE
delay loading MathJax until configured

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,8 +1,6 @@
 require 'jquery'
 require 'bootstrap' # Attach bootstrap to jQuery
 
-MathJax = window.MathJax
-
 window._STORES =
   APP_CONFIG: require './src/flux/app-config'
   COURSE: require './src/flux/course'
@@ -27,12 +25,16 @@ MATHJAX_CONFIG =
     "#MathJax_Message":    visibility: "hidden", left: "", right: 0
     "#MathJax_MSIE_Frame": visibility: "hidden", left: "", right: 0
 
-if MathJax?.Hub
-  MathJax.Hub.Config(MATHJAX_CONFIG)
-  MathJax.Hub.Configured()
+if window.MathJax?.Hub
+  window.MathJax.Hub.Config(MATHJAX_CONFIG)
+  window.MathJax.Hub.Configured()
 else
+  # If the MathJax.js file has not loaded yet:
+  # Call MathJax.Configured once MathJax loads and
+  # loads this config JSON since the CDN URL
+  # says to `delayStartupUntil=configured`
   MATHJAX_CONFIG.AuthorInit = ->
-    MathJax.Hub.Configured()
+    window.MathJax.Hub.Configured()
 
   window.MathJax = MATHJAX_CONFIG
 

--- a/index.coffee
+++ b/index.coffee
@@ -1,6 +1,8 @@
 require 'jquery'
 require 'bootstrap' # Attach bootstrap to jQuery
 
+MathJax = window.MathJax
+
 window._STORES =
   APP_CONFIG: require './src/flux/app-config'
   COURSE: require './src/flux/course'
@@ -16,7 +18,7 @@ window._STORES =
   TIME: require './src/flux/time'
   TOC: require './src/flux/toc'
 
-window.MathJax?.Hub.Config(
+MATHJAX_CONFIG =
   showProcessingMessages: false
   tex2jax:
     displayMath: [['\u200c\u200c\u200c', '\u200c\u200c\u200c']] # zero-width non-joiner
@@ -24,7 +26,16 @@ window.MathJax?.Hub.Config(
   styles:
     "#MathJax_Message":    visibility: "hidden", left: "", right: 0
     "#MathJax_MSIE_Frame": visibility: "hidden", left: "", right: 0
-)
+
+if MathJax?.Hub
+  MathJax.Hub.Config(MATHJAX_CONFIG)
+  MathJax.Hub.Configured()
+else
+  MATHJAX_CONFIG.AuthorInit = ->
+    MathJax.Hub.Configured()
+
+  window.MathJax = MATHJAX_CONFIG
+
 api = require './src/api'
 api.start()
 router = require './src/router'

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF8">
     <link rel="stylesheet" href="/dist/tutor.css" />
-    <script src="//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full" async></script>
+    <script src="//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
   </head>
   <body>
     <script src="/dist/tutor.js"></script>

--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -48,7 +48,8 @@ module.exports = React.createClass
     hasMath = root.querySelector('math')
 
     # Return immediatly if no [data-math] or <math> elements are present
-    return unless window.MathJax and (_.any(nodes) or hasMath)
+    # TODO: If the MathJax Queue is not available then MathJax has not loaded yet. Add a load callback to enqueue.
+    return unless window.MathJax.Hub?.Queue? and (_.any(nodes) or hasMath)
 
     for node in nodes
       formula = node.getAttribute('data-math')
@@ -57,18 +58,17 @@ module.exports = React.createClass
         node.textContent = "\u200c\u200c\u200c#{formula}\u200c\u200c\u200c"
       else
         node.textContent = "\u200b\u200b\u200b#{formula}\u200b\u200b\u200b"
-      # TODO: If the MathJax Queue is not available then MathJax has not loaded yet. Add a load callback to enqueue.
-      window.MathJax.Hub?.Queue?(['Typeset', MathJax.Hub, node])
+      window.MathJax.Hub.Queue(['Typeset', MathJax.Hub, node])
       # mark node as processed
       node.classList.add('math-rendered')
 
     # render MathML with MathJax
-    window.MathJax.Hub?.Queue?(['Typeset', MathJax.Hub, root]) if hasMath
+    window.MathJax.Hub.Queue(['Typeset', MathJax.Hub, root]) if hasMath
 
     # Once MathJax finishes processing, cleanup the MathJax message nodes to prevent
     # React "Invariant Violation" exceptions.
     # MathJax calls queued events in order, so this will be called after processing completes
-    window.MathJax.Hub?.Queue?([ ->
+    window.MathJax.Hub.Queue([ ->
       for nodeId in ['MathJax_Message', 'MathJax_Hidden', 'MathJax_Font_Test']
         el = document.getElementById(nodeId)
         break unless el # the elements won't exist if MathJax didn't do anything

--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -57,17 +57,18 @@ module.exports = React.createClass
         node.textContent = "\u200c\u200c\u200c#{formula}\u200c\u200c\u200c"
       else
         node.textContent = "\u200b\u200b\u200b#{formula}\u200b\u200b\u200b"
-      window.MathJax.Hub.Queue(['Typeset', MathJax.Hub, node])
+      # TODO: If the MathJax Queue is not available then MathJax has not loaded yet. Add a load callback to enqueue.
+      window.MathJax.Hub?.Queue?(['Typeset', MathJax.Hub, node])
       # mark node as processed
       node.classList.add('math-rendered')
 
     # render MathML with MathJax
-    window.MathJax.Hub.Queue(['Typeset', MathJax.Hub, root]) if hasMath
+    window.MathJax.Hub?.Queue?(['Typeset', MathJax.Hub, root]) if hasMath
 
     # Once MathJax finishes processing, cleanup the MathJax message nodes to prevent
     # React "Invariant Violation" exceptions.
     # MathJax calls queued events in order, so this will be called after processing completes
-    window.MathJax.Hub.Queue([ ->
+    window.MathJax.Hub?.Queue?([ ->
       for nodeId in ['MathJax_Message', 'MathJax_Hidden', 'MathJax_Font_Test']
         el = document.getElementById(nodeId)
         break unless el # the elements won't exist if MathJax didn't do anything


### PR DESCRIPTION
No UI Changes (except that MathJax should load and work).

Paired with https://github.com/openstax/tutor-server/pull/318

Source: http://docs.mathjax.org/en/latest/configuration.html?highlight=authorinit#configuring-mathjax-after-it-is-loaded