### PR TITLE
Set fixed height of navbar

### DIFF
--- a/resources/styles/global/navbar.less
+++ b/resources/styles/global/navbar.less
@@ -2,7 +2,13 @@
 @tutor-navbar-padding-horizontal: 4rem;
 
 .navbar-fixed-top {
-
+  
+  // override bootstrap material design media query for (max-width: 1199px)
+  .navbar-brand {
+    height: 60px;
+    padding: 15px;
+  }
+  
   .transition(transform 0.2s ease-out);
 
   // override the bootstrap defaults with tutor defaults


### PR DESCRIPTION
Override's a media query that bootstrap material design uses to set the height to 50px on `(max-width: 1199px)`

Before (screen width 900px):
![screen shot 2015-06-02 at 5 26 36 pm](https://cloud.githubusercontent.com/assets/79566/7948759/9a6fcbb6-094c-11e5-9ac7-813bbb6c4e18.png)

After:
![screen shot 2015-06-02 at 5 26 55 pm](https://cloud.githubusercontent.com/assets/79566/7948758/9a3f5116-094c-11e5-9920-7f17473e4692.png)
