### PR TITLE
Remove italic styling from notes

### DIFF
--- a/resources/styles/global/forms.less
+++ b/resources/styles/global/forms.less
@@ -37,7 +37,6 @@ textarea {
 .note {
 	color: @tutor-neutral;
 	font-size: 1.4rem;
-	font-style: italic;
 }
 
 button i.fa { margin-right: 0.5rem; }


### PR DESCRIPTION
Styling was cascading down to all titles and paragraphs inside a note causing everything to appear italic.