### PR TITLE
fix late styling for reading task footer -- don't show

### DIFF
--- a/resources/styles/components/task-step/step-footer-mixin.less
+++ b/resources/styles/components/task-step/step-footer-mixin.less
@@ -39,7 +39,6 @@
     }
 
     i.late {
-      .pull-right();
       .tutor-late-icon();
       padding-left: 8px;
     }

--- a/resources/styles/components/task/details.less
+++ b/resources/styles/components/task/details.less
@@ -21,6 +21,10 @@
       color: @tutor-info;
     }
   }
+
+  .task-details-due-date {
+    display: inline-block;
+  }
 }
 
 .task-details-popover{

--- a/resources/styles/components/task/index.less
+++ b/resources/styles/components/task/index.less
@@ -7,6 +7,15 @@
   margin: 0 auto;
 
   .step-footer-mixin();
+
+  // no such thing as a late reading
+  &.task-reading {
+    .task-footer-details {
+      i.late {
+        display: none;
+      }
+    }
+  }
 }
 
 .task-view {

--- a/src/components/task-step/step-footer-mixin.cjsx
+++ b/src/components/task-step/step-footer-mixin.cjsx
@@ -56,18 +56,21 @@ module.exports =
       {@renderCoversSections(sections) if sections.length}
     </div>
 
+    buildLateMessage = (task, status) ->
+      "#{status.how_late} late"
+
     taskDetails = <Details
       key='details'
       task={task}
-      className='task-footer-detail' />
-
-    buildLateMessage = (task, status) ->
-      "#{status.how_late} late"
+      className='task-footer-detail'>
+        <LateIcon
+          task={task}
+          buildLateMessage={buildLateMessage}/>
+    </Details>
 
     [
       taskAbout
       taskDetails
-      <LateIcon className='task-footer-detail' task={task} buildLateMessage={buildLateMessage}/>
     ]
 
   renderTaskDetails: ({stepId, taskId, courseId, review}) ->

--- a/src/components/task/details.cjsx
+++ b/src/components/task/details.cjsx
@@ -47,7 +47,7 @@ module.exports = React.createClass
     else
       details =
         <div className={className}>
-          <div>
+          <div className='task-details-due-date'>
             {dateLabel} <Time date={task.due_at} format={dateFormat}></Time>
           </div>
           {@props.children}


### PR DESCRIPTION
## After
![screen shot 2015-07-24 at 3 37 18 am](https://cloud.githubusercontent.com/assets/2483873/8870701/9ccacc8a-31b5-11e5-96c3-0274c703337e.png)
![screen shot 2015-07-24 at 3 37 34 am](https://cloud.githubusercontent.com/assets/2483873/8870702/9cd92c4e-31b5-11e5-934b-0e753d41ab9c.png)

## Before
late icon was showing in both, and also info icon was in between due date and late icon