### PR TITLE
fix the builder's confusion around the sticky header

### DIFF
--- a/src/components/pinned-header-footer-card/index.cjsx
+++ b/src/components/pinned-header-footer-card/index.cjsx
@@ -44,7 +44,7 @@ module.exports = React.createClass
   getOffset: ->
     if @props.fixedOffset?
       offset = @props.fixedOffset
-    else
+    else if @refs.header?
       offset = @getTopPosition(@refs.header.getDOMNode())
 
     offset


### PR DESCRIPTION
was causing homework builder to have errors and get stuck at problems selection.

## Bug
![screen shot 2015-07-21 at 7 27 39 pm](https://cloud.githubusercontent.com/assets/2483873/8815433/ab6aa9f0-2fde-11e5-8ecd-48aa3a5ddc64.png)

## Fixed
![screen shot 2015-07-21 at 7 27 02 pm](https://cloud.githubusercontent.com/assets/2483873/8815435/ad9a7e58-2fde-11e5-9860-615d54551439.png)
