### PR TITLE
Reference book styling fixes

### DIFF
--- a/resources/styles/components/reference-book/page.less
+++ b/resources/styles/components/reference-book/page.less
@@ -22,6 +22,10 @@
       section {
         .book-content-step-size();
       }
+
+      > section > div {
+        clear: both;
+      }
     }
   }
 

--- a/resources/styles/components/reference-book/page.less
+++ b/resources/styles/components/reference-book/page.less
@@ -1,4 +1,9 @@
 .reference-book {
+  .dropdown-toggle {
+    font-size: 3rem;
+    line-height: 30px;
+  }
+
   .content {
     margin-top: 75px;
 

--- a/resources/styles/components/reference-book/page.less
+++ b/resources/styles/components/reference-book/page.less
@@ -34,14 +34,41 @@
     position: absolute;
     top: 200px;
     cursor: pointer;
+    opacity: 0;
+    background-color: @tutor-neutral-lighter;
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+      opacity: 0.8;
+    }
+
     &:hover {
       color: @tutor-neutral;
     }
+
+    &.prev,
     &.next {
-      right: 20px
+      display: -webkit-flex;
+      display: -ms-flex;
+      display: flex;
+      position: fixed;
+      top: 60px;
+      height: 100vh;
+      justify-content: -webkit-center;
+      justify-content: -ms-center;
+      justify-content: center;
+      flex-direction: -webkit-column;
+      flex-direction: -ms-column;
+      flex-direction: column;
     }
+
     &.prev {
-      left: 20px;
+      left: 0;
+    }
+
+    &.next {
+      right: 0;
     }
   }
 

--- a/resources/styles/global/maths.less
+++ b/resources/styles/global/maths.less
@@ -14,3 +14,17 @@
 // Hide the HTML and use MathJax for rendering
 // TODO: Decide whether to remove KaTeX (involves additional code for MathJax)
 .has-html .katex > .katex-html { display: none; }
+
+// HACK: Override some odd properties being directly added on to 2 MathJax-related elements
+.MathJax .math {
+  > span {
+    display: inline !important;
+    position: static !important;
+    width: auto !important;
+    height: auto !important;
+
+    > span {
+      position: static !important;
+    }
+  }
+}


### PR DESCRIPTION
- [x] Clear floats before block-level elements
- [x] Fix layout for math equations
- [x] Make nav buttons take up full view height and hide until moused over
- [x] Increase size of dropdown menu icon

![screen shot 2015-06-18 at 2 29 04 am](https://cloud.githubusercontent.com/assets/1371232/8225390/04aeee32-1562-11e5-8d53-c21daf4e7c2d.png)
![screen shot 2015-06-18 at 2 29 14 am](https://cloud.githubusercontent.com/assets/1371232/8225392/0741d682-1562-11e5-9ac2-cc6581f03472.png)
![screen shot 2015-06-18 at 2 29 45 am](https://cloud.githubusercontent.com/assets/1371232/8225394/09adaedc-1562-11e5-81dd-169963eab449.png)
![screen shot 2015-06-18 at 2 30 07 am](https://cloud.githubusercontent.com/assets/1371232/8225397/0cd16810-1562-11e5-9fec-8286d72723ff.png)
