### PR TITLE
Don't specify invalid 'background-repeat: none;' on browse the book icon

### DIFF
--- a/resources/styles/components/student-dashboard/dashboard.less
+++ b/resources/styles/components/student-dashboard/dashboard.less
@@ -32,7 +32,6 @@
     height: 80px;
     background-repeat: no-repeat;
     display: inline-block;
-    background-repeat: none;
     div {
       margin: 10px 0 0 100px;
       text-align: left; // override center specified for actions-box


### PR DESCRIPTION
Believe it was overwriting the earlier correct no-repeat in some browsers since we've had a bug report saying the background was repeating.  Chrome & Firefox both seemed to handle it fine though.