### PR TITLE
put review metrics button back in

### DIFF
--- a/src/components/course-calendar/plan-details.cjsx
+++ b/src/components/course-calendar/plan-details.cjsx
@@ -34,6 +34,7 @@ CoursePlanDetails = React.createClass
         <BS.Button>View Performance Report</BS.Button>
       </Router.Link>
 
+    reviewButton
 
   render: ->
     {plan, courseId, className} = @props


### PR DESCRIPTION
Oops. A bug I introduced from changing the button for external plans

## Before
![screen shot 2015-07-21 at 1 21 21 pm](https://cloud.githubusercontent.com/assets/2483873/8809004/8705ac50-2fab-11e5-9fd0-2ce92c93dcc8.png)

## After
![screen shot 2015-07-21 at 1 20 18 pm](https://cloud.githubusercontent.com/assets/2483873/8809005/87087034-2fab-11e5-96b9-1d808c6f63d5.png)
