### PR TITLE
Fix practice buttons that lead to empty practice sets.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "karma-phantomjs-launcher": "~0.1.4",
     "merge-stream": "~0.1.7",
     "mocha": "~2.2.1",
+    "sinon": "^1.15.4",
+    "sinon-chai": "^2.8.0",
     "vinyl-source-stream": "~1.1.0",
     "watchify": "~2.4.0",
     "when": "~3.7.2"

--- a/src/components/learning-guide/guide.cjsx
+++ b/src/components/learning-guide/guide.cjsx
@@ -25,7 +25,7 @@ module.exports = React.createClass
 
 
   showPracticeButton: (type, title) ->
-    <PracticeByTypeButton 
+    <PracticeByTypeButton
     practiceType={type}
     practiceTitle={title}
     courseId={@props.courseId} />
@@ -45,7 +45,7 @@ module.exports = React.createClass
       <div className='guide-group'>
         <BS.Row>
           <BS.Col mdPull={0} xs={12} md={9}>
-              {for chapter, i in @props.chapters
+              {for chapter, i in (@props.chapters or [])
                 <BS.Col key={i} lg={4} md={4} sm={6} xs={12}>
                   <Chapter chapter={chapter} {...@props} />
                 </BS.Col>}

--- a/src/components/learning-guide/practice-by-type-button.cjsx
+++ b/src/components/learning-guide/practice-by-type-button.cjsx
@@ -5,6 +5,8 @@ _ = require 'underscore'
 LearningGuide = require '../../flux/learning-guide'
 
 module.exports = React.createClass
+  displayName: 'PracticeByTypeButton'
+
   propTypes:
     courseId: React.PropTypes.string.isRequired
     practiceType: React.PropTypes.string.isRequired

--- a/src/components/learning-guide/practice-by-type-button.cjsx
+++ b/src/components/learning-guide/practice-by-type-button.cjsx
@@ -1,6 +1,5 @@
 React = require 'react'
 BS = require 'react-bootstrap'
-S = require '../../helpers/string'
 _ = require 'underscore'
 
 LearningGuide = require '../../flux/learning-guide'
@@ -16,13 +15,25 @@ module.exports = React.createClass
 
   onClick: ->
     {courseId} = @props
-    all = LearningGuide.Student.store.getSortedSections(@props.courseId)
-    sections = if @props.practiceType is 'weaker' then _.first(all, 4) else _.last(all, 4)
-    page_ids = _.chain(sections).pluck('page_ids').flatten().uniq().value()
-    @context.router.transitionTo('viewPractice', {courseId}, {page_ids})
+    page_ids = LearningGuide.Student.store.getPracticePages(@props.courseId, @props.practiceType)
+    unless _.isEmpty(page_ids)
+      @context.router.transitionTo('viewPractice', {courseId}, {page_ids})
 
   render: ->
-    <BS.Button className={@props.practiceType} onClick={@onClick}>
-      {S.capitalize(@props.practiceTitle)}
+    page_ids = LearningGuide.Student.store.getPracticePages(@props.courseId, @props.practiceType)
+    classNames = ['practice', @props.practiceType]
+    isDisabled = _.isEmpty(page_ids)
+    classNames.push 'disabled' if isDisabled
+
+    button = <BS.Button className={classNames.join(' ')} onClick={@onClick}>
+      {@props.practiceTitle}
       <i />
     </BS.Button>
+
+    if isDisabled
+      tooltip = <BS.Tooltip>No problems are available for practicing</BS.Tooltip>
+      <BS.OverlayTrigger placement='top' overlay={tooltip}>
+        {button}
+      </BS.OverlayTrigger>
+    else
+      button

--- a/src/components/student-dashboard/practice-buttons.cjsx
+++ b/src/components/student-dashboard/practice-buttons.cjsx
@@ -1,0 +1,30 @@
+React = require 'react'
+BS = require 'react-bootstrap'
+_ = require 'underscore'
+
+LearningGuide = require '../../flux/learning-guide'
+PracticeByTypeButton = require '../learning-guide/practice-by-type-button'
+
+module.exports = React.createClass
+  displayName: 'PracticeButtonsPanel'
+
+  propTypes:
+    courseId: React.PropTypes.string.isRequired
+
+  render: ->
+    sections = LearningGuide.Student.store.getAllSections(@props.courseId)
+    return null if _.isEmpty(sections)
+
+    <div className='actions-box'>
+      <h1 className='panel-title'>Practice</h1>
+      <BS.ButtonGroup>
+        <PracticeByTypeButton
+          practiceType='stronger'
+          practiceTitle='stronger'
+          courseId={@props.courseId} />
+        <PracticeByTypeButton
+          practiceType='weaker'
+          practiceTitle='weaker'
+          courseId={@props.courseId} />
+      </BS.ButtonGroup>
+    </div>

--- a/src/components/student-dashboard/progress-guide.cjsx
+++ b/src/components/student-dashboard/progress-guide.cjsx
@@ -9,7 +9,7 @@ ChapterSection = require '../task-plan/chapter-section'
 ChapterSectionMixin = require '../chapter-section-mixin'
 LearningGuideSection = require '../learning-guide/section'
 LearningGuideColorKey = require '../learning-guide/color-key'
-PracticeByTypeButton = require '../learning-guide/practice-by-type-button'
+PracticeButtonsPanel = require './practice-buttons'
 
 # Number of sections to display
 NUM_SECTIONS = 4
@@ -61,19 +61,7 @@ ProgressGuidePanels = React.createClass
   render: ->
     <div className='progress-guide'>
 
-      <div className='actions-box'>
-        <h1 className='panel-title'>Practice</h1>
-        <BS.ButtonGroup>
-          <PracticeByTypeButton 
-          practiceType='stronger' 
-          practiceTitle='stronger' 
-          courseId={@props.courseId} />
-          <PracticeByTypeButton 
-          practiceType='weaker' 
-          practiceTitle='weaker' 
-          courseId={@props.courseId} />
-        </BS.ButtonGroup>
-      </div>
+      <PracticeButtonsPanel courseId={@props.courseId} />
 
       <div className='actions-box'>
         <ProgressGuide courseId={@props.courseId} />

--- a/src/flux/learning-guide.coffee
+++ b/src/flux/learning-guide.coffee
@@ -42,6 +42,13 @@ Student = makeSimpleStore extendConfig {
     getAllSections: (courseId) ->
       findAllSections(@_get(courseId))
 
+    getPracticePages: (courseId, practiceType) ->
+      all = @exports.getSortedSections.call(this, courseId)
+      count = Math.min(all.length / 2, 4)
+      sections = if practiceType is 'weaker' then _.first(all, count) else _.last(all, count)
+      _.chain(sections).pluck('page_ids').flatten().uniq().value()
+
+
 }, new CrudConfig
 
 

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -19,10 +19,10 @@ require './components/task-homework-past-due.spec'
 require './components/practice.spec'
 require './components/learning-guide.spec'
 require './components/learning-guide/practice-by-type-button.spec'
-
 require './components/course-periods-nav.spec'
 require './components/course-calendar.spec'
 require './components/student-dashboard.spec'
+require './components/student-dashboard/practice-buttons.spec'
 require './components/reference-book.spec'
 require './components/course-settings.spec'
 require './crud-store.spec'
@@ -35,5 +35,5 @@ require './current-user-store.spec'
 require './course-listing-store.spec'
 require './task-helpers.spec'
 
-# # # # This should be done **last** because it starts up the whole app
+# This should be done **last** because it starts up the whole app
 require './router.spec'

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -1,4 +1,6 @@
-{expect} = require 'chai'
+chai = require 'chai'
+sinonChai = require("sinon-chai")
+chai.use(sinonChai)
 
 # For some reason, this navbar component test will have warnings about setting
 # state when component is unmounted if it's after some of the other specs.
@@ -16,6 +18,8 @@ require './components/task-homework.spec'
 require './components/task-homework-past-due.spec'
 require './components/practice.spec'
 require './components/learning-guide.spec'
+require './components/learning-guide/practice-by-type-button.spec'
+
 require './components/course-periods-nav.spec'
 require './components/course-calendar.spec'
 require './components/student-dashboard.spec'
@@ -31,5 +35,5 @@ require './current-user-store.spec'
 require './course-listing-store.spec'
 require './task-helpers.spec'
 
-# # # This should be done **last** because it starts up the whole app
+# # # # This should be done **last** because it starts up the whole app
 require './router.spec'

--- a/test/components/helpers/component-testing.coffee
+++ b/test/components/helpers/component-testing.coffee
@@ -1,0 +1,59 @@
+_ = require 'underscore'
+chai  = require 'chai'
+sinon = require 'sinon'
+sinonChai = require("sinon-chai")
+expect = chai.expect
+chai.use(sinonChai)
+
+React = require 'react'
+ReactAddons    = require('react/addons')
+ReactTestUtils = React.addons.TestUtils
+{Promise}      = require 'es6-promise'
+{commonActions} = require './utilities'
+sandbox = null
+ROUTER = null
+
+# Mock a router for the context
+beforeEach ->
+  sandbox = sinon.sandbox.create()
+  ROUTER  = sandbox.spy()
+  ROUTER.transitionTo = sandbox.spy()
+
+afterEach ->
+  sandbox.restore()
+
+# A wrapper component to setup the router context
+Wrapper = React.createClass
+  childContextTypes:
+    router: React.PropTypes.func
+  getChildContext: ->
+    router: ROUTER
+  render: ->
+    React.createElement(@props._wrapped_component,
+      _.extend(_.omit(@props, '_wrapped_component'), ref: 'element')
+    )
+
+Testing = {
+
+  renderComponent: (component, options) ->
+    options.props ||= {}
+    new Promise (resolve, reject) ->
+      props = _.clone(options.props)
+      props._wrapped_component = component
+      wrapper = ReactTestUtils.renderIntoDocument React.createElement(Wrapper, props)
+      resolve({
+        wrapper,
+        element: wrapper.refs.element,
+        dom: React.findDOMNode(wrapper.refs.element)
+      })
+
+  actions: commonActions
+
+}
+
+# Hide the router behind a defined property so it can access the ROUTER variable that's set in the beforeEach
+Object.defineProperty(Testing, 'router', {
+  get: -> ROUTER
+})
+
+module.exports = {Testing, expect, sinon, React, _}

--- a/test/components/helpers/component-testing.coffee
+++ b/test/components/helpers/component-testing.coffee
@@ -1,10 +1,7 @@
 _ = require 'underscore'
 chai  = require 'chai'
 sinon = require 'sinon'
-sinonChai = require("sinon-chai")
 expect = chai.expect
-chai.use(sinonChai)
-
 React = require 'react'
 ReactAddons    = require('react/addons')
 ReactTestUtils = React.addons.TestUtils
@@ -56,4 +53,4 @@ Object.defineProperty(Testing, 'router', {
   get: -> ROUTER
 })
 
-module.exports = {Testing, expect, sinon, React, _}
+module.exports = {Testing, expect, sinon, React, _, ReactTestUtils}

--- a/test/components/learning-guide/practice-by-type-button.spec.coffee
+++ b/test/components/learning-guide/practice-by-type-button.spec.coffee
@@ -1,0 +1,45 @@
+{Testing, expect, _} = require '../helpers/component-testing'
+
+LearningGuide = require '../../../src/flux/learning-guide'
+Button = require '../../../src/components/learning-guide/practice-by-type-button'
+
+COURSE_ID  = '1'
+GUIDE_DATA = require '../../../api/courses/1/guide.json'
+
+describe 'Learning Guide Practice Button', ->
+
+  beforeEach ->
+    LearningGuide.Student.actions.loaded(GUIDE_DATA, COURSE_ID)
+
+  it 'can be rendered and sets the name', ->
+    Testing.renderComponent( Button,
+      props: { courseId: COURSE_ID, practiceType: 'weaker', practiceTitle: 'Practice moar' }
+    ).then ({dom}) ->
+      expect(dom.textContent).to.equal('Practice moar')
+
+
+  it 'practices weakest pages', ->
+    Testing.renderComponent( Button,
+      props: { courseId: COURSE_ID, practiceType: 'stronger', practiceTitle: 'Practice moar' }
+    ).then ({dom}) ->
+      Testing.actions.click(dom)
+      expect(Testing.router.transitionTo).to.have.been.calledWith( 'viewPractice',
+        { courseId: COURSE_ID }, { page_ids: ['2', '3'] }
+      )
+
+  it 'practices stronger pages', ->
+    Testing.renderComponent( Button,
+      props: { courseId: COURSE_ID, practiceType: 'weaker', practiceTitle: 'Practice moar' }
+    ).then ({dom}) ->
+      Testing.actions.click(dom)
+      expect(Testing.router.transitionTo).to.have.been.calledWith( 'viewPractice',
+        { courseId: COURSE_ID }, { page_ids: ['6', '5'] }
+      )
+
+  it 'is disabled if no page ids exist', ->
+    newdata = {"title": "Physics"}
+    LearningGuide.Student.actions.loaded(newdata, COURSE_ID)
+    Testing.renderComponent( Button,
+      props: { courseId: COURSE_ID, practiceType: 'weaker', practiceTitle: 'title' }
+    ).then ({dom, element}) ->
+      expect(_.toArray dom.classList).to.include('disabled')

--- a/test/components/student-dashboard/practice-buttons.spec.coffee
+++ b/test/components/student-dashboard/practice-buttons.spec.coffee
@@ -1,0 +1,25 @@
+{Testing, expect, _, ReactTestUtils} = require '../helpers/component-testing'
+
+LearningGuide = require '../../../src/flux/learning-guide'
+Buttons = require '../../../src/components/student-dashboard/practice-buttons'
+
+COURSE_ID  = '1'
+GUIDE_DATA = require '../../../api/courses/1/guide.json'
+
+describe 'Learning Guide Practice Buttons', ->
+  it 'renders stronger/weaker buttons', ->
+    LearningGuide.Student.actions.loaded(GUIDE_DATA, COURSE_ID)
+    Testing.renderComponent( Buttons,
+      props: { courseId: COURSE_ID }
+    ).then ({dom, element}) ->
+      expect(dom).not.to.be.null
+      expect(dom.querySelector('.weaker')).not.to.be.null
+      expect(dom.querySelector('.stronger')).not.to.be.null
+
+
+  it 'are disabled if performance report sections are empty', ->
+    LearningGuide.Student.actions.loaded({"title": "Physics"}, COURSE_ID)
+    Testing.renderComponent( Buttons,
+      props: { courseId: COURSE_ID }
+    ).then ({dom, element}) ->
+      expect(dom).to.be.null


### PR DESCRIPTION

![screen shot 2015-07-27 at 10 27 11 am](https://cloud.githubusercontent.com/assets/79566/8910011/1bcc7254-344a-11e5-9101-f0f9c70611dc.png)

When BL doesn't return any pages the button needs to be aware of that and not attempt the practice.

**Note:** This adds a new component rendering helper, and also imports the sinon mocking library.  suggestions are welcome on whether this is a good idea or how it could be improved.  My goals with the helper are to allow testing a component with as little effort as possible.