### PR TITLE
Adding iReading specific styles

### DIFF
--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -132,7 +132,17 @@ figure {
 }
 
 [data-type="footnote-refs"] {
-  ul {
+  ol {
+    padding-left: 0;
     list-style: none;
+    li {
+      list-style: none;
+      a {
+        padding-right: 10px;
+      }
+      p {
+        display:inline;
+      }
+    }
   }
 }

--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -53,6 +53,21 @@ ol {
   margin: 0 0 2.4rem 0;
 }
 
+ul {
+  list-style-type: none;
+  > li {
+    &::before {
+      list-style-type: none;
+      content: "";
+      width: .4em;
+      height: .4em;
+      float: left;
+      margin: 0.75em -0.8em 0;
+      border-radius: 50%;
+    }
+  }
+}
+
 section h1 + p:first-of-type,
 div[data-type="document-title"] ~ p:first-of-type {
   .tutor-reading-first-letter();
@@ -116,3 +131,8 @@ figure {
   img { width: 100%; }
 }
 
+[data-type="footnote-refs"] {
+  ul {
+    list-style: none;
+  }
+}

--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -28,7 +28,7 @@ table {
   }
   tbody {
     border-top: solid  4px  @tutor-neutral-light;
-   border-bottom: solid  4px  @tutor-neutral-light;
+    border-bottom: solid  4px  @tutor-neutral-light;
   }
   caption,
   thead tr:first-of-type:not(:last-child) th{

--- a/resources/styles/book-content/context-mixins.less
+++ b/resources/styles/book-content/context-mixins.less
@@ -1,6 +1,6 @@
 .tutor-book-note(reading) {
   > .note,
-  > section > .note:not(.learning-objectives),
+  > section > .note:not(.learning-objectives, .tips-for-success),
   section > section > .note {
     background: none;
     padding: 20px 0;
@@ -8,7 +8,6 @@
       margin: -68px 0 0 0;
     }
   }
-
   section > h1 {
     clear: both;
   }

--- a/resources/styles/book-content/context-mixins.less
+++ b/resources/styles/book-content/context-mixins.less
@@ -8,8 +8,10 @@
       margin: -68px 0 0 0;
     }
   }
+}
+
+.tutor-book-titles(reading){
   section > h1 {
     clear: both;
   }
-
 }

--- a/resources/styles/book-content/context-mixins.less
+++ b/resources/styles/book-content/context-mixins.less
@@ -5,7 +5,7 @@
     background: none;
     padding: 20px 0;
     &:before {
-      margin: -68px 0 0 0;
+      margin: @book-content-note-without-background-margin;
     }
   }
 }

--- a/resources/styles/book-content/context-mixins.less
+++ b/resources/styles/book-content/context-mixins.less
@@ -1,0 +1,15 @@
+.tutor-book-note(reading) {
+  > .note,
+  > section > .note:not(.learning-objectives),
+  section > section > .note {
+    background: none;
+    padding: 20px 0;
+    &:before {
+      margin: -68px 0 0 0;
+    }
+  }
+
+  section > h1 {
+    clear: both;
+  }
+}

