### PR TITLE
Alt/export btn changes to dl button

### DIFF
--- a/resources/styles/components/performance/export.less
+++ b/resources/styles/components/performance/export.less
@@ -12,3 +12,9 @@
     .clearfix();
   }
 }
+
+.tutor-downloader {
+  width: 0;
+  height: 0;
+  float: right;
+}

--- a/src/components/performance/export.cjsx
+++ b/src/components/performance/export.cjsx
@@ -1,6 +1,5 @@
 BS = require 'react-bootstrap'
 React = require 'react'
-moment = require 'moment'
 mime = require 'mime-types'
 
 BindStoreMixin = require '../bind-store-mixin'
@@ -67,16 +66,23 @@ PerformanceExport = React.createClass
     downloadUrlChecker = new XMLHttpRequest()
     downloadUrlChecker.open('GET', downloadUrl, true)
 
+    cancelDownload = @cancelDownload.bind(@, {downloadUrl, lastExported})
+    triggerDownload = @triggerDownload.bind(@, {downloadUrl, lastExported})
+
     downloadUrlChecker.onreadystatechange = =>
       # when response received...
-      if downloadUrlChecker.readyState is 4
+      if downloadUrlChecker.readyState is 2
         contentType = downloadUrlChecker.getResponseHeader('Content-Type') if @isRequestOK(downloadUrlChecker)
         # Check for whether the return contentType from the header
         # matches the expected type.
         if contentType is mime.contentType('.xlsx')
-          @triggerDownload({downloadUrl, lastExported})
+          triggerDownload()
         else
-          @cancelDownload({downloadUrl, lastExported})
+          cancelDownload()
+
+    downloadUrlChecker.onabort = cancelDownload
+    downloadUrlChecker.onerror = cancelDownload
+    downloadUrlChecker.timeout = cancelDownload
 
     downloadUrlChecker.send()
 

--- a/src/components/performance/export.cjsx
+++ b/src/components/performance/export.cjsx
@@ -20,6 +20,7 @@ PerformanceExport = React.createClass
 
   getInitialState: ->
     downloadUrl: null
+    forceDownloadUrl: null
     lastExported: null
     tryToDownload: false
     exportedSinceLoad: false
@@ -33,11 +34,11 @@ PerformanceExport = React.createClass
     {courseId} = @props
     PerformanceExportActions.load(courseId)
 
-  componentWillUpdate: (nextProps, nextState) ->
-    window.location = nextState.downloadUrl if @shouldTriggerDownload(@state, nextState)
+  componentDidUpdate: (prevProps, prevState) ->
+    @setState(forceDownloadUrl: @state.downloadUrl) if @shouldTriggerDownload(prevState, @state)
 
-  shouldTriggerDownload: (currentState, nextState) ->
-    currentState.tryToDownload and not nextState.tryToDownload and not nextState.downloadHasError and nextState.downloadUrl?
+  shouldTriggerDownload: (prevState, currentState) ->
+    prevState.tryToDownload and not currentState.tryToDownload and not currentState.downloadHasError and currentState.downloadUrl?
 
   handleCompletedExport: (exportData) ->
     {courseId} = @props
@@ -84,6 +85,7 @@ PerformanceExport = React.createClass
       tryToDownload: false
       exportedSinceLoad: true
       downloadHasError: true
+      forceDownloadUrl: null
 
     invalidDownloadState.downloadUrl = null if @state.downloadUrl is downloadUrl
 
@@ -95,6 +97,7 @@ PerformanceExport = React.createClass
       exportedSinceLoad: true
       downloadUrl: downloadUrl
       lastExported: lastExported
+      forceDownloadUrl: null
 
     @setState(downloadState)
 
@@ -113,7 +116,7 @@ PerformanceExport = React.createClass
 
   render: ->
     {courseId, className} = @props
-    {downloadUrl, lastExported, exportedSinceLoad, downloadHasError, tryToDownload} = @state
+    {downloadUrl, lastExported, exportedSinceLoad, downloadHasError, tryToDownload, forceDownloadUrl} = @state
 
     className += ' export-button'
     exportClass = 'primary'
@@ -133,18 +136,27 @@ PerformanceExport = React.createClass
       lastExportedTime = <i>
         <TimeDifference date={lastExported}/>
       </i>
-      lastExportedTime = <a onClick={@downloadCurrentExport} href='#'>
-        {lastExportedTime}
-      </a> if downloadUrl?
+      
+      if downloadUrl?
+        lastExportedTime = <a onClick={@downloadCurrentExport} href='#'>
+          Download export from {lastExportedTime}
+        </a>
+      else
+        lastExportedTime = "Last exported #{lastExportedTime}"
 
       lastExportedLabel = <small className='export-button-time'>
-        Last exported {lastExportedTime}
+        {lastExportedTime}
       </small>
 
     <span className={className}>
       <div className='export-button-buttons'>
         {exportButton}
       </div>
+      <iframe
+        ref='downloader'
+        className='tutor-downloader'
+        frameBorder={0}
+        src={forceDownloadUrl}/>
       {lastExportedLabel}
     </span>
 

--- a/src/components/performance/export.cjsx
+++ b/src/components/performance/export.cjsx
@@ -124,12 +124,16 @@ PerformanceExport = React.createClass
     actionButtonClass = 'primary'
     actionButtonClass = 'default' if downloadedSinceLoad
 
+    failedProps =
+      beforeText: 'There was a problem exporting. '
+
     actionButton =
       <AsyncButton
         bsStyle={actionButtonClass}
         onClick={-> PerformanceExportActions.export(courseId)}
         isWaiting={PerformanceExportStore.isExporting(courseId) or tryToDownload}
         isFailed={PerformanceExportStore.isFailed(courseId) or downloadHasError}
