### PR TITLE
date picker CSS was not being included

### DIFF
--- a/resources/styles/global/react-datepicker.less
+++ b/resources/styles/global/react-datepicker.less
@@ -1,1 +1,1 @@
-@import '../../../node_modules/react-datepicker/dist/react-datepicker.css';
+@import (inline) '../../../node_modules/react-datepicker/dist/react-datepicker.css';


### PR DESCRIPTION
Fixes a bug on deployed code.

`@import "...css";` by default keeps the `@import` directive instead of including the CSS file in the minified `tutor.css` file.