### PR TITLE
"All Periods" checkbox support

### DIFF
--- a/resources/styles/components/task-plan/builder.less
+++ b/resources/styles/components/task-plan/builder.less
@@ -1,10 +1,10 @@
 .assignment {
 
-  label.all-periods {
+  label.period {
     // extend styling from bootstrap material design to match other labels
     .form-control-wrapper .floating-label;
     opacity: 1;
-    top: 0px;
+    top: 3px;
     left: 35px;
   }
   .periods-listing {
@@ -16,9 +16,18 @@
 
   .instructions {
     color: @tutor-neutral;
-    #fonts >.sans(1.1rem, 1.1rem);
+    #fonts >.sans(1.1rem, 1.2rem);
   }
   .assignment-description {
     margin-top: 1rem;
+  }
+
+  .task-plan {
+    input[type=checkbox] {
+      margin-left: 1rem;
+    }
+    label.period {
+      left: 45px;
+    }
   }
 }

--- a/resources/styles/components/task-plan/builder.less
+++ b/resources/styles/components/task-plan/builder.less
@@ -7,12 +7,6 @@
     top: 3px;
     left: 35px;
   }
-  .periods-listing {
-    .table;
-    .table-striped;
-    .table-bordered;
-    .form-control { background-image: inherit; }
-  }
 
   .instructions {
     color: @tutor-neutral;
@@ -23,11 +17,11 @@
   }
 
   .task-plan {
-    input[type=checkbox] {
-      margin-left: 1rem;
-    }
-    label.period {
-      left: 45px;
+    input[type=checkbox] { margin-left: 1rem; }
+    label.period { left: 45px; }
+    &.disabled {
+      label { text-decoration: line-through; }
     }
   }
+
 }

--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -48,11 +48,11 @@ module.exports = React.createClass
 
   setOpensAt: (value, period) ->
     {planId} = @props
-    TaskPlanActions.updateOpensAt(planId, value, period?.target_id)
+    TaskPlanActions.updateOpensAt(planId, value, period?.id)
 
   setDueAt: (value, period) ->
     {planId} = @props
-    TaskPlanActions.updateDueAt(planId, value, period?.target_id)
+    TaskPlanActions.updateDueAt(planId, value, period?.id)
 
   togglePeriodsDisplay: (ev) ->
     @setState(showingPeriods: not ev.target.checked)
@@ -72,7 +72,7 @@ module.exports = React.createClass
     TaskPlanActions.updateDescription(id, desc)
 
   renderTaskPlanRow: (plan) ->
-    <tr key={plan.target_id}>
+    <tr key={plan.id}>
       <td>{plan.name}</td>
       <td>
         <TutorDateInput
@@ -176,5 +176,4 @@ module.exports = React.createClass
 
   render: ->
     plan = TaskPlanStore.get(@props.planId)
-
     if @state.showingPeriods then @renderShownPeriods(plan) else @renderHiddenPeriods(plan)

--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -57,123 +57,108 @@ module.exports = React.createClass
   togglePeriodsDisplay: (ev) ->
     @setState(showingPeriods: not ev.target.checked)
 
-  renderPeriodsToggle: (columns) ->
-    <BS.Col xs=12 sm={columns}>
-      <input
-        id='toggle-periods-checkbox'
-        type='checkbox'
-        onChange={@togglePeriodsDisplay}
-        checked={not @state.showingPeriods}/>
-      <label className="all-periods" htmlFor='toggle-periods-checkbox'>All Periods</label>
-    </BS.Col>
-
   setDescription:(desc, descNode) ->
     {id} = @props
     TaskPlanActions.updateDescription(id, desc)
 
+
+  render: ->
+    plan = TaskPlanStore.get(@props.planId)
+    <div className="assignment">
+      <BS.Row>
+        <BS.Col sm=8 xs=12>
+          <TutorInput
+            label='Assignment Name'
+            className='assignment-name'
+            value={plan.title}
+            id='reading-title'
+            default={plan.title}
+            required={true}
+            onChange={@setTitle} />
+        </BS.Col>
+      </BS.Row><BS.Row>
+        <BS.Col xs=12>
+          <TutorTextArea
+            label='Description'
+            className='assignment-description'
+            id='assignment-description'
+            default={TaskPlanStore.getDescription(@props.planId)}
+            onChange={@setDescription} />
+        </BS.Col>
+      </BS.Row><BS.Row>
+        <BS.Col sm=4 md=3>Assign to</BS.Col>
+        <BS.Col sm=4 md=3>Open date</BS.Col>
+        <BS.Col sm=4 md=3>Due date</BS.Col>
+      </BS.Row><BS.Row>
+
+        <BS.Col sm=4 md=3>
+          <input
+            id='toggle-periods-checkbox'
+            type='checkbox'
+            onChange={@togglePeriodsDisplay}
+            checked={not @state.showingPeriods}/>
+          <label className="period" htmlFor='toggle-periods-checkbox'>All Periods</label>
+        </BS.Col>
+
+        <BS.Col sm=4 md=3>
+          <TutorDateInput
+            id='reading-open-date'
+            readOnly={TaskPlanStore.isPublished(@props.planId)}
+            required={true}
+            onChange={@setOpensAt}
+            value={TaskPlanStore.getOpensAt(@props.planId)}/>
+        </BS.Col>
+
+        <BS.Col sm=4 md=3>
+          <TutorDateInput
+            id='reading-due-date'
+            readOnly={TaskPlanStore.isPublished(@props.planId)}
+            required={true}
+            onChange={@setDueAt}
+            value={TaskPlanStore.getDueAt(@props.planId)}/>
+        </BS.Col>
+
+        <BS.Col sm=12 md=3>
+          <div className="instructions">Feedback will be released after the due date.</div>
+        </BS.Col>
+
+      </BS.Row>
+
+      { _.map(CourseStore.get(@props.courseId)?.periods, @renderTaskPlanRow) if @state.showingPeriods }
+
+      <BS.Row>
+        <BS.Col sm=4 md=3></BS.Col>
+        <BS.Col sm=4 md=3>
+          <div className="instructions">Open time is 12:01am.</div>
+          <div className="instructions">Set date to today to open immediately.</div>
+        </BS.Col>
+        <BS.Col sm=4 md=3>
+          <div className="instructions">Due time is 7:00am</div>
+        </BS.Col>
+      </BS.Row>
+    </div>
+
   renderTaskPlanRow: (plan) ->
-    <tr key={plan.id}>
-      <td>{plan.name}</td>
-      <td>
+
+    <BS.Row key={plan.id} className="task-plan">
+      <BS.Col sm=4 md=3>
+        <input
+          id={"period-toggle-#{plan.id}"}
+          type='checkbox'
+          onChange={@togglePeriodsDisplay}
+          checked={not @state.showingPeriods}/>
+        <label className="period" htmlFor={"period-toggle-#{plan.id}"}>{plan.name}</label>
+      </BS.Col><BS.Col sm=4 md=3>
         <TutorDateInput
-          id='reading-open-date'
           readOnly={TaskPlanStore.isPublished(@props.planId)}
           required={true}
           onChange={_.partial(@setOpensAt, _, plan)}
           value={TaskPlanStore.getOpensAt(@props.planId, plan.id)}/>
-      </td><td>
+      </BS.Col><BS.Col sm=4 md=3>
         <TutorDateInput
-          id='reading-due-date'
           readOnly={TaskPlanStore.isPublished(@props.planId)}
           required={true}
           onChange={_.partial(@setDueAt, _, plan)}
           value={TaskPlanStore.getDueAt(@props.planId, plan.id)}/>
-      </td>
-    </tr>
-
-  renderName: (plan) ->
-    <TutorInput
-      label='Assignment Name'
-      className='assignment-name'
-      value={plan.title}
-      id='reading-title'
-      default={plan.title}
-      required={true}
-      onChange={@setTitle} />
-
-  renderDescription: ->
-    <TutorTextArea
-      label='Description'
-      className='assignment-description'
-      id='assignment-description'
-      default={TaskPlanStore.getDescription(@props.planId)}
-      onChange={@setDescription} />
-
-  renderShownPeriods: (plan) ->
-    <BS.Row className="assignment">
-      <BS.Col md={12} lg={6}>
-        <BS.Col xs={12}>
-          {@renderName(plan)}
         </BS.Col>
-        <BS.Col xs={12}>
-          {@renderDescription()}
-        </BS.Col>
-      </BS.Col>
-      <BS.Col md=12 lg=6>
-        {@renderPeriodsToggle(12)}
-        <table className="periods-listing">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Opens</th>
-              <th>Closes</th>
-            </tr>
-          </thead>
-          <tbody>
-            { _.map CourseStore.get(@props.courseId)?.periods, @renderTaskPlanRow }
-          </tbody>
-        </table>
-      </BS.Col>
     </BS.Row>
-
-  renderHiddenPeriods: (plan) ->
-    <BS.Row className="assignment">
-      <BS.Row>
-        <BS.Col md={12} lg={6}>
-          {@renderName(plan)}
-        </BS.Col>
-        <BS.Col md=12 lg=6>
-          {@renderPeriodsToggle(4)}
-          <BS.Col xs=12 sm=4>
-            <TutorDateInput
-              id='reading-open-date'
-              label='Open Date'
-              readOnly={TaskPlanStore.isPublished(@props.planId)}
-              required={true}
-              onChange={@setOpensAt}
-              value={TaskPlanStore.getOpensAt(@props.planId)}/>
-            <div className="instructions">Open time is 12:01am</div>
-            <div className="instructions">Set date to today to open immediately.</div>
-          </BS.Col>
-          <BS.Col xs=6 sm=4>
-            <TutorDateInput
-              id='reading-due-date'
-              label='Due Date'
-              readOnly={TaskPlanStore.isPublished(@props.planId)}
-              required={true}
-              onChange={@setDueAt}
-              value={TaskPlanStore.getDueAt(@props.planId)}/>
-            <div className="instructions">Due time is 7:00am</div>
-          </BS.Col>
-        </BS.Col>
-      </BS.Row>
-      <BS.Row>
-        <BS.Col md=12>
-          {@renderDescription()}
-        </BS.Col>
-      </BS.Row>
-    </BS.Row>
-
-  render: ->
-    plan = TaskPlanStore.get(@props.planId)
-    if @state.showingPeriods then @renderShownPeriods(plan) else @renderHiddenPeriods(plan)

--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -57,6 +57,15 @@ module.exports = React.createClass
   togglePeriodsDisplay: (ev) ->
     @setState(showingPeriods: not ev.target.checked)
 
+  togglePeriodEnabled: (period, ev) ->
+    if ev.target.checked
+      TaskPlanActions.enableTasking(@props.planId, period.id,
+        @refs.openDate.getValue(), @refs.dueDate.getValue()
+      )
+    else
+      TaskPlanActions.disableTasking(@props.planId, period.id)
+
+
   setDescription:(desc, descNode) ->
     {id} = @props
     TaskPlanActions.updateDescription(id, desc)
@@ -103,6 +112,7 @@ module.exports = React.createClass
         <BS.Col sm=4 md=3>
           <TutorDateInput
             id='reading-open-date'
+            ref="openDate"
             readOnly={TaskPlanStore.isPublished(@props.planId)}
             required={true}
             onChange={@setOpensAt}
@@ -112,6 +122,7 @@ module.exports = React.createClass
         <BS.Col sm=4 md=3>
           <TutorDateInput
             id='reading-due-date'
+            ref="dueDate"
             readOnly={TaskPlanStore.isPublished(@props.planId)}
             required={true}
             onChange={@setDueAt}
@@ -139,14 +150,31 @@ module.exports = React.createClass
     </div>
 
   renderTaskPlanRow: (plan) ->
+    if TaskPlanStore.hasTasking(@props.planId, plan.id)
+      @renderEnabledTasking(plan)
+    else
+      @renderDisabledTasking(plan)
 
+  renderDisabledTasking: (plan) ->
+    <BS.Row key={plan.id} className="task-plan disabled">
+      <BS.Col sm=12>
+        <input
+          id={"period-toggle-#{plan.id}"}
+          type='checkbox'
+          onChange={_.partial(@togglePeriodEnabled, plan)}
+          checked={false}/>
+        <label className="period" htmlFor={"period-toggle-#{plan.id}"}>{plan.name}</label>
+      </BS.Col>
+    </BS.Row>
+
+  renderEnabledTasking: (plan) ->
     <BS.Row key={plan.id} className="task-plan">
       <BS.Col sm=4 md=3>
         <input
           id={"period-toggle-#{plan.id}"}
           type='checkbox'
-          onChange={@togglePeriodsDisplay}
-          checked={not @state.showingPeriods}/>
+          onChange={_.partial(@togglePeriodEnabled, plan)}
+          checked={true}/>
         <label className="period" htmlFor={"period-toggle-#{plan.id}"}>{plan.name}</label>
       </BS.Col><BS.Col sm=4 md=3>
         <TutorDateInput

--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -28,12 +28,15 @@ module.exports = React.createClass
   setPeriodDefaults: ->
     {date} = @getQuery() # attempt to read the start date from query params
     opensAt = if date
-      moment(date, "MM-DD-YYYY")
+      moment(date, "MM-DD-YYYY").toDate()
     else
-      moment(TimeStore.getNow()).add(1, 'day')
+      moment(TimeStore.getNow()).add(1, 'day').toDate()
     course = CourseStore.get(@props.courseId)
-    if course?.periods
-      TaskPlanActions.setPeriods(@props.planId, course.periods, opensAt.toDate())
+    periods = _.map course?.periods, (period) ->
+      id: period.id, name: period.name, opens_at: opensAt
+    @setState(periods: periods)
+    # Inform the store of the available periods
+    TaskPlanActions.setPeriods(@props.planId, periods)
 
   # this will be called whenever the course store loads, but won't if
   # the store has already finished loading by the time the component mounts
@@ -127,7 +130,7 @@ module.exports = React.createClass
             </tr>
           </thead>
           <tbody>
-            { _.map plan.tasking_plans, @renderTaskPlanRow }
+            { _.map @state.periods, @renderTaskPlanRow }
           </tbody>
         </table>
       </BS.Col>

--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -33,8 +33,8 @@ module.exports = React.createClass
       moment(TimeStore.getNow()).add(1, 'day').toDate()
     course = CourseStore.get(@props.courseId)
     periods = _.map course?.periods, (period) ->
-      id: period.id, name: period.name, opens_at: opensAt
-    @setState(periods: periods)
+      id: period.id, opens_at: opensAt
+
     # Inform the store of the available periods
     TaskPlanActions.setPeriods(@props.planId, periods)
 
@@ -80,14 +80,14 @@ module.exports = React.createClass
           readOnly={TaskPlanStore.isPublished(@props.planId)}
           required={true}
           onChange={_.partial(@setOpensAt, _, plan)}
-          value={plan.opens_at}/>
+          value={TaskPlanStore.getOpensAt(@props.planId, plan.id)}/>
       </td><td>
         <TutorDateInput
           id='reading-due-date'
           readOnly={TaskPlanStore.isPublished(@props.planId)}
           required={true}
           onChange={_.partial(@setDueAt, _, plan)}
-          value={plan.due_at} />
+          value={TaskPlanStore.getDueAt(@props.planId, plan.id)}/>
       </td>
     </tr>
 
@@ -130,7 +130,7 @@ module.exports = React.createClass
             </tr>
           </thead>
           <tbody>
-            { _.map @state.periods, @renderTaskPlanRow }
+            { _.map CourseStore.get(@props.courseId)?.periods, @renderTaskPlanRow }
           </tbody>
         </table>
       </BS.Col>

--- a/src/components/task-plan/index.cjsx
+++ b/src/components/task-plan/index.cjsx
@@ -62,24 +62,15 @@ PlanShell = React.createClass
     store: TaskPlanStore
     actions: TaskPlanActions
 
-  loadTasks: (id, courseId) ->
+  render: ->
     Type = @getType()
+    {courseId} = @context.router.getCurrentParams()
+    id = @getId()
     <LoadableItem
       id={id}
       store={TaskPlanStore}
       actions={TaskPlanActions}
       renderItem={-> <Type id={id} courseId={courseId} />}
     />
-
-  render: ->
-    id = @getId()
-    {courseId} = @context.router.getCurrentParams()
-    <LoadableItem
-      id={courseId}
-      store={CourseStore}
-      actions={CourseActions}
-      renderItem={ => @loadTasks(id, courseId) }
-    />
-
 
 module.exports = {ReadingShell, HomeworkShell}

--- a/src/components/task-plan/plan-mixin.coffee
+++ b/src/components/task-plan/plan-mixin.coffee
@@ -16,16 +16,6 @@ module.exports =
     #   @setDueAt(dueAt)
     {}
 
-  setOpensAt: (period, value) ->
-    {id} = @props
-    id ?= @props.planId # FIXME: Ugly nasty hack because Readings and homework use different props
-    TaskPlanActions.updateOpensAt(id, period.id, value)
-
-  setDueAt: (period, value) ->
-    {id} = @props
-    id ?= @props.planId # FIXME: Ugly nasty hack because Readings and homework use different props
-    TaskPlanActions.updateDueAt(id, period.id, value)
-
   setTitle: (title) ->
     {id} = @props
     id ?= @props.planId # FIXME: Ugly nasty hack because Readings and homework use different props

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -81,7 +81,7 @@ TutorDateInput = React.createClass
 
     date = new Date(value)
     @props.onChange(date)
-    @setState({expandCalendar: false, valid: valid})
+    @setState({expandCalendar: false, valid: valid, value: date})
 
   onToggle: (open) ->
     @setState({expandCalendar: open})
@@ -92,6 +92,9 @@ TutorDateInput = React.createClass
 
   onBlur: (event) ->
     @setState({hasFocus: false})
+
+  getValue: ->
+    @props.value or @state.value
 
   render: ->
     classes = ['form-control']
@@ -118,6 +121,7 @@ TutorDateInput = React.createClass
         onFocus={@expandCalendar}
         onBlur={@onBlur}
         id={@props.id}
+        ref="picker"
         format='MMM dd, yyyy'
         time={false}
         calendar={true}

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -296,17 +296,17 @@ TaskPlanConfig =
     getStats: (id) ->
       @_getStats(id)
 
-    getOpensAt: (id, period) ->
-      if period
-        tasking = @_getPeriodDates(id, period)
+    getOpensAt: (id, periodId) ->
+      if periodId?
+        tasking = @_getPeriodDates(id, periodId)
         tasking?.opens_at
       else
         # default opens_at to 1 day from now
         @_getTaskingsCommonDate(id, 'opens_at')
 
-    getDueAt: (id, period) ->
-      if period
-        tasking = @_getPeriodDates(id, period)
+    getDueAt: (id, periodId) ->
+      if periodId?
+        tasking = @_getPeriodDates(id, periodId)
         tasking?.due_at
       else
         @_getTaskingsCommonDate(id, 'due_at')

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -39,9 +39,6 @@ TaskPlanConfig =
     _.extend({}, @_local[planId], @_changed[planId])
     obj = _.extend({}, @_local[planId], @_changed[planId])
 
-    # default opens_at to 1 day from now
-    obj.opens_at = moment(TimeStore.getNow()).add(1, 'day').toDate()
-
     # iReadings should not contain exercise_ids and will cause a silent 422 on publish
     if obj.type is PLAN_TYPES.READING
       delete obj.settings.exercise_ids
@@ -49,14 +46,23 @@ TaskPlanConfig =
 
     obj
 
+  FAILED: -> # used by API
+
+  setPeriods: (id, periods) ->
+    plan = @_getPlan(id)
+    {tasking_plans} = plan
+    tasking_plans ?= []
+    tasking_plans = tasking_plans[..] # Clone it
+    for period in periods
+      unless @_findTasking(tasking_plans, period.id)
+        tasking_plans.push(name: period.name, target_id: period.id, tasking_type: 'period')
+    @_change(id, {tasking_plans})
+
   _findTasking: (tasking_plans, periodId) ->
-    taskings = _.filter tasking_plans, (tasking) ->
-      tasking.target_type is 'period' and tasking.target_id is periodId
-    taskings[0]
+    _.findWhere(tasking_plans, {target_id:periodId, tasking_type:'period'})
 
   _getPeriodDates: (id, period) ->
     throw new Error('BUG: Period is required arg') unless period
-
     plan = @_getPlan(id)
     {tasking_plans} = plan
     if tasking_plans
@@ -64,8 +70,13 @@ TaskPlanConfig =
     else
       null
 
-
-  FAILED: -> # used by API
+  # detects if all taskings are set to the same due_at/opens_at date
+  # if so the date is returned, else null
+  _getTaskingsCommonDate: (id, attr) ->
+    {tasking_plans} = @_getPlan(id)
+    # do all the tasking_plans have the same date?
+    dates = _.compact _.uniq  _.pluck(tasking_plans, attr)
+    if dates.length is 1 then _.first(dates) else null
 
   updateTutorSelection: (id, direction) ->
     plan = @_getPlan(id)
@@ -87,51 +98,35 @@ TaskPlanConfig =
     exercise_ids = exercise_ids[..]
     @_change(id, {settings: {page_ids, exercise_ids, description, exercises_count_dynamic}})
 
-  updateOpensAt: (id, periodId, opens_at) ->
-    # Allow null opens_at
-    if opens_at
-      opens_at = opens_at.toISOString()
-
-    throw new Error('id is required') unless id
-    throw new Error('periodId is required') unless periodId
-    throw new Error('opens_at is required') unless opens_at
-
+  # updates due_at/opens_at dates for taskings
+  # If a periodId is given, only that tasking is updated.
+  # If not, all taskings are set to that date
+  updateDateAttribute: (id, attr, date, periodId) ->
     plan = @_getPlan(id)
     {tasking_plans} = plan
     tasking_plans ?= []
     tasking_plans = tasking_plans[..] # Clone it
-
-    tasking = @_findTasking(tasking_plans, periodId)
-    if tasking
-      tasking.opens_at = opens_at
-    else
-      tasking = {target_type: 'period', target_id: periodId, opens_at}
-      tasking_plans.push(tasking)
-
-    @_change(id, {tasking_plans})
-
-  updateDueAt: (id, periodId, due_at) ->
-    # Allow null due_at
-    if due_at
-      due_at = due_at.toISOString()
-
     throw new Error('id is required') unless id
-    throw new Error('periodId is required') unless periodId
-    throw new Error('due_at is required') unless due_at
+    throw new Error("#{attr} is required") unless date
 
-    plan = @_getPlan(id)
-    {tasking_plans} = plan
-    tasking_plans ?= []
-    tasking_plans = tasking_plans[..] # Clone it
-
-    tasking = @_findTasking(tasking_plans, periodId)
-    if tasking
-      tasking.due_at = due_at
+    if periodId
+      tasking = @_findTasking(tasking_plans, periodId)
+      if tasking
+        tasking[attr] = date
+      else
+        tasking = _.extend({tasking_type: 'period', target_id: periodId}, {"#{attr}":val})
+        tasking_plans.push(tasking)
     else
-      tasking = {target_type: 'period', target_id: periodId, due_at}
-      tasking_plans.push(tasking)
+      for tasking in tasking_plans
+        tasking[attr] = date
 
     @_change(id, {tasking_plans})
+
+  updateOpensAt: (id, opens_at, periodId) ->
+    @updateDateAttribute(id, 'opens_at', opens_at, periodId)
+
+  updateDueAt: (id, due_at, periodId) ->
+    @updateDateAttribute(id, 'due_at', due_at, periodId)
 
   sortTopics: (id) ->
     plan = @_getPlan(id)
@@ -302,14 +297,21 @@ TaskPlanConfig =
     getStats: (id) ->
       @_getStats(id)
 
-
     getOpensAt: (id, period) ->
-      tasking = @_getPeriodDates(id, period)
-      tasking?.opens_at
+      if period
+        tasking = @_getPeriodDates(id, period)
+        tasking?.opens_at
+      else
+        # default opens_at to 1 day from now
+        @_getTaskingsCommonDate(id, 'opens_at') or
+          moment(TimeStore.getNow()).add(1, 'day').toDate()
 
     getDueAt: (id, period) ->
-      tasking = @_getPeriodDates(id, period)
-      tasking?.due_at
+      if period
+        tasking = @_getPeriodDates(id, period)
+        tasking?.due_at
+      else
+        @_getTaskingsCommonDate(id, 'due_at')
 
     isStatsLoading: (id) -> @_asyncStatusStats[id] is 'loading'
 

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -51,12 +51,12 @@ TaskPlanConfig =
   setPeriods: (id, periods, opens_at) ->
     tasking_plans = _.map periods, (period) ->
       _.extend( _.pick(period, 'opens_at', 'due_at'),
-        target_id: period.id, tasking_type:'period'
+        target_id: period.id, target_type:'period'
       )
     @_change(id, {tasking_plans})
 
   _findTasking: (tasking_plans, periodId) ->
-    _.findWhere(tasking_plans, {target_id:periodId, tasking_type:'period'})
+    _.findWhere(tasking_plans, {target_id:periodId, target_type:'period'})
 
   _getPeriodDates: (id, period) ->
     throw new Error('BUG: Period is required arg') unless period
@@ -113,7 +113,7 @@ TaskPlanConfig =
       if tasking
         tasking[attr] = date
       else
-        tasking = _.extend({tasking_type: 'period', target_id: periodId}, {"#{attr}":val})
+        tasking = _.extend({target_type: 'period', target_id: periodId}, {"#{attr}":val})
         tasking_plans.push(tasking)
     else
       for tasking in tasking_plans

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -2,8 +2,8 @@
 _ = require 'underscore'
 moment = require 'moment'
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
-{TimeStore} = require './time'
 {TocStore} = require './toc'
+{TimeStore} = require './time'
 {ExerciseStore} = require './exercise'
 
 TUTOR_SELECTIONS =
@@ -48,14 +48,19 @@ TaskPlanConfig =
 
   FAILED: -> # used by API
 
-  setPeriods: (id, periods) ->
+  setPeriods: (id, periods, opensAtDate) ->
     plan = @_getPlan(id)
     {tasking_plans} = plan
     tasking_plans ?= []
     tasking_plans = tasking_plans[..] # Clone it
     for period in periods
-      unless @_findTasking(tasking_plans, period.id)
-        tasking_plans.push(name: period.name, target_id: period.id, tasking_type: 'period')
+      tasking = @_findTasking(tasking_plans, period.id)
+      if tasking
+        tasking.opens_at = opensAtDate
+      else
+        tasking_plans.push
+          name: period.name, opens_at: opensAtDate
+          target_id: period.id, tasking_type: 'period'
     @_change(id, {tasking_plans})
 
   _findTasking: (tasking_plans, periodId) ->


### PR DESCRIPTION
If the "All  Periods" checkbox is checked, the periods are hidden and any updates to the dates are copied to all the periods.

If dates are set while the checkbox is checked, all taskings are set to the date.

When the checkbox is unchecked and then checked, the tastings dates are compared and the "global" date inputs are updated if all taskings have the same opens_at/due_at
![screen shot 2015-06-19 at 12 28 15 pm](https://cloud.githubusercontent.com/assets/79566/8258974/b2c1c068-167e-11e5-92bd-917c6292efa4.png)