+        failedProps={failedProps}
         waitingText='Generating Export…'>
         Generate Export
       </AsyncButton>
@@ -141,7 +145,7 @@ PerformanceExport = React.createClass
           href={forceDownloadUrl}
           onClick={@downloadCurrentExport}>Download Export</BS.Button>
 
-    if lastExported?
+    if lastExported? and not downloadHasError
       lastExportedTime = <i>
         <TimeDifference date={lastExported}/>
       </i>

--- a/src/components/performance/export.cjsx
+++ b/src/components/performance/export.cjsx
@@ -113,7 +113,7 @@ PerformanceExport = React.createClass
 
   render: ->
     {courseId, className} = @props
-    {downloadUrl, lastExported, exportedSinceLoad, downloadHasError} = @state
+    {downloadUrl, lastExported, exportedSinceLoad, downloadHasError, tryToDownload} = @state
 
     className += ' export-button'
     exportClass = 'primary'
@@ -123,7 +123,7 @@ PerformanceExport = React.createClass
       <AsyncButton
         bsStyle={exportClass}
         onClick={-> PerformanceExportActions.export(courseId)}
-        isWaiting={PerformanceExportStore.isExporting(courseId)}
+        isWaiting={PerformanceExportStore.isExporting(courseId) or tryToDownload}
         isFailed={PerformanceExportStore.isFailed(courseId) or downloadHasError}
         waitingText='Exporting…'>
         Export

--- a/src/components/time-difference.cjsx
+++ b/src/components/time-difference.cjsx
@@ -21,7 +21,7 @@ module.exports = React.createClass
     compareWith: TimeStore.getNow()
     compare: 'from'
     customSuffix: undefined
-    toleranceMS: 15000
+    toleranceMS: 60000
     defaultText: 'just now'
 
   shouldRenderDifference: ->

--- a/src/flux/performance-export.coffee
+++ b/src/flux/performance-export.coffee
@@ -3,9 +3,13 @@
 _ = require 'underscore'
 moment = require 'moment'
 
-EXPORTING = 'exporting'
-EXPORT_QUEUED = 'export_queued'
+EXPORT_REQUESTING = 'export_requesting'
+EXPORT_REQUESTED = 'export_queued'
+EXPORTING = 'working'
+EXPORT_QUEUED = 'queued'
 EXPORTED = 'completed'
+EXPORT_FAILED = 'failed'
+EXPORT_KILLED = 'killed'
 
 PerformanceExportConfig = {
 
@@ -34,7 +38,7 @@ PerformanceExportConfig = {
     @_job[id].push(jobId)
 
   export: (id) ->
-    @_asyncStatus[id] = EXPORTING
+    @_asyncStatus[id] = EXPORT_REQUESTING
     @emitChange()
 
   exported: (obj, id) ->
@@ -43,7 +47,7 @@ PerformanceExportConfig = {
 
     # export job has been queued
     @emit('performanceExport.queued', {jobId, id})
-    @_asyncStatus[id] = EXPORT_QUEUED
+    @_asyncStatus[id] = EXPORT_REQUESTED
     @saveJob(jobId, id)
 
     # checks job until final status is reached
@@ -61,7 +65,22 @@ PerformanceExportConfig = {
 
   exports:
     isExporting: (id) ->
-      @_asyncStatus[id] is EXPORTING or @_asyncStatus[id] is EXPORT_QUEUED
+      exportingStates = [
+        EXPORT_REQUESTING
+        EXPORT_REQUESTED
+        EXPORT_QUEUED
+        EXPORTING
+      ]
+
+      exportingStates.indexOf(@_asyncStatus[id]) > -1
+
+    isFailed: (id) ->
+      failedStates = [
+        EXPORT_FAILED
+        EXPORT_KILLED
+      ]
+
+      failedStates.indexOf(@_asyncStatus[id]) > -1
 
     isExported: (id, jobId) ->
       jobId ?= _.last(@_getJobs(id))


### PR DESCRIPTION
Another way, #564

# on page load
![screen shot 2015-07-30 at 1 58 46 pm](https://cloud.githubusercontent.com/assets/2483873/8992749/f0016ad4-36c5-11e5-9bba-8e4ef2e0b416.png)

# generating
![screen shot 2015-07-30 at 1 59 06 pm](https://cloud.githubusercontent.com/assets/2483873/8992753/f6470e3a-36c5-11e5-9533-373bb2aee9da.png)

# after export generated and dl link verified
![screen shot 2015-07-30 at 1 58 50 pm](https://cloud.githubusercontent.com/assets/2483873/8992756/fbf29d54-36c5-11e5-804f-4c379a91332c.png)

# after first download
![screen shot 2015-07-30 at 2 01 34 pm](https://cloud.githubusercontent.com/assets/2483873/8992759/0185bca6-36c6-11e5-9e23-11c7a1305b79.png)
 dims button to discourage repeated clicking

# when theres a problem with any of the following
* queueing export
* job
* download url not validating as xlsx

![screen shot 2015-07-30 at 5 15 25 pm](https://cloud.githubusercontent.com/assets/2483873/8996595/b4a7d9d2-36de-11e5-9e89-e0ae980f5a02.png)


# Pros and Cons
- User has to know to wait for export to finish and click the DL button
- Not able to export again per page load.
- Could potentially take out the HEAD checking code and avoid having to update CORS
  - I actually think it's a good idea to have this check in there regardless.  Prevents DL of other types of files accidentally.