### PR TITLE
Specify -webkit prefixes for chapter headings

### DIFF
--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -44,16 +44,16 @@ cnx-pi
   > div[data-type=title] { display: none; }
 
   p {
-    #fonts > .sans(1.5rem, 1.2em);
+    #fonts > .sans(1.5rem, 1.8em);
     width: 220px; // keep line length consistent
     color: rgba(255,255,255,.75);
     text-transform: uppercase;
     text-align: right;
     margin: 0 20px 0 0;
-    justify-content: center;
     display: flex;
     flex-direction: column;
     display: -webkit-flex;
+    justify-content: center;
     -webkit-justify-content: center;
     -webkit-flex-direction: column;
   }
@@ -65,19 +65,21 @@ cnx-pi
     display: flex;
     flex-direction: column;
     flex: 1;
+    justify-content: center;
     display: -webkit-flex;
+    -webkit-justify-content: center;
     -webkit-flex-direction: column;
     -webkit-flex: 1;
     .ost-learning-objective-def {
-      #fonts > .sans(1.5rem, 1.2em);
+      #fonts > .sans(1.5rem, 1.8em);
       font-weight: 300;
       list-style-type: none;
       display: flex;
       justify-content: center;
       flex-direction: column;
-      flex: 1;
+      // flex: 1;
       display: -webkit-flex;
-      -webkit-flex: 1;
+      // -webkit-flex: 1;
       -webkit-justify-content: center;
       -webkit-flex-direction: column;
       &:before {

--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -31,23 +31,32 @@ cnx-pi
   #fonts > .sans(1.8rem, 1.8rem);
   width: 100%;
   min-height: 100px;
-  display: inline-flex;
-  display: -ms-inline-flexbox; // IE10 support
   margin-top: -@tutor-card-body-padding-vertical;
   color: #ffffff;
   padding: 10px 20px;
   background: @tutor-secondary;
 
+  display: inline-flex;
+  display: -ms-inline-flexbox; // IE10 support
+  display: -webkit-inline-flex;
+
   // hide the "Section learning Objectives" phrase
   > div[data-type=title] { display: none; }
 
   p {
-    width: 220px; // added this to keep line length consistent, may be wonky with flexbox, feel free to handle diffreently
-    color: rgba(255,255,255,.75);
     #fonts > .sans(1.5rem, 1.2em);
+    color: rgba(255,255,255,.75);
     text-transform: uppercase;
     text-align: right;
-    margin: auto 20px auto 0;
+    margin: 0 20px 0 0;
+    justify-content: center;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    display: -webkit-flex;
+    -webkit-flex: 1;
+    -webkit-justify-content: center;
+    -webkit-flex-direction: column;
   }
 
   ul {
@@ -56,14 +65,22 @@ cnx-pi
     border-left: 1px solid rgba(255,255,255,.4);
     display: flex;
     flex-direction: column;
+    flex: 1;
+    display: -webkit-flex;
+    -webkit-flex-direction: column;
+    -webkit-flex: 1;
     .ost-learning-objective-def {
       #fonts > .sans(1.5rem, 1.2em);
       font-weight: 300;
       list-style-type: none;
-      flex: 1;
       display: flex;
       justify-content: center;
       flex-direction: column;
+      flex: 1;
+      display: -webkit-flex;
+      -webkit-flex: 1;
+      -webkit-justify-content: center;
+      -webkit-flex-direction: column;
       &:before {
         content: none;
       }

--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -45,6 +45,7 @@ cnx-pi
 
   p {
     #fonts > .sans(1.5rem, 1.2em);
+    width: 220px; // keep line length consistent
     color: rgba(255,255,255,.75);
     text-transform: uppercase;
     text-align: right;
@@ -52,9 +53,7 @@ cnx-pi
     justify-content: center;
     display: flex;
     flex-direction: column;
-    flex: 1;
     display: -webkit-flex;
-    -webkit-flex: 1;
     -webkit-justify-content: center;
     -webkit-flex-direction: column;
   }


### PR DESCRIPTION
Before:
![screen shot 2015-06-05 at 2 31 45 pm](https://cloud.githubusercontent.com/assets/79566/8013545/a7336480-0b8f-11e5-841c-12fde021ce1a.png)

After:
![screen shot 2015-06-05 at 2 34 12 pm](https://cloud.githubusercontent.com/assets/79566/8013587/f4dce260-0b8f-11e5-9e9b-4072da79aad4.png)


Does anyone know of a good flex box less mixin?  I think this bit of styling would benefit from it since it now has both -ie and -webkit prefixes.