### PR TITLE
course data can pass title and category onto elements

### DIFF
--- a/src/components/course-data-mixin.cjsx
+++ b/src/components/course-data-mixin.cjsx
@@ -1,0 +1,10 @@
+{CourseStore} = require '../flux/course'
+
+module.exports =
+  getCourseDataProps: (courseId) ->
+    unless courseId?
+      {courseId} = @context.router.getCurrentParams()
+
+    dataProps =
+      'data-title': CourseStore.getShortName(courseId)
+      'data-category': CourseStore.getCategory(courseId)

--- a/src/components/html.cjsx
+++ b/src/components/html.cjsx
@@ -17,10 +17,18 @@ module.exports = React.createClass
     classes.push(@props.className) if @props.className
     classes = classes.join(' ')
 
+    otherProps = _.omit(@props, 'className', 'block', 'html')
+
     if @props.block
-      <div className={classes} dangerouslySetInnerHTML={@getHTMLFromProp()} />
+      <div
+        {...otherProps}
+        className={classes}
+        dangerouslySetInnerHTML={@getHTMLFromProp()} />
     else
-      <span className={classes} dangerouslySetInnerHTML={@getHTMLFromProp()} />
+      <span
+        {...otherProps}
+        className={classes}
+        dangerouslySetInnerHTML={@getHTMLFromProp()} />
 
   getHTMLFromProp: ->
     {html} = @props

--- a/src/components/reference-book/reference-book.cjsx
+++ b/src/components/reference-book/reference-book.cjsx
@@ -4,6 +4,7 @@ BS = require 'react-bootstrap'
 _  = require 'underscore'
 
 BindStoreMixin = require '../bind-store-mixin'
+CourseDataMixin = require '../course-data-mixin'
 NavBar = require './navbar'
 Menu = require './slide-out-menu'
 
@@ -18,7 +19,7 @@ module.exports = React.createClass
   displayName: 'ReferenceBook'
   contextTypes:
     router: React.PropTypes.func
-  mixins: [BindStoreMixin]
+  mixins: [BindStoreMixin, CourseDataMixin]
   bindStore: CourseListingStore
   bindEvent: 'loaded'
 
@@ -42,6 +43,8 @@ module.exports = React.createClass
 
   render: ->
     {courseId} = @context.router.getCurrentParams()
+    courseDataProps = @getCourseDataProps(courseId)
+
     course = CourseStore.get(courseId)
     classnames = ["reference-book"]
     classnames.push('menu-open') if @state.isMenuVisible
@@ -53,7 +56,7 @@ module.exports = React.createClass
       else
         "Show Teacher Edition"
 
-    <div className={classnames.join(' ')}>
+    <div {...courseDataProps} className={classnames.join(' ')}>
       <NavBar
         toggleTocMenu={@toggleMenuState}
         teacherLinkText={teacherLinkText}

--- a/src/components/student-dashboard/dashboard.cjsx
+++ b/src/components/student-dashboard/dashboard.cjsx
@@ -11,6 +11,9 @@ ThisWeekPanel   = require './this-week-panel'
 PracticeButton = require '../buttons/practice-button'
 ProgressGuideShell = require './progress-guide'
 BrowseBookButton = require '../buttons/browse-the-book'
+
+CourseDataMixin = require '../course-data-mixin'
+
 {StudentDashboardStore} = require '../../flux/student-dashboard'
 {CourseStore} = require '../../flux/course'
 
@@ -19,6 +22,8 @@ module.exports = React.createClass
 
   propTypes:
     courseId: React.PropTypes.string.isRequired
+
+  mixins: [CourseDataMixin]
 
   contextTypes:
     router: React.PropTypes.func
@@ -31,12 +36,12 @@ module.exports = React.createClass
 
   render: ->
     courseId = @props.courseId
+    courseDataProps = @getCourseDataProps(courseId)
+
     info = StudentDashboardStore.get(courseId)
     # The large background image is currently set via CSS based on
     # the short title of the course, which will be something like 'Physics'
-    <div className="tutor-booksplash-background"
-      data-title={CourseStore.getShortName(courseId)}
-      data-category={CourseStore.getCategory(courseId)}>
+    <div {...courseDataProps} className="tutor-booksplash-background">
 
       <div className='container'>
 

