### PR TITLE
Adjust starting dates for HW builder 

### DIFF
--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -116,6 +116,7 @@ module.exports = React.createClass
             readOnly={TaskPlanStore.isPublished(@props.id)}
             required={true}
             onChange={@setOpensAt}
+            min={TimeStore.getNow()}
             max={TaskPlanStore.getDueAt(@props.id)}
             value={TaskPlanStore.getOpensAt(@props.id)}/>
         </BS.Col>
@@ -181,12 +182,14 @@ module.exports = React.createClass
         <TutorDateInput
           readOnly={TaskPlanStore.isPublished(@props.id)}
           required={true}
+          min={TimeStore.getNow()}
           onChange={_.partial(@setOpensAt, _, plan)}
           value={TaskPlanStore.getOpensAt(@props.id, plan.id)}/>
       </BS.Col><BS.Col sm=4 md=3>
         <TutorDateInput
           readOnly={TaskPlanStore.isPublished(@props.id)}
           required={true}
+          min={TaskPlanStore.getOpensAt(@props.id, plan.id)}
           onChange={_.partial(@setDueAt, _, plan)}
           value={TaskPlanStore.getDueAt(@props.id, plan.id)}/>
         </BS.Col>

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -111,10 +111,13 @@ ReadingPlan = React.createClass
     {id, courseId} = @props
     plan = TaskPlanStore.get(id)
 
-    headerText = if TaskPlanStore.isNew(id) then 'Add Reading Assignment' else 'Edit Reading Assignment'
+    headerText = <span key='header-text'>
+      {if TaskPlanStore.isNew(id) then 'Add Reading Assignment' else 'Edit Reading Assignment'}
+    </span>
     topics = TaskPlanStore.getTopics(id)
     formClasses = ['edit-reading', 'dialog']
     closeBtn = <Close
+      key='close-button'
       className='pull-right'
       onClick={@cancel}/>
 

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -65,6 +65,9 @@ TutorDateInput = React.createClass
     @props.onChange(date)
     @setState({expandCalendar: false, valid: valid, value: date})
 
+  getValue: ->
+    @props.value or @state.value
+
   onToggle: (open) ->
     @setState({expandCalendar: open})
 
@@ -100,7 +103,7 @@ TutorDateInput = React.createClass
       </div>
 
       <div className="date-wrapper">
-        <DatePicker 
+        <DatePicker
           minDate={min}
           maxDate={max}
           onFocus={@expandCalendar}


### PR DESCRIPTION
The earliest date for opens_at date is today, and due date should be the value of the opens_at date.

Also fixes the bug when un-selecting/re-selecting a period, and silences some missing key React warnings.

Not much UI change, other than past date selection is now disabled (screenshot taken on the 25th):
![screen shot 2015-06-25 at 12 15 43 pm](https://cloud.githubusercontent.com/assets/79566/8360690/fae7c306-1b33-11e5-893d-f9dd01e71353.png)
