### PR TITLE
Feature/exercise links in readings

### DIFF
--- a/resources/styles/components/reference-book/exercise.less
+++ b/resources/styles/components/reference-book/exercise.less
@@ -1,0 +1,13 @@
+.reference-book {
+  .exercise[data-type=exercise] {
+    margin-bottom: 40px;
+    .question {
+      padding: 0;
+
+      .answers-table label.answer-label:hover {
+        background-color: @answer-background;
+        cursor: default;
+      }
+    }
+  }
+}

--- a/resources/styles/components/reference-book/index.less
+++ b/resources/styles/components/reference-book/index.less
@@ -3,6 +3,7 @@
 @import './toc';
 @import './slide-out-menu';
 @import './page-navigation-controls';
+@import './exercise';
 
 .reference-book {
   .section-number {

--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -12,10 +12,6 @@
   .interactive-step > .interactive-content,
   .reading-step {
     .tutor-book-content();
-
-    .exercise[data-type=exercise] {
-      display: none;
-    }
   }
 }
 

--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -12,6 +12,10 @@
   .interactive-step > .interactive-content,
   .reading-step {
     .tutor-book-content();
+
+    .exercise[data-type=exercise] {
+      display: none;
+    }
   }
 }
 

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -28,6 +28,7 @@ _ = require 'underscore'
 {ReferenceBookActions, ReferenceBookStore} = require './flux/reference-book'
 {ReferenceBookPageActions, ReferenceBookPageStore} = require './flux/reference-book-page'
 {ReferenceBookExerciseActions, ReferenceBookExerciseStore} = require './flux/reference-book-exercise'
+{ExerciseAPIStore} = require './flux/exercise-api'
 
 # Do some special things when running without a tutor-server backend.
 #
@@ -230,7 +231,9 @@ start = ->
 
   # TODO update with exercise link from BE when available
   apiHelper ReferenceBookExerciseActions, ReferenceBookExerciseActions.load, ReferenceBookExerciseActions.loaded, 'GET', (itemCode) ->
-    url: "https://exercises-dev.openstax.org/api/exercises?q=tag:#{itemCode}"
+    exerciseAPIUrl = ExerciseAPIStore.get(itemCode)
+
+    url: exerciseAPIUrl
 
   apiHelper StudentDashboardActions, StudentDashboardActions.load, StudentDashboardActions.loaded, 'GET', (courseId) ->
     url: "/api/courses/#{courseId}/dashboard"

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -27,6 +27,7 @@ _ = require 'underscore'
 {CourseListingActions, CourseListingStore} = require './flux/course-listing'
 {ReferenceBookActions, ReferenceBookStore} = require './flux/reference-book'
 {ReferenceBookPageActions, ReferenceBookPageStore} = require './flux/reference-book-page'
+{ReferenceBookExerciseActions, ReferenceBookExerciseStore} = require './flux/reference-book-exercise'
 
 # Do some special things when running without a tutor-server backend.
 #
@@ -226,6 +227,10 @@ start = ->
 
   apiHelper ReferenceBookPageActions, ReferenceBookPageActions.load, ReferenceBookPageActions.loaded, 'GET', (cnxId) ->
     url: "/api/pages/#{cnxId}"
+
+  # TODO update with exercise link from BE when available
+  apiHelper ReferenceBookExerciseActions, ReferenceBookExerciseActions.load, ReferenceBookExerciseActions.loaded, 'GET', (itemCode) ->
+    url: "https://exercises-dev.openstax.org/api/exercises?q=tag:#{itemCode}"
 
   apiHelper StudentDashboardActions, StudentDashboardActions.load, StudentDashboardActions.loaded, 'GET', (courseId) ->
     url: "/api/courses/#{courseId}/dashboard"

--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -1,5 +1,6 @@
 _ = require 'underscore'
 S = require '../helpers/string'
+{ReferenceBookExerciseActions, ReferenceBookExerciseStore} = require '../flux/reference-book-exercise'
 
 module.exports =
   componentDidMount:  ->
