### PR TITLE
Move .splash specifier below others for precedence

### DIFF
--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -145,7 +145,7 @@ figure {
     // This means child elements that normally have a fixed pixel width will not expand to fit
     // unless their widths are set to be 100%
     [data-type=media]{ width: 100%; }
-    .tutor-ui-horizontal-img elements{ width: 100%; }
+    .tutor-ui-horizontal-img { width: 100%; }
     img { width: 100%; }
   }
   figcaption {

--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -138,10 +138,14 @@ figure {
       width: 100%;
     }
   }
-  // splash images inside are always full width
+  // splash images are always full width without margin or surrounding padding
   &.splash {
     width: 100%;
+    // .splash is wider than other elements on the page since it has 0 surrounding padding
+    // This means child elements that normally have a fixed pixel width will not expand to fit
+    // unless their widths are set to be 100%
     [data-type=media]{ width: 100%; }
+    .tutor-ui-horizontal-img elements{ width: 100%; }
     img { width: 100%; }
   }
   figcaption {

--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -131,16 +131,18 @@ figure {
     margin: 10px 0 0 0;
     padding: 0;
   }
-  // splash images inside are full width
-  &.splash {
-    img { width: 100%; }
-  }
   .tutor-ui-horizontal-img {
     display:block;
     .book-content-full-width();
     img {
       width: 100%;
     }
+  }
+  // splash images inside are always full width
+  &.splash {
+    width: 100%;
+    [data-type=media]{ width: 100%; }
+    img { width: 100%; }
   }
   figcaption {
     display: table-caption;


### PR DESCRIPTION
Fixes bug where .splash element wasn't resizing it's children to be 100% width

![screen shot 2015-06-01 at 1 29 11 pm](https://cloud.githubusercontent.com/assets/79566/7920139/8fd6bd30-0862-11e5-981d-31d6f28f265b.png)

![screen shot 2015-06-01 at 1 29 28 pm](https://cloud.githubusercontent.com/assets/79566/7920141/91ba9b08-0862-11e5-8bf7-ad1fd3236e1e.png)
