### PR TITLE
Display assignment names with an ellipsis when they're too long for the column

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "cors": "^2.5.3",
     "del": "~1.1.1",
     "es6-promise": "^2.0.1",
-    "fixed-data-table": "0.3.0",
+    "fixed-data-table": "0.4.1",
     "gulp": "~3.8.8",
     "gulp-coffeelint": "^0.4.0",
     "gulp-connect": "^2.2.0",

--- a/resources/styles/components/performance/index.less
+++ b/resources/styles/components/performance/index.less
@@ -25,6 +25,17 @@
     max-height: 100%;
   }
 
+  // removes the display as table, table-row, & table-cell
+  // from the wrappers so the header-cell below can set
+  // it's width to 100% with text-overflow: ellipsis;
+  .public_fixedDataTable_header {
+    .public_fixedDataTableCell_wrap1,
+    .public_fixedDataTableCell_wrap2,
+    .public_fixedDataTableCell_wrap3 {
+      display: block;
+      width: 100%;
+    }
+  }
 
   .header-cell {
     .no-select();
@@ -33,16 +44,20 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    &.is-ascending:after {
-      padding-left:8px;
-      content: @fa-var-sort-asc;
-      .fa-icon();
+    width: 100%;
+    position: relative;
+    &.is-ascending,
+    &.is-descending {
+      padding-right: 20px;
+      &:after {
+        position: absolute;
+        right: 8px;
+        top: 15px;
+        .fa-icon();
+      }
     }
-    &.is-descending:after {
-      padding-left:8px;
-      content: @fa-var-sort-desc;
-      .fa-icon();
-    }
+    &.is-ascending:after  { content: @fa-var-sort-asc;  }
+    &.is-descending:after { content: @fa-var-sort-desc; }
   }
 
   i.late {

--- a/resources/styles/components/performance/index.less
+++ b/resources/styles/components/performance/index.less
@@ -25,9 +25,8 @@
     max-height: 100%;
   }
 
-  // removes the display as table, table-row, & table-cell
-  // from the wrappers so the header-cell below can set
-  // it's width to 100% with text-overflow: ellipsis;
+  // removes the display as table, table-row & table-cell
+  // from the wrappers so the "width:100%" rule is effective on .header-cell
   .public_fixedDataTable_header {
     .public_fixedDataTableCell_wrap1,
     .public_fixedDataTableCell_wrap2,


### PR DESCRIPTION
Also updates fixed-data-table to 0.4.1, which includes a bug fix for the scrollbars appearing on top of the row headers.

<img width="1061" alt="screen shot 2015-07-26 at 6 09 24 pm" src="https://cloud.githubusercontent.com/assets/79566/8896421/b887fc1e-33c1-11e5-829d-b59900144cb6.png">
