### PR TITLE
Bug/confusing export

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "flux-react": "~2.6.4",
     "font-awesome": "~4.3.0",
     "markdown-it": "^4.1.1",
+    "mime-types": "^2.1.3",
     "moment": "^2.9.0",
     "pluralize": "^1.1.2",
     "react": "0.13.1",

--- a/src/components/performance/export.cjsx
+++ b/src/components/performance/export.cjsx
@@ -75,25 +75,28 @@ PerformanceExport = React.createClass
         if contentType is mime.contentType('.xlsx')
           @triggerDownload({downloadUrl, lastExported})
         else
-          @cancelDownload()
+          @cancelDownload({downloadUrl, lastExported})
 
     downloadUrlChecker.send()
 
-  cancelDownload: ->
-    @setState(
+  cancelDownload: ({downloadUrl}) ->
+    invalidDownloadState =
       tryToDownload: false
       exportedSinceLoad: true
       downloadHasError: true
-    )
+
+    invalidDownloadState.downloadUrl = null if @state.downloadUrl is downloadUrl
+
+    @setState(invalidDownloadState)
 
   triggerDownload: ({downloadUrl, lastExported}) ->
-    downloadedState =
+    downloadState =
       tryToDownload: false
       exportedSinceLoad: true
       downloadUrl: downloadUrl
       lastExported: lastExported
 
-    @setState(downloadedState)
+    @setState(downloadState)
 
   downloadCurrentExport: (linkClickEvent) ->
     linkClickEvent.preventDefault()

--- a/src/components/performance/export.cjsx
+++ b/src/components/performance/export.cjsx
@@ -1,9 +1,8 @@
 BS = require 'react-bootstrap'
 React = require 'react'
+moment = require 'moment'
 BindStoreMixin = require '../bind-store-mixin'
-Time = require '../time'
 AsyncButton = require '../buttons/async-button'
-$ = require 'jquery'
 
 {PerformanceExportStore, PerformanceExportActions} = require '../../flux/performance-export'
 
@@ -43,7 +42,7 @@ PerformanceExport = React.createClass
 
       exportState =
         downloadUrl: lastExport.url
-        lastExported: lastExport.created_at
+        lastExported: moment(lastExport.created_at).fromNow()
 
       @triggerDownload(lastExport.url) if @state.triggerDownload
       @setState(exportState)
@@ -79,15 +78,13 @@ PerformanceExport = React.createClass
       </AsyncButton>
 
     if lastExported?
-      lastExportedTime = <i>
-        <Time date={lastExported} format='long'/>
-      </i>
+      lastExportedTime = <i>{lastExported}</i>
       lastExportedTime = <a href={downloadUrl}>
         {lastExportedTime}
       </a> if downloadUrl?
 
       lastExportedLabel = <small className='export-button-time'>
-        Last exported on {lastExportedTime}
+        Last exported {lastExportedTime}
       </small>
 
     <span className={className}>

--- a/src/components/performance/export.cjsx
+++ b/src/components/performance/export.cjsx
@@ -72,7 +72,7 @@ PerformanceExport = React.createClass
       <AsyncButton
         bsStyle={exportClass}
         onClick={-> PerformanceExportActions.export(courseId)}
-        isWaiting={true}
+        isWaiting={PerformanceExportStore.isExporting(courseId)}
         isFailed={PerformanceExportStore.isFailed(courseId)}
         waitingText='Exporting…'>
         Export

--- a/src/components/time-difference.cjsx
+++ b/src/components/time-difference.cjsx
@@ -1,0 +1,39 @@
+moment = require 'moment'
+{TimeStore} = require '../flux/time'
+React = require 'react'
+
+module.exports = React.createClass
+  displayName: 'TimeDifference'
+  propTypes:
+    date: React.PropTypes.oneOfType([
+      React.PropTypes.string
+      React.PropTypes.instanceOf(Date)
+    ]).isRequired
+    compareWith: React.PropTypes.oneOfType([
+      React.PropTypes.string
+      React.PropTypes.instanceOf(Date)
+    ])
+    compare: React.PropTypes.oneOf(['from', 'to'])
+    toleranceMS: React.PropTypes.number
+    defaultText: React.PropTypes.string
+
+  getDefaultProps: ->
+    compareWith: TimeStore.getNow()
+    compare: 'from'
+    customSuffix: undefined
+    toleranceMS: 15000
+    defaultText: 'just now'
+
+  shouldRenderDifference: ->
+    {date, compareWith, toleranceMS} = @props
+    Math.abs(moment(date).diff(compareWith)) > toleranceMS
+
+  render: ->
+    {date, compareWith, compare, customSuffix, defaultText} = @props
+
+    differenceText = defaultText
+    if @shouldRenderDifference()
+      differenceText = moment(date)[compare](compareWith, customSuffix?)
+      differenceText += customSuffix if customSuffix?
+
+    <span>{differenceText}</span>

--- a/src/components/time.cjsx
+++ b/src/components/time.cjsx
@@ -1,7 +1,6 @@
 moment = require 'moment'
 {TimeStore} = require '../flux/time'
 React = require 'react'
-moment = require 'moment'
 
 module.exports = React.createClass
   displayName: 'Time'


### PR DESCRIPTION
# on first page on load
![screen shot 2015-07-28 at 3 00 28 pm](https://cloud.githubusercontent.com/assets/2483873/8942139/885d4160-3539-11e5-85e2-5304e3a7c110.png)

# when export has been clicked
![screen shot 2015-07-28 at 3 00 53 pm](https://cloud.githubusercontent.com/assets/2483873/8942150/92e2f152-3539-11e5-9e33-d4a7908504f5.png)

Once download is completed, **download is forced** without any extra action needed from user

# After export and download
![screen shot 2015-07-29 at 1 16 35 am](https://cloud.githubusercontent.com/assets/2483873/8951510/17a23e98-3594-11e5-9260-2f608e96c16c.png)

# If download URL doesn't validate for whatever reason
![screen shot 2015-07-29 at 12 59 26 am](https://cloud.githubusercontent.com/assets/2483873/8951509/17a1c8c8-3594-11e5-8fc4-4a1ce75d9f68.png)


Export button dims to discourage multiple exports per page load.  Linked export time with last export download link as well.

Once the user leaves the perf report and comes back at another time, export button will be primary again, as in first screen.

Thoughts?  @Fredasaurus, @philschatz, @jpslav 


If your local exports does not work, you may need to use this: openstax/tutor-server#527

tests with be in separate PR after behavior is agreed on