### PR TITLE
half calendar issue is haunting us

### DIFF
--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -8,6 +8,8 @@ PlanMixin = require './plan-mixin'
 BindStoreMixin = require '../bind-store-mixin'
 
 {TimeStore} = require '../../flux/time'
+TimeHelper = require '../../helpers/time'
+
 {TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
 {TutorInput, TutorDateInput, TutorDateFormat, TutorTextArea} = require '../tutor-input'
 {CourseStore}   = require '../../flux/course'
@@ -22,7 +24,9 @@ module.exports = React.createClass
 
   getInitialState: ->
     isNewPlan = TaskPlanStore.isNew(@props.id)
-    {showingPeriods: not isNewPlan}
+
+    showingPeriods: not isNewPlan
+    currentLocale: TimeHelper.getCurrentLocales()
 
   # Copies the available periods from the course store and sets
   # them to open at the default start date
@@ -158,7 +162,8 @@ module.exports = React.createClass
             disabled={@state.showingPeriods}
             min={TimeStore.getNow()}
             max={TaskPlanStore.getDueAt(@props.id)}
-            value={commonOpensAt}/>
+            value={commonOpensAt}
+            currentLocale={@state.currentLocale} />
         </BS.Col>
 
         <BS.Col sm=4 md=3>
@@ -171,7 +176,8 @@ module.exports = React.createClass
             onChange={@setDueAt}
             disabled={@state.showingPeriods}
             min={TaskPlanStore.getOpensAt(@props.id)}
-            value={commonDueAt}/>
+            value={commonDueAt}
+            currentLocale={@state.currentLocale} />
         </BS.Col>
         {feedbackNote}
 
@@ -245,7 +251,8 @@ module.exports = React.createClass
           min={TimeStore.getNow()}
           max={TaskPlanStore.getDueAt(@props.id, plan.id)}
           onChange={_.partial(@setOpensAt, _, plan)}
-          value={ taskingOpensAt }/>
+          value={ taskingOpensAt }
+          currentLocale={@state.currentLocale} />
       </BS.Col><BS.Col sm=4 md=3>
         <TutorDateInput
           readOnly={TaskPlanStore.isPublished(@props.id)}
@@ -253,6 +260,7 @@ module.exports = React.createClass
           required={@state.showingPeriods}
           min={taskingOpensAt}
           onChange={_.partial(@setDueAt, _, plan)}
-          value={TaskPlanStore.getDueAt(@props.id, plan.id)}/>
+          value={TaskPlanStore.getDueAt(@props.id, plan.id)}
+          currentLocale={@state.currentLocale} />
         </BS.Col>
     </BS.Row>

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -4,6 +4,8 @@ moment = require 'moment'
 _ = require 'underscore'
 
 {TimeStore} = require '../flux/time'
+TimeHelper = require '../helpers/time'
+
 DatePicker = require 'react-datepicker'
 TutorErrors = require './tutor-errors'
 TutorDateFormat = "MM/DD/YYYY"
@@ -77,29 +79,32 @@ TutorInput = React.createClass
     </div>
 
 TutorDateInput = React.createClass
+  displayName: 'TutorDateInput'
+  propTypes:
+    currentLocale: React.PropTypes.shape(
+      abbr: React.PropTypes.string
+      week: React.PropTypes.object
+      weekdaysMin: React.PropTypes.array
+    )
+
+  getDefaultProps: ->
+    currentLocale = TimeHelper.getCurrentLocales()
+    {currentLocale}
 
   getInitialState: ->
     expandCalendar: false
-    currentLocale: @getCurrentLocales()
-
-  componentWillUnmount: ->
-    @restoreLocales()
 
   # For some reason, react-datepicker chooses to GLOBALLY override moment's locale.
   # This tends to do nasty things to the dashboard calendar.
   # Therefore, grab the current locale settings, and restore them when unmounting.
   # TODO: debug react-datepicker and submit a PR so that it will no longer thrash moment's global.
-  getCurrentLocales: ->
-    currentGlobalLocale = moment.localeData()
-
-    abbr: currentGlobalLocale._abbr
-    week: currentGlobalLocale._week
-    weekdaysMin: currentGlobalLocale._weekdaysMin
+  componentWillUnmount: ->
+    @restoreLocales()
 
   restoreLocales: ->
-    {abbr} = @state.currentLocale
+    {abbr} = @props.currentLocale
 
-    localeOptions = _.omit(@state.currentLocale, 'abbr')
+    localeOptions = _.omit(@props.currentLocale, 'abbr')
     moment.locale(abbr, localeOptions)
 
   expandCalendar: ->
@@ -167,7 +172,7 @@ TutorDateInput = React.createClass
           onChange={@dateSelected}
           disabled={@props.disabled}
           selected={value}
-          weekStart={@state.currentLocale.week.dow}
+          weekStart={@props.currentLocale.week.dow}
         />
     else if @props.disabled and value
       displayValue = value.toString(TutorDateFormat)

--- a/src/helpers/time.coffee
+++ b/src/helpers/time.coffee
@@ -1,0 +1,11 @@
+moment = require 'moment'
+
+TimeHelper =
+  getCurrentLocales: ->
+    currentLocale = moment.localeData()
+
+    abbr: currentLocale._abbr
+    week: currentLocale._week
+    weekdaysMin: currentLocale._weekdaysMin
+
+module.exports = TimeHelper


### PR DESCRIPTION
calendar was messing up again when the one datepicker opening would set the locale globally. when switching to individual periods, new datepickers would mount and pick up the wrong locale to reset to.  the current locale needs to be able to be passed in from the parent

# To Do
- [x] fix
- [ ] tests
  - [ ] on individual datepickers
  - [ ] builder

# How to reproduce and what happens now
![screen shot 2015-07-24 at 3 19 58 pm](https://cloud.githubusercontent.com/assets/2483873/8883827/8081e2e0-3217-11e5-8828-4dc314c5c612.png)
![screen shot 2015-07-24 at 3 20 02 pm](https://cloud.githubusercontent.com/assets/2483873/8883828/808e66d2-3217-11e5-84bb-dfc3d139ff76.png)
![screen shot 2015-07-24 at 3 20 06 pm](https://cloud.githubusercontent.com/assets/2483873/8883830/80944c46-3217-11e5-82e4-8ff3b76506c3.png)
![screen shot 2015-07-24 at 3 20 11 pm](https://cloud.githubusercontent.com/assets/2483873/8883829/80909a2e-3217-11e5-964d-fe34dd585cb7.png)

# What happens now
![screen shot 2015-07-24 at 3 18 33 pm](https://cloud.githubusercontent.com/assets/2483873/8883802/5dfa1cf6-3217-11e5-846e-7c151b82b118.png)
![screen shot 2015-07-24 at 3 18 38 pm](https://cloud.githubusercontent.com/assets/2483873/8883800/5df71f56-3217-11e5-9185-b427fa75673d.png)
![screen shot 2015-07-24 at 3 18 46 pm](https://cloud.githubusercontent.com/assets/2483873/8883803/5dfc2f32-3217-11e5-8a25-50bb2c1c583b.png)
![screen shot 2015-07-24 at 3 18 51 pm](https://cloud.githubusercontent.com/assets/2483873/8883801/5df9f488-3217-11e5-83e3-9a7dc75d2bf5.png)


