### PR TITLE
fix input cursor to right bug

### DIFF
--- a/src/components/course-settings/add-student.cjsx
+++ b/src/components/course-settings/add-student.cjsx
@@ -12,7 +12,7 @@ Field = React.createClass
   propTypes:
     label: React.PropTypes.string.isRequired
     name:  React.PropTypes.string.isRequired
-    value: React.PropTypes.string.isRequired
+    default: React.PropTypes.string.isRequired
     onChange:  React.PropTypes.func.isRequired
     autofocus: React.PropTypes.bool
 
@@ -26,7 +26,7 @@ Field = React.createClass
     <TutorInput
       ref="input"
       label={@props.label}
-      value={@props.value}
+      default={@props.default}
       required={true}
       onChange={@onChange} />
 
@@ -55,16 +55,16 @@ module.exports = React.createClass
     <BS.Popover className='teacher-add-student-form'
       title={'Student Information:'} {...@props}>
 
-      <Field label='First Name' name='first_name' value={@state.first_name}
+      <Field label='First Name' name='first_name' default={@state.first_name}
         onChange={(val) => @setState(first_name: val)} autofocus />
 
-      <Field label='Last Name' name='last_name' value={@state.last_name}
+      <Field label='Last Name' name='last_name' default={@state.last_name}
         onChange={(val) => @setState(last_name: val)} />
 
-      <Field label='Email' name='email' value={@state.email}
+      <Field label='Email' name='email' default={@state.email}
         onChange={(val) => @setState(email: val)} />
 
-      <Field label='Password' name='password' value={@state.password}
+      <Field label='Password' name='password' default={@state.password}
         onChange={(val) => @setState(password: val)} />
 
       <BS.Button block onClick={@performUpdate}>

--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -116,7 +116,6 @@ module.exports = React.createClass
           <TutorInput
             label='Assignment Name'
             className='assignment-name'
-            value={plan.title}
             id='reading-title'
             default={plan.title}
             required={true}

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -55,6 +55,14 @@ TutorInput = React.createClass
       <errorWarning key={error}/>
     )
 
+    # Please do not set value={@props.value} on input.
+    #
+    # Because we are updating the store in some cases on change, and
+    # the store is providing the @props.value being passed in here,
+    # the cursor for typing in this input could be forced to move to the
+    # right when the input re-renders since the props have changed.
+    #
+    # Instead, use @props.default to set an intial defaul value.
     <div className={wrapperClasses.join(' ')}>
       <input
         id={@props.id}
@@ -62,7 +70,6 @@ TutorInput = React.createClass
         type={@props.type}
         className={classes.join(' ')}
         defaultValue={@props.default}
-        value={@props.value}
         onChange={@onChange}
       />
       <div className='floating-label'>{@props.label}</div>
@@ -186,7 +193,6 @@ TutorTextArea = React.createClass
     id: React.PropTypes.string
     className: React.PropTypes.string
     onChange: React.PropTypes.func
-    value: React.PropTypes.any
 
   resize: (event) ->
     event.target.style.height = ''


### PR DESCRIPTION
removing ```value={@props.value}``` from ```input``` because whenever ```@props.value``` was updating from the parent scope, the re-rendering of the input element would force the cursor to the right all the time

Seems to behave like normal now.  I also checked the behavior of the Add Student form in Course Settings and it preserves student info if you close the form without saving, as intended.