### PR TITLE
Slide out menu for reference book

### DIFF
--- a/api/courses/1/readings.json
+++ b/api/courses/1/readings.json
@@ -1,5 +1,5 @@
-{
-  "0":  {
+[
+  {
     "id":"1",
     "title":"Updated Tutor HS Physics Content - legacy",
     "type":"part",
@@ -19,13 +19,15 @@
           "type": "page",
           "title": "Kinematics in 2 dim",
           "chapter_section": [1, 2],
-          "id": "235"
+          "id": "235",
+          "cnx_id": "0e58aa87-2e09-40a7-8bf3-269b2fa16510"
         },
         {
           "type": "page",
           "title": "Kinematics in 3 dim",
           "chapter_section": [1, 3],
-          "id": "236"
+          "id": "236",
+          "cnx_id": "0e58aa87-2e09-40a7-8bf3-269b2fa16511"
         }
       ]
     },
@@ -80,4 +82,4 @@
       ]
     }]
   }
-}
+]

--- a/resources/styles/components/reference-book/index.less
+++ b/resources/styles/components/reference-book/index.less
@@ -1,9 +1,11 @@
 @import './navbar';
 @import './page';
 @import './toc';
+@import './slide-out-menu';
+
 .reference-book {
-    .section-number {
-      color: @tutor-secondary;
-      margin-right: 0.4rem;
-    }
+  .section-number {
+    color: @tutor-secondary;
+    margin-right: 0.4rem;
+  }
 }

--- a/resources/styles/components/reference-book/navbar.less
+++ b/resources/styles/components/reference-book/navbar.less
@@ -14,13 +14,12 @@
       .chapter-section { margin-right: 0.5rem; }
     }
 
-    .dropdown-menu {
-      position: fixed;
-      top: 60px;
-      left: 0;
-      bottom: 0;
-      width: 300px;
-    }
 
+    .menu-toggle:before{ content: @fa-var-list; }
+
+  }
+
+  &.menu-open {
+    .menu-toggle:before{ content: @fa-var-outdent; }
   }
 }

--- a/resources/styles/components/reference-book/page.less
+++ b/resources/styles/components/reference-book/page.less
@@ -36,6 +36,7 @@
           }
         }
       }
+
     }
   }
 
@@ -88,6 +89,19 @@
 
     &.next {
       right: 0;
+    }
+  }
+
+  .page-wrapper {
+    transition: margin-left 0.2s linear;
+  }
+  // when menu is open and the screen is wide enough, slide everything to the right so it's still visible
+  &.menu-open {
+    @media screen and (min-width: (@reference-book-page-width + @reference-book-menu-width + 50px) ) {
+      .page-wrapper{
+        margin-left: @reference-book-menu-width;
+        > .nav.prev { left: @reference-book-menu-width; }
+      }
     }
   }
 

--- a/resources/styles/components/reference-book/slide-out-menu.less
+++ b/resources/styles/components/reference-book/slide-out-menu.less
@@ -1,0 +1,19 @@
+.reference-book {
+    .menu {
+      position: fixed;
+      top: 60px;
+      left: 0;
+      background: white;
+      border-right: 1px solid @tutor-neutral;
+      margin-left: -@reference-book-menu-width;
+      bottom: 0;
+      width: @reference-book-menu-width;
+      z-index: 3;  // on top of book elements (booksplash, forward/prev controls)
+      transition: margin-left 0.2s linear;
+    }
+
+  &.menu-open {
+    .menu { margin-left: 0; }
+  }
+
+}

--- a/resources/styles/variables.less
+++ b/resources/styles/variables.less
@@ -27,6 +27,9 @@
 @reading-color: @tutor-quaternary;
 @homework-color: @tutor-tertiary-light;
 
+@reference-book-page-width: 1000px;
+@reference-book-menu-width: 300px;
+
 // Async
 @tutor-async-loading-timeout: 30s;
 @-webkit-keyframes tutorAsyncFadeIn { from { opacity: 0; } to { opacity: 1; visibility: visible; } }

--- a/resources/styles/variables.less
+++ b/resources/styles/variables.less
@@ -27,6 +27,8 @@
 @reading-color: @tutor-quaternary;
 @homework-color: @tutor-tertiary-light;
 
+// if these are updated, also change MENU_VISIBLE_BREAKPOINT
+// in src/components/reference-book/reference-book.cjsx
 @reference-book-page-width: 1000px;
 @reference-book-menu-width: 300px;
 

--- a/src/components/reference-book/navbar.cjsx
+++ b/src/components/reference-book/navbar.cjsx
@@ -1,9 +1,9 @@
 React = require 'react'
 Router = require 'react-router'
 BS = require 'react-bootstrap'
+_  = require 'underscore'
 
 ChapterSection = require '../task-plan/chapter-section'
