### PR TITLE
Fix "booksplash" banner so it displays in IE

### DIFF
--- a/resources/styles/global/tutor-booksplash-background.less
+++ b/resources/styles/global/tutor-booksplash-background.less
@@ -7,19 +7,20 @@
   &:before {
     content: attr(data-title);
     position: fixed;
-    top: 48px;
+    top: 60px;
     left: 0px;
     right: 0px;
+    height: 24rem;
     overflow: hidden;
     background-color: @tutor-tertiary;
     color: @tutor-secondary;
     text-align: center;
     font-size: 35rem;
-    line-height: 24rem;
+    padding-top: 10rem;
     #fonts > .book-cover();
     z-index: -1;
   }
-  
+
   // The background is applied as a :after block so the opacity can
   // be applied to only the background image, not the content itself
   &:after {
@@ -32,7 +33,7 @@
     right: 0;
     opacity: 0.05;
   }
-  
+
   // custom backgrounds images for different types
   &[data-category=physics]:after{ .tutor-background-image("physics.jpg"); }
 }

--- a/resources/styles/global/typography.less
+++ b/resources/styles/global/typography.less
@@ -54,11 +54,11 @@
     font-family: 'Lato-RegularItalic', Helvetica, sans-serif;
   }
   .guide-header(){
-    font-family: 'Lato-Black', Helvetica, sans-serif;  
+    font-family: 'Lato-Black', Helvetica, sans-serif;
   }
   .book-cover(){
-    font-family: 'HelveticaNeue-Bold', 'Helvetica Neue Bold', 'Helvetica Neue', Helvetica, sans-serif;
-    font-weight: 700;
+    font-family: 'Lato';
+    font-weight: 900;
   }
 }
 


### PR DESCRIPTION
The main issue was that the :before block was missing a height, which IE defaulted to 0.

The rest is tweaks so it displays identically in both IE and chrome/firefox/safari.

