### PR TITLE
Fix mathjax exercise answer rendering height

### DIFF
--- a/resources/styles/global/maths.less
+++ b/resources/styles/global/maths.less
@@ -14,17 +14,3 @@
 // Hide the HTML and use MathJax for rendering
 // TODO: Decide whether to remove KaTeX (involves additional code for MathJax)
 .has-html .katex > .katex-html { display: none; }
-
-// HACK: Override some odd properties being directly added on to 2 MathJax-related elements
-.MathJax .math {
-  > span {
-    display: inline !important;
-    position: static !important;
-    width: auto !important;
-    height: auto !important;
-
-    > span {
-      position: static !important;
-    }
-  }
-}

--- a/resources/styles/global/maths.less
+++ b/resources/styles/global/maths.less
@@ -2,11 +2,10 @@
 // Hides all data-math elements, but still reserves their space in the DOM.
 // when .MathJax renders them, it'll be inside a .MathJax element which is displayed
 [data-math]{
-    visibility: hidden;
-
-    .MathJax {
-      visibility: visible;
-    }
+  visibility: hidden;
+  .MathJax {
+    visibility: visible;
+  }
 }
 
 // KaTeX 1.0.2 generates both HTML and MathML

--- a/src/helpers/mathjax.coffee
+++ b/src/helpers/mathjax.coffee
@@ -59,7 +59,6 @@ startMathJax = ->
 
   configuredCallback = ->
     window.MathJax.Hub.Configured()
-    cleanMathArtifacts()
 
   if window.MathJax?.Hub
     window.MathJax.Hub.Config(MATHJAX_CONFIG)

--- a/src/helpers/mathjax.coffee
+++ b/src/helpers/mathjax.coffee
@@ -9,7 +9,7 @@ cleanMathArtifacts = ->
   # MathJax calls queued events in order, so this will be called after processing completes
   window.MathJax.Hub.Queue([ ->
     # copy-pasta in `/index.coffee`
-    for nodeId in ['MathJax_Message', 'MathJax_Hidden', 'MathJax_Font_Test']
+    for nodeId in ['MathJax_Message', 'MathJax_Font_Test']
       el = document.getElementById(nodeId)
       break unless el # the elements won't exist if MathJax didn't do anything
       # Some of the elements are wrapped by divs without selectors under body


### PR DESCRIPTION
This corrects the height of the mathjax spans.

Before:
![screen shot 2015-07-06 at 11 51 19 am](https://cloud.githubusercontent.com/assets/79566/8527963/6addc382-23d5-11e5-9491-49c1f4a5448c.png)


After:
![screen shot 2015-07-06 at 11 50 49 am](https://cloud.githubusercontent.com/assets/79566/8527964/6aeda39c-23d5-11e5-9154-e157ec6517de.png)

This also removes call to `cleanMathArtifacts` on startup.  I'd noticed that occasionally I'd see a "this.queue is undefined" exception when the page was reloaded in chrome but hadn't been able to find the source of the error.  Mathjax continued to render fine, so I didn't pay it too much attention.  When debugging the mathjax positioning I loaded in Firefox where it occurred more often and was able to find it originating from the cleanup call.