-ReferenceBookTOC = require './toc'
 BindStoreMixin = require '../bind-store-mixin'
 {ReferenceBookStore} = require '../../flux/reference-book'
 {ReferenceBookPageStore} = require '../../flux/reference-book-page'
@@ -14,12 +14,8 @@ module.exports = React.createClass
   bindStore: ReferenceBookPageStore
   propTypes:
     teacherLinkText: React.PropTypes.string
+    toggleTocMenu: React.PropTypes.func.isRequired
     showTeacherEdition: React.PropTypes.func
-
-  componentDidMount: ->
-    {cnxId} = @getParams()
-    # Pop open the menu unless the page was explicitly navigated to
-    @refs.tocmenu.setDropdownState(true) unless cnxId
 
   renderSectionTitle: ->
     {cnxId, section} = @getParams()
@@ -28,14 +24,12 @@ module.exports = React.createClass
       section = page?.chapter_section
     else if section
       page = ReferenceBookStore.getChapterSectionPage(@getParams())
+    section = section.split('.') if section and _.isString(section)
     <BS.Nav navbar className="section-title">
       <ChapterSection section={section} />
       {page?.title}
     </BS.Nav>
 
-  onMenuClick: ->
-    # close the dropdown menu when a link is clicked
-    @refs.tocmenu.setDropdownState(false)
 
   renderTeacher: ->
     <BS.Nav navbar right>
@@ -49,9 +43,9 @@ module.exports = React.createClass
     {cnxId} = @getParams()
     <BS.Navbar toggleNavKey={0} fixedTop fluid>
       <BS.Nav navbar>
-        <BS.DropdownButton ref="tocmenu" buttonClassName="fa fa-bars" noCaret>
-          <ReferenceBookTOC courseId={@props.courseId} onClick={@onMenuClick} />
-        </BS.DropdownButton>
+        <BS.NavItem onClick={@props.toggleTocMenu}>
+          <i className="menu-toggle fa fa-2x" />
+        </BS.NavItem>
       </BS.Nav>
       {@renderSectionTitle()}
       {@renderTeacher() if @props.showTeacherEdition}

--- a/src/components/reference-book/reference-book.cjsx
+++ b/src/components/reference-book/reference-book.cjsx
@@ -5,27 +5,42 @@ _  = require 'underscore'
 
 BindStoreMixin = require '../bind-store-mixin'
 NavBar = require './navbar'
+Menu = require './slide-out-menu'
 
 {CourseListingStore} = require '../../flux/course-listing'
 {CourseStore} = require '../../flux/course'
 
 module.exports = React.createClass
   displayName: 'ReferenceBook'
+  contextTypes:
+    router: React.PropTypes.func
 
-  mixins: [Router.State, BindStoreMixin]
+  mixins: [BindStoreMixin]
   bindStore: CourseListingStore
   bindEvent: 'loaded'
 
   componentWillMount: ->
     CourseListingStore.ensureLoaded()
 
+  getInitialState: ->
+    {cnxId} = @context.router.getCurrentParams()
+    # Pop open the menu unless the page was explicitly navigated to
+    {isMenuVisible: not cnxId}
+
   showTeacherEdition: ->
     @setState(showTeacherEdition: not @state.showTeacherEdition)
 
+  onMenuClick: ->
+    @toggleMenuState() unless window.innerWidth > 1350
+
+  toggleMenuState: ->
+    @setState(isMenuVisible: not @state.isMenuVisible)
+
   render: ->
-    {courseId} = @getParams()
+    {courseId} = @context.router.getCurrentParams()
     course = CourseStore.get(courseId)
     classnames = ["reference-book"]
+    classnames.push('menu-open') if @state.isMenuVisible
     if course and _.findWhere(course.roles, type: 'teacher')
       showTeacher = @showTeacherEdition
       teacherLinkText = if @state.showTeacherEdition
@@ -36,10 +51,12 @@ module.exports = React.createClass
 
     <div className={classnames.join(' ')}>
       <NavBar
+        toggleTocMenu={@toggleMenuState}
         teacherLinkText={teacherLinkText}
         showTeacherEdition={showTeacher}
         courseId={courseId}/>
       <div className="content">
+        <Menu onMenuSelection={@onMenuClick} />
         <Router.RouteHandler courseId={courseId} />
       </div>
     </div>

--- a/src/components/reference-book/reference-book.cjsx
+++ b/src/components/reference-book/reference-book.cjsx
@@ -10,6 +10,10 @@ Menu = require './slide-out-menu'
 {CourseListingStore} = require '../../flux/course-listing'
 {CourseStore} = require '../../flux/course'
 
+# menu width (300) + page width (1000) + 50 px padding
+# corresponds to @reference-book-page-width and @reference-book-menu-width in variables.less
+MENU_VISIBLE_BREAKPOINT = 1350
+
 module.exports = React.createClass
   displayName: 'ReferenceBook'
   contextTypes:
