### PR TITLE
Spinners on one button at a time

### DIFF
--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -23,6 +23,14 @@ PlanFooter = React.createClass
       TaskPlanActions.delete(id)
       @context.router.transitionTo('taskplans', {courseId})
 
+  onSave: ->
+    @setState({saving: true, publishing: false})
+    @props.onSave()
+
+  onPublish: ->
+    @setState({publishing: true, saving: false})
+    @props.onPublish()
+
   onCancel: ->
     {id, courseId} = @props
     if confirm('Are you sure you want to cancel?')
@@ -47,8 +55,8 @@ PlanFooter = React.createClass
         <AsyncButton
           bsStyle='primary'
           className='-publish'
-          onClick={onPublish}
-          isWaiting={isWaiting}
+          onClick={@onPublish}
+          isWaiting={isWaiting and @state.publishing}
           isFailed={isFailed}
           waitingText='Publishing…'
           >
@@ -63,8 +71,8 @@ PlanFooter = React.createClass
       saveLink =
           <AsyncButton
             className='-save'
-            onClick={onSave}
-            isWaiting={isWaiting}
+            onClick={@onSave}
+            isWaiting={isWaiting and @state.saving}
             isFailed={isFailed}
             waitingText='Saving…'
             >


### PR DESCRIPTION
![screen shot 2015-07-23 at 11 40 34 pm](https://cloud.githubusercontent.com/assets/6434717/8854775/3d074218-3194-11e5-9442-0b7367a90156.png)

Now the publish button won't show a spinner when saving and the save as draft button won't show a spinner when publishing.  
Though maybe we should disable actions when either are occurring? @philschatz