### PR TITLE
Set and target a data-crumb-count attribute (AKA media queries gone wild)

### DIFF
--- a/resources/styles/components/task/breadcrumbs.less
+++ b/resources/styles/components/task/breadcrumbs.less
@@ -1,3 +1,35 @@
+// TODO: 2.9rem was determined by trial and error
+// Can't figure out why it doesn't correspond to the
+// 2rem radius (4rem diameter) specified below for .crumb-circle
+@crumb-size: 2.9rem;
+@crumb-vertical-margin: 1rem;
+// Stop generating breakpoints for screens with width greater than 120rem
+.breadcrumb-media-queries(@screen-width; @crumb-count) when (@screen-width < 120rem){
+  .breadcrumb-media-queries(@screen-width + @crumb-size, @crumb-count);
+
+  @desired-width: (@crumb-size * @crumb-count) + (@tutor-navbar-padding-horizontal*2);
+  // only generate a media query if it's needed
+  & when (@desired-width > @screen-width) {
+    @rows: ceil(@desired-width / @screen-width);
+    @media (max-width: @screen-width) {
+      margin-top: (@rows * @crumb-size) + (@rows * @crumb-vertical-margin);
+    }
+  }
+}
+
+// Calculate breakpoints for up to 50 breadcrumbs. Adjust as needed
+.breadcrumb-breakpoints(@crumb-count:10) when (@crumb-count < 50) {
+  .breadcrumb-breakpoints(@crumb-count + 1);
+  &[data-crumb-count="@{crumb-count}"] {
+    // Generate breackpoints for screens more than 20rem wide
+    .breadcrumb-media-queries(20rem, @crumb-count);
+  }
+}
+
+.task {
+  .breadcrumb-breakpoints(10);
+}
+
 .crumb-circle(@radius){
   font-size: @radius;
   border-radius: 2 * @radius;

--- a/src/components/pinned-header-footer-card/index.cjsx
+++ b/src/components/pinned-header-footer-card/index.cjsx
@@ -12,6 +12,7 @@ module.exports = React.createClass
   propTypes:
     buffer: React.PropTypes.number
     fixedOffset: React.PropTypes.number
+    crumbCount: React.PropTypes.number
 
   getDefaultProps: ->
     buffer: 60
@@ -135,7 +136,7 @@ module.exports = React.createClass
 
     childrenProps = _.omit(@props, 'children', 'header', 'footer', 'className')
 
-    <div className={classes}>
+    <div className={classes} data-crumb-count={@props.crumbCount}>
       <PinnedHeader {...childrenProps} ref='header'>
         {@props.header}
       </PinnedHeader>

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -209,6 +209,7 @@ module.exports = React.createClass
         key="task-#{id}-breadcrumbs"/>
 
     <PinnedHeaderFooterCard
+      crumbCount={@getCrumableCrumbs().length}
       forceShy={true}
       className={taskClasses}
       fixedOffset={0}


### PR DESCRIPTION
Top-margin is determined by the interection of screen width and data-crumb-count values

Single row after answering last question which created new breadcrumb.  The content pushes down as it should: 
![screen shot 2015-06-03 at 3 50 46 pm]
(https://cloud.githubusercontent.com/assets/79566/7971747/b24199b6-0a0c-11e5-917b-41117b54d5b8.png)


Even supports 4 rows :grin: 

![screen shot 2015-06-03 at 4 18 27 pm](https://cloud.githubusercontent.com/assets/79566/7971743/ae3d1a16-0a0c-11e5-95d6-27b14bac6376.png)