@@ -31,7 +35,7 @@ module.exports = React.createClass
     @setState(showTeacherEdition: not @state.showTeacherEdition)
 
   onMenuClick: ->
-    @toggleMenuState() unless window.innerWidth > 1350
+    @toggleMenuState() unless window.innerWidth > MENU_VISIBLE_BREAKPOINT
 
   toggleMenuState: ->
     @setState(isMenuVisible: not @state.isMenuVisible)

--- a/src/components/reference-book/slide-out-menu.cjsx
+++ b/src/components/reference-book/slide-out-menu.cjsx
@@ -1,0 +1,16 @@
+React = require 'react'
+BS = require 'react-bootstrap'
+ReferenceBookTOC = require './toc'
+
+module.exports = React.createClass
+  displayName: 'SlideOutMenu'
+  propTypes:
+    onMenuSelection: React.PropTypes.func.isRequired
+
+
+  render: ->
+    <div className='menu'>
+      <ReferenceBookTOC visible={@props.visible}
+        courseId={@props.courseId}
+        onMenuSelection={@props.onMenuSelection} />
+    </div>

--- a/src/components/reference-book/toc.cjsx
+++ b/src/components/reference-book/toc.cjsx
@@ -10,21 +10,21 @@ Section = React.createClass
   mixins: [ Router.State ]
   propTypes:
     section: React.PropTypes.object.isRequired
-    onClick: React.PropTypes.func
+    onMenuSelection: React.PropTypes.func.isRequired
 
   render: ->
     {courseId} = @getParams()
     sections = @props.section.chapter_section.join('.')
     linkTarget = if @props.section.cnx_id then 'viewReferenceBookPage' else 'viewReferenceBookSection'
     <ul className="section" data-depth={@props.section.chapter_section.length}>
-      <Router.Link onClick={@props.onClick} to={linkTarget}
+      <Router.Link onClick={@props.onMenuSelection} to={linkTarget}
           params={courseId: courseId, cnxId: @props.section.cnx_id, section: sections}>
           <span className="section-number">{sections}</span>
           {@props.section.title}
       </Router.Link>
       { _.map @props.section.children, (child) =>
         <li key={child.id}>
-          <Section onClick={@props.onClick} section={child} />
+          <Section onMenuSelection={@props.onMenuSelection} section={child} />
         </li> }
     </ul>
 
@@ -33,12 +33,12 @@ module.exports = React.createClass
   displayName: 'ReferenceBookTOC'
   mixins: [ Router.State ]
   propTypes:
-    onClick: React.PropTypes.func
+    onMenuSelection: React.PropTypes.func
 
   render: ->
     {courseId} = @getParams()
     toc = ReferenceBookStore.getToc(courseId)
     <div className="toc">
       { _.map toc.children, (child) =>
-        <Section onClick={@props.onClick} key={child.id} section={child} /> }
+        <Section onMenuSelection={@props.onMenuSelection} key={child.id} section={child} /> }
     </div>

--- a/test/components/helpers/utilities.coffee
+++ b/test/components/helpers/utilities.coffee
@@ -78,8 +78,8 @@ commonActions =
     commonActions.click(button)
     button = div.querySelector(selector)
 
-  click: (clickElementNode) ->
-    React.addons.TestUtils.Simulate.click(clickElementNode)
+  click: (clickElementNode, eventData = {}) ->
+    React.addons.TestUtils.Simulate.click(clickElementNode, eventData)
 
   select: (selectElementNode) ->
     React.addons.TestUtils.Simulate.select(selectElementNode)

--- a/test/components/reference-book.spec.coffee
+++ b/test/components/reference-book.spec.coffee
@@ -62,3 +62,22 @@ describe 'Reference Book Component', ->
     commonActions.click(toggle)
     expect(_.toArray(@state.div.querySelector('.reference-book').classList))
       .to.not.contain('menu-open')
+
+  it 'navigates forward and back between pages', ->
+    prevControl = @state.div.querySelector('.page-wrapper > .prev')
+    expect(prevControl).to.not.exist # on first page
+
+    nextControl = @state.div.querySelector('.page-wrapper > .next')
+    expect(nextControl).to.exist
+    expect(nextControl.href).to.contain(SECOND_PAGE_ID)
+    page = ReactTestUtils.findRenderedComponentWithType(@state.book, Page)
+
+    commonActions.click(nextControl)
+
+    # expect(page.context.router.getCurrentParams().cnxId)
+    #   .to.equal(SECOND_PAGE_ID)
+
+    # expect(@state.div.querySelector('.page-wrapper > .next').href)
+    #   .to.contain(THIRD_PAGE_ID)
+    # expect(@state.div.querySelector('.page-wrapper > .prev').href)
+    #   .to.contain(FIRST_PAGE_ID)

