### PR TITLE
Book content styles

### DIFF
--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -33,7 +33,6 @@ cnx-pi
   width: 100%;
   min-height: 100px;
   .book-content-full-width();
-  margin-top: -@tutor-card-body-padding-vertical;
 
   color: #ffffff;
   padding: 10px 20px;

--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -32,7 +32,9 @@ cnx-pi
   #fonts > .sans(1.8rem, 1.8rem);
   width: 100%;
   min-height: 100px;
+  .book-content-full-width();
   margin-top: -@tutor-card-body-padding-vertical;
+
   color: #ffffff;
   padding: 10px 20px;
   background: @tutor-secondary;
@@ -99,13 +101,6 @@ div[data-type="document-title"] ~ p:first-of-type {
   .tutor-reading-first-letter();
 }
 
-div[data-type="document-title"] ~ p {padding: 0 @tutor-card-body-padding-horizontal;}
-
-
-> section:not(.section-opener),
-.worked-examples {
-  .book-content-step-size(0);
-}
 
 .splash {
   width: 100%;
@@ -135,6 +130,7 @@ div[data-type="document-title"] ~ p {padding: 0 @tutor-card-body-padding-horizon
   }
 }
 
+
 figure {
   max-width: 100%;
   display: table;
@@ -143,6 +139,7 @@ figure {
   margin-bottom: 20px;
   padding: 0;
   float: left;
+  &.full-width { width: 100%; }
   &.tutor-ui-vertical-img {
     @media (min-width: @screen-sm-min) {
       width: 50%;
@@ -157,7 +154,7 @@ figure {
   }
   .tutor-ui-horizontal-img {
     display:block;
-    .book-content-full-width();
+
     &.full-width {
       img { width: 100%; }
     }
@@ -165,12 +162,12 @@ figure {
 
   // splash images are always full width without margin or surrounding padding
   &.splash {
-    width: 100%;
+
     // .splash is wider than other elements on the page since it has 0 surrounding padding
     // This means child elements that normally have a fixed pixel width will not expand to fit
     // unless their widths are set to be 100%
-    [data-type=media]{ width: 100%; }
-    .tutor-ui-horizontal-img { width: 100%; }
+
+    .tutor-ui-horizontal-img { .book-content-full-width(); }
     img { width: 100%; }
   }
   figcaption {

--- a/resources/styles/book-content/fun-in-physics.less
+++ b/resources/styles/book-content/fun-in-physics.less
@@ -1,9 +1,7 @@
 // This file is part of the book-content mixin and should not be included directly
 .fun-in-physics {
-  .book-content-step-size(0);
 
   & > .title:first-child {
     .tutor-reading-main-title();
   }
 }
-

--- a/resources/styles/book-content/glossary.less
+++ b/resources/styles/book-content/glossary.less
@@ -1,6 +1,0 @@
-// This file is part of the book-content mixin and should not be included directly
-div[data-type=glossary] {
-  margin-left: @tutor-card-body-padding-horizontal;
-  margin-right: @tutor-card-body-padding-horizontal;
-}
-

--- a/resources/styles/book-content/index.less
+++ b/resources/styles/book-content/index.less
@@ -16,5 +16,5 @@
   @import './fun-in-physics';
   @import './grasp-check';
   @import './target';
-
+  @import './visual-connection';
 }

--- a/resources/styles/book-content/index.less
+++ b/resources/styles/book-content/index.less
@@ -1,7 +1,7 @@
 // A mixin to style book content from CNX
 .tutor-book-content() {
   @reading-ui-banner-height: 40px;
-
+  padding: @tutor-card-body-padding;
   @import './mixins';
 
   @import './base';
@@ -14,7 +14,6 @@
   @import './virtual-physics.less';
   @import './fun-in-physics';
   @import './grasp-check';
-  @import './glossary';
   @import './target';
 
 }

--- a/resources/styles/book-content/index.less
+++ b/resources/styles/book-content/index.less
@@ -1,7 +1,7 @@
 // A mixin to style book content from CNX
 .tutor-book-content() {
   @reading-ui-banner-height: 40px;
-  padding: @tutor-card-body-padding;
+  padding: 0 @tutor-card-body-padding-horizontal @tutor-card-body-padding-vertical @tutor-card-body-padding-horizontal;
   @import './mixins';
 
   @import './base';

--- a/resources/styles/book-content/index.less
+++ b/resources/styles/book-content/index.less
@@ -7,6 +7,7 @@
   @import './base';
   // type specific styling comes last so it can override the above styles
   @import './links-to-physics';
+  @import './link-to-learning';
   @import './worked-examples';
   @import './work-in-physics';
   @import './watch-physics';

--- a/resources/styles/book-content/link-to-learning.less
+++ b/resources/styles/book-content/link-to-learning.less
@@ -1,0 +1,4 @@
+// This file is part of the book-content mixin and should not be included directly
+[data-alt='QR Code representing a URL'] {
+  display: none;
+}

--- a/resources/styles/book-content/links-to-physics.less
+++ b/resources/styles/book-content/links-to-physics.less
@@ -1,7 +1,6 @@
 // This file is part of the book-content mixin and should not be included directly
 .links-to-physics {
   margin-top: 20px;
-  .book-content-step-size(0);
 
   // match the specificity of the rule so we can add our icon
   &.ost-assessed-feature.note[data-label] {

--- a/resources/styles/book-content/mixins.less
+++ b/resources/styles/book-content/mixins.less
@@ -28,7 +28,7 @@
     font-weight: 600;
     color: @tutor-secondary;
     margin: .1em .08em 0 -.06em; //best combination on line-height and margin to look good in chrome and ff
-  } 
+  }
   // ensure that the p is heigh enough for the drop cap
   // to fit beside it, otherwise it will overlay on top of the next element
   min-height: 8rem;
@@ -42,19 +42,10 @@
   font-size: 2rem;
 }
 
-.book-content-step-size(@vertical: @tutor-card-body-padding-vertical) {
-  padding: @vertical @tutor-card-body-padding-horizontal;
-  @media (max-width: @tutor-card-padding-collapse-breakpoint) {
-    padding: @vertical @tutor-card-body-narrow-padding-horizontal;
-  }
-}
 
 // sets an element to be the width of the content pane
 // used for cases where the parent element is not set to 100% width and cannot be targeted
-// handles breakpoints set by .book-content-step-size
 .book-content-full-width(){
-  width: @tutor-task-width - (@tutor-card-body-padding-horizontal * 2);
-  @media (max-width: @tutor-card-padding-collapse-breakpoint) {
-    width: @tutor-task-width - @tutor-card-body-padding-horizontal;
-  }
+  margin-left: -@tutor-card-body-padding-horizontal;
+  width: calc(~"100% + "@tutor-card-body-padding-horizontal*2);
 }

--- a/resources/styles/book-content/note.less
+++ b/resources/styles/book-content/note.less
@@ -1,6 +1,9 @@
 // This file is part of the book-content mixin and should not be included directly
-.tips-for-success, .os-teacher {
-
+.tips-for-success,
+.os-teacher,
+.ost-background-info,
+.ost-misconception {
+  margin-top: @tutor-card-body-padding-vertical;
   &:before {
     height: 35px;
     content: attr(data-label);
@@ -11,7 +14,7 @@
     background-repeat: no-repeat;
     // table cell is chosen since it needs to be only as wide as the text,
     // yet still break to a new line after the content
-    display: table-cell; 
+    display: table-cell;
     text-indent: 30px;
     background-position: 10px 5px;
     background-size: 25px 25px;

--- a/resources/styles/book-content/visual-connection.less
+++ b/resources/styles/book-content/visual-connection.less
@@ -1,0 +1,14 @@
+.visual-connection {
+  float: left;
+  +* {
+    clear: both;
+  }
+  &+.visual-connection{
+    clear: right;
+    float: right;
+    .title {
+      visibility: hidden;
+    }
+  }
+
+}

--- a/resources/styles/book-content/watch-physics.less
+++ b/resources/styles/book-content/watch-physics.less
@@ -3,8 +3,7 @@
   &:before {
     display: none;
   }
-  
-  .book-content-step-size(0);
+
 
   .title {
     .tutor-reading-main-title();
@@ -15,5 +14,5 @@
   [data-type=media] {
     .tutor-framed-video();
   }
-  
+
 }

--- a/resources/styles/book-content/work-in-physics.less
+++ b/resources/styles/book-content/work-in-physics.less
@@ -1,7 +1,6 @@
 // This file is part of the book-content mixin and should not be included directly
 .work-in-physics {
   margin-top: 20px;
-  .book-content-step-size(0);
 
   // match the specificity of the rule so we can add our icon
   &.ost-assessed-feature.note[data-label] {
@@ -12,9 +11,9 @@
   > p:first-of-type {
     .tutor-reading-first-letter();
   }
-  
+
   & > .title:first-child {
     .tutor-reading-main-title();
   }
-  
+
 }

--- a/resources/styles/book-content/worked-examples.less
+++ b/resources/styles/book-content/worked-examples.less
@@ -2,12 +2,10 @@
 .worked-example.note:first-child,
 .worked-examples.note:first-child {
 
-  .book-content-step-size();
-
   &:before {
     .tutor-reading-step-banner-icon("icon-calculator.svg");
   }
-  
+
   > .exercise > [data-type=title] {
     .tutor-reading-main-title();
   }

--- a/resources/styles/components/reference-book/page.less
+++ b/resources/styles/components/reference-book/page.less
@@ -1,8 +1,4 @@
 .reference-book {
-  .dropdown-toggle {
-    font-size: 3rem;
-    line-height: 30px;
-  }
 
   .content {
     margin-top: 75px;

--- a/resources/styles/components/reference-book/page.less
+++ b/resources/styles/components/reference-book/page.less
@@ -18,18 +18,12 @@
         display: none;
       }
 
-      section.section-opener +
-      section {
-        .book-content-step-size();
-      }
-
       > section {
         > * {
           clear: both;
         }
 
         .os-teacher {
-          padding: 10px 140px;
 
           > ul {
             padding-left: 40px;

--- a/resources/styles/components/reference-book/toc.less
+++ b/resources/styles/components/reference-book/toc.less
@@ -30,8 +30,12 @@
         color: @tutor-black;
         padding: 5px;
       }
+      > ul > li:first-child { border-top: 0; }
     }
-    ul { padding-left: 0rem; }
+    ul {
+      margin-bottom: 0;
+      padding-left: 0rem;
+    }
     .toc-indented-levels(4);
   }
   .content {

--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -106,6 +106,8 @@ module.exports =
 sizeImage = ->
   if @naturalWidth > @naturalHeight
     @parentNode.classList.add('tutor-ui-horizontal-img')
+    if @parentNode.parentNode.tagName is 'FIGURE'
+      @parentNode.parentNode.classList.add('full-width')
     if @naturalWidth > 450
       @parentNode.classList.add('full-width')
   else

--- a/src/components/reference-book/navbar.cjsx
+++ b/src/components/reference-book/navbar.cjsx
@@ -11,28 +11,23 @@ BindStoreMixin = require '../bind-store-mixin'
 module.exports = React.createClass
   displayName: 'ReferenceBookNavBar'
   mixins: [BindStoreMixin]
-  contextTypes:
-    router: React.PropTypes.func
   bindStore: ReferenceBookPageStore
   propTypes:
     teacherLinkText: React.PropTypes.string
     toggleTocMenu: React.PropTypes.func.isRequired
     showTeacherEdition: React.PropTypes.func
-
-  componentDidMount: ->
-    {cnxId} = @context.router.getCurrentParams()
-    # Pop open the menu unless the page was explicitly navigated to
-    @refs.tocmenu.setDropdownState(true) unless cnxId
+  contextTypes:
+    router: React.PropTypes.func
 
   renderSectionTitle: ->
-    {cnxId, section} = @context.router.getCurrentParams()
+    params = @context.router.getCurrentParams()
+    {cnxId, section} = params
     if cnxId
-      page = ReferenceBookStore.getPageInfo(@context.router.getCurrentParams())
+      page = ReferenceBookStore.getPageInfo(params)
       section = page?.chapter_section
     else if section
-      page = ReferenceBookStore.getChapterSectionPage(@context.router.getCurrentParams())
+      page = ReferenceBookStore.getChapterSectionPage(params)
     section = section.split('.') if section and _.isString(section)
-
     <BS.Nav navbar className="section-title">
       <ChapterSection section={section} />
       {page?.title}

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -23,8 +23,9 @@ module.exports = React.createClass
     @props.cnxId or @context.router.getCurrentParams().cnxId
 
   getSplashTitle: ->
-    {cnxId} = @context.router.getCurrentParams()
+    {cnxId} = @props.cnxId or @context.router.getCurrentParams().cnxId
     page = ReferenceBookStore.getPageInfo(@context.router.getCurrentParams())
+    page = ReferenceBookStore.getPageInfo({courseId: @props.courseId, cnxId})
     page?.title
 
   prevLink: (info) ->

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -19,12 +19,11 @@ module.exports = React.createClass
     router: React.PropTypes.func
   mixins: [BookContentMixin, GetPositionMixin]
 
-  getCNXId: ->
+  getCnxId: ->
     @props.cnxId or @context.router.getCurrentParams().cnxId
 
   getSplashTitle: ->
-    {cnxId} = @props.cnxId or @context.router.getCurrentParams().cnxId
-    page = ReferenceBookStore.getPageInfo(@context.router.getCurrentParams())
+    cnxId = @getCnxId()
     page = ReferenceBookStore.getPageInfo({courseId: @props.courseId, cnxId})
     page?.title
 
@@ -82,7 +81,7 @@ module.exports = React.createClass
   render: ->
     {courseId} = @context.router.getCurrentParams()
     # read the id from props, or failing that the url
-    cnxId = @getCNXId()
+    cnxId = @getCnxId()
     page = ReferenceBookPageStore.get(cnxId)
     info = ReferenceBookStore.getPageInfo({courseId, cnxId})
 

--- a/src/components/reference-book/toc.cjsx
+++ b/src/components/reference-book/toc.cjsx
@@ -16,10 +16,13 @@ Section = React.createClass
   render: ->
     {courseId} = @context.router.getCurrentParams()
     sections = @props.section.chapter_section.join('.')
-    linkTarget = if @props.section.cnx_id then 'viewReferenceBookPage' else 'viewReferenceBookSection'
+    [linkTarget, params] = if @props.section.cnx_id
+      ['viewReferenceBookPage',  {courseId: courseId, cnxId: @props.section.cnx_id}]
+    else
+      ['viewReferenceBookSection', {courseId: courseId, section: sections}]
     <ul className="section" data-depth={@props.section.chapter_section.length}>
       <Router.Link onClick={@props.onMenuSelection} to={linkTarget}
-          params={courseId: courseId, cnxId: @props.section.cnx_id, section: sections}>
+          params={params}>
           <span className="section-number">{sections}</span>
           {@props.section.title}
       </Router.Link>

--- a/src/components/reference-book/toc.cjsx
+++ b/src/components/reference-book/toc.cjsx
@@ -21,11 +21,13 @@ Section = React.createClass
     else
       ['viewReferenceBookSection', {courseId: courseId, section: sections}]
     <ul className="section" data-depth={@props.section.chapter_section.length}>
-      <Router.Link onClick={@props.onMenuSelection} to={linkTarget}
-          params={params}>
-          <span className="section-number">{sections}</span>
-          {@props.section.title}
-      </Router.Link>
+      <li>
+        <Router.Link onClick={@props.onMenuSelection} to={linkTarget}
+            params={params}>
+            <span className="section-number">{sections}</span>
+            {@props.section.title}
+        </Router.Link>
+      </li>
       { _.map @props.section.children, (child) =>
         <li key={child.id}>
           <Section onMenuSelection={@props.onMenuSelection} section={child} />


### PR DESCRIPTION
Mainly biology related but fixes a few bugs also.  Namely it:

  * Adds uniform padding to the book content container element vs the individual elements setting their margins.
  * Fixes the intro image overlay from not appearing on chapter_sections.
  * Adds highlighting to the current page being displayed on the table of contents

<img width="1448" alt="screen shot 2015-07-14 at 8 50 38 pm" src="https://cloud.githubusercontent.com/assets/79566/8689175/0798a210-2a6a-11e5-8956-172e656a404a.png">

![screen shot 2015-07-14 at 8 49 30 pm](https://cloud.githubusercontent.com/assets/79566/8689158/e0f70b56-2a69-11e5-8101-7587e698eb3e.png)

This is an interesting one.  Should the teacher always have content, or should I not style the misconception if it immediately follows `ost-teacher` ?

<img width="827" alt="screen shot 2015-07-14 at 8 54 31 pm" src="https://cloud.githubusercontent.com/assets/79566/8689230/94c675b8-2a6a-11e5-8fad-e23641c539fe.png">