### PR TITLE
Remove Add, Delete and PW reset actions

### DIFF
--- a/resources/styles/components/course-settings.less
+++ b/resources/styles/components/course-settings.less
@@ -10,20 +10,10 @@
   .nav-tabs { .tutor-nav-tabs(); }
 
   .roster {
-
-    .td {
-      flex: 1;
-    }
+    table-layout: fixed;
     .actions {
-      display: flex;
-      flex-direction: row;
-      align-content: space-between;
       a{
         cursor: pointer;
-        list-style: none;
-        flex-grow: 1;
-        text-align: center;
-        flex: 1;
         &:hover {
           background-color: @tutor-neutral-light;
           text-decoration: none;

--- a/src/components/course-settings/period-roster.cjsx
+++ b/src/components/course-settings/period-roster.cjsx
@@ -4,9 +4,9 @@ _  = require 'underscore'
 
 {RosterStore, RosterActions} = require '../../flux/roster'
 ChangePeriodLink  = require './change-period'
-DeleteStudentLink = require './delete-student'
-ResetPasswordLink = require './reset-password'
-AddStudentButton  = require './add-student'
+
+
+
 module.exports = React.createClass
   displayName: 'PeriodRoster'
   propTypes:
@@ -19,31 +19,25 @@ module.exports = React.createClass
       <td>{student.last_name}</td>
       <td>{student.id}</td>
       <td className="actions">
-        <ResetPasswordLink courseId={@props.courseId} student={student} />
         <ChangePeriodLink courseId={@props.courseId} student={student} />
-        <DeleteStudentLink student={student} />
       </td>
     </tr>
 
   render: ->
+    students = _.sortBy(RosterStore.getStudentsForPeriod(@props.courseId, @props.period.id), 'last_name')
     <div className="period">
       <h3>Period: {@props.period.name}</h3>
-      <BS.Row>
-        <BS.Col sm=2>
-          <AddStudentButton {...@props} />
-        </BS.Col>
-      </BS.Row>
       <BS.Table striped bordered condensed hover className="roster">
         <thead>
           <tr>
             <th>First Name</th>
             <th>Last Name</th>
-            <th>Tutor ID</th>
+            <th>Student ID</th>
             <th>Actions</th>
           </tr>
         </thead>
         <tbody>
-          {for student in RosterStore.getStudentsForPeriod(@props.courseId, @props.period.id)
+          {for student in students
             @renderStudentRow(student)}
         </tbody>
       </BS.Table>

--- a/test/components/course-settings.spec.coffee
+++ b/test/components/course-settings.spec.coffee
@@ -37,7 +37,12 @@ describe 'Course Settings', ->
     expect(titles)
       .to.deep.equal(['1st', '2nd', '3rd', '4th', '5th', '6th', '7th'])
 
+
   it 'renders students in the panels', ->
-    names = _.pluck(@state.div.querySelectorAll('tbody tr td:first-child'), 'textContent')
-    expect(names)
-      .to.deep.equal(['Harry', 'Clyde', 'Florentino'])
+    # Pluck the last names from second column.  Should appear in alphabetical order
+    for names, tab in [['Potter'], ['Ariza', 'Griffiths']]
+      rendered_names = _.pluck(@state.div.querySelectorAll(
+        ".tab-content .tab-pane:nth-child(#{tab+1}) tr td:nth-child(2)"
+      ), 'textContent')
+      expect(rendered_names)
+        .to.deep.equal(names)


### PR DESCRIPTION
WIP until it's decided if the "Tutor ID" column should be removed and if the link to it on the menu should be changed to read "Student Roster" or something else.

![screen shot 2015-07-26 at 1 50 58 pm](https://cloud.githubusercontent.com/assets/79566/8895360/5f673074-339d-11e5-9d5a-a05374f7981a.png)
