### PR TITLE
Hides all inactive students

### DIFF
--- a/api/courses/1/students.json
+++ b/api/courses/1/students.json
@@ -6,7 +6,7 @@
     "first_name": "Clyde",
     "last_name": "Griffiths",
     "full_name": "Clyde Griffiths",
-    "active": true
+    "is_active": true
   },
   "1": {
     "id": "11",
@@ -15,7 +15,7 @@
     "first_name": "Harry",
     "last_name": "Potter",
     "full_name": "Harry Potter",
-    "active": true
+    "is_active": true
   },
   "2": {
     "id": "9",
@@ -24,6 +24,15 @@
     "first_name": "Florentino",
     "last_name": "Ariza",
     "full_name": "Florentino Ariza",
-    "active": true
+    "is_active": true
+  },
+  "3": {
+    "id": "10",
+    "period_id": "2",
+    "role_id": "15",
+    "first_name": "Jimmy",
+    "last_name": "Bud",
+    "full_name": "Jimmy Bud",
+    "is_active": false
   }
 }

--- a/api/courses/1/students.json
+++ b/api/courses/1/students.json
@@ -5,7 +5,8 @@
     "role_id": "9",
     "first_name": "Clyde",
     "last_name": "Griffiths",
-    "full_name": "Clyde Griffiths"
+    "full_name": "Clyde Griffiths",
+    "active": true
   },
   "1": {
     "id": "11",
@@ -13,7 +14,8 @@
     "role_id": "13",
     "first_name": "Harry",
     "last_name": "Potter",
-    "full_name": "Harry Potter"
+    "full_name": "Harry Potter",
+    "active": true
   },
   "2": {
     "id": "9",
@@ -21,6 +23,7 @@
     "role_id": "11",
     "first_name": "Florentino",
     "last_name": "Ariza",
-    "full_name": "Florentino Ariza"
+    "full_name": "Florentino Ariza",
+    "active": true
   }
 }

--- a/src/components/course-settings/period-roster.cjsx
+++ b/src/components/course-settings/period-roster.cjsx
@@ -25,6 +25,7 @@ module.exports = React.createClass
 
   render: ->
     students = _.sortBy(RosterStore.getStudentsForPeriod(@props.courseId, @props.period.id), 'last_name')
+    students = _.filter(students, (student) -> student.active)
     <div className="period">
       <h3>Period: {@props.period.name}</h3>
       <BS.Table striped bordered condensed hover className="roster">

--- a/src/components/course-settings/period-roster.cjsx
+++ b/src/components/course-settings/period-roster.cjsx
@@ -25,7 +25,7 @@ module.exports = React.createClass
 
   render: ->
     students = _.sortBy(RosterStore.getStudentsForPeriod(@props.courseId, @props.period.id), 'last_name')
-    students = _.filter(students, (student) -> student.active)
+    students = _.where(students, is_active: true)
     <div className="period">
       <h3>Period: {@props.period.name}</h3>
       <BS.Table striped bordered condensed hover className="roster">

--- a/test/components/course-settings.spec.coffee
+++ b/test/components/course-settings.spec.coffee
@@ -39,7 +39,7 @@ describe 'Course Settings', ->
 
 
   it 'renders students in the panels', ->
-    # Pluck the last names from second column.  Should appear in alphabetical order
+    # Pluck the last names from second column.  Should appear in alphabetical order and obey is_active
     for names, tab in [['Potter'], ['Ariza', 'Griffiths']]
       rendered_names = _.pluck(@state.div.querySelectorAll(
         ".tab-content .tab-pane:nth-child(#{tab+1}) tr td:nth-child(2)"


### PR DESCRIPTION
When students are removed from a course they are marked inactive, but up until this PR that has had no effect in the FE.   https://github.com/openstax/tutor-server/pull/530 adds an `active` property to the student JSON in the roster.  This PR filter out all inactive students from the roster -- later the FE can choose to show them differently so we can enable reactivation of students (undropping them).