### PR TITLE
Bug/smooth out review nav

### DIFF
--- a/src/components/course-periods-nav.cjsx
+++ b/src/components/course-periods-nav.cjsx
@@ -35,7 +35,7 @@ CoursePeriodsNav = React.createClass
 
     period = periods?[key]
     unless period?
-      console.warn("#{key} period does not exist for course #{courseId}. There are only #{periods.length}.")
+      throw new Error("BUG: #{key} period does not exist for course #{courseId}. There are only #{periods.length}.")
       return
 
     handleSelect?(period)

--- a/src/components/course-periods-nav.cjsx
+++ b/src/components/course-periods-nav.cjsx
@@ -34,13 +34,15 @@ CoursePeriodsNav = React.createClass
     periods = CourseStore.getPeriods(courseId)
 
     period = periods?[key]
-    console.warn("#{key} period does not exist for course #{courseId}. There are only #{periods.length}.") unless period?
+    unless period?
+      console.warn("#{key} period does not exist for course #{courseId}. There are only #{periods.length}.")
+      return
 
     handleSelect?(period)
     @setState(active: key)
 
   renderPeriod: (period, key) ->
-    <BS.NavItem eventKey={key}>{period.name}</BS.NavItem>
+    <BS.NavItem eventKey={key} key="period-nav-#{period.id}">{period.name}</BS.NavItem>
 
   render: ->
     {courseId} = @props
@@ -70,13 +72,12 @@ CoursePeriodsNavShell = React.createClass
 
   render: ->
     courseId = @getCourseId()
-    @props.courseId ?= courseId
 
     <LoadableItem
       id={courseId}
       store={CourseStore}
       actions={CourseActions}
-      renderItem={=> <CoursePeriodsNav courseId={courseId} {...@props}/>}
+      renderItem={=> <CoursePeriodsNav {...@props} courseId={courseId} />}
     />
 
 module.exports = {CoursePeriodsNav, CoursePeriodsNavShell}

--- a/src/components/course-periods-nav.cjsx
+++ b/src/components/course-periods-nav.cjsx
@@ -21,13 +21,14 @@ CoursePeriodsNav = React.createClass
     active: @props.intialActive
 
   componentWillMount: ->
-    CourseStore.on('change', @selectPeriod)
+    CourseStore.on('course.loaded', @selectPeriod)
 
   componentWillUnmount: ->
-    CourseStore.off('change', @selectPeriod)
+    CourseStore.off('course.loaded', @selectPeriod)
 
-  selectPeriod: ->
-    @onSelect(@state.active)
+  selectPeriod: (courseId) ->
+    if courseId is @props.courseId
+      @onSelect(@state.active)
 
   onSelect: (key) ->
     {courseId, handleSelect} = @props

--- a/src/components/scroll-tracker.cjsx
+++ b/src/components/scroll-tracker.cjsx
@@ -3,16 +3,29 @@ React = require 'react'
 ScrollTracker =
   propTypes:
     setScrollPoint: React.PropTypes.func.isRequired
+    unsetScrollPoint: React.PropTypes.func
     scrollState: React.PropTypes.object.isRequired
+
+  getInitialState: ->
+    scrollPoint: 0
 
   setScrollPoint: ->
     {setScrollPoint, scrollState} = @props
 
     scrollPoint = @getPosition(@getDOMNode())
+    @setState({scrollPoint})
+
     setScrollPoint(scrollPoint, scrollState)
+
+  unsetScrollPoint: ->
+    {unsetScrollPoint} = @props
+    unsetScrollPoint?(@state.scrollPoint)
 
   componentDidMount: ->
     @setScrollPoint()
+
+  componentWillUnmount: ->
+    @unsetScrollPoint()
 
   getPosition: (el) -> el.getBoundingClientRect().top - document.body.getBoundingClientRect().top
 

--- a/src/components/scroll-tracker.cjsx
+++ b/src/components/scroll-tracker.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+_ = require 'underscore'
 
 ScrollTracker =
   propTypes:
@@ -29,4 +30,75 @@ ScrollTracker =
 
   getPosition: (el) -> el.getBoundingClientRect().top - document.body.getBoundingClientRect().top
 
