### PR TITLE
Restrict rendering to routes based on user role

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -21,9 +21,12 @@ window._STORES =
   TIME: require './src/flux/time'
   TOC: require './src/flux/toc'
 
-api.start()
+api.start(
+  JSON.parse(document.getElementById('tutor-boostrap-data')?.textContent or '{}')
+)
 startMathJax()
 TransitionAssistant.startMonitoring()
+
 
 # This is added because MathJax puts in extra divs on initial load.
 # Moves the React Root to be an element inside a div

--- a/index.coffee
+++ b/index.coffee
@@ -3,6 +3,7 @@ require 'bootstrap' # Attach bootstrap to jQuery
 
 api = require './src/api'
 router = require './src/router'
+dom = require './src/helpers/dom'
 {startMathJax} = require './src/helpers/mathjax'
 {TransitionAssistant} = require './src/components/unsaved-state'
 
@@ -21,9 +22,9 @@ window._STORES =
   TIME: require './src/flux/time'
   TOC: require './src/flux/toc'
 
-api.start(
-  JSON.parse(document.getElementById('tutor-boostrap-data')?.textContent or '{}')
-)
+
+api.start(dom.readBootstrapData())
+
 startMathJax()
 TransitionAssistant.startMonitoring()
 

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -104,8 +104,16 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker) ->
       $.ajax(url, opts)
       .then(resolved, rejected)
 
+BOOTSTRAPED_STORES = {
+  user:   CurrentUserActions.loaded
+  courses: CourseListingActions.loaded
+}
 
-start = ->
+start = (bootstrapData) ->
+  for storeId, action of BOOTSTRAPED_STORES
+    data = bootstrapData[storeId]
+    action(data) if data
+
   apiHelper TaskActions, TaskActions.load, TaskActions.loaded, 'GET', (id) ->
     url: "/api/tasks/#{id}"
 

--- a/src/components/navbar/index.cjsx
+++ b/src/components/navbar/index.cjsx
@@ -25,7 +25,7 @@ module.exports = React.createClass
     router: React.PropTypes.func
 
   componentWillMount: ->
-    CurrentUserActions.load()
+    CurrentUserStore.ensureLoaded()
     CourseListingStore.ensureLoaded()
 
   getInitialState: ->

--- a/src/flux/course-listing.coffee
+++ b/src/flux/course-listing.coffee
@@ -48,10 +48,10 @@ CourseListingStore = flux.createStore
     # Loads the store if it's not already loaded or loading
     # Returns false if the store is already loaded, true otherwise
     ensureLoaded: ->
-      if @_asyncStatus is LOADED
+      if CourseListingStore.isLoaded()
         false
       else
-        CourseListingActions.load() unless @_asyncStatus is LOADING
+        CourseListingActions.load() unless CourseListingStore.isLoading()
         true
 
     allCourses: ->

--- a/src/flux/current-user.coffee
+++ b/src/flux/current-user.coffee
@@ -99,9 +99,12 @@ CurrentUserStore = flux.createStore
 
   setToken: (@_token) -> # Save the token
 
-  load: -> # Used by API
+  load: -> @_loading = true
+
   loaded: (results) ->
     @_user = results
+    @_loaded = true
+    @_loading = false
     @emitChange()
 
   reset: ->
@@ -117,6 +120,12 @@ CurrentUserStore = flux.createStore
     getName: -> @_user.name
     isAdmin: -> @_user.is_admin
     getProfileUrl: -> @_user.profile_url
+
+    # Loads the store if it's not already loaded or loading
+    # Returns false if the store is already loaded, true otherwise
+    ensureLoaded: ->
+      CurrentUserActions.load() unless @_loaded or @_loading
+
 
     getCourseRole: (courseId, silent = true) ->
       @_getCourseRole(courseId, silent)

--- a/src/helpers/conditional-rendering.coffee
+++ b/src/helpers/conditional-rendering.coffee
@@ -10,12 +10,10 @@ module.exports = (component, options = {}) ->
   RouteHandler.contextTypes = { router: React.PropTypes.func }
   RouteHandler::render = ->
     {courseId} = @context.router.getCurrentParams()
-    if options.requireRole and courseId
-      role = CurrentUserStore.getCourseRole(courseId)
-      if role is not options.requireRole
-        return React.createElement(Invalid)
-
-    React.createElement(component)
-
-
+    React.createElement(
+      if options.requireRole and courseId and options.requireRole isnt CurrentUserStore.getCourseRole(courseId)
+        Invalid
+      else
+        component
+    )
   return RouteHandler

