### PR TITLE
Display and style past dates on date picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-calendar": "^0.4.0",
     "react-router": "~0.13.2",
     "react-scroll-components": "^0.2.2",
-    "react-widgets": "^2.2.6",
+    "react-widgets": "^2.7.0",
     "twix": "^0.6.3",
     "underscore": "~1.8.2"
   },

--- a/resources/styles/components/tutor-input.less
+++ b/resources/styles/components/tutor-input.less
@@ -1,10 +1,34 @@
 .tutor-input {
-  // dates on the date picker that are in the past and cannot be choosen
-  .is-invalid-date {
-    text-decoration: line-through;
-    color: @tutor-neutral;
+  .rw-calendar-grid {
+    td {
+      // these override the default styles for the date picker so we can apply our own
+      // based on the <span> element that we render inside the rw-btn
+      .rw-btn {
+        border-radius: 0;
+        padding: 0;
+        &:hover { cursor: default; background-color: inherit; }
+        &.rw-off-range { color: inherit; }
+      }
+      &:hover{ cursor: default; }
+      .rw-state-selected { border-radius: @input-border-radius; }
+    }
+    // dates on the date picker that are in the past and cannot be choosen
+    .date {
+      border-radius: @input-border-radius;
+      padding: 0 .4em 0 .1em;
+      &:hover {
+        background-color: @tutor-neutral-light;
+      }
+      &.is-invalid {
+        text-decoration: line-through;
+        color: @tutor-neutral;
+        &:hover {
+          background-color: inherit;
+          cursor: default;
+        }
+      }
+    }
   }
-
   &.form-control-wrapper {
     // override line-height styles for paper form controls
     line-height: 1em;

--- a/resources/styles/components/tutor-input.less
+++ b/resources/styles/components/tutor-input.less
@@ -1,92 +1,100 @@
 // override line-height styles for paper form controls
-.form-control-wrapper {
-  line-height: 1em;
+.tutor-input {
+  .is-invalid {
+    text-decoration: line-through;
+    color: @tutor-neutral;
+  }
+
+  .form-control-wrapper {
+    line-height: 1em;
+
+    textarea {
+      overflow: hidden;
+    }
+
+    .rw-datetimepicker.rw-widget {
+      position: absolute;
+      top: 0;
+
+      &:hover {
+        background-color: transparent;
+      }
+
+      input.rw-input {
+        background: transparent;
+        padding: 0;
+        border: 0;
+        box-shadow: none;
+      }
+
+      .rw-select {
+        border: 0;
+      }
+    }
+
+    .form-control {
+      font-size: 1.8rem;
+      color: #424242;
+
+      &:focus,
+      &.focus {
+        background-image: linear-gradient(@info, @info), linear-gradient(@input-underline-color, @input-underline-color);
+        animation: input-highlight 0.125s forwards;
+
+        ~ .floating-label {
+          color: @info;
+        }
+
+        ~.required-hint {
+          display: none;
+        }
+      }
+    }
+
+    .rw-datetimepicker.rw-widget {
+      input.rw-input {
+        height: 30px;
+        color: #424242;
+      }
+    }
+  }
+
+  .is-invalid-form {
+    .form-control-wrapper.is-required {
+      margin-bottom: 1em;
+      .form-control.empty {
+        background-image: linear-gradient(@form-error-color, @form-error-color), 
+        linear-gradient(@form-error-color, @form-error-color);
+      }
+      .form-control.empty ~ .floating-label {
+        color: @form-error-color;
+      }
+      .form-control.empty ~ .required-hint {
+        display: block;
+        margin-bottom: 1em;
+        color: @form-error-color;
+      }
+    }
+  }
+
+  .required-hint.hint {
+    display: none;
+  }
+  
+  .form-note {
+    color: @tutor-neutral;
+    font-size: 1.4rem;
+    font-style: italic;
+  }
 
   textarea {
-    overflow: hidden;
-  }
+    border: 1px solid @tutor-neutral;
 
-  .rw-datetimepicker.rw-widget {
-    position: absolute;
-    top: 0;
-
-    &:hover {
-      background-color: transparent;
-    }
-
-    input.rw-input {
-      background: transparent;
-      padding: 0;
-      border: 0;
-      box-shadow: none;
-    }
-
-    .rw-select {
-      border: 0;
+    &:focus {
+      border: 1px solid @tutor-tertiary-light;
+      box-shadow: 0 0 10px fade(@tutor-tertiary-light, 25%);
     }
   }
 
-  .form-control {
-    font-size: 1.8rem;
-    color: #424242;
-
-    &:focus,
-    &.focus {
-      background-image: linear-gradient(@info, @info), linear-gradient(@input-underline-color, @input-underline-color);
-      animation: input-highlight 0.125s forwards;
-
-      ~ .floating-label {
-        color: @info;
-      }
-
-      ~.required-hint {
-        display: none;
-      }
-    }
-  }
-
-  .rw-datetimepicker.rw-widget {
-    input.rw-input {
-      height: 30px;
-      color: #424242;
-    }
-  }
+  button i.fa { margin-right: 0.5rem; }
 }
-
-.is-invalid-form {
-  .form-control-wrapper.is-required {
-    margin-bottom: 1em;
-    .form-control.empty {
-      background-image: linear-gradient(@form-error-color, @form-error-color), 
-                        linear-gradient(@form-error-color, @form-error-color);
-    }
-    .form-control.empty ~ .floating-label {
-      color: @form-error-color;
-    }
-    .form-control.empty ~ .required-hint {
-      display: block;
-      margin-bottom: 1em;
-      color: @form-error-color;
-    }
-  }
-}
-
-.required-hint.hint {
-  display: none;
-}
-.form-note {
-  color: @tutor-neutral;
-  font-size: 1.4rem;
-  font-style: italic;
-}
-
-textarea {
-  border: 1px solid @tutor-neutral;
-  
-  &:focus {
-    border: 1px solid @tutor-tertiary-light;
-    box-shadow: 0 0 10px fade(@tutor-tertiary-light, 25%);
-  }
-}
-
-button i.fa { margin-right: 0.5rem; }

--- a/resources/styles/components/tutor-input.less
+++ b/resources/styles/components/tutor-input.less
@@ -1,11 +1,12 @@
-// override line-height styles for paper form controls
 .tutor-input {
-  .is-invalid {
+  // dates on the date picker that are in the past and cannot be choosen
+  .is-invalid-date {
     text-decoration: line-through;
     color: @tutor-neutral;
   }
 
-  .form-control-wrapper {
+  &.form-control-wrapper {
+    // override line-height styles for paper form controls
     line-height: 1em;
 
     textarea {
@@ -63,7 +64,7 @@
     .form-control-wrapper.is-required {
       margin-bottom: 1em;
       .form-control.empty {
-        background-image: linear-gradient(@form-error-color, @form-error-color), 
+        background-image: linear-gradient(@form-error-color, @form-error-color),
         linear-gradient(@form-error-color, @form-error-color);
       }
       .form-control.empty ~ .floating-label {
@@ -77,24 +78,4 @@
     }
   }
 
-  .required-hint.hint {
-    display: none;
-  }
-  
-  .form-note {
-    color: @tutor-neutral;
-    font-size: 1.4rem;
-    font-style: italic;
-  }
-
-  textarea {
-    border: 1px solid @tutor-neutral;
-
-    &:focus {
-      border: 1px solid @tutor-tertiary-light;
-      box-shadow: 0 0 10px fade(@tutor-tertiary-light, 25%);
-    }
-  }
-
-  button i.fa { margin-right: 0.5rem; }
 }

--- a/resources/styles/global/forms.less
+++ b/resources/styles/global/forms.less
@@ -1,1 +1,19 @@
+.required-hint.hint {
+  display: none;
+}
 
+.form-note {
+  color: @tutor-neutral;
+  font-size: 1.4rem;
+  font-style: italic;
+}
+
+textarea {
+  border: 1px solid @tutor-neutral;
+  &:focus {
+    border: 1px solid @tutor-tertiary-light;
+    box-shadow: 0 0 10px fade(@tutor-tertiary-light, 25%);
+  }
+}
+
+button i.fa { margin-right: 0.5rem; }

--- a/resources/styles/tutor.less
+++ b/resources/styles/tutor.less
@@ -26,6 +26,7 @@
 @import './components/course-calendar/index';
 @import './components/close';
 @import './components/dialog';
+@import './components/tutor-input';
 @import './components/learning-guide';
 @import './components/task/index';
 @import './components/task-step/index';

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -1,5 +1,8 @@
 React = require 'react'
 BS = require 'react-bootstrap'
+moment = require 'moment'
+
+{TimeStore} = require '../flux/time'
 {DateTimePicker} = require 'react-widgets'
 
 TutorInput = React.createClass
@@ -33,6 +36,19 @@ TutorInput = React.createClass
         Required Field <i className="fa fa-exclamation-circle"></i>
       </div>
     </div>
+
+DayComponent = React.createClass
+  propTypes:
+    date:  React.PropTypes.string.isRequired
+    label: React.PropTypes.string.isRequired
+
+
+  render: ->
+    className = if moment(@props.date).startOf('day') < TimeStore.getNow()
+      'invalid'
+    else
+      'valid'
+    <span className={className}>{@props.label}</span>
 
 TutorDateInput = React.createClass
 
@@ -70,7 +86,7 @@ TutorDateInput = React.createClass
 
   render: ->
     classes = ['form-control']
-    wrapperClasses = ["form-control-wrapper"]
+    wrapperClasses = ["form-control-wrapper tutor-input"]
     value = @props.value
     open = false
 
@@ -90,7 +106,7 @@ TutorDateInput = React.createClass
         Required Field <i className="fa fa-exclamation-circle"></i>
       </div>
       <DateTimePicker onClick={@clickHandler}
-        onFocus={@expandCalendar} 
+        onFocus={@expandCalendar}
         onBlur={@onBlur}
         id={@props.id}
         format='MMM dd, yyyy'
@@ -101,7 +117,7 @@ TutorDateInput = React.createClass
         className={classes.join(' ')}
         onChange={@dateSelected}
         readOnly={@props.readOnly}
-        min={@props.min}
+        dayComponent={DayComponent}
         value={value}
       />
     </div>

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -18,7 +18,7 @@ TutorInput = React.createClass
 
   render: ->
     classes = ['form-control']
-    wrapperClasses = ["form-control-wrapper"]
+    wrapperClasses = ["form-control-wrapper", "tutor-input"]
 
     unless @props.default then classes.push('empty')
     if @props.required then wrapperClasses.push('is-required')
@@ -44,7 +44,7 @@ DayComponent = React.createClass
 
 
   render: ->
-    className = 'is-invalid' if moment(@props.date).startOf('day') < TimeStore.getNow()
+    className = 'is-invalid-date' if moment(@props.date).startOf('day') < TimeStore.getNow()
     <span className={className}>{@props.label}</span>
 
 TutorDateInput = React.createClass
@@ -83,7 +83,7 @@ TutorDateInput = React.createClass
 
   render: ->
     classes = ['form-control']
-    wrapperClasses = ["form-control-wrapper tutor-input"]
+    wrapperClasses = ["form-control-wrapper", "tutor-input"]
     value = @props.value
     open = false
 
@@ -137,7 +137,7 @@ TutorTextArea = React.createClass
 
   render: ->
     classes = ['form-control']
-    wrapperClasses = ["form-control-wrapper"]
+    wrapperClasses = ["form-control-wrapper", "tutor-input"]
 
     unless @props.default then classes.push('empty')
     if @props.required then wrapperClasses.push('is-required')

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -49,9 +49,11 @@ DayComponent = React.createClass
     ev.stopPropagation() if @isInvalid()
 
   render: ->
-    <span onClick={@onClick} className={'is-invalid-date' if @isInvalid()}>
+    classNames = ['date']
+    classNames.push('is-invalid') if @isInvalid()
+    <div onClick={@onClick} className={classNames.join(' ')}>
       {@props.label}
-    </span>
+    </div>
 
 TutorDateInput = React.createClass
 

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -44,10 +44,7 @@ DayComponent = React.createClass
 
 
   render: ->
-    className = if moment(@props.date).startOf('day') < TimeStore.getNow()
-      'invalid'
-    else
-      'valid'
+    className = 'is-invalid' if moment(@props.date).startOf('day') < TimeStore.getNow()
     <span className={className}>{@props.label}</span>
 
 TutorDateInput = React.createClass

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -42,10 +42,16 @@ DayComponent = React.createClass
     date:  React.PropTypes.string.isRequired
     label: React.PropTypes.string.isRequired
 
+  isInvalid: ->
+    moment(@props.date).startOf('day') < TimeStore.getNow()
+
+  onClick: (ev) ->
+    ev.stopPropagation() if @isInvalid()
 
   render: ->
-    className = 'is-invalid-date' if moment(@props.date).startOf('day') < TimeStore.getNow()
-    <span className={className}>{@props.label}</span>
+    <span onClick={@onClick} className={'is-invalid-date' if @isInvalid()}>
+      {@props.label}
+    </span>
 
 TutorDateInput = React.createClass
 


### PR DESCRIPTION
Just as I was starting to fork the component in order to add something like this, I discovered that they've just added a new `dayComponent` prop that allows you to render the dates yourself.

![screen shot 2015-06-10 at 10 05 01 am](https://cloud.githubusercontent.com/assets/79566/8085927/6cecdcbc-0f58-11e5-9ed4-6f49f6db9a80.png)

