### PR TITLE
Perf report fix

### DIFF
--- a/src/components/performance.cjsx
+++ b/src/components/performance.cjsx
@@ -27,7 +27,7 @@ Performance = React.createClass
 
 
   getInitialState: ->
-    period_id: "1"
+    period_id: null
     periodIndex: 1
     sortOrder: 'is-ascending'
     sortIndex: 0
@@ -170,7 +170,11 @@ Performance = React.createClass
     performance = PerformanceStore.get(@props.courseId)
 
     {period_id} = @state
-    performance = _.findWhere(performance, {period_id})
+    # The period may not have been selected. If not, just use the 1st period
+    if period_id
+      performance = _.findWhere(performance, {period_id})
+    else
+      performance = performance[0] or throw new Error('BUG: No periods')
 
     headers = performance.data_headings
     headers.unshift({"title":"Student"})

--- a/src/flux/helpers.coffee
+++ b/src/flux/helpers.coffee
@@ -128,8 +128,13 @@ CrudConfig = ->
 
     # Keep this here so other exports method have access to it
     _get: (id) ->
-      return null unless @_local[id] or @_asyncStatus[id] is SAVING
-      _.extend({}, @_local[id], @_changed[id])
+      val = @_local[id]
+      return null unless val or @_asyncStatus[id] is SAVING
+      # Performance Report stores an Array unlike most other stores
+      if _.isArray(val)
+        val
+      else
+        _.extend({}, val, @_changed[id])
 
     exports:
       isUnknown: (id) -> not @_asyncStatus[id]


### PR DESCRIPTION
Performance report was not loading for 2 reasons:

- an assumption was made on the initial id (set to `"1"` but rarely true)
- the CRUD store assumed stored things were objects, not Arrays