### PR TITLE
Force Mathjax text elements to use lato font-family

### DIFF
--- a/resources/styles/global/maths.less
+++ b/resources/styles/global/maths.less
@@ -13,3 +13,6 @@
 // Hide the HTML and use MathJax for rendering
 // TODO: Decide whether to remove KaTeX (involves additional code for MathJax)
 .has-html .katex > .katex-html { display: none; }
+
+// Override the inline style on mathjax text elements to match the tutor default of lato
+.MathJax .mtext { font-family: lato !important; }


### PR DESCRIPTION
This changes the text in Mathjax from using it's built-in STIXGeneral-Regular font:
![screen shot 2015-07-08 at 10 16 14 am](https://cloud.githubusercontent.com/assets/79566/8574078/6c334866-255a-11e5-88d6-caa96c9c5665.png)


To use lato:
![screen shot 2015-07-08 at 10 17 11 am](https://cloud.githubusercontent.com/assets/79566/8574097/87d716ce-255a-11e5-823b-48428925a1d4.png)

Unfortunately, the difference isn't very apparent on the screenshots.  Viewing them at full-size is a bit better but it's still not a big change.

If we want to spend more time on this, Mathjax does provide a method to import the Lato font so it knows about it's glyph data and can render everything with it.  http://docs.mathjax.org/en/latest/font-support.html  has the details.