### PR TITLE
A few student dashboard style tweaks

### DIFF
--- a/resources/styles/global/tutor-booksplash-background.less
+++ b/resources/styles/global/tutor-booksplash-background.less
@@ -15,7 +15,6 @@
     right: 0px;
     height: 24rem;
     overflow: hidden;
-    background-color: @tutor-tertiary;
     color: @tutor-secondary;
     text-align: center;
     font-size: 35rem;

--- a/src/components/student-dashboard/dashboard.cjsx
+++ b/src/components/student-dashboard/dashboard.cjsx
@@ -41,7 +41,7 @@ module.exports = React.createClass
       <div className='container'>
 
         <BS.Row>
-          <BS.Col mdPush={9} xs={12} md={3}>
+          <BS.Col xs=12 md=4 lg=3 mdPush=8 lgPush=9>
 
             <ProgressGuideShell courseId={courseId} />
 
@@ -53,7 +53,7 @@ module.exports = React.createClass
             </div>
           </BS.Col>
 
-          <BS.Col mdPull={3} xs={12} md={9}>
+          <BS.Col xs=12 md=8 lg=9 mdPull=4 lgPull=3>
 
             <BS.TabbedArea
               activeKey = {@state.selectedTabIndex}


### PR DESCRIPTION
Removes the default color from the booksplash, which was set to the physics.  I think this is the cause of the "shows physics colors, then rapidly switches to biology on load" bug.

Also fixes spacing on a 1024 wide display:
Before/after

![screen shot 2015-07-21 at 9 36 36 am](https://cloud.githubusercontent.com/assets/79566/8803360/19456af8-2f8c-11e5-9979-981888140a7f.png)

![screen shot 2015-07-21 at 9 35 50 am](https://cloud.githubusercontent.com/assets/79566/8803359/18eedada-2f8c-11e5-8740-183edec35647.png)
