### PR TITLE
Center and disable text wrapping on exercise images

### DIFF
--- a/resources/styles/components/task-step/exercise/index.less
+++ b/resources/styles/components/task-step/exercise/index.less
@@ -1,6 +1,13 @@
 .exercise-free-response {
   .size-exercise-card();
 
+  // images in exercises are not wrapped and don't have a class.
+  // This will work fine until there's some images that shouldn't be targeted
+  img {
+    display: block;
+    margin: 0 auto;
+  }
+
   textarea {
     margin: 1em 0;
     padding: 5px;


### PR DESCRIPTION
Unfortunately, images on exercises are just a IMG tag without a class or wrapping element so more specific selection isn't possible.

The `margin: @auto` bit isn't strictly needed, but it makes some larger images look better since they have equal margin on both sides rather than just a slightly larger white space on the right.

Before:
![screen shot 2015-06-12 at 11 54 39 am](https://cloud.githubusercontent.com/assets/79566/8135168/a40a9998-10fa-11e5-872f-b50a8bdda4d2.png)

After:
![screen shot 2015-06-12 at 11 55 10 am](https://cloud.githubusercontent.com/assets/79566/8135167/a405f17c-10fa-11e5-89c5-549bbbebe4d0.png)

