### PR TITLE
use transition to instead of full page reload for adding homeworks and readings from calendar

### DIFF
--- a/src/components/course-calendar/add-menu-mixin.cjsx
+++ b/src/components/course-calendar/add-menu-mixin.cjsx
@@ -17,6 +17,11 @@ CourseAddMenuMixin =
   getDefaultProps: ->
     dateFormat: 'MM-DD-YYYY'
 
+  goToBuilder: (link) ->
+    (clickEvent) =>
+      clickEvent.preventDefault()
+      @context.router.transitionTo(link.to, link.params, link.query)
+
   renderAddActions: ->
     {courseId} = @context.router.getCurrentParams()
     {dateFormat} = @props
@@ -43,7 +48,11 @@ CourseAddMenuMixin =
 
     _.map(links, (link) =>
       href = @context.router.makeHref(link.to, link.params, link.query)
-      <BS.MenuItem href={href} key={link.type} ref="#{link.type}Link">{link.text}</BS.MenuItem>
+      <BS.MenuItem
+        onClick={@goToBuilder(link)}
+        href={href}
+        key={link.type}
+        ref="#{link.type}Link">{link.text}</BS.MenuItem>
     )
 
 module.exports = CourseAddMenuMixin


### PR DESCRIPTION
No UI changes, smoother experience from calendar to builder