### PR TITLE
Margin on container should be based on headerHeight

### DIFF
--- a/resources/styles/components/pinned-header-footer-card/index.less
+++ b/resources/styles/components/pinned-header-footer-card/index.less
@@ -11,3 +11,7 @@ body.pinned-force-shy {
   // force min height to allow shy scroll on a short task step
   min-height: 120%;
 }
+
+.pinned-container {
+  .transition(margin-top 0.2s);
+}

--- a/resources/styles/components/pinned-header-footer-card/index.less
+++ b/resources/styles/components/pinned-header-footer-card/index.less
@@ -11,7 +11,3 @@ body.pinned-force-shy {
   // force min height to allow shy scroll on a short task step
   min-height: 120%;
 }
-
-.pinned-container {
-  .transition(margin-top 0.2s);
-}

--- a/resources/styles/components/task-plan/homework.less
+++ b/resources/styles/components/task-plan/homework.less
@@ -29,9 +29,6 @@
 
 .homework-builder-view {
   &.pinned-on {
-    // .pinned-container {
-    //   margin-top: 120px;      
-    // }
     .pinned-header {
       background: @tutor-white;
       .tutor-shadow(1);

--- a/resources/styles/components/task-plan/homework.less
+++ b/resources/styles/components/task-plan/homework.less
@@ -29,9 +29,9 @@
 
 .homework-builder-view {
   &.pinned-on {
-    .pinned-container {
-      margin-top: 120px;      
-    }
+    // .pinned-container {
+    //   margin-top: 120px;      
+    // }
     .pinned-header {
       background: @tutor-white;
       .tutor-shadow(1);

--- a/resources/styles/components/task/index.less
+++ b/resources/styles/components/task/index.less
@@ -13,7 +13,6 @@
 
   &.pinned-on {
     .pinned-container {
-      padding-top: 1.5 * @tutor-navbar-height;
       padding-bottom: 1.5 * @tutor-navbar-height;
     }
   }

--- a/src/components/pinned-header-footer-card/index.cjsx
+++ b/src/components/pinned-header-footer-card/index.cjsx
@@ -115,16 +115,19 @@ module.exports = React.createClass
     @setState(shouldBeShy: true)
 
   getHeaderHeight: ->
-    header = @refs.header.getDOMNode()
-    headerHeight = header.offsetHeight
+    header = @refs.header?.getDOMNode()
+    headerHeight = header?.offsetHeight or 0
 
   setOriginalContainerMargin: ->
-    container = @refs.container.getDOMNode()
+    container = @refs.container?.getDOMNode()
+    return unless container
+
     @setState(containerMarginTop: window.getComputedStyle(container).marginTop) if window.getComputedStyle?
 
   setContainerMargin: ->
     headerHeight = @getHeaderHeight()
-    container = @refs.container.getDOMNode()
+    container = @refs.container?.getDOMNode()
+    return unless container
 
     @setState(headerHeight: headerHeight)
     if @state.pinned

--- a/src/components/pinned-header-footer-card/index.cjsx
+++ b/src/components/pinned-header-footer-card/index.cjsx
@@ -40,6 +40,7 @@ module.exports = React.createClass
 
   componentWillUnmount: ->
     document.body.className = @previousBodyClasses
+    window.removeEventListener('resize', @setContainerMargin)
 
   getPosition: (el) -> el.getBoundingClientRect().top - document.body.getBoundingClientRect().top
 

--- a/src/components/pinned-header-footer-card/index.cjsx
+++ b/src/components/pinned-header-footer-card/index.cjsx
@@ -1,7 +1,5 @@
 React = require 'react'
-BS = require 'react-bootstrap'
 _ = require 'underscore'
-camelCase = require 'camelcase'
 
 {ScrollListenerMixin} = require 'react-scroll-components'
 
@@ -40,7 +38,7 @@ module.exports = React.createClass
 
   componentWillUnmount: ->
     document.body.className = @previousBodyClasses
-    window.removeEventListener('resize', @setContainerMargin)
+    window.removeEventListener('resize', @resizeListener)
 
   getPosition: (el) -> el.getBoundingClientRect().top - document.body.getBoundingClientRect().top
 
@@ -138,13 +136,18 @@ module.exports = React.createClass
     else
       container.style.marginTop = @state.containerMarginTop
 
+  resizeListener: _.throttle( ->
+    @setContainerMargin()
+    # any other resize side-effects here
+  , 200)
+
   componentDidMount: ->
     @setOffset()
     @updatePinState(0)
     @setOriginalContainerMargin()
     @setContainerMargin()
 
-    window.addEventListener('resize', @setContainerMargin)
+    window.addEventListener('resize', @resizeListener)
 
   componentDidUpdate: (prevProps, prevState) ->
     didOffsetChange = (not @state.pinned) and not (@state.offset is @getOffset())

--- a/src/components/pinned-header-footer-card/index.cjsx
+++ b/src/components/pinned-header-footer-card/index.cjsx
@@ -138,6 +138,8 @@ module.exports = React.createClass
     @setOriginalContainerMargin()
     @setContainerMargin()
 
+    window.addEventListener('resize', @setContainerMargin)
+
   componentDidUpdate: (prevProps, prevState) ->
     didOffsetChange = (not @state.pinned) and not (@state.offset is @getOffset())
     didShouldPinChange = not prevState.pinned is @shouldPinHeader(prevState.scrollTop, @state.scrollTop)

--- a/src/components/pinned-header-footer-card/index.cjsx
+++ b/src/components/pinned-header-footer-card/index.cjsx
@@ -11,7 +11,9 @@ module.exports = React.createClass
   displayName: 'PinnedHeaderFooterCard'
   propTypes:
     buffer: React.PropTypes.number
-    fixedOffset: React.PropTypes.number
+    scrollSpeedBuffer: React.PropTypes.number
+    forceShy: React.PropTypes.bool
+    containerBuffer: React.PropTypes.number
 
   getDefaultProps: ->
     buffer: 60

--- a/src/components/pinned-header-footer-card/index.cjsx
+++ b/src/components/pinned-header-footer-card/index.cjsx
@@ -133,7 +133,7 @@ module.exports = React.createClass
     didOffsetChange = (not @state.pinned) and not (@state.offset is @getOffset())
     didShouldPinChange = not prevState.pinned is @shouldPinHeader(prevState.scrollTop, @state.scrollTop)
     didShouldBeShyChange = not prevState.shy is @shouldBeShy(prevState.scrollTop, @state.scrollTop)
-    didHeaderHeightChange = not @state.headerHeight is @getHeaderHeight()
+    didHeaderHeightChange = not (prevState.headerHeight is @getHeaderHeight())
 
     @setOffset() if didOffsetChange
     @updatePinState(prevState.scrollTop) if didShouldPinChange or didShouldBeShyChange

--- a/src/components/task-plan/homework.cjsx
+++ b/src/components/task-plan/homework.cjsx
@@ -68,6 +68,7 @@ ChooseExercises = React.createClass
         hide={hide} />
 
       <PinnedHeaderFooterCard
+        containerBuffer={50}
         header={exerciseSummary}
         cardType='homework-builder'>
         {addExercises}
@@ -138,6 +139,7 @@ HomeworkPlan = React.createClass
         planId={id}/>
 
       reviewExercisesSummary = <PinnedHeaderFooterCard
+        containerBuffer={50}
         header={exerciseSummary}
         cardType='homework-builder'>
         {exerciseTable}


### PR DESCRIPTION
handles different header heights for pinned containers

working on handling header height changes properly

a different take on #368 

## Margin top automatically updates as header size changes
For example when breadcrumbs fill into a new row
![screen shot 2015-06-03 at 5 26 30 pm](https://cloud.githubusercontent.com/assets/2483873/7972912/e36e9e36-0a15-11e5-8826-268fdb281eae.png)

## Smoothly adjusts on window resize
![screen shot 2015-06-03 at 6 36 27 pm](https://cloud.githubusercontent.com/assets/2483873/7973831/b820f210-0a1f-11e5-94fd-7021a8b0ba4e.png)

## Works with pinned headers with offsets as well
![screen shot 2015-06-03 at 6 37 05 pm](https://cloud.githubusercontent.com/assets/2483873/7973832/b821c424-0a1f-11e5-8cf7-3b773665061d.png)

![screen shot 2015-06-03 at 6 58 32 pm](https://cloud.githubusercontent.com/assets/2483873/7974048/96fba488-0a22-11e5-92c5-47456bb9ad9a.png)
