### PR TITLE
Use getAttribute instead of dataset

### DIFF
--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -39,9 +39,8 @@ module.exports =
     _.last(beforeHash.split('/'))
 
   getMediaTag: (media) ->
-    # form media tag text based on tag name or data-type
-    tag = media.tagName
-    tag = media.dataset.type if media.dataset.type?
+    # form media tag text based on data-type or tag name
+    tag = media.getAttribute('data-type') or media.tagName
     S.capitalize(tag)
 
   buildReferenceBookLink: (cnxId) ->


### PR DESCRIPTION
The dataset attribute isn't supported by IE 10 and it's use without a `?` guard was causing an "Unable to get property 'type' of undefined or null reference” exception.