### PR TITLE
handle external tasks in perf report properly

### DIFF
--- a/resources/styles/components/performance/index.less
+++ b/resources/styles/components/performance/index.less
@@ -61,6 +61,10 @@
       float: right;
       margin-right: 1rem;
     }
+
+    span.review-plan {
+      color: @tutor-neutral;
+    }
   }
 
 }

--- a/src/components/performance/external-cell.cjsx
+++ b/src/components/performance/external-cell.cjsx
@@ -1,14 +1,14 @@
 React    = require 'react'
-Router = require 'react-router'
+CellStatusMixin = require './cell-status-mixin'
+
+STATUS =
+  'completed':   'Clicked'
+  'in_progress': 'Viewed'
+  'not_started': 'Not started'
 
 module.exports = React.createClass
-  displayName: 'NameCell'
+  displayName: 'ExternalCell'
+  mixins: [CellStatusMixin]
 
   render: ->
-    {courseId} = @props
-    linkParams = {courseId, id: @props.task.id, stepIndex: 1}
-    status = switch @props.task.status
-      when 'completed'   then 'Clicked'
-      when 'in_progress' then 'Viewed'
-      when 'not_started' then 'Not started'
-    <Router.Link to='viewTaskStep' params={linkParams}>{status}</Router.Link>
+    @renderLink( message: STATUS[@props.task.status] )

--- a/src/components/performance/index.cjsx
+++ b/src/components/performance/index.cjsx
@@ -73,7 +73,10 @@ Performance = React.createClass
   renderHeadingCell: (heading, i) ->
     i += FIRST_DATA_COLUMN # for the first/last name colums
     if heading.type is 'external'
-      customHeader = <QuickStatsShell id={"#{heading.plan_id}"} periodId={@state.period_id}/>
+      reviewSummary = <QuickStatsShell
+        className='review-plan'
+        id={"#{heading.plan_id}"}
+        periodId={@state.period_id}/>
 
     else if heading.plan_id?
       linkParams =
@@ -81,17 +84,17 @@ Performance = React.createClass
         periodIndex: @state.periodIndex
         courseId: @props.courseId
 
-    linkToPlanSummary =
-      <Router.Link to='reviewTaskPeriod' params={linkParams} className='review-plan'>
-        {if heading.average then heading.average.toFixed(2) else 'Review'}
-      </Router.Link>
+      reviewSummary =
+        <Router.Link to='reviewTaskPeriod' params={linkParams} className='review-plan'>
+          {if heading.average then heading.average.toFixed(2) else 'Review'}
+        </Router.Link>
 
     sortingHeader = <SortingHeader sortKey={i}
       sortState={@state.sort} onSort={@changeSortingOrder}
     >{heading.title}</SortingHeader>
 
     customHeader = <div className='assignment-header-cell'>
-      <Time date={heading.due_at}/>{linkToPlanSummary}
+      <Time date={heading.due_at}/>{reviewSummary}
     </div>
 
     <ColumnGroup key={i} groupHeaderRenderer={-> sortingHeader} >

--- a/src/components/performance/quick-external-stats.cjsx
+++ b/src/components/performance/quick-external-stats.cjsx
@@ -25,17 +25,19 @@ QuickStats = React.createClass
     stats: stats
 
   renderStats: (data) ->
-    "#{data.complete_count} clicked of #{data.total_count}"
+    "#{data.complete_count}/#{data.total_count} clicked"
 
   render: ->
     {id, className} = @props
     {stats} = @state
 
-    className = "#{className} quick-external-stats"
+    classes = 'quick-external-stats'
+    classes += " #{className}" if className?
+
     # A Draft does not contain any stats
     course = @renderStats(stats) if stats?
 
-    <span className={className}>
+    <span className={classes}>
       {course}
     </span>
 

--- a/src/components/task/viewing-as-student-name.cjsx
+++ b/src/components/task/viewing-as-student-name.cjsx
@@ -18,7 +18,7 @@ ViewingAsStudentName = React.createClass
     student = PerformanceStore.getStudentOfTask(courseId, taskId)
 
     studentName = <div className={className}>
-      {student.name}
+      {student.first_name} {student.last_name}
     </div> if student?
 
     studentName


### PR DESCRIPTION
## Before
Broke when trying to make header for external task with linkToSummary.
![screen shot 2015-07-24 at 2 54 02 am](https://cloud.githubusercontent.com/assets/2483873/8869961/8477a6d6-31af-11e5-8975-c63312464c6c.png)

## After
Does not linkToSummary for header.  Instead, should show plan text clicked counts.
![screen shot 2015-07-24 at 2 51 34 am](https://cloud.githubusercontent.com/assets/2483873/8869962/8990d6a6-31af-11e5-9491-8ee82da77c61.png)