--- a/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -11,6 +11,7 @@ LoadableItem = require '../loadable-item'
 DATE_FORMAT = 'YYYY-MM-DD'
 
 CourseCalendar = require '../course-calendar'
+CourseDataMixin = require '../course-data-mixin'
 
 TeacherTaskPlans = React.createClass
 
@@ -60,6 +61,8 @@ TeacherTaskPlanListing = React.createClass
   getDefaultProps: ->
     dateFormat: DATE_FORMAT
 
+  mixins: [CourseDataMixin]
+
   componentDidMount: ->
     {courseId} = @context.router.getCurrentParams()
 
@@ -91,15 +94,15 @@ TeacherTaskPlanListing = React.createClass
 
   render: ->
     {courseId} = @context.router.getCurrentParams()
+    courseDataProps = @getCourseDataProps(courseId)
+
     date = @getDateFromParams()
 
     plansList = TeacherTaskPlanStore.getCoursePlans(courseId)
 
     loadedCalendarProps = {plansList, courseId, date}
 
-    <div className="tutor-booksplash-background"
-      data-title={CourseStore.getShortName(courseId)}
-      data-category={CourseStore.getCategory(courseId)}>
+    <div {...courseDataProps} className="tutor-booksplash-background">
 
       <BS.Panel
           className='list-courses'

--- a/src/components/task-step/all-steps.cjsx
+++ b/src/components/task-step/all-steps.cjsx
@@ -10,6 +10,8 @@ Markdown = require '../markdown'
 StepMixin = require './step-mixin'
 StepFooterMixin = require './step-footer-mixin'
 BookContentMixin = require '../book-content-mixin'
+CourseDataMixin = require '../course-data-mixin'
+
 {StepPanel} = require '../../helpers/policies'
 
 # React swallows thrown errors so log them first
@@ -19,7 +21,7 @@ err = (msgs...) ->
 
 Reading = React.createClass
   displayName: 'Reading'
-  mixins: [StepMixin, StepFooterMixin, BookContentMixin]
+  mixins: [StepMixin, StepFooterMixin, BookContentMixin, CourseDataMixin]
   contextTypes:
     router: React.PropTypes.func
   isContinueEnabled: -> true
@@ -40,7 +42,12 @@ Reading = React.createClass
   renderBody: ->
     {id} = @props
     {content_html} = TaskStepStore.get(id)
-    <ArbitraryHtmlAndMath className='reading-step' html={content_html} />
+    courseDataProps = @getCourseDataProps()
+
+    <ArbitraryHtmlAndMath
+      {...courseDataProps}
+      className='reading-step'
+      html={content_html} />
 
 
 Interactive = React.createClass


### PR DESCRIPTION
For iReading, reference book, calendar, and dashboard as data-attributes -- ```data-title``` and ```data-category```, following pattern set up by @nathanstitt for dashboard and calendar.

So that theming for content can happen following the same pattern for book-content.  As per discussion with @helenemccarron, this should allow us to do our theming something like this:

```less
// A mixin to style book content from CNX
.tutor-book-content() {
  @reading-ui-banner-height: 40px;
  padding: 0 @tutor-card-body-padding-horizontal @tutor-card-body-padding-vertical @tutor-card-body-padding-horizontal;
  display: block;
  @import './mixins';
  @import './base';
  @import './splash-image';
  // type specific styling comes last so it can override the above styles
  @import './link-to-learning';
  @import './worked-examples';
  @import './note';
  @import './grasp-check';
  @import './target';
  @import './visual-connection';
}

.tutor-book-category-physics() {
  // maybe subject specific vars here

  @import './links-to-physics';
  @import './virtual-physics';
  @import './fun-in-physics';
  @import './work-in-physics';
  @import './watch-physics';
}

.tutor-book-category-physics() {
  // maybe subject specific vars here

  @import './links-to-biology';
  @import './virtual-biology';
  @import './fun-in-biology';
  @import './work-in-biology';
  @import './watch-biology';
}

.reference-book {
  .tutor-book-content();

  &[data-category=physics] {
    .tutor-book-category-physics();
  }
  &[data-category=biology] {
    .tutor-book-category-biology();
  }
}
```