-module.exports = ScrollTracker
+ScrollTrackerParentMixin =
+
+  getInitialState: ->
+    scrollPoints: []
+    scrollState: {}
+    scrollTopBuffer: 0
+
+  setScrollTopBuffer: ->
+    scrollTopBuffer = @getPosition(@getDOMNode())
+    @setState({scrollTopBuffer})
+
+  setScrollPoint: (scrollPoint, scrollState) ->
+    scrollPointData = _.extend({scrollPoint: scrollPoint}, scrollState)
+    @state.scrollPoints.push(scrollPointData)
+
+  unsetScrollPoint: (unsetScrollPoint) ->
+    @state.scrollPoints = _.reject @state.scrollPoints, (scrollPoint) ->
+      scrollPoint.scrollPoint is unsetScrollPoint
+
+  sortScrollPoints: ->
+    sortedDescScrollPoints = _.sortBy @state.scrollPoints, (scrollData) ->
+      -1 * scrollData.scrollPoint
+
+    @setState({scrollPoints: sortedDescScrollPoints})
+
+  getScrollStateByScroll: (scrollTop) ->
+    scrollState = _.find @state.scrollPoints, (scrollData) =>
+      scrollTop > (scrollData.scrollPoint - @state.scrollTopBuffer)
+
+    scrollState or _.last(@state.scrollPoints)
+
+  getScrollStateByKey: (stepKey) ->
+    scrollState = _.find @state.scrollPoints, (scrollData) ->
+      scrollData.key is stepKey
+
+  setScrollState: ->
+    scrollState = @getScrollStateByScroll(@state.scrollTop)
+    @setState({scrollState})
+
+    @props.setScrollState(scrollState)
+
+  componentDidMount: ->
+    @setScrollTopBuffer()
+    @sortScrollPoints()
+    @scrollToKey(@props.currentStep)
+    @setScrollState()
+
+  componentWillUpdate: (nextProps, nextState) ->
+    willScrollStateKeyChange = not (nextState.scrollState.key is @state.scrollState.key)
+    @props.goToStep(nextState.scrollState.key)() if willScrollStateKeyChange
+
+  componentDidUpdate: (prevProps, prevState) ->
+    doesScrollStateMatch = (prevState.scrollState.key is @getScrollStateByScroll(@state.scrollTop).key)
+    didCurrentStepChange = not (@props.currentStep is prevState.scrollState?.key)
+    didScrollPointsChange = not (prevState.scrollPoints.length is @state.scrollPoints.length) and @state.scrollPoints.length
+
+    if didScrollPointsChange
+      @sortScrollPoints()
+
+    unless doesScrollStateMatch
+      @setScrollState()
+    else if didCurrentStepChange
+      @scrollToKey(@props.currentStep)
+
+  getPosition: (el) -> el.getBoundingClientRect().top - document.body.getBoundingClientRect().top
+
+  scrollToKey: (stepKey) ->
+    scrollState = @getScrollStateByKey(stepKey)
+    window.scrollTo(0, (scrollState.scrollPoint - @state.scrollTopBuffer))
+
+
+module.exports = {ScrollTracker, ScrollTrackerParentMixin}

--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -171,7 +171,7 @@ Stats = React.createClass
     handlePeriodSelect?(period)
 
   render: ->
-    {id} = @props
+    {id, courseId} = @props
     {stats} = @state
 
     plan = TaskPlanStatsStore.get(id)
@@ -192,7 +192,10 @@ Stats = React.createClass
       </section>
 
     <BS.Panel className='reading-stats'>
-      <CoursePeriodsNavShell handleSelect={@handlePeriodSelect} intialActive={@state.period}/>
+      <CoursePeriodsNavShell
+        handleSelect={@handlePeriodSelect}
+        intialActive={@state.period}
+        courseId={courseId} />
       <section>
         {course}
       </section>

--- a/src/components/task-teacher-review/crumb-mixin.cjsx
+++ b/src/components/task-teacher-review/crumb-mixin.cjsx
@@ -135,13 +135,11 @@ module.exports =
     crumbs = @_generateCrumbsFromStats(stats, review.type)
 
   generateCrumbs: ->
-    {id} = @props
-    {period} = @state
+    {id, period} = @props
     @_generateCrumbs id, period
 
   getContents: ->
-    {id} = @props
-    {period} = @state
+    {id, period} = @props
     review = TaskTeacherReviewStore.get(id)
 
     allCrumbs = @generateCrumbs()

--- a/src/components/task-teacher-review/exercise.cjsx
+++ b/src/components/task-teacher-review/exercise.cjsx
@@ -9,9 +9,7 @@ FreeResponse = require '../task-step/exercise/free-response'
 TaskTeacherReviewExercise = React.createClass
   displayName: 'TaskTeacherReviewExercise'
   propTypes:
-    id: React.PropTypes.string.isRequired
-    onStepCompleted: React.PropTypes.func.isRequired
-    goToStep: React.PropTypes.func.isRequired
+    content: React.PropTypes.object.isRequired
 
   onChangeAnswerAttempt: (answer) ->
     # TODO show cannot change answer message here

