### PR TITLE
Apply image sizing logic to reference book pages

### DIFF
--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -158,10 +158,11 @@ figure {
   .tutor-ui-horizontal-img {
     display:block;
     .book-content-full-width();
-    img {
-      width: 100%;
+    &.full-width {
+      img { width: 100%; }
     }
   }
+
   // splash images are always full width without margin or surrounding padding
   &.splash {
     width: 100%;

--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -24,9 +24,16 @@ module.exports =
   detectImgAspectRatio: ->
     root = @getDOMNode()
     for img in root.querySelectorAll('img')
-      # Wait until an image loads before trying to detect its dimensions
-      img.onload = ->
-        if @width > @height
-          @parentNode.classList.add('tutor-ui-horizontal-img')
-        else
-          @parentNode.classList.add('tutor-ui-vertical-img')
+      if img.complete
+        sizeImage.call(img)
+      else
+        img.onload = sizeImage
+
+# called with the context set to the image
+sizeImage = ->
+  if @naturalWidth > @naturalHeight
+    @parentNode.classList.add('tutor-ui-horizontal-img')
+    if @naturalWidth > 450
+      @parentNode.classList.add('full-width')
+  else
+    @parentNode.classList.add('tutor-ui-vertical-img')

--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -45,5 +45,4 @@ module.exports = React.createClass
     links = root.querySelectorAll('a')
     _.each links, (link) ->
       link.setAttribute('target', '_blank') unless link.getAttribute('href')?[0] is '#'
-
     typesetMath(root)

--- a/src/components/reference-book/navbar.cjsx
+++ b/src/components/reference-book/navbar.cjsx
@@ -4,8 +4,8 @@ BS = require 'react-bootstrap'
 
 ReferenceBookTOC = require './toc'
 BindStoreMixin = require '../bind-store-mixin'
-{ReferenceBookActions, ReferenceBookStore} = require '../../flux/reference-book'
-{ReferenceBookPageActions, ReferenceBookPageStore} = require '../../flux/reference-book-page'
+{ReferenceBookStore} = require '../../flux/reference-book'
+{ReferenceBookPageStore} = require '../../flux/reference-book-page'
 
 module.exports = React.createClass
   displayName: 'ReferenceBookNavBar'

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -7,18 +7,18 @@ HTML = require '../html'
 ArbitraryHtmlAndMath = require '../html'
 BookContentMixin = require '../book-content-mixin'
 
-{ReferenceBookPageActions, ReferenceBookPageStore} = require '../../flux/reference-book-page'
-{ReferenceBookActions, ReferenceBookStore} = require '../../flux/reference-book'
+{ReferenceBookPageStore} = require '../../flux/reference-book-page'
+{ReferenceBookStore} = require '../../flux/reference-book'
 
 module.exports = React.createClass
   displayName: 'ReferenceBookPage'
   propTypes:
     courseId: React.PropTypes.string.isRequired
 
-  mixins: [Router.State]
+  mixins: [Router.State, BookContentMixin]
   getSplashTitle: ->
     {cnxId} = @getParams()
-    page = ReferenceBookPageStore.get(cnxId)
+    page = ReferenceBookStore.getPageInfo(@getParams())
     page?.title
 
   prevLink: (info) ->


### PR DESCRIPTION
Oops, the `BookContentMixin` was required by reference book pages component, but not inserted into the `mixins` array.

This also tweaks the image `onload` function to only scale a `tutor-ui-horizontal-img` up to full width if it's naturalWidth is more than 450px.  That prevents small images being blown up and looking jaggy.

Before:
![screen shot 2015-06-26 at 2 29 03 pm](https://cloud.githubusercontent.com/assets/79566/8385741/2a796796-1c10-11e5-8c1d-76fae324fe9d.png)

After:
![screen shot 2015-06-26 at 2 29 18 pm](https://cloud.githubusercontent.com/assets/79566/8385742/2a7a0dc2-1c10-11e5-926b-fb12b4368513.png)
