### PR TITLE
Disabling actions on plan footer

### DIFF
--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -59,6 +59,7 @@ PlanFooter = React.createClass
           isWaiting={isWaiting and @state.publishing}
           isFailed={isFailed}
           waitingText='Publishing…'
+          disabled={isWaiting}
           >
           {'Publish'}
         </AsyncButton>
@@ -75,6 +76,7 @@ PlanFooter = React.createClass
             isWaiting={isWaiting and @state.saving}
             isFailed={isFailed}
             waitingText='Saving…'
+            disabled={isWaiting}
             >
             {'Save as Draft'}
           </AsyncButton>
@@ -95,7 +97,7 @@ PlanFooter = React.createClass
 
     <div className='footer-buttons'>
       {publishButton}
-      <BS.Button aria-role='close' onClick={@onCancel}>Cancel</BS.Button>
+      <BS.Button aria-role='close' disabled={isWaiting} onClick={@onCancel}>Cancel</BS.Button>
       {saveLink}
       <BS.OverlayTrigger trigger='click' placement='top' overlay={tips} rootClose={true}>
         <BS.Button className="footer-instructions" bsStyle="link">

--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -47,8 +47,8 @@ PlanFooter = React.createClass
     plan = TaskPlanStore.get(id)
 
     saveable = not TaskPlanStore.isPublished(id)
-    deleteable = not TaskPlanStore.isNew(id) and not TaskPlanStore.isOpened(id)
     isWaiting = TaskPlanStore.isSaving(id)
+    deleteable = not TaskPlanStore.isNew(id) and not TaskPlanStore.isOpened(id) and not isWaiting
     isFailed = TaskPlanStore.isFailed(id)
 
     publishButton =

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -342,16 +342,17 @@ TaskPlanConfig =
     getOpensAt: (id, periodId) ->
       if periodId?
         tasking = @_getPeriodDates(id, periodId)
-        opensAt = new Date(tasking?.opens_at) if tasking?.opens_at?
-
-      opensAt ?= @_getTaskingsCommonDate(id, 'opens_at')
+        new Date(tasking?.opens_at)
+      else
+        # default opens_at to 1 day from now
+        @_getTaskingsCommonDate(id, 'opens_at')
 
     getDueAt: (id, periodId) ->
       if periodId?
         tasking = @_getPeriodDates(id, periodId)
-        dueAt = new Date(tasking?.due_at) if tasking?.due_at?
-
-      dueAt ?= @_getTaskingsCommonDate(id, 'due_at')
+        new Date(tasking?.due_at)
+      else
+        @_getTaskingsCommonDate(id, 'due_at')
 
     hasTasking: (id, periodId) ->
       plan = @_getPlan(id)


### PR DESCRIPTION
Disables publish, save, cancel and delete in the plan footer when either saving or publishing.