### PR TITLE
Course Roster changes

### DIFF
--- a/src/components/course-settings/drop-student.cjsx
+++ b/src/components/course-settings/drop-student.cjsx
@@ -1,9 +1,11 @@
 React = require 'react'
 BS = require 'react-bootstrap'
+
 {RosterActions} = require '../../flux/roster'
+Icon = require '../icon'
 
 module.exports = React.createClass
-  displayName: 'DeleteStudentLink'
+  displayName: 'DropStudentLink'
   propTypes:
     student: React.PropTypes.object.isRequired
 
@@ -11,14 +13,14 @@ module.exports = React.createClass
     RosterActions.delete(@props.student.id)
 
   confirmPopOver: ->
-    <BS.Popover title={"Delete #{@props.student.full_name}?"} {...@props}>
+    <BS.Popover title={"Drop #{@props.student.full_name}?"} {...@props}>
       <BS.Button onClick={@performDeletion} bsStyle="danger">
-        <i className='fa fa-trash' /> Delete
+        <Icon type='ban' /> Drop
       </BS.Button>
     </BS.Popover>
 
   render: ->
     <BS.OverlayTrigger rootClose={true} trigger='click' placement='left'
       overlay={@confirmPopOver()}>
-        <a><i className='fa fa-trash' /> Delete</a>
+        <a><Icon type='ban' /> Drop</a>
     </BS.OverlayTrigger>

--- a/src/components/course-settings/period-roster.cjsx
+++ b/src/components/course-settings/period-roster.cjsx
@@ -6,7 +6,6 @@ Icon = require '../icon'
 {RosterStore, RosterActions} = require '../../flux/roster'
 ChangePeriodLink  = require './change-period'
 DeleteStudentLink = require './delete-student'
-AddStudentButton  = require './add-student'
 
 module.exports = React.createClass
   displayName: 'PeriodRoster'
@@ -28,11 +27,6 @@ module.exports = React.createClass
   render: ->
     students = RosterStore.getActiveStudentsForPeriod(@props.courseId, @props.period.id)
     <div className="period">
-      <BS.Row>
-        <BS.Col sm=2>
-          <AddStudentButton {...@props} />
-        </BS.Col>
-       </BS.Row>
       <BS.Table striped bordered condensed hover className="roster">
         <thead>
           <tr>

--- a/src/components/course-settings/period-roster.cjsx
+++ b/src/components/course-settings/period-roster.cjsx
@@ -5,7 +5,7 @@ Icon = require '../icon'
 
 {RosterStore, RosterActions} = require '../../flux/roster'
 ChangePeriodLink  = require './change-period'
-DeleteStudentLink = require './delete-student'
+DropStudentLink = require './drop-student'
 
 module.exports = React.createClass
   displayName: 'PeriodRoster'
@@ -20,7 +20,7 @@ module.exports = React.createClass
       <td>{student.deidentifier}</td>
       <td className="actions">
         <ChangePeriodLink courseId={@props.courseId} student={student} />
-        <DeleteStudentLink student={student} />
+        <DropStudentLink student={student} />
       </td>
     </tr>
 

--- a/src/components/icon.cjsx
+++ b/src/components/icon.cjsx
@@ -15,7 +15,8 @@ module.exports = React.createClass
     icon = <i className={classes.join(' ')} />
 
     if @props.tooltip
+      console.log @props
       tooltip = <BS.Tooltip>Useful for talking securely about students over email.</BS.Tooltip>
       <BS.OverlayTrigger placement='bottom' overlay={tooltip}>{icon}</BS.OverlayTrigger>
     else
-      tooltip
+      icon

--- a/src/flux/current-user.coffee
+++ b/src/flux/current-user.coffee
@@ -42,7 +42,7 @@ ROUTES =
     roles:
       teacher: 'viewPerformance'
   course:
-    label: 'Course Settings'
+    label: 'Course Roster'
     roles:
       teacher: 'courseSettings'
   book:

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -30,6 +30,7 @@ require './components/student-dashboard/progress-guide.spec'
 require './components/reference-book.spec'
 require './components/course-settings.spec'
 require './components/tutor-input.spec'
+require './components/icon.spec'
 
 require './crud-store.spec'
 require './task-store.spec'

--- a/test/components/icon.spec.cjsx
+++ b/test/components/icon.spec.cjsx
@@ -1,0 +1,20 @@
+{Testing, expect, sinon, _, ReactTestUtils} = require './helpers/component-testing'
+
+Icon = require '../../src/components/icon'
+
+describe 'Icon Component', ->
+
+  beforeEach ->
+    @props = { type: 'test' }
+
+  it 'renders', ->
+    Testing.renderComponent( Icon, props: @props ).then ({dom}) ->
+      expect(dom.tagName).to.equal('I')
+      expect(_.toArray(dom.classList)).to.include('fa-test', 'fa')
+
+  it 'renders with a tooltip', ->
+    @props.tooltip = 'a testing tooltip'
+    Testing.renderComponent( Icon, props: @props ).then ({dom}) ->
+      # Can't figure out how to find the actual DOM element that's rendered by the tooltip
+      expect(dom.tagName).to.equal('I')
+      expect(_.toArray(dom.classList)).to.include('fa-test', 'fa')

--- a/test/components/navbar.spec.coffee
+++ b/test/components/navbar.spec.coffee
@@ -52,7 +52,7 @@ TEACHER_MENU = [
   }
   {
     name: 'courseSettings'
-    label: 'Course Settings'
+    label: 'Course Roster'
   }
   {
     name: 'viewReferenceBook'

--- a/test/current-user-store.spec.coffee
+++ b/test/current-user-store.spec.coffee
@@ -39,7 +39,7 @@ TEACHER_MENU = [
   }
   {
     name: 'courseSettings'
-    label: 'Course Settings'
+    label: 'Course Roster'
   }
   {
     name: 'viewReferenceBook'


### PR DESCRIPTION

 * Renames Delete action to be Drop
 * Renames the link to be "Course Roster"
 * Removes the add student button
 * Fixes a dumb bug in the Icon component and adds a spec so it doesn't re-occur.

![screen shot 2015-08-03 at 1 07 03 pm](https://cloud.githubusercontent.com/assets/79566/9044181/8f5fcb26-39e0-11e5-81eb-ec0005b9a5ad.png)

