### PR TITLE
only show refresh my memory when we can

### DIFF
--- a/src/components/task-step/exercise/modes.cjsx
+++ b/src/components/task-step/exercise/modes.cjsx
@@ -163,7 +163,12 @@ ExerciseReview = React.createClass
   canTryAnother: ->
     {id} = @props
     step = TaskStepStore.get(id)
-    return step.has_recovery and step.correct_answer_id isnt step.answer_id
+    step.has_recovery and step.correct_answer_id isnt step.answer_id
+
+  canRefreshMemory: ->
+    {id} = @props
+    step = TaskStepStore.get(id)
+    step?.related_content?.length and step.has_recovery and step.correct_answer_id isnt step.answer_id
 
   continueButtonText: ->
     if @canTryAnother() then 'Move On' else 'Continue'
@@ -171,17 +176,27 @@ ExerciseReview = React.createClass
   renderFooterButtons: ->
     {review} = @props
 
+    extraButtons = []
+
     if @canTryAnother()
-      extraButtons = [
-        <BS.Button bsStyle='primary' className='-try-another' onClick={@tryAnother}>
-          Try Another
-        </BS.Button>
-        <BS.Button bsStyle='primary' className='-refresh-memory' onClick={@refreshMemory}>
-          Refresh My Memory
-        </BS.Button>
-      ]
+      tryAnotherButton = <BS.Button
+        bsStyle='primary'
+        className='-try-another'
+        onClick={@tryAnother}>
+        Try Another
+      </BS.Button>
+
+    if @canRefreshMemory()
+      refreshMemoryButton = <BS.Button
+        bsStyle='primary'
+        className='-refresh-memory'
+        onClick={@refreshMemory}>
+        Refresh My Memory
+      </BS.Button>
+
     <div className='footer-buttons'>
-      {extraButtons}
+      {tryAnotherButton}
+      {refreshMemoryButton}
       {@renderContinueButton() unless review is 'completed'}
     </div>
 


### PR DESCRIPTION
Will talk to BE about related_content have info, but this is good to prevent trying to refresh something that is not refreshable

## Before
Always show "Refresh My Memory" with "Try Another" even when there is not related content to refresh with
![screen shot 2015-06-03 at 12 17 18 pm](https://cloud.githubusercontent.com/assets/2483873/7966586/a831e718-09ea-11e5-85f4-56a2db4dac16.png)

## After
![screen shot 2015-06-03 at 12 17 29 pm](https://cloud.githubusercontent.com/assets/2483873/7966587/a8329c30-09ea-11e5-8236-24bf2172504a.png)