--- a/src/components/task-teacher-review/index.cjsx
+++ b/src/components/task-teacher-review/index.cjsx
@@ -140,8 +140,6 @@ TaskTeacherReview = React.createClass
           taskId={task.id}
           setScrollPoint={@setScrollPoint}
           setScrollTopBuffer={@setScrollTopBuffer}
-          goToStep={@goToStep}
-          onNextStep={@onNextStep}
           review='teacher'
           panel='teacher-review' />
 
@@ -172,9 +170,6 @@ TaskTeacherReview = React.createClass
           </BS.Row>
         </BS.Grid>
     </PinnedHeaderFooterCard>
-
-  onNextStep: ->
-    @goToStep(@state.currentStep + 1)()
 
 
 TaskTeacherReviewShell = React.createClass

--- a/src/components/task-teacher-review/index.cjsx
+++ b/src/components/task-teacher-review/index.cjsx
@@ -82,16 +82,18 @@ TaskTeacherReview = React.createClass
     @goToStep(@state.scrollState.key)() if @state.scrollState?.key?
 
   componentDidUpdate: (prevProps, prevState) ->
-    didScrollStateChange = not (prevState.scrollState.scrollPoint is @getScrollStateByScroll(@state.scrollTop).scrollPoint)
+    didScrollStateChange = not (prevState.scrollState.key is @getScrollStateByScroll(@state.scrollTop).key)
     didCurrentStepChange = not (@state.currentStep is prevState.scrollState?.key)
 
-    @setScrollState() if didScrollStateChange
-    @scrollToKey(@state.currentStep) if didCurrentStepChange and not didScrollStateChange
+    if didCurrentStepChange and not didScrollStateChange
+      @scrollToKey(@state.currentStep)
+    else if didScrollStateChange
+      @setScrollState()
 
   scrollToKey: (stepKey) ->
     scrollState = @getScrollStateByKey(stepKey)
 
-    window.scrollTo(0, (scrollState.scrollPoint - @state.scrollTopBuffer + 1))
+    window.scrollTo(0, (scrollState.scrollPoint - @state.scrollTopBuffer + 2))
 
   # Curried for React
   goToStep: (stepKey) ->

--- a/src/components/task-teacher-review/index.cjsx
+++ b/src/components/task-teacher-review/index.cjsx
@@ -1,23 +1,17 @@
 React = require 'react'
 BS = require 'react-bootstrap'
 Router = require 'react-router'
-{ScrollListenerMixin} = require 'react-scroll-components'
-
-_ = require 'underscore'
-camelCase = require 'camelcase'
-
-{TaskTeacherReviewActions, TaskTeacherReviewStore} = require '../../flux/task-teacher-review'
-{TaskPlanStatsStore} = require '../../flux/task-plan-stats'
-
-CrumbMixin = require './crumb-mixin'
-ChapterSectionMixin = require '../chapter-section-mixin'
 
 Breadcrumbs = require './breadcrumbs'
 {ReviewShell} = require './review'
 {StatsModalShell} = require '../task-plan/reading-stats'
-
 PinnedHeaderFooterCard = require '../pinned-header-footer-card'
-LoadableItem = require '../loadable-item'
+
+_ = require 'underscore'
+camelCase = require 'camelcase'
+
+{TaskTeacherReviewStore} = require '../../flux/task-teacher-review'
+
 
 TaskTeacherReview = React.createClass
   propTypes:

--- a/src/components/task-teacher-review/review.cjsx
+++ b/src/components/task-teacher-review/review.cjsx
@@ -73,8 +73,8 @@ Review = React.createClass
         scrollState={scrollState}
         setScrollPoint={@props.setScrollPoint} />
 
-    <ReactCSSTransitionGroup transitionName="homework-review-problem">
+    <div>
       {stepsList}
-    </ReactCSSTransitionGroup>
+    </div>
 
 module.exports = Review

--- a/src/components/task-teacher-review/review.cjsx
+++ b/src/components/task-teacher-review/review.cjsx
@@ -1,4 +1,4 @@
-React = require 'react/addons'
+React = require 'react'
 _ = require 'underscore'
 
 TaskTeacherReviewExercise = require './exercise'

--- a/src/components/task-teacher-review/review.cjsx
+++ b/src/components/task-teacher-review/review.cjsx
@@ -1,10 +1,15 @@
 React = require 'react/addons'
-ReactCSSTransitionGroup = React.addons.CSSTransitionGroup
-
 _ = require 'underscore'
 
 TaskTeacherReviewExercise = require './exercise'
-ScrollTracker = require '../scroll-tracker'
+{ScrollTracker, ScrollTrackerParentMixin} = require '../scroll-tracker'
+LoadableItem = require '../loadable-item'
+
+CrumbMixin = require './crumb-mixin'
+ChapterSectionMixin = require '../chapter-section-mixin'
+{ScrollListenerMixin} = require 'react-scroll-components'
+
+{TaskTeacherReviewActions, TaskTeacherReviewStore} = require '../../flux/task-teacher-review'
 
 
 ReviewTracker = React.createClass