@@ -64,6 +65,7 @@ module.exports =
     mediaLink.target = '_blank' if @shouldOpenNewTab?()
 
   processLink: (mediaLink) ->
+    @renderExercise?(mediaLink)
     return unless @isMediaLink(mediaLink)
     root = @getDOMNode()
 
@@ -97,6 +99,9 @@ module.exports =
     linkSelector = 'a:not(.nav):not([data-type=footnote-number]):not([data-type=footnote-ref])'
     mediaLinks = root.querySelectorAll(linkSelector)
 
+    # For now
+    # TODO pull this logic into page component
+    ReferenceBookExerciseStore.setMaxListeners(mediaLinks.length) if @renderExercise?
     _.each(mediaLinks, @processLink)
 
 

--- a/src/components/reference-book/exercise.cjsx
+++ b/src/components/reference-book/exercise.cjsx
@@ -1,6 +1,8 @@
 React = require 'react'
 
 {ReferenceBookExerciseActions, ReferenceBookExerciseStore} = require '../../flux/reference-book-exercise'
+{ExerciseAPIStore} = require '../../flux/exercise-api'
+
 Question = require '../question'
 LoadableItem = require '../loadable-item'
 
@@ -9,6 +11,14 @@ ReferenceBookExercise = React.createClass
   render: ->
     {exerciseId} = @props
     {items} = ReferenceBookExerciseStore.get(exerciseId)
+
+    unless items?.length
+      # warning about missing exercise --
+      # is there a need to show the reader anything?
+      exerciseAPIUrl = ExerciseAPIStore.get(exerciseId)
+      console.warn("WARNING: #{exerciseId} appears to be missing.  Please check #{exerciseAPIUrl}.")
+      return <small>Missing exercise</small>
+
     {questions} = items[0]
     question = questions[0]
 

--- a/src/components/reference-book/exercise.cjsx
+++ b/src/components/reference-book/exercise.cjsx
@@ -1,0 +1,29 @@
+React = require 'react'
+
+{ReferenceBookExerciseActions, ReferenceBookExerciseStore} = require '../../flux/reference-book-exercise'
+Question = require '../question'
+LoadableItem = require '../loadable-item'
+
+ReferenceBookExercise = React.createClass
+  displayName: 'ReferenceBookExercise'
+  render: ->
+    {exerciseId} = @props
+    {items} = ReferenceBookExerciseStore.get(exerciseId)
+    {questions} = items[0]
+    question = questions[0]
+
+    <Question model={question}/>
+
+ReferenceBookExerciseShell = React.createClass
+  displayName: 'ReferenceBookExerciseShell'
+  render: ->
+    {exerciseId} = @props
+
+    <LoadableItem
+      id={exerciseId}
+      store={ReferenceBookExerciseStore}
+      actions={ReferenceBookExerciseActions}
+      renderItem={=> <ReferenceBookExercise {...@props} />}
+    />
+
+module.exports = {ReferenceBookExercise, ReferenceBookExerciseShell}

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -11,10 +11,12 @@ GetPositionMixin = require '../get-position-mixin'
 
 {ReferenceBookPageStore} = require '../../flux/reference-book-page'
 {ReferenceBookStore} = require '../../flux/reference-book'
+{ReferenceBookExerciseStore} = require '../../flux/reference-book-exercise'
 
 EXERCISE_MATCHER = new RegExp('#ost\/api\/ex\/(.*)')
 
 module.exports = React.createClass
+  _exerciseNodes: []
   displayName: 'ReferenceBookPage'
   propTypes:
     courseId: React.PropTypes.string.isRequired
@@ -87,11 +89,23 @@ module.exports = React.createClass
   getExerciseId: (link) ->
     link.hash.match(EXERCISE_MATCHER)[1]
 
