### PR TITLE
Disallow actions after plan is visible

### DIFF
--- a/src/components/task-plan/homework/exercises.cjsx
+++ b/src/components/task-plan/homework/exercises.cjsx
@@ -73,7 +73,7 @@ ReviewExerciseCard = React.createClass
     if confirm('Are you sure you want to remove this exercise?')
       TaskPlanActions.removeExercise(@props.planId, @props.exercise)
 
-  renderHeader: ->
+  getActionButtons: ->
     unless @props.index is 0
       moveUp =
         <BS.Button onClick={@moveExerciseUp} className="btn-xs -move-exercise-up">
@@ -86,8 +86,7 @@ ReviewExerciseCard = React.createClass
         <i className="fa fa-arrow-down"/>
       </BS.Button>
 
-    <span className="-exercise-header">
-      <span className="exercise-number">{@props.index + 1}</span>
+    if not TaskPlanStore.isVisibleToStudents(@props.planId)
       <span className="pull-right card-actions">
         {moveUp}
         {moveDown}
@@ -95,6 +94,13 @@ ReviewExerciseCard = React.createClass
           <i className="fa fa-close"/>
         </BS.Button>
       </span>
+
+  renderHeader: ->
+    actionButtons = @getActionButtons()
+
+    <span className="-exercise-header">
+      <span className="exercise-number">{@props.index + 1}</span>
+      {actionButtons}
     </span>
 
   getPanelStyle: ->

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -31,17 +31,13 @@ ReviewReadingLi = React.createClass
   removeTopic: ->
     TaskPlanActions.removeTopic(@props.planId, @props.topicId)
 
-  render: ->
-    topic = TocStore.getSectionInfo(@props.topicId)
-
+  getActionButtons: ->
     if @props.index
       moveUpButton = <BS.Button onClick={@moveReadingUp} className="btn-xs -move-reading-up">
         <i className="fa fa-arrow-up"/>
       </BS.Button>
 
-    <li className='selected-section'>
-      <ChapterSection section={topic.chapter_section}/>
-      <span className='section-title'>{topic?.title}</span>
+    if not TaskPlanStore.isVisibleToStudents(@props.planId)
       <span className='section-buttons'>
         {moveUpButton}
         <BS.Button onClick={@moveReadingDown} className="btn-xs move-reading-down">
@@ -51,6 +47,18 @@ ReviewReadingLi = React.createClass
           <i className="fa fa-close"/>
         </BS.Button>
       </span>
+
+  render: ->
+    topic = TocStore.getSectionInfo(@props.topicId)
+
+
+
+    actionButtons = @getActionButtons()
+
+    <li className='selected-section'>
+      <ChapterSection section={topic.chapter_section}/>
+      <span className='section-title'>{topic?.title}</span>
+      {actionButtons}
     </li>
 
 ReviewReadings = React.createClass


### PR DESCRIPTION
![screen shot 2015-07-31 at 11 02 50 pm](https://cloud.githubusercontent.com/assets/6434717/9010226/4a38d588-37d8-11e5-9554-050e7d6f95ae.png)
![screen shot 2015-07-31 at 11 03 12 pm](https://cloud.githubusercontent.com/assets/6434717/9010230/5849d5be-37d8-11e5-8e88-ad501a677ceb.png)

- [x] Readings cannot sort or remove sections after visible to students
- [x] HWs cannot sort or remove exercises after visible to students
- [ ] Add unit tests