--- a/test/components/reference-book.spec.coffee
+++ b/test/components/reference-book.spec.coffee
@@ -72,12 +72,16 @@ describe 'Reference Book Component', ->
     expect(nextControl.href).to.contain(SECOND_PAGE_ID)
     page = ReactTestUtils.findRenderedComponentWithType(@state.book, Page)
 
-    commonActions.click(nextControl)
 
-    # expect(page.context.router.getCurrentParams().cnxId)
-    #   .to.equal(SECOND_PAGE_ID)
+    ReferenceBookPageActions.loaded(PAGE, SECOND_PAGE_ID)
+    # button:0 is a mystery argument needed by ReactRouter, taken from their specs
+    commonActions.click(nextControl, {button: 0})
 
-    # expect(@state.div.querySelector('.page-wrapper > .next').href)
-    #   .to.contain(THIRD_PAGE_ID)
-    # expect(@state.div.querySelector('.page-wrapper > .prev').href)
-    #   .to.contain(FIRST_PAGE_ID)
+    expect(page.context.router.getCurrentParams().cnxId)
+      .to.equal(SECOND_PAGE_ID)
+
+    expect(@state.div.querySelector('.page-wrapper > .next').href)
+      .to.contain(THIRD_PAGE_ID)
+
+    expect(@state.div.querySelector('.page-wrapper > .prev').href)
+      .to.contain(FIRST_PAGE_ID)

--- a/test/components/reference-book.spec.coffee
+++ b/test/components/reference-book.spec.coffee
@@ -5,15 +5,19 @@ React          = require 'react'
 {TimeActions}  = require '../../src/flux/time'
 ReactAddons    = require 'react/addons'
 ReactTestUtils = React.addons.TestUtils
-{routerStub}   = require './helpers/utilities'
+{routerStub, commonActions} = require './helpers/utilities'
 
 {ReferenceBookActions, ReferenceBookStore} = require '../../src/flux/reference-book'
 {ReferenceBookPageActions, ReferenceBookPageStore} = require '../../src/flux/reference-book-page'
 ReferenceBook = require '../../src/components/reference-book/reference-book'
+Page = require '../../src/components/reference-book/page'
 
 COURSE_ID = '1'
 TOC  = require '../../api/courses/1/readings.json'
-PAGE_ID = '0e58aa87-2e09-40a7-8bf3-269b2fa16509'
+FIRST_PAGE_ID  = '0e58aa87-2e09-40a7-8bf3-269b2fa16509'
+SECOND_PAGE_ID = '0e58aa87-2e09-40a7-8bf3-269b2fa16510'
+THIRD_PAGE_ID  = '0e58aa87-2e09-40a7-8bf3-269b2fa16511'
+
 PAGE = require '../../api/pages/0e58aa87-2e09-40a7-8bf3-269b2fa16509.json'
 
 
@@ -33,8 +37,8 @@ describe 'Reference Book Component', ->
 
   beforeEach ->
     ReferenceBookActions.loaded(TOC, COURSE_ID)
-    ReferenceBookPageActions.loaded(PAGE, PAGE_ID)
-    renderBook(PAGE_ID).then (state) =>
+    ReferenceBookPageActions.loaded(PAGE, FIRST_PAGE_ID)
+    renderBook(FIRST_PAGE_ID).then (state) =>
       @state = state
 
   it 'renders the section title on the navbar',  ->
@@ -44,3 +48,17 @@ describe 'Reference Book Component', ->
   it 'renders page html', ->
     expect(@state.div.querySelector('.page').textContent)
       .to.equal('A bunch of html')
+
+  it 'toggles menu when navbar control is clicked', ->
+    toggle = @state.div.querySelector('.menu-toggle')
+
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.not.contain('menu-open')
+
+    commonActions.click(toggle)
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.contain('menu-open')
+
+    commonActions.click(toggle)
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.not.contain('menu-open')


### PR DESCRIPTION
This changes the drop down menu on the reference book to slide in from the side.

The icon on the top navbar toggles depending on the menu's state.

The menu behaves in two different ways depending on the screen width.   1350pixels wide was chosen as the break point since the page width is 1,000px and the menu is 300.

If the page is narrower than 1350px, the menu slides over the page content and is dismissed once a link on it is clicked.

![screen shot 2015-07-13 at 4 32 11 pm](https://cloud.githubusercontent.com/assets/79566/8661381/bf991c12-297c-11e5-97a0-5e4f0fc95c15.png)


If the screen is wider than 1350px appears on the left and pushes the page content and the "previous page" control to the right.  It remains visible when links on it are clicked.

![screen shot 2015-07-13 at 4 28 22 pm](https://cloud.githubusercontent.com/assets/79566/8661302/49259330-297c-11e5-9cb8-8bd92a6af117.png)



