### PR TITLE
Specify default handler for courses/<id> url

### DIFF
--- a/src/router.cjsx
+++ b/src/router.cjsx
@@ -22,6 +22,8 @@ routes = (
       <Redirect from='/' to='dashboard' />
       <Route path='dashboard/?' name='dashboard' handler={CourseListing} />
       <Route path='courses/:courseId/?'>
+        <Router.DefaultRoute handler={TeacherTaskPlans}/>
+
         <Route path='list/?' name='viewStudentDashboard' handler={StudentDashboardShell} />
         <Route path='tasks/:id/?' name='viewTask' handler={SingleTask}/>
         <Route path='tasks/:id/steps/:stepIndex/?'


### PR DESCRIPTION
Ideally we could redirect on this to the `courses/<id>t/t/calendar` url but React router doesn't seem to support that. 