### PR TITLE
Scroll reference ToC so the entry for the current page is visible

### DIFF
--- a/src/components/reference-book/exercise.cjsx
+++ b/src/components/reference-book/exercise.cjsx
@@ -14,8 +14,9 @@ ReferenceBookExercise = React.createClass
   displayName: 'ReferenceBookExercise'
   render: ->
     {exerciseAPIUrl} = @props
-    {items} = ReferenceBookExerciseStore.get(exerciseAPIUrl)
-
+    exercise = ReferenceBookExerciseStore.get(exerciseAPIUrl)
+    return null unless exercise
+    {items} = exercise
     unless items?.length
       # warning about missing exercise --
       # is there a need to show the reader anything?

--- a/src/components/reference-book/exercise.cjsx
+++ b/src/components/reference-book/exercise.cjsx
@@ -14,9 +14,8 @@ ReferenceBookExercise = React.createClass
   displayName: 'ReferenceBookExercise'
   render: ->
     {exerciseAPIUrl} = @props
-    exercise = ReferenceBookExerciseStore.get(exerciseAPIUrl)
-    return null unless exercise
-    {items} = exercise
+    {items} = ReferenceBookExerciseStore.get(exerciseAPIUrl)?
+
     unless items?.length
       # warning about missing exercise --
       # is there a need to show the reader anything?

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -31,14 +31,14 @@ module.exports = React.createClass
     page?.title
 
   prevLink: (info) ->
-    <Router.Link className='nav prev' to='viewReferenceBookPage'
-      params={courseId: @props.courseId, cnxId: info.prev.cnx_id}>
+    <Router.Link className='nav prev' to='viewReferenceBookSection'
+      params={courseId: @props.courseId, section: info.prev.chapter_section.join('.')}>
       <div className='triangle' />
     </Router.Link>
 
   nextLink: (info) ->
-    <Router.Link className='nav next' to='viewReferenceBookPage'
-      params={courseId: @props.courseId, cnxId: info.next.cnx_id}>
+    <Router.Link className='nav next' to='viewReferenceBookSection'
+      params={courseId: @props.courseId, section: info.next.chapter_section.join('.')}>
       <div className='triangle' />
     </Router.Link>
 
@@ -112,6 +112,7 @@ module.exports = React.createClass
     html = html
       .replace(/^[\s\S]*<body[\s\S]*?>/, '')
       .replace(/<\/body>[\s\S]*$/, '')
+
     <div className='page-wrapper'>
       {@prevLink(info) if info.prev}
       <ArbitraryHtmlAndMath className='page' block html={html} />

--- a/src/components/reference-book/toc.cjsx
+++ b/src/components/reference-book/toc.cjsx
@@ -16,16 +16,14 @@ Section = React.createClass
   render: ->
     {courseId} = @context.router.getCurrentParams()
     sections = @props.section.chapter_section.join('.')
-    [linkTarget, params] = if @props.section.cnx_id
-      ['viewReferenceBookPage',  {courseId: courseId, cnxId: @props.section.cnx_id}]
-    else
-      ['viewReferenceBookSection', {courseId: courseId, section: sections}]
     <ul className="section" data-depth={@props.section.chapter_section.length}>
