### PR TITLE
fix when task is due, breadcrumbs should show correct or incorrect status

### DIFF
--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -188,8 +188,8 @@ TaskConfig =
       allSteps.length
 
     isTaskPastDue: (taskId) ->
-      task = @_local[taskId]
-      moment(TimeStore.getNow()).isAfter(task.due_at, 'day')
+      task = @_get(taskId)
+      moment(TimeStore.getNow()).isAfter(task.due_at)
 
     isPractice: (taskId) ->
       practices = [

--- a/test/task-store.spec.coffee
+++ b/test/task-store.spec.coffee
@@ -1,6 +1,11 @@
 {expect} = require 'chai'
+moment = require 'moment'
+_ = require 'underscore'
 
 {TaskActions, TaskStore} = require '../src/flux/task'
+{TimeActions, TimeStore} = require '../src/flux/time'
+
+VALID_MODEL = require '../api/tasks/5.json'
 
 describe 'Task Store', ->
   afterEach ->
@@ -68,3 +73,18 @@ describe 'Task Store', ->
     expect(TaskStore.isLoaded(id)).to.be.false
     expect(TaskStore.isLoading(id)).to.be.false
     expect(TaskStore.isFailed(id)).to.be.true
+
+
+  it 'should be able to tell us if something is past due', ->
+    timeNow = TimeStore.getNow()
+    pastDue = _.clone(VALID_MODEL)
+    beforeDue = _.clone(VALID_MODEL)
+    pastDue.due_at = moment(timeNow).subtract(1, 'minute').format()
+    beforeDue.due_at = moment(timeNow).add(1, 'hour').format()
+
+    TaskActions.loaded(pastDue, 'past')
+    TaskActions.loaded(beforeDue, 'before')
+
+    expect(TaskStore.isTaskPastDue('past')).to.be.true
+    expect(TaskStore.isTaskPastDue('before')).to.be.false
+


### PR DESCRIPTION
Past due-ness used to be based on whether current time is after the due DATE.  However, this is changed now that we have a set due time.  Use due time as opposed just due DATE.

Note: Need to use task due date to compare because other determining whether something is past due will be dependent on whether someone has worked a task.

- [x] fix
- [x] add test