### PR TITLE
Clear float on note type elements

### DIFF
--- a/resources/styles/book-content/note.less
+++ b/resources/styles/book-content/note.less
@@ -4,6 +4,7 @@
 .ost-background-info,
 .ost-misconception {
   margin-top: @tutor-card-body-padding-vertical;
+  clear: both;
   &:before {
     height: 35px;
     content: attr(data-label);


### PR DESCRIPTION
Otherwise they'll float alongside vertical images

Before/After:

<img width="776" alt="screen shot 2015-07-18 at 6 38 21 pm" src="https://cloud.githubusercontent.com/assets/79566/8763956/6b3ae1b0-2d7c-11e5-99c9-01b72bbc54b8.png">
<img width="821" alt="screen shot 2015-07-18 at 6 38 58 pm" src="https://cloud.githubusercontent.com/assets/79566/8763957/6b68ea2e-2d7c-11e5-8750-9b90ae0acd13.png">

