### PR TITLE
alpha: show both lines of a plan label when active

### DIFF
--- a/resources/styles/components/course-calendar/plan.less
+++ b/resources/styles/components/course-calendar/plan.less
@@ -67,6 +67,7 @@
       max-height: @calendar-plan-active-height;
       margin-top: -@calendar-plan-active-top-offset;
       z-index: 2;
+      line-height: @calendar-plan-active-height/2;
 
       label {
         margin-top: 0;


### PR DESCRIPTION
## One approach
![screen shot 2015-06-05 at 6 18 02 pm](https://cloud.githubusercontent.com/assets/2483873/8016873/433a6062-0baf-11e5-9e70-6323bd866693.png)
