### PR TITLE
handle when not all periods are assigned a task plan

### DIFF
--- a/src/components/course-periods-nav.cjsx
+++ b/src/components/course-periods-nav.cjsx
@@ -32,8 +32,7 @@ CoursePeriodsNav = React.createClass
       @onSelect(@state.active)
 
   onSelect: (key) ->
-    {courseId, handleSelect, handleKeyUpdate} = @props
-    periods = CourseStore.getPeriods(courseId)
+    {courseId, periods, handleSelect, handleKeyUpdate} = @props
 
     period = periods?[key]
     unless period?
@@ -48,10 +47,9 @@ CoursePeriodsNav = React.createClass
     <BS.NavItem eventKey={key} key="period-nav-#{period.id}">{period.name}</BS.NavItem>
 
   render: ->
-    {courseId} = @props
+    {periods} = @props
     {active} = @state
-
-    periods = CourseStore.getPeriods(courseId)
+    periods = _.sortBy(periods, 'name')
     periodsItems = _.map(periods, @renderPeriod)
 
     <BS.Nav bsStyle='tabs' activeKey={active} onSelect={@onSelect}>
@@ -73,6 +71,12 @@ CoursePeriodsNavShell = React.createClass
 
     courseId
 
+  renderCoursePeriodNav: ->
+    courseId = @getCourseId()
+    periods = CourseStore.getPeriods(courseId)
+
+    <CoursePeriodsNav {...@props} courseId={courseId} periods={periods}/>
+
   render: ->
     courseId = @getCourseId()
 
@@ -80,7 +84,7 @@ CoursePeriodsNavShell = React.createClass
       id={courseId}
       store={CourseStore}
       actions={CourseActions}
-      renderItem={=> <CoursePeriodsNav {...@props} courseId={courseId} />}
+      renderItem={@renderCoursePeriodNav}
     />
 
 module.exports = {CoursePeriodsNav, CoursePeriodsNavShell}

--- a/src/components/course-periods-nav.cjsx
+++ b/src/components/course-periods-nav.cjsx
@@ -14,6 +14,7 @@ CoursePeriodsNav = React.createClass
     handleSelect: React.PropTypes.func
     handleKeyUpdate: React.PropTypes.func
     initialActive: React.PropTypes.number.isRequired
+    periods: React.PropTypes.array.isRequired
 
   getDefaultProps: ->
     initialActive: 0

--- a/src/components/task-plan/reading-stats.cjsx
+++ b/src/components/task-plan/reading-stats.cjsx
@@ -7,7 +7,7 @@ Router = require 'react-router'
 LoadableItem = require '../loadable-item'
 SmartOverflow = require '../smart-overflow'
 ChapterSectionMixin = require '../chapter-section-mixin'
-{CoursePeriodsNavShell} = require '../course-periods-nav'
+{CoursePeriodsNav} = require '../course-periods-nav'
 
 Stats = React.createClass
   propTypes:
@@ -184,6 +184,8 @@ Stats = React.createClass
     {stats} = @state
 
     plan = TaskPlanStatsStore.get(id)
+    periods = TaskPlanStatsStore.getPeriods(id)
+
     # A Draft does not contain any stats
     if stats
       course = @renderCourseBar(stats, plan.type)
@@ -222,10 +224,11 @@ Stats = React.createClass
       </div>
 
     <BS.Panel className='reading-stats'>
-      <CoursePeriodsNavShell
+      <CoursePeriodsNav
         handleSelect={@handlePeriodSelect}
         handleKeyUpdate={@props.handlePeriodKeyUpdate}
         initialActive={@props.initialActivePeriod}
+        periods={periods}
         courseId={courseId} />
       {dataComponent}
     </BS.Panel>

--- a/src/flux/task-plan-stats.coffee
+++ b/src/flux/task-plan-stats.coffee
@@ -1,6 +1,15 @@
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
+_ = require 'underscore'
 
 TaskPlanStatsConfig = {
+
+  exports:
+    getPeriods: (id) ->
+      plan = @_get(id)
+      periods = _.map(plan.stats, (stat) ->
+        id: stat.period_id
+        name: stat.name
+      )
 
 }
 

--- a/test/components/course-periods-nav.spec.coffee
+++ b/test/components/course-periods-nav.spec.coffee
@@ -21,7 +21,10 @@ describe 'Course Periods Navigation', ->
       @selectedPeriod = period
 
     componentStub
-      .render(<CoursePeriodsNav courseId={COURSE_ID} handleSelect={handleSelect}/>)
+      .render(<CoursePeriodsNav
+        courseId={COURSE_ID}
+        handleSelect={handleSelect}
+        periods={COURSE_PERIODS}/>)
       .then((result) =>
         @result = result
 


### PR DESCRIPTION
Course nav bar will only show as many stats as available on plan stats

There may be some backend or some frontend issues during plan creation for the full bug to be fixed, but this will work once the stats json only returns for as many periods are assigned the plan

![screen shot 2015-07-09 at 3 25 07 pm](https://cloud.githubusercontent.com/assets/2483873/8606097/0578a94a-264f-11e5-8320-b8b18dc4043d.png)
