### PR TITLE
Fix "value.format is not a function" bug

### DIFF
--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -100,15 +100,15 @@ TutorDateInput = React.createClass
 
   isValid: (value) ->
     valid = true
-    valid = false if (@props.min and value < @props.min)
-    valid = false if (@props.max and value > @props.max)
+    valid = false if (@props.min and value.isBefore(@props.min, 'day'))
+    valid = false if (@props.max and value.isAfter(@props.max, 'day'))
     valid
 
   dateSelected: (value) ->
     valid = @isValid(value)
 
     if (not valid)
-      value = @props.min or null
+      value = moment(@props.min) or null
 
     date = value.format(TutorDateFormat)
     @props.onChange(date)


### PR DESCRIPTION
Fixes #513

The value passed to isValid is a momentjs instance, which
can't be compared using > < operators.  This switches to
the isBefore and isAfer methods with the granularity set to day.

Also if false was returned from the date picker, the min property
would be used.  However if the min property is a plain date object
it would lack the .format method which was later called on it.