### PR TITLE
Center video and collapse padding on small screens

### DIFF
--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -32,6 +32,7 @@ cnx-pi { display: none; }
   width: 100%;
   min-height: 100px;
   display: inline-flex;
+  display: -ms-inline-flexbox; // IE10 support
   margin-top: -@tutor-card-body-padding-vertical;
   color: #ffffff;
   padding: 10px 40px;

--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -82,8 +82,9 @@ div[data-type="document-title"] ~ p {padding: 0 @tutor-card-body-padding-horizon
 
 > section:not(.section-opener),
 > section > section,
-.worked-example,
-.virtual-physics { padding: 0 140px; }
+.worked-examples {
+  .book-content-step-size(0);
+}
 
 
 .splash {

--- a/resources/styles/book-content/mixins.less
+++ b/resources/styles/book-content/mixins.less
@@ -33,3 +33,10 @@
   // to fit beside it, otherwise it will overlay on top of the next element
   min-height: 8rem;
 }
+
+.book-content-step-size(@vertical: @tutor-card-body-padding-vertical) {
+  padding: @vertical @tutor-card-body-padding-horizontal;
+  @media (max-width: @tutor-card-padding-collapse-breakpoint) {
+    padding: @vertical @tutor-card-body-narrow-padding-horizontal;
+  }
+}

--- a/resources/styles/book-content/watch-physics.less
+++ b/resources/styles/book-content/watch-physics.less
@@ -4,15 +4,13 @@
     display: none;
   }
   
-  padding: 0 @tutor-card-body-padding-horizontal;
-  .title{
+  .book-content-step-size(0);
+
+  .title {
     .tutor-reading-main-title();
     border-top: 0;
   }
 
-  @iframe-width:  720px;
-  @iframe-height: 405px;
-  @iframe-shadow-size: 3px;
 
   [data-type=media] {
     .tutor-framed-video();

--- a/resources/styles/book-content/worked-examples.less
+++ b/resources/styles/book-content/worked-examples.less
@@ -1,15 +1,13 @@
-// This file is part of the book-content mixin and should not be included directly
-.tutor-reading-ui-banner {
-  
-  > .worked-example.note:first-child {
+.worked-example.note:first-child {
 
-    &:before {
-      .tutor-reading-step-banner-icon("icon-calculator.svg");
-    }
-    
-    > .exercise > [data-type=title] {
-      .tutor-reading-main-title();
-    }
-    
+  .book-content-step-size();
+
+  &:before {
+    .tutor-reading-step-banner-icon("icon-calculator.svg");
   }
+  
+  > .exercise > [data-type=title] {
+    .tutor-reading-main-title();
+  }
+  
 }

--- a/resources/styles/components/task-step/index.less
+++ b/resources/styles/components/task-step/index.less
@@ -1,5 +1,12 @@
 .size-exercise-card() {
   font-size: 2.1rem;
   font-weight: 400;
-  padding: 10px 140px;
+  padding: @tutor-card-body-padding;
+}
+
+.size-task-step-card() {
+  padding: @tutor-card-body-padding;
+  @media (max-width: @tutor-card-padding-collapse-breakpoint) {
+    padding: @tutor-card-body-padding-vertical @tutor-card-body-narrow-padding-horizontal;
+  }
 }

--- a/resources/styles/components/task-step/reading/interactive.less
+++ b/resources/styles/components/task-step/reading/interactive.less
@@ -1,8 +1,12 @@
 .task-reading {
-  .interactive {
+  .interactive-step {
+    
+    .size-task-step-card();
+    
     iframe {
-      width: 100%;
+      width: 960px;
       height: 560px;
+      margin-left: -(@tutor-card-body-padding-horizontal - 20px);
     }
   }
 }

--- a/resources/styles/components/task-step/video.less
+++ b/resources/styles/components/task-step/video.less
@@ -1,6 +1,6 @@
 .task-step .video-step {
   
-  padding: @tutor-card-body-padding;
+  .size-task-step-card();
   
   .video-content > .note:first-child .title{
     display: none;
@@ -8,6 +8,7 @@
 
   .ost-video {
     iframe {
+      display: block;
       width:  @tutor-video-iframe-width;
       height: @tutor-video-iframe-height;
     }

--- a/resources/styles/variables.less
+++ b/resources/styles/variables.less
@@ -5,6 +5,9 @@
 @tutor-card-body-padding-vertical: 20px;
 @tutor-card-body-padding-horizontal: 140px;
 @tutor-card-body-padding: @tutor-card-body-padding-vertical @tutor-card-body-padding-horizontal;
+@tutor-card-padding-collapse-breakpoint: 1020px;
+@tutor-card-body-narrow-padding-horizontal: 20px;
+
 @student-dashboard-row-height: 60px;
 @tutor-teacher-plan-stats-border-style: 1px dotted @tutor-neutral-light;
 


### PR DESCRIPTION
Fixes an assortment of problems that crop up when the screen is narrower
than around 1000px.  Sims and video were particularly bad

Before:
![screen shot 2015-05-27 at 5 10 44 pm](https://cloud.githubusercontent.com/assets/79566/7848685/9cc6d214-0493-11e5-9204-66aec8b1a7be.png)

After:
![screen shot 2015-05-27 at 5 10 54 pm](https://cloud.githubusercontent.com/assets/79566/7848680/961eaff4-0493-11e5-93ac-72910da4bcef.png)

As discovered by @kevinburleigh75 with his tiny screen.