-  renderExercise: (mediaLink) ->
-    if @isExerciseLink(mediaLink)
-      exerciseId = @getExerciseId(mediaLink)
-      if mediaLink.parentNode.parentNode?
-        React.render(<ReferenceBookExerciseShell exerciseId={exerciseId}/>, mediaLink.parentNode.parentNode)
+  renderOtherLinks: (otherLinks) ->
+    ReferenceBookExerciseStore.setMaxListeners(otherLinks.length)
+    _.each(otherLinks, @renderExercise)
+
+  renderExercise: (link) ->
+    if @isExerciseLink(link)
+      exerciseId = @getExerciseId(link)
+      if link.parentNode.parentNode?
+        @_exerciseNodes.push(link.parentNode.parentNode)
+        React.render(<ReferenceBookExerciseShell exerciseId={exerciseId}/>, link.parentNode.parentNode)
+
+  unmountExerciseComponent: (node, nodeIndex) ->
+    React.unmountComponentAtNode(node) if node?
+    @_exerciseNodes.splice(nodeIndex, 1)
+
+  componentWillUnmount: ->
+    _.each(@_exerciseNodes, @unmountExerciseComponent)
 
   render: ->
     {courseId} = @context.router.getCurrentParams()

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -7,9 +7,12 @@ HTML = require '../html'
 ArbitraryHtmlAndMath = require '../html'
 BookContentMixin = require '../book-content-mixin'
 GetPositionMixin = require '../get-position-mixin'
+{ReferenceBookExerciseShell} = require './exercise'
 
 {ReferenceBookPageStore} = require '../../flux/reference-book-page'
 {ReferenceBookStore} = require '../../flux/reference-book'
+
+EXERCISE_MATCHER = new RegExp('#ost\/api\/ex\/(.*)')
 
 module.exports = React.createClass
   displayName: 'ReferenceBookPage'
@@ -77,6 +80,18 @@ module.exports = React.createClass
 
       for image in images
         image.addEventListener('load', onImageLoad)
+
+  isExerciseLink: (link) ->
+    link.hash.search(EXERCISE_MATCHER) is 0
+
+  getExerciseId: (link) ->
+    link.hash.match(EXERCISE_MATCHER)[1]
+
+  renderExercise: (mediaLink) ->
+    if @isExerciseLink(mediaLink)
+      exerciseId = @getExerciseId(mediaLink)
+      if mediaLink.parentNode.parentNode?
+        React.render(<ReferenceBookExerciseShell exerciseId={exerciseId}/>, mediaLink.parentNode.parentNode)
 
   render: ->
     {courseId} = @context.router.getCurrentParams()

--- a/src/flux/exercise-api.coffee
+++ b/src/flux/exercise-api.coffee
@@ -1,0 +1,8 @@
+flux = require 'flux-react'
+# TODO make this real when BE can send us this.
+ExerciseAPIStore = flux.createStore
+  exports:
+    get: (itemCode) ->
+      "https://exercises-dev.openstax.org/api/exercises?q=tag:#{itemCode}"
+
+module.exports = {ExerciseAPIStore}

--- a/src/flux/reference-book-exercise.coffee
+++ b/src/flux/reference-book-exercise.coffee
@@ -1,0 +1,10 @@
+{CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
+_ = require 'underscore'
+
+ReferenceBookExerciseConfig = {
+
+}
+
+extendConfig(ReferenceBookExerciseConfig, new CrudConfig())
+{actions, store} = makeSimpleStore(ReferenceBookExerciseConfig)
+module.exports = {ReferenceBookExerciseActions:actions, ReferenceBookExerciseStore:store}


### PR DESCRIPTION
![screen shot 2015-07-17 at 7 39 30 pm](https://cloud.githubusercontent.com/assets/2483873/8759565/49dd87cc-2cbc-11e5-9a12-3ab8899d92ae.png)

CORS is an issue.  Need to do this to Chrome to load in exercises:
```bash
open -a Google\ Chrome --args --allow-file-access-from-files --disable-web-security
```

- [x] Make processLink in ```book-content-mixin``` less atrocious.
  * pulling out if else stuff using filter or something similar to group types of links first and then processing
- [ ] ~~style updates as needed~~, separate PR
- [X] hide ```ost-reading-discard```, already hidden