### PR TITLE
Add booksplash to Readings component (was on Interactives)

### DIFF
--- a/src/components/task-step/all-steps.cjsx
+++ b/src/components/task-step/all-steps.cjsx
@@ -17,11 +17,14 @@ err = (msgs...) ->
 
 Reading = React.createClass
   displayName: "Reading"
-  mixins: [StepMixin, StepFooterMixin]
+  mixins: [StepMixin, StepFooterMixin, BookContentMixin]
   isContinueEnabled: -> true
   onContinue: ->
     @props.onStepCompleted()
     @props.onNextStep()
+
+  getSplashTitle: ->
+    TaskStepStore.get(@props.id)?.title or ''
 
   renderBody: ->
     {id} = @props
@@ -31,14 +34,11 @@ Reading = React.createClass
 
 Interactive = React.createClass
   displayName: "Interactive"
-  mixins: [StepMixin, StepFooterMixin, BookContentMixin]
+  mixins: [StepMixin, StepFooterMixin]
   isContinueEnabled: -> true
   onContinue: ->
     @props.onStepCompleted()
     @props.onNextStep()
-
-  getSplashTitle: ->
-    TaskStepStore.get(@props.id)?.title or ''
 
   renderBody: ->
     {id} = @props


### PR DESCRIPTION
Not sure why it wasn't on Readings originally, or how it ever worked since when they lacked it. The only thing I can think of is that task steps where not using the Readings component in the past?

Works now at least:
![screen shot 2015-07-02 at 6 07 24 pm](https://cloud.githubusercontent.com/assets/79566/8489799/380e1a62-20e5-11e5-94a4-e94938514de2.png)