-      <li>
-        <Router.Link onClick={@props.onMenuSelection} to={linkTarget}
-            params={params}>
-            <span className="section-number">{sections}</span>
-            {@props.section.title}
+      <li data-section={sections}>
+        <Router.Link
+          onClick={@props.onMenuSelection} to='viewReferenceBookSection'
+          params={{courseId: courseId, section: sections}}
+        >
+          <span className="section-number">{sections}</span>
+          {@props.section.title}
         </Router.Link>
       </li>
       { _.map @props.section.children, (child) =>

--- a/src/components/reference-book/toc.cjsx
+++ b/src/components/reference-book/toc.cjsx
@@ -27,7 +27,7 @@ Section = React.createClass
         </Router.Link>
       </li>
       { _.map @props.section.children, (child) =>
-        <li key={child.id}>
+        <li key={child.id} data-section={child.chapter_section.join('.')}>
           <Section onMenuSelection={@props.onMenuSelection} section={child} />
         </li> }
     </ul>
@@ -39,6 +39,22 @@ module.exports = React.createClass
     router: React.PropTypes.func
   propTypes:
     onMenuSelection: React.PropTypes.func
+
+  componentDidMount:  -> @scrollSelectionIntoView()
+  componentDidUpdate: -> @scrollSelectionIntoView()
+  scrollSelectionIntoView: ->
+    {section} = @context.router.getCurrentParams()
+    return unless section
+
+    root = React.findDOMNode(@)
+    li = root.querySelector("[data-section='#{section}']")
+    return unless li
+
+    beforeTop = li.offsetTop - root.offsetTop < root.scrollTop
+    pastBottom = (li.offsetTop - root.offsetTop + li.clientHeight) >
+      (root.scrollTop + root.clientHeight)
+    li.scrollIntoView() if beforeTop or pastBottom
+
 
   render: ->
     {courseId} = @context.router.getCurrentParams()

--- a/test/components/reference-book.spec.coffee
+++ b/test/components/reference-book.spec.coffee
@@ -14,17 +14,19 @@ Page = require '../../src/components/reference-book/page'
 
 COURSE_ID = '1'
 TOC  = require '../../api/courses/1/readings.json'
-FIRST_PAGE_ID  = '0e58aa87-2e09-40a7-8bf3-269b2fa16509'
+FIRST_PAGE_ID = '0e58aa87-2e09-40a7-8bf3-269b2fa16509'
+FIRST_PAGE  = '1.1'
+SECOND_PAGE = '1.2'
 SECOND_PAGE_ID = '0e58aa87-2e09-40a7-8bf3-269b2fa16510'
-THIRD_PAGE_ID  = '0e58aa87-2e09-40a7-8bf3-269b2fa16511'
+THIRD_PAGE  = '1.3'
 
 PAGE = require '../../api/pages/0e58aa87-2e09-40a7-8bf3-269b2fa16509.json'
 
 
-renderBook = (page) ->
+renderBook = (section) ->
   new Promise (resolve, reject) ->
     url = "/books/#{COURSE_ID}"
-    url += "/page/#{page}" if page
+    url += "/section/#{section}" if section
     routerStub.goTo(url).then( (result) ->
       resolve(_.extend({
         book: ReactTestUtils.findRenderedComponentWithType(result.component, ReferenceBook)
@@ -38,7 +40,7 @@ describe 'Reference Book Component', ->
   beforeEach ->
     ReferenceBookActions.loaded(TOC, COURSE_ID)
     ReferenceBookPageActions.loaded(PAGE, FIRST_PAGE_ID)
-    renderBook(FIRST_PAGE_ID).then (state) =>
+    renderBook(FIRST_PAGE).then (state) =>
       @state = state
 
   it 'renders the section title on the navbar',  ->
@@ -49,13 +51,15 @@ describe 'Reference Book Component', ->
     expect(@state.div.querySelector('.page').textContent)
       .to.equal('A bunch of html')
 
+  it 'sets current page to active on menu', ->
+    page = ReferenceBookActions.loaded(TOC, COURSE_ID)
+    console.log page
+    expect(@state.div.querySelector('.page').textContent)
+      .to.equal('A bunch of html')
+
   it 'toggles menu when navbar control is clicked', ->
     toggle = @state.div.querySelector('.menu-toggle')
 
-    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
-      .to.not.contain('menu-open')
-
-    commonActions.click(toggle)
     expect(_.toArray(@state.div.querySelector('.reference-book').classList))
       .to.contain('menu-open')
 
@@ -63,25 +67,34 @@ describe 'Reference Book Component', ->
     expect(_.toArray(@state.div.querySelector('.reference-book').classList))
       .to.not.contain('menu-open')
 
+    commonActions.click(toggle)
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.contain('menu-open')
+
   it 'navigates forward and back between pages', ->
     prevControl = @state.div.querySelector('.page-wrapper > .prev')
     expect(prevControl).to.not.exist # on first page
 
     nextControl = @state.div.querySelector('.page-wrapper > .next')
     expect(nextControl).to.exist
-    expect(nextControl.href).to.contain(SECOND_PAGE_ID)
+    expect(nextControl.href).to.contain(SECOND_PAGE)
     page = ReactTestUtils.findRenderedComponentWithType(@state.book, Page)
-
 
     ReferenceBookPageActions.loaded(PAGE, SECOND_PAGE_ID)
     # button:0 is a mystery argument needed by ReactRouter, taken from their specs
     commonActions.click(nextControl, {button: 0})
 
-    expect(page.context.router.getCurrentParams().cnxId)
-      .to.equal(SECOND_PAGE_ID)
+    expect(page.context.router.getCurrentParams().section)
+      .to.equal(SECOND_PAGE)
 
     expect(@state.div.querySelector('.page-wrapper > .next').href)
-      .to.contain(THIRD_PAGE_ID)
+      .to.contain(THIRD_PAGE)
 
     expect(@state.div.querySelector('.page-wrapper > .prev').href)
-      .to.contain(FIRST_PAGE_ID)
+      .to.contain(FIRST_PAGE)
+
+
+  it 'sets the menu item to be active based on the current page', ->
+    selection = @state.div.querySelector(".toc [data-section='#{FIRST_PAGE}'] a")
+    expect(selection).not.to.be.null
+    expect(_.toArray(selection.classList)).to.include('active')


### PR DESCRIPTION
Corrects bug where a link to a chapter such as 7.2 was clicked but the table of contents menu wouldn't show it because it was below the scroll area.