### PR TITLE
stop footer-buttons from breaking to new line next to details

### DIFF
--- a/resources/styles/components/task-step/step-mixin.less
+++ b/resources/styles/components/task-step/step-mixin.less
@@ -5,6 +5,6 @@
   float: right;
   font-weight: 600;
 }
-.footer-buttons {
+.task-footer-buttons {
   display: inline-block;
 }

--- a/src/components/task-step/exercise/modes.cjsx
+++ b/src/components/task-step/exercise/modes.cjsx
@@ -194,7 +194,7 @@ ExerciseReview = React.createClass
         Refresh My Memory
       </BS.Button>
 
-    <div className='footer-buttons'>
+    <div className='task-footer-buttons'>
       {tryAnotherButton}
       {refreshMemoryButton}
       {@renderContinueButton() unless review is 'completed'}

--- a/test/components/helpers/task/checks.coffee
+++ b/test/components/helpers/task/checks.coffee
@@ -100,8 +100,8 @@ checks =
     {div, component, stepId, taskId, state, router, history, correct_answer, feedback_html}
 
   _checkRecoveryRefreshChoice: ({div, component, stepId, taskId, state, router, history}) ->
-    expect(div.querySelector('.footer-buttons').children.length).to.equal(3)
-    classes = _.pluck(div.querySelector('.footer-buttons').children, 'className')
+    expect(div.querySelector('.task-footer-buttons').children.length).to.equal(3)
+    classes = _.pluck(div.querySelector('.task-footer-buttons').children, 'className')
     expect(classes).to.deep.equal([
       '-try-another btn btn-primary', '-refresh-memory btn btn-primary', 'async-button -continue btn btn-primary'
     ])
@@ -109,7 +109,7 @@ checks =
 
   _checkRecoveryContent: ({div, component, stepId, taskId, state, router, history}) ->
     expect(div.innerText).to.contain('recovery')
-    expect(div.querySelector('.footer-buttons')).to.be.null
+    expect(div.querySelector('.task-footer-buttons')).to.be.null
     expect(div.querySelector('.-continue')).to.not.be.null
 
     {div, component, stepId, taskId, state, router, history}


### PR DESCRIPTION
## Before
![screen shot 2015-06-19 at 11 04 44 am](https://cloud.githubusercontent.com/assets/2483873/8257422/21a88d38-1673-11e5-95ff-fd398cd2149b.png)

## After
![screen shot 2015-06-19 at 11 05 09 am](https://cloud.githubusercontent.com/assets/2483873/8257427/280d35a2-1673-11e5-8f17-ea7f151094c8.png)

