### PR TITLE
Style the title for worked-example solutions blocks

### DIFF
--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -16,11 +16,7 @@
 }
 
 .note > .title, .commentary [data-type=title] {
-  color: @tutor-secondary;
-  font-weight: 300;
-  text-transform: uppercase;
-  margin: 20px 0;
-  font-size: 2rem;
+  .book-content-subtitle();
 }
 
 

--- a/resources/styles/book-content/mixins.less
+++ b/resources/styles/book-content/mixins.less
@@ -20,7 +20,6 @@
   margin-bottom: 1.5rem;
 }
 
-
 .tutor-reading-first-letter() {
   &::first-letter{
     float: left;
@@ -32,6 +31,14 @@
   // ensure that the p is heigh enough for the drop cap
   // to fit beside it, otherwise it will overlay on top of the next element
   min-height: 8rem;
+}
+
+.book-content-subtitle() {
+  color: @tutor-secondary;
+  font-weight: 300;
+  text-transform: uppercase;
+  margin: 20px 0;
+  font-size: 2rem;
 }
 
 .book-content-step-size(@vertical: @tutor-card-body-padding-vertical) {

--- a/resources/styles/book-content/worked-examples.less
+++ b/resources/styles/book-content/worked-examples.less
@@ -1,4 +1,6 @@
-.worked-example.note:first-child {
+// sometimes it's plural, sometimes not?
+.worked-example.note:first-child,
+.worked-examples.note:first-child {
 
   .book-content-step-size();
 
@@ -9,5 +11,14 @@
   > .exercise > [data-type=title] {
     .tutor-reading-main-title();
   }
-  
+
+  .exercise {
+    .solution {
+      &:before {
+        content: "Solution";
+        display: block;
+       .book-content-subtitle();
+      }
+    }
+  }
 }


### PR DESCRIPTION
WIP until @Fredasaurus lets us know what they should look like.  Right now I'm styling them the same as a sub-title element.

![screen shot 2015-05-29 at 1 11 42 pm](https://cloud.githubusercontent.com/assets/79566/7889295/4ef0bc7c-0604-11e5-906e-212b6582f157.png)
