### PR TITLE
Correct tag usage to accommodate Biology content

### DIFF
--- a/src/flux/exercise.coffee
+++ b/src/flux/exercise.coffee
@@ -9,6 +9,9 @@ EXERCISE_TAGS =
   LO: ['lo', 'aplo']
   GENERIC: 'generic'
 
+getTagName = (tag) ->
+  [tag.name, tag.description].join(' ')
+
 getImportantTags = (tags) ->
   obj =
     lo: ""
@@ -21,7 +24,7 @@ getImportantTags = (tags) ->
       tagArr.push(tag.id)
       memo.tagString = tagArr.join(" / ")
     else if (_.include(EXERCISE_TAGS.LO, tag.type))
-      memo.lo = tag.name
+      memo.lo = getTagName(tag)
       memo.section = tag.chapter_section
     memo
   , obj)
@@ -73,13 +76,13 @@ ExerciseConfig =
     getTeksString: (exercise_id) ->
       tags = @_exerciseCache[exercise_id].tags
       teksTags = _.where(tags, {type: EXERCISE_TAGS.TEKS})
-      _.pluck(teksTags, 'name').join(" / ")
+      _.map(teksTags, getTagName).join(" / ")
 
     getContent: (exercise_id) ->
       @_exerciseCache[exercise_id].content.questions[0].stem_html
 
     getTagContent: (tag) ->
-      content = if tag.name then tag.name else tag.id
+      content = getTagName(tag) or tag.id
       isLO = _.include(EXERCISE_TAGS.LO, tag.type)
       {content, isLO}
 

--- a/src/flux/exercise.coffee
+++ b/src/flux/exercise.coffee
@@ -6,7 +6,7 @@ _ = require 'underscore'
 
 EXERCISE_TAGS =
   TEKS: 'teks'
-  LO: 'lo'
+  LO: ['lo', 'aplo']
   GENERIC: 'generic'
 
 getImportantTags = (tags) ->
@@ -20,7 +20,7 @@ getImportantTags = (tags) ->
       tagArr = memo.tagString.split("/")
       tagArr.push(tag.id)
       memo.tagString = tagArr.join(" / ")
-    else if (tag.type is EXERCISE_TAGS.LO)
+    else if (_.include(EXERCISE_TAGS.LO, tag.type))
       memo.lo = tag.name
       memo.section = tag.chapter_section
     memo
@@ -40,7 +40,7 @@ ExerciseConfig =
   loaded: (obj, courseId, pageIds) ->
     key = pageIds.toString()
     return if @_exercises[key] and @_HACK_DO_NOT_RELOAD
-    
+
     @_exercises[key] = obj.items
     _exerciseCache = []
     _.each obj.items, (exercise) ->
@@ -60,8 +60,10 @@ ExerciseConfig =
 
     getGroupedExercises: (pageIds) ->
       byChapterSection = (exercise) ->
-        _.findWhere(exercise.tags, {type: EXERCISE_TAGS.LO}).chapter_section
-
+        tag = _.find(exercise.tags, (t) ->
+          _.include(EXERCISE_TAGS.LO, t.type)
+        )
+        tag?.chapter_section
       exercises = _.sortBy(@_exercises[pageIds.toString()], byChapterSection)
       _.groupBy(exercises, byChapterSection)
 
@@ -78,7 +80,7 @@ ExerciseConfig =
 
     getTagContent: (tag) ->
       content = if tag.name then tag.name else tag.id
-      isLO = tag.type is EXERCISE_TAGS.LO
+      isLO = _.include(EXERCISE_TAGS.LO, tag.type)
       {content, isLO}
 
     getTagStrings: (exercise_id) ->


### PR DESCRIPTION
With the new Biology content, the LO tag can be called either `lo` or `aplo`, and the tag's name field no longer contains the description.

The exercise builder has JS errors without this when it attempts to find a LO tag and cannot