### PR TITLE
fix some invariant errors caused by MathJax

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -42,4 +42,10 @@ api = require './src/api'
 api.start()
 router = require './src/router'
 
-router.start(document.body)
+# This is added because MathJax puts in extra divs on initial load.
+# Moves the React Root to be an element inside a div
+# instead of the only element in the body.
+mainDiv = document.createElement('div')
+mainDiv.id = 'react-main'
+document.body.appendChild(mainDiv)
+router.start(mainDiv)

--- a/index.coffee
+++ b/index.coffee
@@ -1,6 +1,11 @@
 require 'jquery'
 require 'bootstrap' # Attach bootstrap to jQuery
 
+api = require './src/api'
+router = require './src/router'
+{startMathJax} = require './src/helpers/mathjax'
+
+
 window._STORES =
   APP_CONFIG: require './src/flux/app-config'
   COURSE: require './src/flux/course'
@@ -16,9 +21,8 @@ window._STORES =
   TIME: require './src/flux/time'
   TOC: require './src/flux/toc'
 
-api = require './src/api'
 api.start()
-router = require './src/router'
+startMathJax()
 
 # This is added because MathJax puts in extra divs on initial load.
 # Moves the React Root to be an element inside a div

--- a/index.coffee
+++ b/index.coffee
@@ -16,28 +16,6 @@ window._STORES =
   TIME: require './src/flux/time'
   TOC: require './src/flux/toc'
 
-MATHJAX_CONFIG =
-  showProcessingMessages: false
-  tex2jax:
-    displayMath: [['\u200c\u200c\u200c', '\u200c\u200c\u200c']] # zero-width non-joiner
-    inlineMath:  [['\u200b\u200b\u200b', '\u200b\u200b\u200b']] # zero-width space
-  styles:
-    "#MathJax_Message":    visibility: "hidden", left: "", right: 0
-    "#MathJax_MSIE_Frame": visibility: "hidden", left: "", right: 0
-
-if window.MathJax?.Hub
-  window.MathJax.Hub.Config(MATHJAX_CONFIG)
-  window.MathJax.Hub.Configured()
-else
-  # If the MathJax.js file has not loaded yet:
-  # Call MathJax.Configured once MathJax loads and
-  # loads this config JSON since the CDN URL
-  # says to `delayStartupUntil=configured`
-  MATHJAX_CONFIG.AuthorInit = ->
-    window.MathJax.Hub.Configured()
-
-  window.MathJax = MATHJAX_CONFIG
-
 api = require './src/api'
 api.start()
 router = require './src/router'
@@ -46,6 +24,6 @@ router = require './src/router'
 # Moves the React Root to be an element inside a div
 # instead of the only element in the body.
 mainDiv = document.createElement('div')
-mainDiv.id = 'react-main'
+mainDiv.id = 'react-root-container'
 document.body.appendChild(mainDiv)
 router.start(mainDiv)

--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -1,6 +1,8 @@
 _ = require 'underscore'
 React = require 'react'
 
+{typesetMath} = require '../helpers/mathjax'
+
 module.exports = React.createClass
   displayName: 'ArbitraryHtmlAndMath'
   propTypes:
@@ -44,36 +46,4 @@ module.exports = React.createClass
     _.each links, (link) ->
       link.setAttribute('target', '_blank') unless link.getAttribute('href')?[0] is '#'
 
-    nodes = root.querySelectorAll('[data-math]:not(.math-rendered)') or []
-    hasMath = root.querySelector('math')
-
-    # Return immediatly if no [data-math] or <math> elements are present
-    # TODO: If the MathJax Queue is not available then MathJax has not loaded yet. Add a load callback to enqueue.
-    return unless window.MathJax.Hub?.Queue? and (_.any(nodes) or hasMath)
-
-    for node in nodes
-      formula = node.getAttribute('data-math')
-      # divs with data-math should be rendered as a block
-      if node.tagName.toLowerCase() is 'div'
-        node.textContent = "\u200c\u200c\u200c#{formula}\u200c\u200c\u200c"
-      else
-        node.textContent = "\u200b\u200b\u200b#{formula}\u200b\u200b\u200b"
-      window.MathJax.Hub.Queue(['Typeset', MathJax.Hub, node])
-      # mark node as processed
-      node.classList.add('math-rendered')
-
-    # render MathML with MathJax
-    window.MathJax.Hub.Queue(['Typeset', MathJax.Hub, root]) if hasMath
-
-    # Once MathJax finishes processing, cleanup the MathJax message nodes to prevent
-    # React "Invariant Violation" exceptions.
-    # MathJax calls queued events in order, so this will be called after processing completes
-    window.MathJax.Hub.Queue([ ->
-      for nodeId in ['MathJax_Message', 'MathJax_Hidden', 'MathJax_Font_Test']
-        el = document.getElementById(nodeId)
-        break unless el # the elements won't exist if MathJax didn't do anything
-        # Some of the elements are wrapped by divs without selectors under body
-        # Select the parentElement unless it's already directly under body.
-        el = el.parentElement unless el.parentElement is document.body
-        el.parentElement.removeChild(el)
-    ])
+    typesetMath(root)

