### PR TITLE
Filter out tasks that are being deleted from calendar

### DIFF
--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -1,4 +1,3 @@
-
 React = require 'react'
 BS = require 'react-bootstrap'
 {TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
@@ -64,8 +63,16 @@ PlanFooter = React.createClass
         </AsyncButton>
 
     if deleteable
-      deleteLink = <a className='delete-link pull-right' onClick={@onDelete}>
-        <i className="fa fa-trash"></i> Delete Assignment</a>
+      deleteLink =
+        <AsyncButton
+          className='delete-link pull-right'
+          onClick={@onDelete}
+          isWaiting={TaskPlanStore.isDeleting(id)}
+          isFailed={isFailed}
+          waitingText='Deleting…'
+        >
+          <i className="fa fa-trash"></i> Delete Assignment
+        </AsyncButton>
 
     if saveable
       saveLink =

--- a/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -98,7 +98,7 @@ TeacherTaskPlanListing = React.createClass
 
     date = @getDateFromParams()
 
-    plansList = TeacherTaskPlanStore.getCoursePlans(courseId)
+    plansList = TeacherTaskPlanStore.getActiveCoursePlans(courseId)
 
     loadedCalendarProps = {plansList, courseId, date}
 

--- a/src/flux/helpers.coffee
+++ b/src/flux/helpers.coffee
@@ -140,6 +140,7 @@ CrudConfig = ->
       isUnknown: (id) -> not @_asyncStatus[id]
       isLoading: (id) -> @_asyncStatus[id] is LOADING
       isLoaded: (id) -> @_asyncStatus[id] is LOADED
+      isDeleting: (id) -> @_asyncStatus[id] is DELETING
       isSaving: (id) -> @_asyncStatus[id] is SAVING
       isFailed: (id) -> @_asyncStatus[id] is FAILED
       getAsyncStatus: (id) -> @_asyncStatus[id]

--- a/src/flux/teacher-task-plan.coffee
+++ b/src/flux/teacher-task-plan.coffee
@@ -10,8 +10,11 @@ TeacherTaskPlanConfig =
     @_local[id] = plans
 
   exports:
-    getCoursePlans: (id) ->
-      @_local[id] or []
+    getActiveCoursePlans: (id) ->
+      plans = @_local[id] or []
+      # don't return plans that are in the process of being deleted
+      _.filter plans, (plan) =>
+        not @exports.isDeleting.call(@, plan.id)
 
 
 extendConfig(TeacherTaskPlanConfig, new CrudConfig())

--- a/test/components/helpers/calendar/actions.coffee
+++ b/test/components/helpers/calendar/actions.coffee
@@ -51,7 +51,7 @@ actions =
     args[0]
 
   _getMomentWithPlans: (courseId) ->
-    plansList = TeacherTaskPlanStore.getCoursePlans(courseId)
+    plansList = TeacherTaskPlanStore.getActiveCoursePlans(courseId)
 
     firstPlan = _.chain(plansList)
       .clone()

--- a/test/components/helpers/calendar/checks.coffee
+++ b/test/components/helpers/calendar/checks.coffee
@@ -213,7 +213,7 @@ _.each(checks, (check, checkName) ->
 )
 
 checks._checkDoesViewShowPlan = (planId, {div, component, state, router, history, courseId}) ->
-  plansList = TeacherTaskPlanStore.getCoursePlans(courseId)
+  plansList = TeacherTaskPlanStore.getActiveCoursePlans(courseId)
   plan = _.findWhere(plansList, {id: planId})
 
   expect(document.querySelector(".modal-title").innerText).to.equal(plan.title)

--- a/test/components/helpers/calendar/index.coffee
+++ b/test/components/helpers/calendar/index.coffee
@@ -25,7 +25,7 @@ tests =
     componentStub._render(div, <CourseCalendar plansList={plansList}/>, {plansList, courseId})
 
   renderCalendar: (courseId) ->
-    plansList = TeacherTaskPlanStore.getCoursePlans(courseId)
+    plansList = TeacherTaskPlanStore.getActiveCoursePlans(courseId)
     @_renderCalendar(courseId, plansList)
 
   goToCalendar: (route, courseId) ->


### PR DESCRIPTION
When a large task is deleted, it takes the BE quite awhile to process the network request.  This causes problems due to how our flux stores are setup.  The sequence is:

* The delete action fires, which fires off the request to the BE and sets the store's asyncStatus = DELETING
* Teacher browses around, while the delete xhr request is still pending.  The data is still present in the store and shows on the calendar.
* xhr delete finally completes and than we finally delete the task from the store

Other options for this might be to delete the task from the store immediately when we fire the delete action to the BE.  This would stop the task from showing up, but if the delete failed we wouldn't be able to "resurrect" the task very easily.