### PR TITLE
Events that are un-opened should not be worked

### DIFF
--- a/api/courses/1/dashboard.json
+++ b/api/courses/1/dashboard.json
@@ -23,7 +23,7 @@
         {
             "id": "7",
             "title": "iReading 3: Newton's Second Law of Motion:",
-            "opens_at": "2015-04-22T14:15:58.856Z",
+            "opens_at": "2015-04-13T14:15:58.856Z",
             "due_at": "2015-04-16T14:15:58.856Z",
             "type": "reading",
             "complete": false,
@@ -33,7 +33,7 @@
         {
             "id": "9",
             "title": "iReading 4: Newton's Third Law of Motion",
-            "opens_at": "2015-05-07T14:15:58.856Z",
+            "opens_at": "2015-04-13T14:16:58.856Z",
             "due_at": "2015-04-19T14:15:58.856Z",
             "type": "reading",
             "complete": false,

--- a/src/flux/student-dashboard.coffee
+++ b/src/flux/student-dashboard.coffee
@@ -17,8 +17,8 @@ StudentDashboardConfig = {
   exports:
 
     eventsByWeek: (courseId) ->
-      now = TimeStore.getNow()
-      tasks = _.filter( @_get(courseId).tasks, (event) -> new Date(event.opens_at) < now )
+      data = @_get(courseId)
+      tasks = data.tasks or []
       weeks = _.groupBy tasks, (event) ->
         moment(event.due_at).startOf('isoweek').format('YYYYww')
       sorted = {}
@@ -36,24 +36,20 @@ StudentDashboardConfig = {
       events[moment(day).startOf('isoweek').format('YYYYww')] or []
 
     canWorkTask: (event) ->
-      # currently all tasks are workable
-      return true
+      return new Date(event.opens_at) < TimeStore.getNow()
+
 
     # Returns events who's due date has not passed
     upcomingEvents: (courseId, now = TimeStore.getNow()) ->
       _.chain(@_get(courseId)?.tasks or [])
-        .filter( (event) ->
-          new Date(event.due_at) > now and new Date(event.opens_at) < now
-        )
+        .filter( (event) -> new Date(event.due_at) > now )
         .sortBy('due_at')
         .value()
 
     # Returns events who's due date is in the past
     pastDueEvents: (courseId, now = TimeStore.getNow()) ->
       _.chain(@_get(courseId)?.tasks or [])
-        .filter( (event) ->
-          new Date(event.due_at) < now and new Date(event.opens_at) < now
-        )
+        .filter( (event) -> new Date(event.due_at) < now )
         .sortBy('due_at')
         .value()
 }

--- a/src/flux/student-dashboard.coffee
+++ b/src/flux/student-dashboard.coffee
@@ -17,8 +17,8 @@ StudentDashboardConfig = {
   exports:
 
     eventsByWeek: (courseId) ->
-      data = @_get(courseId)
-      tasks = data.tasks or []
+      now = TimeStore.getNow()
+      tasks = _.filter( @_get(courseId).tasks, (event) -> new Date(event.opens_at) < now )
       weeks = _.groupBy tasks, (event) ->
         moment(event.due_at).startOf('isoweek').format('YYYYww')
       sorted = {}
@@ -42,14 +42,18 @@ StudentDashboardConfig = {
     # Returns events who's due date has not passed
     upcomingEvents: (courseId, now = TimeStore.getNow()) ->
       _.chain(@_get(courseId)?.tasks or [])
-        .filter( (event) -> new Date(event.due_at) > now )
+        .filter( (event) ->
+          new Date(event.due_at) > now and new Date(event.opens_at) < now
+        )
         .sortBy('due_at')
         .value()
 
     # Returns events who's due date is in the past
     pastDueEvents: (courseId, now = TimeStore.getNow()) ->
       _.chain(@_get(courseId)?.tasks or [])
-        .filter( (event) -> new Date(event.due_at) < now )
+        .filter( (event) ->
+          new Date(event.due_at) < now and new Date(event.opens_at) < now
+        )
         .sortBy('due_at')
         .value()
 }

--- a/test/components/student-dashboard.spec.coffee
+++ b/test/components/student-dashboard.spec.coffee
@@ -38,36 +38,35 @@ describe 'Student Dashboard Component', ->
     #  * one event that started at 8am, before the timestamp, but part of the week
     #  * one event a few days later
     #  * one event on the next sunday, the 19th.  As spece'd that should also be included
+    #  * one event ('iReading 4: Newton's Third Law of Motion') is not opened yet
     renderDashBoard().then (state) ->
       tasks = state.div.querySelectorAll('.-this-week .task .title')
-      expect(tasks.length).equal(3)
+      expect(tasks.length).equal(2)
       expect(_.pluck(tasks, 'textContent'))
         .to.have.deep.equal([
           'iReading 2: Newton\'s First Law of Motion: Inertia'
           'iReading 3: Newton\'s Second Law of Motion:'
-          'iReading 4: Newton\'s Third Law of Motion'
         ])
 
 
   it 'shows accurate feedback', ->
-    TimeActions.setNow(NOW)
+    # move 10 mins into future, just past the unopened event's opens_at
+    TimeActions.setNow( new Date( NOW.getTime() + 100000) )
     renderDashBoard().then (state) ->
       feedback = state.div.querySelectorAll('.-this-week .task .feedback')
-      console.log _.pluck(feedback, 'textContent')
       expect(_.pluck(feedback, 'textContent'))
         .to.have.deep.equal([
           'Complete', 'In progress', 'Not started'
         ])
-
       feedback = state.div.querySelectorAll('.-upcoming .task .feedback')
-      console.log _.pluck(feedback, 'textContent')
       expect(_.pluck(feedback, 'textContent'))
-        .to.have.deep.equal(['6/7 correct', '7/8 correct', '6/6 answered', '7/3 answered'])
+        .to.have.deep.equal(['6/7 correct', '7/8 correct'])
 
 
   it 'renders only upcoming events to week panel', ->
     TimeActions.setNow(new Date('2015-04-24T11:15:58.856Z'))
     renderDashBoard().then (state) ->
       tasks = state.div.querySelectorAll('.-upcoming .task .title')
+      console.log _.pluck(tasks, 'textContent')
       expect(_.pluck(tasks, 'textContent'))
-        .to.have.deep.equal(['Homework #3', 'Homework #4 (final)'])
+        .to.have.deep.equal(['Homework #3'])

--- a/test/components/student-dashboard.spec.coffee
+++ b/test/components/student-dashboard.spec.coffee
@@ -38,35 +38,43 @@ describe 'Student Dashboard Component', ->
     #  * one event that started at 8am, before the timestamp, but part of the week
     #  * one event a few days later
     #  * one event on the next sunday, the 19th.  As spece'd that should also be included
-    #  * one event ('iReading 4: Newton's Third Law of Motion') is not opened yet
     renderDashBoard().then (state) ->
       tasks = state.div.querySelectorAll('.-this-week .task .title')
-      expect(tasks.length).equal(2)
+      expect(tasks.length).equal(3)
       expect(_.pluck(tasks, 'textContent'))
         .to.have.deep.equal([
           'iReading 2: Newton\'s First Law of Motion: Inertia'
           'iReading 3: Newton\'s Second Law of Motion:'
+          'iReading 4: Newton\'s Third Law of Motion'
         ])
 
 
   it 'shows accurate feedback', ->
-    # move 10 mins into future, just past the unopened event's opens_at
-    TimeActions.setNow( new Date( NOW.getTime() + 100000) )
+    TimeActions.setNow(NOW)
     renderDashBoard().then (state) ->
       feedback = state.div.querySelectorAll('.-this-week .task .feedback')
       expect(_.pluck(feedback, 'textContent'))
         .to.have.deep.equal([
           'Complete', 'In progress', 'Not started'
         ])
+
       feedback = state.div.querySelectorAll('.-upcoming .task .feedback')
       expect(_.pluck(feedback, 'textContent'))
-        .to.have.deep.equal(['6/7 correct', '7/8 correct'])
+        .to.have.deep.equal(['6/7 correct', '7/8 correct', '6/6 answered', '7/3 answered'])
 
 
   it 'renders only upcoming events to week panel', ->
     TimeActions.setNow(new Date('2015-04-24T11:15:58.856Z'))
     renderDashBoard().then (state) ->
       tasks = state.div.querySelectorAll('.-upcoming .task .title')
-      console.log _.pluck(tasks, 'textContent')
       expect(_.pluck(tasks, 'textContent'))
-        .to.have.deep.equal(['Homework #3'])
+        .to.have.deep.equal(['Homework #3', 'Homework #4 (final)'])
+
+  it 'does not work unopened tasks', ->
+    TimeActions.setNow(NOW)
+    renderDashBoard().then (state) ->
+      classes = _.map(state.div.querySelectorAll('.-upcoming .task'), (el) ->
+        _.without(el.classList, 'task', 'row', 'homework')
+      )
+      expect(classes)
+        .to.have.deep.equal([['workable'], ['workable'], [], []])


### PR DESCRIPTION
Since the student dashboard shouldn't know about them at all, just set the store's methods to filter them out.