--- a/resources/styles/book-content/context-mixins.less
+++ b/resources/styles/book-content/context-mixins.less
@@ -1,6 +1,6 @@
 .tutor-book-note(reading) {
   > .note,
-  > section > .note:not(.learning-objectives, .tips-for-success),
+  > section > .note:not(.learning-objectives),
   section > section > .note {
     background: none;
     padding: 20px 0;
@@ -11,4 +11,5 @@
   section > h1 {
     clear: both;
   }
+
 }

--- a/resources/styles/book-content/context-mixins.less
+++ b/resources/styles/book-content/context-mixins.less
@@ -1,6 +1,6 @@
 .tutor-book-note(reading) {
   > .note,
-  > section > .note:not(.learning-objectives),
+  > section > .note:not(.learning-objectives):not(.tips-for-success),
   section > section > .note {
     background: none;
     padding: 20px 0;

--- a/resources/styles/book-content/hs-physics/grasp-check.less
+++ b/resources/styles/book-content/hs-physics/grasp-check.less
@@ -1,19 +1,18 @@
 // This file is part of the book-content mixin and should not be included directly
 .grasp-check {
-  background: @tutor-white;
-  display:  inline-block;
+  margin: 68px 0 32px 0;
+  padding: 20px 0;
   clear: both;
-  width:  100%;
-  margin-top: 50px;
-  padding: 15px;
-  border: solid 3px @tutor-secondary;
+  display: inline-block;
+  border-top: solid 8px @tutor-secondary;
   &:before {
-    display: inline-block;
-    content: "Grasp Check";
-    text-transform:  uppercase;
-    color:  @tutor-secondary;
     position: absolute;
-    margin: -45px 0 0 -17px;
+    content: attr(data-label);
     #fonts > .sans(@tutor-book-ui-top-height - 18px, @tutor-book-ui-top-height);
+    font-weight: 900;
+    padding: 0 40px;
+    height: @tutor-book-ui-top-height;
+    display: inline-block;
+    margin: -68px 0 0 0px;
   }
 }

--- a/resources/styles/book-content/hs-physics/index.less
+++ b/resources/styles/book-content/hs-physics/index.less
@@ -1,6 +1,7 @@
 .tutor-book-theme-hs-physics-specific() {
+
   @import './variables';
- @import './links-to-physics';
+  @import './links-to-physics';
   @import './worked-examples';
   @import './interactive';
   @import './work-in-physics';

--- a/resources/styles/book-content/index.less
+++ b/resources/styles/book-content/index.less
@@ -40,6 +40,7 @@
   .tutor-book-theme-learning-objectives(@tutor-book-hs-physics-primary);
   .tutor-book-theme-splash-image(@tutor-book-hs-physics-primary);
   .tutor-book-theme-note(@tutor-book-hs-physics-primary; @tutor-book-hs-physics-secondary);
+  .tutor-bullet-lists(@tutor-book-hs-physics-secondary);
 }
 
 .tutor-book-content-theme-biology() {
@@ -52,4 +53,5 @@
   .tutor-book-theme-learning-objectives(@tutor-book-ap-bio-primary);
   .tutor-book-theme-splash-image(@tutor-book-ap-bio-primary);
   .tutor-book-theme-note(@tutor-book-ap-bio-primary; @tutor-book-text-on-dark-labels);
+  .tutor-bullet-lists(@tutor-book-ap-bio-secondary);
 }

--- a/resources/styles/book-content/index.less
+++ b/resources/styles/book-content/index.less
@@ -2,6 +2,7 @@
 @import './variables';
 @import './mixins';
 @import './theming-mixins';
+@import './context-mixins';
 
 .tutor-book-content() {
 

--- a/resources/styles/book-content/index.less
+++ b/resources/styles/book-content/index.less
@@ -53,5 +53,5 @@
   .tutor-book-theme-learning-objectives(@tutor-book-ap-bio-primary);
   .tutor-book-theme-splash-image(@tutor-book-ap-bio-primary);
   .tutor-book-theme-note(@tutor-book-ap-bio-primary; @tutor-book-text-on-dark-labels);
-  .tutor-bullet-lists(@tutor-book-ap-bio-secondary);
+  .tutor-bullet-lists(@tutor-book-ap-bio-primary);
 }

--- a/resources/styles/book-content/learning-objectives.less
+++ b/resources/styles/book-content/learning-objectives.less
@@ -44,8 +44,9 @@
     -webkit-flex-direction: column;
     -webkit-flex: 1;
     .ost-learning-objective-def {
-      #fonts > .sans(1.5rem, 1.8em);
+      #fonts > .sans(1.5rem, 1.4em);
       margin-left: 20px;
+      padding-bottom: 5px;
       font-weight: 300;
       justify-content: center;
       -webkit-justify-content: center;

--- a/resources/styles/book-content/learning-objectives.less
+++ b/resources/styles/book-content/learning-objectives.less
@@ -30,6 +30,7 @@
   }
 
   ul {
+    list-style: disc;
     margin: 0 0;
     padding: 0 20px;
     border-left-style: solid;

--- a/resources/styles/book-content/note.less
+++ b/resources/styles/book-content/note.less
@@ -7,7 +7,7 @@
     padding: 0 40px;
     height: @tutor-book-ui-top-height;
     display: inline-block;
-    margin: -68px 0 0 -40px;
+    margin: @book-content-note-with-background-margin;
   }
 
   :last-child {

--- a/resources/styles/book-content/note.less
+++ b/resources/styles/book-content/note.less
@@ -55,4 +55,3 @@ section > section > .note {
   padding: 20px 40px;
   .tutor-book-note-style();
 }
-

--- a/resources/styles/book-content/theming-mixins.less
+++ b/resources/styles/book-content/theming-mixins.less
@@ -47,6 +47,13 @@
     }
   }
 }
+.tutor-bullet-lists(@bullet-color: @tutor-book-secondary){
+  ul > li {
+    &::before {
+      background: @bullet-color;
+    }
+  }
+}
 
 .tutor-book-content-theme(@book-theme-name) {
   @book-theme-primary: "tutor-book-@{book-theme-name}-primary";

--- a/resources/styles/book-content/theming-mixins.less
+++ b/resources/styles/book-content/theming-mixins.less
@@ -16,11 +16,17 @@
 .tutor-book-theme-note(@label-background: @tutor-book-primary; @label-text: @tutor-book-text-on-dark-labels) {
   > .note,
   > section > .note,
-  section > section > .note {
+  section > section > .note, .grasp-check {
     &:before {
       color: @label-text;
       background: @label-background;
     }
+  }
+}
+.tutor-book-theme-note-borders(@border-color: @tutor-book-secondary) {
+  .grasp-check {
+    border-top: solid 8px @border-color;
+    border-bottom: solid 8px @border-color;
   }
 }
 

--- a/resources/styles/book-content/theming-mixins.less
+++ b/resources/styles/book-content/theming-mixins.less
@@ -16,7 +16,8 @@
 .tutor-book-theme-note(@label-background: @tutor-book-primary; @label-text: @tutor-book-text-on-dark-labels) {
   > .note,
   > section > .note,
-  section > section > .note, .grasp-check {
+  section > section > .note,
+  .grasp-check {
     &:before {
       color: @label-text;
       background: @label-background;

--- a/resources/styles/book-content/variables.less
+++ b/resources/styles/book-content/variables.less
@@ -31,3 +31,6 @@
 @tutor-book-padding-vertical: @tutor-card-body-padding-vertical;
 @tutor-book-ui-top-height: 40px;
 @reading-ui-banner-height: @tutor-book-ui-top-height;
+
+@book-content-note-with-background-margin: -68px 0 0 -40px;
+@book-content-note-without-background-margin: -68px 0 0 0;

--- a/resources/styles/components/question.less
+++ b/resources/styles/components/question.less
@@ -71,8 +71,8 @@
   .clearfix();
 
   counter-reset: answer 0;
-  #fonts > .sans (2.1rem, 3rem);
-  font-weight: 400;
+  #fonts > .sans (2rem, 3rem);
+  font-weight: 600;
   padding-top: .5em;
 
   .question-stem {

--- a/resources/styles/components/reference-book/page.less
+++ b/resources/styles/components/reference-book/page.less
@@ -19,7 +19,7 @@
       }
 
       > section {
-        > h1 {
+        > h1, > h2 {
           clear: both;
         }
 

--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -13,6 +13,7 @@
   .reading-step {
     .tutor-book-content();
     .tutor-book-note(reading);
+    .tutor-book-titles(reading);
 
     &[data-category=physics]{
       .tutor-book-content-theme-physics();

--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -12,6 +12,7 @@
   .interactive-step > .interactive-content,
   .reading-step {
     .tutor-book-content();
+    .tutor-book-note(reading);
 
     &[data-category=physics]{
       .tutor-book-content-theme-physics();


### PR DESCRIPTION
Allowing for I-Reading specific styles. Added context-mixin for now.

TODO: full refactor, see napkin note https://github.com/openstax/napkin-notes/blob/master/phil/s016-book-styling-refactor.md

*Screenshots not available*
Removed grey background on all notes in the iReading view, removed extra padding within notes, excluded tips-for-success to display as regular notes in the iReading view. 

Reference book new styles:
bullets to match iReading + theming mixin for colors
![2015-08-03_14-09-07](https://cloud.githubusercontent.com/assets/8514591/9045518/531a00b0-39e9-11e5-98a3-4d8b89124289.png)


Removed numbered list-styles for footnotes
![2015-08-04_09-23-28](https://cloud.githubusercontent.com/assets/8514591/9062870/7eb8f928-3a8a-11e5-834d-a121cee827dc.png)

Tightened up question styles
![2015-08-04_09-24-20](https://cloud.githubusercontent.com/assets/8514591/9062884/97fce9da-3a8a-11e5-9463-8fd7e129efdc.png)

Tightened up learning objectives styles
![2015-08-04_09-25-18](https://cloud.githubusercontent.com/assets/8514591/9062899/baa18180-3a8a-11e5-9e09-87378dce8e12.png)

Restyled grasp checks
![2015-08-04_09-25-52](https://cloud.githubusercontent.com/assets/8514591/9062918/ce968eb0-3a8a-11e5-8028-3065c88cfa39.png)

