### PR TITLE
Style/ref book exercises

### DIFF
--- a/resources/styles/components/question.less
+++ b/resources/styles/components/question.less
@@ -54,6 +54,18 @@
   #fonts > .sans (1.8rem, 2.4rem);
 }
 
+.answer-label-disable() {
+  label.answer-label {
+    padding: 4px 0;
+    background-color: transparent;
+    cursor: default;
+
+    &:hover {
+      background-color: transparent;
+    }
+  }
+}
+
 .question {
   .size-exercise-card();
   .clearfix();

--- a/resources/styles/components/reference-book/exercise.less
+++ b/resources/styles/components/reference-book/exercise.less
@@ -4,9 +4,8 @@
     .question {
       padding: 0;
 
-      .answers-table label.answer-label:hover {
-        background-color: @answer-background;
-        cursor: default;
+      .answers-table {
+        .answer-label-disable();
       }
     }
   }

--- a/resources/styles/components/task-teacher-review/question.less
+++ b/resources/styles/components/task-teacher-review/question.less
@@ -47,15 +47,7 @@
   }
 
   .answers-table {
-    label.answer-label {
-      padding: 4px 0;
-      background-color: transparent;
-      cursor: default;
-
-      &:hover {
-        background-color: transparent;
-      }
-    }
+    .answer-label-disable();
 
     .answers-answer {
       align-items: flex-start;


### PR DESCRIPTION
![screen shot 2015-07-23 at 11 25 07 am](https://cloud.githubusercontent.com/assets/2483873/8855988/b9aecbb8-312d-11e5-943c-ac80761daed9.png)

Initial taking out blue background of answers on ref book exercises

@Fredasaurus any other quick stylings?  this might be all we can do now without digging into where the exercises show up in the books, and how to style notes, etc