--- a/src/helpers/mathjax.coffee
+++ b/src/helpers/mathjax.coffee
@@ -1,0 +1,74 @@
+_ = require 'underscore'
+
+MATH_MARKER_BLOCK  = '\u200c\u200c\u200c' # zero-width non-joiner
+MATH_MARKER_INLINE = '\u200b\u200b\u200b' # zero-width space
+
+cleanMathArtifacts = ->
+  # Once MathJax finishes processing, cleanup the MathJax message nodes to prevent
+  # React "Invariant Violation" exceptions.
+  # MathJax calls queued events in order, so this will be called after processing completes
+  window.MathJax.Hub.Queue([ ->
+    # copy-pasta in `/index.coffee`
+    for nodeId in ['MathJax_Message', 'MathJax_Hidden', 'MathJax_Font_Test']
+      el = document.getElementById(nodeId)
+      break unless el # the elements won't exist if MathJax didn't do anything
+      # Some of the elements are wrapped by divs without selectors under body
+      # Select the parentElement unless it's already directly under body.
+      el = el.parentElement unless el.parentElement is document.body
+      el.parentElement.removeChild(el)
+  ])
+
+
+typesetMath = (root) ->
+  nodes = root.querySelectorAll('[data-math]:not(.math-rendered)') or []
+  hasMath = root.querySelector('math')
+
+  # Return immediatly if no [data-math] or <math> elements are present
+  # TODO: If the MathJax Queue is not available then MathJax has not loaded yet. Add a load callback to enqueue.
+  return unless window.MathJax.Hub?.Queue? and (_.any(nodes) or hasMath)
+
+  for node in nodes
+    formula = node.getAttribute('data-math')
+    # divs with data-math should be rendered as a block
+    if node.tagName.toLowerCase() is 'div'
+      node.textContent = "#{MATH_MARKER_BLOCK}#{formula}#{MATH_MARKER_BLOCK}"
+    else
+      node.textContent = "#{MATH_MARKER_INLINE}#{formula}#{MATH_MARKER_INLINE}"
+    window.MathJax.Hub.Queue(['Typeset', MathJax.Hub, node])
+    # mark node as processed
+    node.classList.add('math-rendered')
+
+  # render MathML with MathJax
+  window.MathJax.Hub.Queue(['Typeset', MathJax.Hub, root]) if hasMath
+
+  cleanMathArtifacts()
+
+
+module.exports = {typesetMath}
+
+
+# The following occurs once and configures MathJax
+MATHJAX_CONFIG =
+  showProcessingMessages: false
+  tex2jax:
+    displayMath: [[MATH_MARKER_BLOCK, MATH_MARKER_BLOCK]]
+    inlineMath:  [[MATH_MARKER_INLINE, MATH_MARKER_INLINE]]
+  styles:
+    '#MathJax_Message':    visibility: 'hidden', left: '', right: 0
+    '#MathJax_MSIE_Frame': visibility: 'hidden', left: '', right: 0
+
+configuredCallback = ->
+  window.MathJax.Hub.Configured()
+  cleanMathArtifacts()
+
+if window.MathJax?.Hub
+  window.MathJax.Hub.Config(MATHJAX_CONFIG)
+  configuredCallback()
+else
+  # If the MathJax.js file has not loaded yet:
+  # Call MathJax.Configured once MathJax loads and
+  # loads this config JSON since the CDN URL
+  # says to `delayStartupUntil=configured`
+  MATHJAX_CONFIG.AuthorInit = configuredCallback
+
+  window.MathJax = MATHJAX_CONFIG

--- a/src/helpers/mathjax.coffee
+++ b/src/helpers/mathjax.coffee
@@ -44,31 +44,34 @@ typesetMath = (root) ->
   cleanMathArtifacts()
 
 
-module.exports = {typesetMath}
+# The following should be called once and configures MathJax.
+# Assumes the script to load MathJax is of the form:
+# `...MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured`
+startMathJax = ->
+  MATHJAX_CONFIG =
+    showProcessingMessages: false
+    tex2jax:
+      displayMath: [[MATH_MARKER_BLOCK, MATH_MARKER_BLOCK]]
+      inlineMath:  [[MATH_MARKER_INLINE, MATH_MARKER_INLINE]]
+    styles:
+      '#MathJax_Message':    visibility: 'hidden', left: '', right: 0
+      '#MathJax_MSIE_Frame': visibility: 'hidden', left: '', right: 0
+
+  configuredCallback = ->
+    window.MathJax.Hub.Configured()
+    cleanMathArtifacts()
+
+  if window.MathJax?.Hub
+    window.MathJax.Hub.Config(MATHJAX_CONFIG)
+    configuredCallback()
+  else
+    # If the MathJax.js file has not loaded yet:
+    # Call MathJax.Configured once MathJax loads and
+    # loads this config JSON since the CDN URL
+    # says to `delayStartupUntil=configured`
+    MATHJAX_CONFIG.AuthorInit = configuredCallback
+
+    window.MathJax = MATHJAX_CONFIG
 
 
-# The following occurs once and configures MathJax
-MATHJAX_CONFIG =
-  showProcessingMessages: false
-  tex2jax:
-    displayMath: [[MATH_MARKER_BLOCK, MATH_MARKER_BLOCK]]
-    inlineMath:  [[MATH_MARKER_INLINE, MATH_MARKER_INLINE]]
-  styles:
-    '#MathJax_Message':    visibility: 'hidden', left: '', right: 0
-    '#MathJax_MSIE_Frame': visibility: 'hidden', left: '', right: 0
-
-configuredCallback = ->
-  window.MathJax.Hub.Configured()
-  cleanMathArtifacts()
-
-if window.MathJax?.Hub
-  window.MathJax.Hub.Config(MATHJAX_CONFIG)
-  configuredCallback()
-else
-  # If the MathJax.js file has not loaded yet:
-  # Call MathJax.Configured once MathJax loads and
-  # loads this config JSON since the CDN URL
-  # says to `delayStartupUntil=configured`
-  MATHJAX_CONFIG.AuthorInit = configuredCallback
-
-  window.MathJax = MATHJAX_CONFIG
+module.exports = {typesetMath, startMathJax}


### PR DESCRIPTION
Seems to fix:

- dashboard -> learning guide
- initial load of the calendar

but @nathanstitt's code for cleaning up MathJax elements might be cleaner and good to include anyway