### PR TITLE
Show exercise uid on HW builder

### DIFF
--- a/resources/styles/components/question.less
+++ b/resources/styles/components/question.less
@@ -238,7 +238,15 @@
       }
     }
   }
-}
+
+  .exercise-uid {
+    position: absolute;
+    right: @tutor-card-body-padding-horizontal;
+    bottom: 10px;
+    .tutor-exercise-question-uid();
+  }
+
+} // end of .question
 
 .task-teacher-read-only {
   .question {

--- a/resources/styles/mixins.less
+++ b/resources/styles/mixins.less
@@ -84,6 +84,10 @@
   }
 }
 
+.tutor-exercise-question-uid() {
+  color: @exercise-question-uid-color;
+  #fonts > .sans(1.2rem, 1.2rem);
+}
 
 .tutor-icon-active(@scale: 1.4) {
   .scale(@scale);

--- a/resources/styles/variables/colors.less
+++ b/resources/styles/variables/colors.less
@@ -30,7 +30,7 @@
 @form-error-color: #E35C3B;
 
 @link-color: #00c1de;
-
+@exercise-question-uid-color: lighten(@tutor-neutral,20%);
 
 // NOTE: Make borders and input background colors one of the above grays with a high opacity so it works on
 //       multiple backgrounds.

--- a/src/components/question.cjsx
+++ b/src/components/question.cjsx
@@ -11,6 +11,7 @@ module.exports = React.createClass
     type: React.PropTypes.string.isRequired
     answer_id: React.PropTypes.string
     correct_answer_id: React.PropTypes.string
+    content_uid: React.PropTypes.string
     feedback_html: React.PropTypes.string
     answered_count: React.PropTypes.number
     onChange: React.PropTypes.func
@@ -99,4 +100,5 @@ module.exports = React.createClass
         {answers}
       </div>
       {feedback}
+      <div className="exercise-uid">{@props.exercise_uid}</div>
     </div>

--- a/src/components/task-plan/homework/exercises.cjsx
+++ b/src/components/task-plan/homework/exercises.cjsx
@@ -27,15 +27,17 @@ ExerciseCardMixin =
     if isLO
       classes = ['lo-tag']
       loLabel = 'LO: '
-    
+
     <span className={classes.join(' ')}>{loLabel} {content}</span>
 
   renderExercise: ->
     content = @props.exercise.content
     question = content.questions[0]
     renderedAnswers = _.map(question.answers, @renderAnswers)
-    renderedTags = _.map(@props.exercise.tags, @renderTags)
-
+    tags = _.clone @props.exercise.tags
+    # Display the exercise uid as a tag
+    tags.push(name: "ID: #{@props.exercise.content.uid}")
+    renderedTags = _.map(_.sortBy(tags, 'name'), @renderTags)
     header = @renderHeader()
     panelStyle = @getPanelStyle()
 
@@ -47,6 +49,7 @@ ExerciseCardMixin =
       <ArbitraryHtmlAndMath className='-stimulus' block={true} html={content.stimulus_html} />
       <ArbitraryHtmlAndMath className='stem' block={true} html={question.stem_html} />
       <div className='answers-table'>{renderedAnswers}</div>
+
       <div className='exercise-tags'>{renderedTags}</div>
     </BS.Panel>
 
@@ -163,7 +166,7 @@ ReviewExercises = React.createClass
     load = @renderLoading()
     if (load)
       return load
-    
+
     {courseId, pageIds, planId} = @props
 
     unless TaskPlanStore.getTopics(planId).length
@@ -186,7 +189,7 @@ ExerciseTable = React.createClass
   renderExerciseRow: (exerciseId, index, hasTeks) ->
     {section, lo, tagString} = ExerciseStore.getTagStrings(exerciseId)
     content = ExerciseStore.getContent(exerciseId)
-    
+
     if (hasTeks)
       teksString = ExerciseStore.getTeksString(exerciseId)
       unless teksString

--- a/src/components/task-step/exercise/modes.cjsx
+++ b/src/components/task-step/exercise/modes.cjsx
@@ -91,6 +91,7 @@ ExerciseMultiChoice = React.createClass
 
     <Question
       model={question}
+      exercise_uid={content.uid}
       answer_id={answer_id}
       correct_answer_id={correct_answer_id}
       onChange={@onAnswerChanged}>

--- a/src/components/task-step/exercise/modes.cjsx
+++ b/src/components/task-step/exercise/modes.cjsx
@@ -133,6 +133,7 @@ ExerciseReview = React.createClass
     <Question
       model={question}
       answer_id={answer_id}
+      exercise_uid={content.uid}
       correct_answer_id={correct_answer_id}
       feedback_html={feedback_html}
       onChangeAttempt={@onChangeAnswerAttempt}>

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -13,6 +13,7 @@ require './components/task-plan/homework-plan.spec'
 require './components/task-plan/homework/exercise-summary.spec'
 require './components/task-plan/footer.spec'
 
+require './components/question.spec'
 require './components/task.spec'
 require './components/task-homework.spec'
 require './components/task-homework-past-due.spec'

--- a/test/components/question.spec.cjsx
+++ b/test/components/question.spec.cjsx
@@ -1,0 +1,35 @@
+{Testing, expect, sinon, _, ReactTestUtils} = require './helpers/component-testing'
+
+Question = require '../../src/components/question'
+
+STEP = (require '../../api/tasks/4.json').steps[0]
+MODEL = STEP.content.questions[0]
+
+describe 'Question Component', ->
+
+  beforeEach ->
+    @props = {
+      exercise_uid: '123@4'
+      model: _.clone(MODEL)
+    }
+
+  it 'displays the exercise uid', ->
+    Testing.renderComponent( Question, props: @props ).then ({dom}) =>
+      expect(dom.querySelector('.exercise-uid').textContent).to.equal(@props.exercise_uid)
+
+  it 'renders the stem html', ->
+    Testing.renderComponent( Question, props: @props ).then ({dom}) ->
+      expect(dom.querySelector('.question-stem').textContent).to.equal('What is 2+2?')
+
+  it 'calls the onChange callback', ->
+    @props.onChange = sinon.spy()
+    Testing.renderComponent( Question, props: @props ).then ({dom}) =>
+      ReactTestUtils.Simulate.change(dom.querySelector("[id='987-option-0']"))
+      expect(@props.onChange).to.have.been.calledWith(content_html: '22', id: 'id1')
+
+  it 'indicates when the answer is correct', ->
+    @props.answer_id = @props.correct_answer_id = STEP.correct_answer_id
+    Testing.renderComponent( Question, props: @props ).then ({dom}) ->
+      correct = dom.querySelector('.answer-correct')
+      expect(correct).not.to.be.null
+      expect(correct.textContent).to.equal( _.findWhere(MODEL.answers, id: STEP.correct_answer_id).content_html )


### PR DESCRIPTION
TODO:
 * [x] Display on HW builder
 * [x] Student i-reading questions
 * [x] Student hw questions
 * [x] Student practice widget


Homework Builder:
<img width="1267" alt="screen shot 2015-07-28 at 9 57 43 pm" src="https://cloud.githubusercontent.com/assets/79566/8949262/7fad8bdc-3576-11e5-8d1a-8ec5592e8e7f.png">

Multiple choice question.  The same component is used for both readings, homeworks, and practice exercise. The UID is displayed identically on them all.
![screen shot 2015-07-29 at 10 29 09 am](https://cloud.githubusercontent.com/assets/79566/8961758/bd14f74c-35dc-11e5-8aa0-8b0395d4f1b8.png)