### PR TITLE
Restore course roster add/remove student actions

### DIFF
--- a/resources/styles/components/course-settings.less
+++ b/resources/styles/components/course-settings.less
@@ -14,6 +14,7 @@
     .actions {
       a{
         cursor: pointer;
+        margin-right: 1rem;
         &:hover {
           background-color: @tutor-neutral-light;
           text-decoration: none;

--- a/resources/styles/global/buttons.less
+++ b/resources/styles/global/buttons.less
@@ -1,0 +1,3 @@
+// bootstrap material design sets this to @darkbg-text
+// which we can't change without affecting quite a few other styles
+.btn-danger:not(.btn-link):not(.btn-flat) { color: darken(@tutor-neutral-light, 10%); }

--- a/resources/styles/tutor.less
+++ b/resources/styles/tutor.less
@@ -14,6 +14,7 @@
 @import './global/forms';
 @import './global/maths';
 @import './global/panel';
+@import './global/buttons';
 @import './global/progress-bars';
 @import './global/tutor-booksplash-background';
 @import './global/popover';

--- a/src/components/course-settings/period-roster.cjsx
+++ b/src/components/course-settings/period-roster.cjsx
@@ -5,8 +5,8 @@ Icon = require '../icon'
 
 {RosterStore, RosterActions} = require '../../flux/roster'
 ChangePeriodLink  = require './change-period'
-
-
+DeleteStudentLink = require './delete-student'
+AddStudentButton  = require './add-student'
 
 module.exports = React.createClass
   displayName: 'PeriodRoster'
@@ -21,12 +21,18 @@ module.exports = React.createClass
       <td>{student.deidentifier}</td>
       <td className="actions">
         <ChangePeriodLink courseId={@props.courseId} student={student} />
+        <DeleteStudentLink student={student} />
       </td>
     </tr>
 
   render: ->
     students = RosterStore.getActiveStudentsForPeriod(@props.courseId, @props.period.id)
     <div className="period">
+      <BS.Row>
+        <BS.Col sm=2>
+          <AddStudentButton {...@props} />
+        </BS.Col>
+       </BS.Row>
       <BS.Table striped bordered condensed hover className="roster">
         <thead>
           <tr>

--- a/src/components/course-settings/period-roster.cjsx
+++ b/src/components/course-settings/period-roster.cjsx
@@ -25,8 +25,7 @@ module.exports = React.createClass
     </tr>
 
   render: ->
-    students = _.sortBy(RosterStore.getStudentsForPeriod(@props.courseId, @props.period.id), 'last_name')
-    students = _.where(students, is_active: true)
+    students = RosterStore.getActiveStudentsForPeriod(@props.courseId, @props.period.id)
     <div className="period">
       <BS.Table striped bordered condensed hover className="roster">
         <thead>
@@ -41,7 +40,7 @@ module.exports = React.createClass
           </tr>
         </thead>
         <tbody>
-          {for student in students
+          {for student in _.sortBy(students, 'last_name')
             @renderStudentRow(student)}
         </tbody>
       </BS.Table>

--- a/src/components/course-settings/period-roster.cjsx
+++ b/src/components/course-settings/period-roster.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 BS = require 'react-bootstrap'
 _  = require 'underscore'
+Icon = require '../icon'
 
 {RosterStore, RosterActions} = require '../../flux/roster'
 ChangePeriodLink  = require './change-period'
@@ -26,7 +27,6 @@ module.exports = React.createClass
   render: ->
     students = _.sortBy(RosterStore.getStudentsForPeriod(@props.courseId, @props.period.id), 'last_name')
     students = _.where(students, is_active: true)
-    random_id_tooltip = <BS.Tooltip>Useful for talking securely about students over email.</BS.Tooltip>
     <div className="period">
       <BS.Table striped bordered condensed hover className="roster">
         <thead>
@@ -34,10 +34,8 @@ module.exports = React.createClass
             <th>First Name</th>
             <th>Last Name</th>
             <th>
-              Random ID
-              <BS.OverlayTrigger placement='bottom' overlay={random_id_tooltip}>
-                <i className="fa fa-question-circle" />
-              </BS.OverlayTrigger>
+              Random ID <Icon type='question-circle'
+                tooltip='Useful for talking securely about students over email.' />
             </th>
             <th>Actions</th>
           </tr>

--- a/src/components/icon.cjsx
+++ b/src/components/icon.cjsx
@@ -1,0 +1,21 @@
+React    = require 'react'
+BS       = require 'react-bootstrap'
+
+module.exports = React.createClass
+  displayName: 'Icon'
+  propTypes:
+    type: React.PropTypes.string
+    className: React.PropTypes.string
+    tooltip: React.PropTypes.string
+
+
+  render: ->
+    classes = ['tutor-icon', 'fa', "fa-#{@props.type}"]
+    classes.push(@props.className) if @props.className
+    icon = <i className={classes.join(' ')} />
+
+    if @props.tooltip
+      tooltip = <BS.Tooltip>Useful for talking securely about students over email.</BS.Tooltip>
+      <BS.OverlayTrigger placement='bottom' overlay={tooltip}>{icon}</BS.OverlayTrigger>
+    else
+      tooltip

--- a/src/flux/roster.coffee
+++ b/src/flux/roster.coffee
@@ -28,8 +28,8 @@ RosterConfig = {
 
   exports:
 
-    getStudentsForPeriod: (courseId, periodId) ->
-      _.where(@_get(courseId), period_id: periodId)
+    getActiveStudentsForPeriod: (courseId, periodId) ->
+      _.where(@_get(courseId), period_id: periodId, is_active: true)
 
 }
 


### PR DESCRIPTION
This adds the add and remove student actions back to the course settings screen.  Reset password is still left as disabled.

![screen shot 2015-07-29 at 3 15 38 pm](https://cloud.githubusercontent.com/assets/79566/8968869/9c22cb26-3605-11e5-9c01-6114a3eaa0ec.png)
