### PR TITLE
reset the body's classlist on unmount

### DIFF
--- a/src/components/pinned-header-footer-card/index.cjsx
+++ b/src/components/pinned-header-footer-card/index.cjsx
@@ -27,15 +27,14 @@ module.exports = React.createClass
   mixins: [ScrollListenerMixin]
 
   componentWillMount: ->
+    @previousBodyClasses = document.body.className
     cardBodyClass = @props.cardType
-    @documentBodyClass = 'pinned-view'
-
     document.body.className = "#{cardBodyClass}-view"
-    document.body.classList.add(@documentBodyClass)
+    document.body.classList.add('pinned-view')
     document.body.classList.add('pinned-force-shy') if @props.forceShy
 
   componentWillUnmount: ->
-    document.body.classList.remove(@documentBodyClass)
+    document.body.className = @previousBodyClasses
 
   getPosition: (el) -> el.getBoundingClientRect().top - document.body.getBoundingClientRect().top
 


### PR DESCRIPTION
Fixes issue with Dashboard and learning guide always scrolling after visiting the a task

Identified during discussion on #353 

The original code was only remembering a single class to remove, but added several other classes.  This just remembers whatever the `body` had on mount and then restores it on unmount.