### PR TITLE
Dashboard Style Cleanup

### DIFF
--- a/resources/styles/components/student-dashboard/dashboard.less
+++ b/resources/styles/components/student-dashboard/dashboard.less
@@ -37,6 +37,7 @@
       text-align: left; // override center specified for actions-box
       #fonts > .sans(2.5rem, 3rem);
       color: @tutor-black;  // override link color
+      font-weight: 900;
     }
     &:hover { text-decoration: initial; }
   }

--- a/resources/styles/components/student-dashboard/progress-guide.less
+++ b/resources/styles/components/student-dashboard/progress-guide.less
@@ -37,6 +37,7 @@
         width: 50%;
         border-top-left-radius: 0 !important;
         border-bottom-left-radius: 0 !important;
+        span { float: left; }
 
         & i:after {
           .fa-icon();

--- a/resources/styles/components/student-dashboard/progress-guide.less
+++ b/resources/styles/components/student-dashboard/progress-guide.less
@@ -2,74 +2,78 @@
 // dashboard specific styles only inside .dashboard-container below
 @import "../learning-guide/chapter-panel-mixin";
 
-.student-dashboard {
-  .progress-guide {
-    .chapter-panel { .learning-guide-chapter-panel(); }
-    h1,h2,h3 { margin: 0; text-align: left; }
-    .panel-title {
-      #fonts > .sans(2.5rem, 5rem);
-      font-weight: 900;
-      border-bottom: thin dotted @tutor-neutral-light;
-    }
-    .current {
-      #fonts > .sans(1.6rem, 5rem);
-      font-weight: 600;
-    }
-    .btn-group {
-      width: 100%;
-      // override material design
-      .btn:not(.btn-link):not(.btn-flat):not(.btn-fab) { margin-right: 0; }
-      .stronger {
-        width: 50%;
-        span { float: right; }
+#react-root-container {
 
-          i {
-          float: left;
-          &:after {
+  .student-dashboard {
+    .progress-guide {
+      .chapter-panel { .learning-guide-chapter-panel(); }
+      h1,h2,h3 { margin: 0; text-align: left; }
+      .panel-title {
+        #fonts > .sans(2.5rem, 5rem);
+        font-weight: 900;
+        border-bottom: thin dotted @tutor-neutral-light;
+      }
+      .current {
+        #fonts > .sans(1.6rem, 5rem);
+        font-weight: 600;
+      }
+      .btn-group {
+        width: 100%;
+        // override material design
+        .btn:not(.btn-link):not(.btn-flat):not(.btn-fab) { margin-right: 0; }
+        .stronger {
+          width: 50%;
+          span { float: right; }
+
+            i {
+            float: left;
+            &:after {
+              .fa-icon();
+              padding-right:8px;
+              content: @fa-var-arrow-up;
+              color: @tutor-success;
+            }
+          }
+        }
+        .weaker {
+          width: 50%;
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+          span { float: left; }
+
+          & i:after {
             .fa-icon();
-            padding-right:8px;
-            content: @fa-var-arrow-up;
-            color: @tutor-success;
+            padding-left:8px;
+            content: @fa-var-arrow-down;
+            color: @tutor-danger;
           }
         }
       }
-      .weaker {
-        width: 50%;
-        border-top-left-radius: 0 !important;
-        border-bottom-left-radius: 0 !important;
-        span { float: left; }
-
-        & i:after {
-          .fa-icon();
-          padding-left:8px;
-          content: @fa-var-arrow-down;
-          color: @tutor-danger;
+      .guide-key {
+        display: flex;
+        .item {
+          float: left;
+          margin: auto;
+          vertical-align: top;
+        }
+        .box {
+          float: left;
+          width: 10px;
+          height: 10px;
+          margin: 10px 5px 0px 0px;
+          .learning-guide-colors()
+        }
+        .title {
+          #fonts > .sans(1.1rem, 1.1rem);
+          font-weight: 200;
+          font-style: italic;
         }
       }
-    }
-    .guide-key {
-      display: flex;
-      .item {
-        float: left;
-        margin: auto;
-        vertical-align: top;
-      }
-      .box {
-        float: left;
-        width: 10px;
-        height: 10px;
-        margin: 10px 5px 0px 0px;
-        .learning-guide-colors()
-      }
-      .title {
-        #fonts > .sans(1.1rem, 1.1rem);
-        font-weight: 200;
-        font-style: italic;
+      .section-heading {
+        text-align: left;
       }
     }
-    .section-heading {
-      text-align: left;
-    }
+    .view-learning-guide { width: 100%; }
   }
-  .view-learning-guide { width: 100%; }
+
 }

--- a/resources/styles/components/student-dashboard/progress-guide.less
+++ b/resources/styles/components/student-dashboard/progress-guide.less
@@ -8,26 +8,42 @@
     h1,h2,h3 { margin: 0; text-align: left; }
     .panel-title {
       #fonts > .sans(2.5rem, 5rem);
+      font-weight: 900;
       border-bottom: thin dotted @tutor-neutral-light;
     }
-    .current { #fonts > .sans(1.6rem, 5rem); }
+    .current {
+      #fonts > .sans(1.6rem, 5rem);
+      font-weight: 600;
+    }
     .btn-group {
+      width: 100%;
       // override material design
       .btn:not(.btn-link):not(.btn-flat):not(.btn-fab) { margin-right: 0; }
-      .stronger i {
-        float: left;
-        &:after {
-          .fa-icon();
-          padding-right:8px;
-          content: @fa-var-arrow-up;
-          color: @tutor-success;
+      .stronger {
+        width: 50%;
+        span { float: right; }
+
+          i {
+          float: left;
+          &:after {
+            .fa-icon();
+            padding-right:8px;
+            content: @fa-var-arrow-up;
+            color: @tutor-success;
+          }
         }
       }
-      .weaker i:after {
-        .fa-icon();
-        padding-left:8px;
-        content: @fa-var-arrow-down;
-        color: @tutor-danger;
+      .weaker {
+        width: 50%;
+        border-top-left-radius: 0 !important;
+        border-bottom-left-radius: 0 !important;
+
+        & i:after {
+          .fa-icon();
+          padding-left:8px;
+          content: @fa-var-arrow-down;
+          color: @tutor-danger;
+        }
       }
     }
     .guide-key {
@@ -35,6 +51,7 @@
       .item {
         float: left;
         margin: auto;
+        vertical-align: top;
       }
       .box {
         float: left;
@@ -43,7 +60,11 @@
         margin: 10px 5px 0px 0px;
         .learning-guide-colors()
       }
-      .title { #fonts > .sans(1.2rem, 1.2rem); }
+      .title {
+        #fonts > .sans(1.1rem, 1.1rem);
+        font-weight: 200;
+        font-style: italic;
+      }
     }
     .section-heading {
       text-align: left;

--- a/resources/styles/old/global/buttons.less
+++ b/resources/styles/old/global/buttons.less
@@ -65,3 +65,12 @@
     .btn-tutor-primary();
   }  
 }
+
+.btn-group {
+  box-shadow: none;
+
+  &:hover {
+    box-shadow: 0 4px 10px rgba(0, 0, 0, .1), 0 6px 28px rgba(0, 0, 0, .2);
+  }
+  
+}

--- a/src/components/student-dashboard/progress-guide.cjsx
+++ b/src/components/student-dashboard/progress-guide.cjsx
@@ -37,8 +37,8 @@ ProgressGuide = React.createClass
         courseId={courseId} />
 
     <div className='progress-guide'>
-      <h1 className='panel-title'>Recent Topics</h1>
-      <h2 className='current'>Current Level of Understanding</h2>
+      <h1 className='panel-title'>Learning Forecast</h1>
+      <h2 className='current'>Recent Topics</h2>
       <div className='guide-group'>
         <div className='chapter-panel'>
         {_.first(sections, 4)}


### PR DESCRIPTION
Makes headers consistent, fixes a button bug is FF.

Before
![screen shot 2015-07-28 at 10 58 42 am](https://cloud.githubusercontent.com/assets/2372608/8936619/e02fbeac-3518-11e5-94eb-b4ecf87ef997.png)

After
![screen shot 2015-07-28 at 10 59 09 am](https://cloud.githubusercontent.com/assets/2372608/8936621/e393234a-3518-11e5-84be-97d371e410c8.png)

Things left to do:

- [ ] Change "Recent Topics" to "Learning Forecast"
- [ ] Just have  "My Weakest Topics" button - move into Learning Forecast panel above "All Topics"
- [ ] Change "Current level of understanding" to "Recent topics" italics, grey, not bold
- [ ] Remove Stronger 
- [ ] Change "X worked" to "X problems worked"