@@ -34,27 +39,21 @@ ReviewTracker = React.createClass
 
 Review = React.createClass
   displayName: 'Review'
+  mixins: [ChapterSectionMixin, CrumbMixin, ScrollListenerMixin, ScrollTrackerParentMixin]
   propTypes:
-    taskId: React.PropTypes.string.isRequired
+    id: React.PropTypes.string.isRequired
     focus: React.PropTypes.bool.isRequired
-    setScrollPoint: React.PropTypes.func.isRequired
+    period: React.PropTypes.object.isRequired
+    currentStep: React.PropTypes.number.isRequired
 
   getDefaultProps: ->
     focus: false
 
-  setScrollTopBuffer: ->
-    scrollTopBuffer = @getPosition(@getDOMNode())
-    @props.setScrollTopBuffer(scrollTopBuffer)
-
-  componentDidMount: ->
-    @setScrollTopBuffer()
-
-  getPosition: (el) -> el.getBoundingClientRect().top - document.body.getBoundingClientRect().top
-
   render: ->
-    {taskId, steps, focus} = @props
+    {id, focus} = @props
+    steps = @getContents()
 
-    stepsProps = _.omit(@props, 'steps', 'focus', 'setScrollTopBuffer')
+    stepsProps = _.omit(@props, 'focus')
 
     stepsList = _.map steps, (step, index) =>
 
@@ -71,10 +70,23 @@ Review = React.createClass
       item = <ReviewTracker
         {...stepProps}
         scrollState={scrollState}
-        setScrollPoint={@props.setScrollPoint} />
+        setScrollPoint={@setScrollPoint}
+        unsetScrollPoint={@unsetScrollPoint}
+      />
 
     <div>
       {stepsList}
     </div>
 
-module.exports = Review
+
+ReviewShell = React.createClass
+  render: ->
+    {id} = @props
+    <LoadableItem
+      id={id}
+      store={TaskTeacherReviewStore}
+      actions={TaskTeacherReviewActions}
+      renderItem={=> <Review {...@props} review='teacher' panel='teacher-review' />}
+    />
+
+module.exports = {Review, ReviewShell}

--- a/src/flux/course.coffee
+++ b/src/flux/course.coffee
@@ -47,6 +47,9 @@ CourseConfig =
     TaskActions.loaded(obj, obj.id)
     @emit('practice.loaded', obj.id)
 
+  _loaded: (obj, id) ->
+    @emit('course.loaded', obj.id)
+
   _reset: ->
     CrudConfig.reset.call(@)
     @_guides = {}

--- a/src/flux/task-teacher-review.coffee
+++ b/src/flux/task-teacher-review.coffee
@@ -6,12 +6,13 @@ _ = require 'underscore'
 
 TaskTeacherReviewConfig = {
   _loaded: (obj, id) ->
-    planStats = _.clone(obj)
-    _.each planStats.stats.periods, (period) ->
-      delete period.current_pages.exercises if period.current_pages.exercises?
-      delete period.spaced_pages.exercises if period.spaced_pages.exercises?
+    if obj?.stats?
+      planStats = _.clone(obj)
+      _.each planStats.stats.periods, (period) ->
+        delete period.current_pages.exercises if period.current_pages.exercises?
+        delete period.spaced_pages.exercises if period.spaced_pages.exercises?
 
-    TaskPlanStatsActions.loaded(planStats, id)
+      TaskPlanStatsActions.loaded(planStats, id)
 
 }
 

--- a/src/flux/task-teacher-review.coffee
+++ b/src/flux/task-teacher-review.coffee
@@ -6,6 +6,7 @@ _ = require 'underscore'
 
 TaskTeacherReviewConfig = {
   _loaded: (obj, id) ->
+    @emit('review.loaded', id)
     if obj?.stats?
       planStats = _.clone(obj)
       _.each planStats.stats.periods, (period) ->


### PR DESCRIPTION
## Various details around review nav including:
- [x] Smoother scroll by removing unnecessary state updates from scroll points
- [x] No more flicker of URL state when clicking on breadcrumbs to navigate problems
- [x] Pruning irrelevant warnings
- [x] Loading state with stats showing if already loaded from calendar stats popup
- [x] Fix when period switching would mess up the states from scroll points when exercises are different between periods

## Loading state when stats are already loaded

![screen shot 2015-06-17 at 4 19 21 pm](https://cloud.githubusercontent.com/assets/2483873/8219020/b0b0af50-150c-11e5-96c7-c6c9521f0faa.png)