--- a/src/helpers/conditional-rendering.coffee
+++ b/src/helpers/conditional-rendering.coffee
@@ -1,0 +1,21 @@
+# coffeelint: disable=no_empty_functions
+
+React = require 'react'
+{CurrentUserStore}   = require '../flux/current-user'
+{Invalid} = require '../components'
+
+module.exports = (component, options = {}) ->
+
+  RouteHandler = ->
+  RouteHandler.contextTypes = { router: React.PropTypes.func }
+  RouteHandler::render = ->
+    {courseId} = @context.router.getCurrentParams()
+    if options.requireRole and courseId
+      role = CurrentUserStore.getCourseRole(courseId)
+      if role is not options.requireRole
+        return React.createElement(Invalid)
+
+    React.createElement(component)
+
+
+  return RouteHandler

--- a/src/helpers/dom.coffee
+++ b/src/helpers/dom.coffee
@@ -10,4 +10,12 @@ module.exports = {
     if @matches(el, selector) then el else @closest(el.parentNode, selector)
 
 
+  readBootstrapData: (root = document) ->
+    el = root.querySelector('#tutor-boostrap-data')
+    if el
+      el.parentNode.removeChild(el)
+      JSON.parse(el.textContent)
+    else
+      {}
+
 }

--- a/src/router.cjsx
+++ b/src/router.cjsx
@@ -15,6 +15,7 @@ TeacherTaskPlans = require './components/task-plan/teacher-task-plans-listing'
 {StatsShell} = require './components/plan-stats'
 CourseSettings = require './components/course-settings'
 Sandbox = require './sandbox'
+Handler = require './helpers/conditional-rendering'
 
 routes = (
   <Route handler={Root} name='root'>
@@ -36,10 +37,12 @@ routes = (
 
         <Route path='t/' name='viewTeacherDashBoard'>
           <Router.DefaultRoute handler={TeacherTaskPlans} />
-          <Route path='performance/?' name='viewPerformance' handler={PerformanceShell} />
-          <Route path='guide' name='viewTeacherGuide' handler={LearningGuideShell.Teacher} />
+          <Route path='performance/?' name='viewPerformance'
+            handler={Handler(PerformanceShell, requireRole: 'teacher')} />
+          <Route path='guide' name='viewTeacherGuide'
+            handler={Handler(LearningGuideShell.Teacher, requireRole: 'teacher')} />
           <Route path='guide/student/:roleId?' name='viewStudentTeacherGuide'
-              handler={LearningGuideShell.TeacherStudent}/>
+            handler={Handler(LearningGuideShell.TeacherStudent, requireRole: 'teacher')}/>
 
           <Route path='calendar/?' name='taskplans'>
             <Router.DefaultRoute handler={TeacherTaskPlans} />

--- a/test/dom-helpers.spec.coffee
+++ b/test/dom-helpers.spec.coffee
@@ -12,6 +12,9 @@ HTML = """
   <div class="wfig">
     <figure>a figure</figure>
   </div>
+  <div id="tutor-boostrap-data">
+    {"user":{"name":"Atticus Finch"}}
+  </div>
 </div>
 """
 
@@ -36,3 +39,6 @@ describe 'DOM Helpers', ->
 
   it 'does not find siblings', ->
     expect( DOM.closest( @p, '.wfig' ) ).to.be.null
+
+  it 'can read bootstrap data', ->
+    expect(DOM.readBootstrapData(@root)).to.deep.equal({"user":{"name":"Atticus Finch"}})


### PR DESCRIPTION
In order to restrict access to a given route, the app needs to know what course roles the user has very early in it's lifecycle. 

The BE PR [#562](https://github.com/openstax/tutor-server/pull/562) provides it to the app via json data enclosed in a script tag.  This will allow the app to continue to function even if the tag isn't provided for some reason, such as running locally.

There's a few other advantages to bootstrapping the stores this way.
  * The FE needs to make two less XHR requests when it's loaded.
  * The "Flash of un-styled content" issue no longer occurs on the reference view. Currently if the view is loaded it will first display using the standard book colors and then switch to the appropriate physics or biology colors once the course store loads.
  * The navbar displays the username immediately rather than blinking it into existence a few seconds after load.

Screenshot taken as a student after pasting in the url and loading

<img width="614" alt="screen shot 2015-08-06 at 9 44 51 pm" src="https://cloud.githubusercontent.com/assets/79566/9127723/6b2b0d5a-3c84-11e5-9d98-b36e2333aae3.png">

