### PR TITLE
Replaced 'Tutor ID' role # in roster with deidentifier

### DIFF
--- a/src/components/course-settings/period-roster.cjsx
+++ b/src/components/course-settings/period-roster.cjsx
@@ -17,7 +17,7 @@ module.exports = React.createClass
     <tr key={student.id}>
       <td>{student.first_name}</td>
       <td>{student.last_name}</td>
-      <td>{student.id}</td>
+      <td>{student.deidentifier}</td>
       <td className="actions">
         <ChangePeriodLink courseId={@props.courseId} student={student} />
       </td>
@@ -26,14 +26,19 @@ module.exports = React.createClass
   render: ->
     students = _.sortBy(RosterStore.getStudentsForPeriod(@props.courseId, @props.period.id), 'last_name')
     students = _.where(students, is_active: true)
+    random_id_tooltip = <BS.Tooltip>Useful for talking securely about students over email.</BS.Tooltip>
     <div className="period">
-      <h3>Period: {@props.period.name}</h3>
       <BS.Table striped bordered condensed hover className="roster">
         <thead>
           <tr>
             <th>First Name</th>
             <th>Last Name</th>
-            <th>Student ID</th>
+            <th>
+              Random ID
+              <BS.OverlayTrigger placement='bottom' overlay={random_id_tooltip}>
+                <i className="fa fa-question-circle" />
+              </BS.OverlayTrigger>
+            </th>
             <th>Actions</th>
           </tr>
         </thead>


### PR DESCRIPTION
The student's role number was displayed in the roster with "Tutor ID" as the heading -- this number is not useful to the teacher.  However, the "deidentifier" is -- it can be used to talk about students over insecure channels like email without divulging names.  This PR replaces the role with the deidentifier.

I also added a tooltip, which probably could use styling if we even want to keep it.  

I also removed the "Period: Period 1" heading that duplicates the name in the tab.

I'm totally fine if no one wants this PR :-)

![image](https://cloud.githubusercontent.com/assets/1001691/8963730/766dcda6-35d6-11e5-8356-1c5e8f14723e.png)
