### PR TITLE
Set bar color based on percent

### DIFF
--- a/src/components/learning-guide/progress-bar.cjsx
+++ b/src/components/learning-guide/progress-bar.cjsx
@@ -10,6 +10,18 @@ module.exports = React.createClass
     section:  ChapterSectionType.isRequired
     onPractice: React.PropTypes.func
 
+  percentToRGB: (percent) ->
+    if percent < 50
+      # green to yellow
+      r = 255
+      g = Math.floor(255 * (percent / 50))
+    else
+      # yellow to red
+      r = Math.floor(255 * ((50 - percent % 50) / 50))
+      g = 255
+    # rgb value: blue is always 0
+    return "rgb(#{r},#{g},0)"
+
   render: ->
     {section, chapter, onPractice} = @props
     level = section.current_level
@@ -18,8 +30,11 @@ module.exports = React.createClass
       when percent >  75 then 'high'
       when percent >= 50 then 'medium'
       else 'low'
-
-    bar = <BS.ProgressBar className={color} now={percent} />
+    bar = <div className='progress'>
+      <div className='progress-bar'
+        ariaValuenow={percent} ariaValuemin=0 ariaValuemax=100
+        style={width: "#{percent}%", backgroundColor: @percentToRGB(percent)} />
+    </div>
     if onPractice
       <BS.Button onClick={-> onPractice(section)} block>{bar}</BS.Button>
     else


### PR DESCRIPTION
Picks a color from the spectrum between dark red to yellow to bright green.  Only student learning guide is shown, but will also apply to teacher as well as the bars on student dashboard since they all use the same component.

Complete color spectrum can be viewed at: http://jsfiddle.net/nathanstitt/kmmLxbhf/1/

![screen shot 2015-07-23 at 10 17 18 am](https://cloud.githubusercontent.com/assets/79566/8854295/d72b7794-3124-11e5-8b60-c8dd2b0f603d.png)
