### PR TITLE
restore locale settings when done with react-datepicker.

### DIFF
--- a/src/components/course-calendar/month.cjsx
+++ b/src/components/course-calendar/month.cjsx
@@ -122,7 +122,8 @@ CourseMonth = React.createClass
           otherProps.classes =
             active: true
 
-      day = <Day date={dayIter} modifiers={modifiers} {...otherProps}/>
+      key = "day-#{dayIter.format(@props.dateFormat)}"
+      day = <Day date={dayIter} modifiers={modifiers} key={key} {...otherProps}/>
       days.push(day)
 
     days

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -70,7 +70,28 @@ TutorInput = React.createClass
 TutorDateInput = React.createClass
 
   getInitialState: ->
-    {expandCalendar: false}
+    expandCalendar: false
+    currentLocale: @getCurrentLocales()
+
+  componentWillUnmount: ->
+    @restoreLocales()
+
+  # For some reason, react-datepicker chooses to GLOBALLY override moment's locale.
+  # This tends to do nasty things to the dashboard calendar.
+  # Therefore, grab the current locale settings, and restore them when unmounting.
+  # TODO: debug react-datepicker and submit a PR so that it will no longer thrash moment's global.
+  getCurrentLocales: ->
+    currentGlobalLocale = moment.localeData()
+
+    abbr: currentGlobalLocale._abbr
+    week: currentGlobalLocale._week
+    weekdaysMin: currentGlobalLocale._weekdaysMin
+
+  restoreLocales: ->
+    {abbr} = @state.currentLocale
+
+    localeOptions = _.omit(@state.currentLocale, 'abbr')
+    moment.locale(abbr, localeOptions)
 
   expandCalendar: ->
     @setState({expandCalendar: true, hasFocus: true})

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -158,7 +158,7 @@ TutorDateInput = React.createClass
           onChange={@dateSelected}
           disabled={@props.disabled}
           selected={value}
-          weekStart={0}
+          weekStart={@state.currentLocale.week.dow}
         />
     else if @props.disabled and value
       displayValue = value.toString("YYYY/MM/DD")


### PR DESCRIPTION
Otherwise, moment locale will be messed up and the dashboard cal suffers as a result, for example.

react-datepicker [sets global locale](https://github.com/Hacker0x01/react-datepicker/blob/master/src/calendar.jsx#L44-L49) and causes moment to be confused

# Minimum steps to replicate bug
1. load builder
![screen shot 2015-07-20 at 3 18 59 pm](https://cloud.githubusercontent.com/assets/2483873/8786265/bc2f96de-2ef2-11e5-9474-9e8086a6792f.png)
2. cancel
![screen shot 2015-07-20 at 3 19 05 pm](https://cloud.githubusercontent.com/assets/2483873/8786266/bc303512-2ef2-11e5-8bc1-0e50a6cc7577.png)
3. the dashboard is :cry: 
![screen shot 2015-07-20 at 3 19 12 pm](https://cloud.githubusercontent.com/assets/2483873/8786264/bc2e0f8a-2ef2-11e5-9886-4866b791b2ce.png)

# What happens now
![screen shot 2015-07-20 at 3 21 59 pm](https://cloud.githubusercontent.com/assets/2483873/8786332/1dcdcbb8-2ef3-11e5-8cde-4e40b212ef25.png)
![screen shot 2015-07-20 at 3 22 03 pm](https://cloud.githubusercontent.com/assets/2483873/8786331/1dcb5e96-2ef3-11e5-83ea-f4eb61b94b3b.png)
3. YAY!
![screen shot 2015-07-20 at 3 22 09 pm](https://cloud.githubusercontent.com/assets/2483873/8786333/1dce5ce0-2ef3-11e5-88ff-a35b23e66c34.png)
