### PR TITLE
Add "Click to practice" tooltip to practice buttons

### DIFF
--- a/src/components/learning-guide/progress-bar.cjsx
+++ b/src/components/learning-guide/progress-bar.cjsx
@@ -21,6 +21,9 @@ module.exports = React.createClass
 
     bar = <BS.ProgressBar className={color} now={percent} />
     if onPractice
-      <BS.Button onClick={-> onPractice(section)} block>{bar}</BS.Button>
+      tooltip = <BS.Tooltip>Click to practice</BS.Tooltip>
+      <BS.OverlayTrigger placement='bottom' overlay={tooltip}>
+        <BS.Button onClick={-> onPractice(section)} block>{bar}</BS.Button>
+      </BS.OverlayTrigger>
     else
       bar


### PR DESCRIPTION
Replaces old title method that was hit or miss on if it would display:

<img width="318" alt="screen shot 2015-07-22 at 9 11 11 pm" src="https://cloud.githubusercontent.com/assets/79566/8841655/555c5a80-30b6-11e5-9e21-c9d1befea939.png">

With a tooltip component:
<img width="330" alt="screen shot 2015-07-22 at 9 11 55 pm" src="https://cloud.githubusercontent.com/assets/79566/8841656/5571e54e-30b6-11e5-9b14-28d6c07ef319.png">