### PR TITLE
Fix various bugs to do with plan publishing and clicking on plans

### DIFF
--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -105,6 +105,8 @@ CourseDuration = React.createClass
     if plan.published_at? and plan.publish_last_requested_at?
       # is the last requested publishing after the last completed publish?
       isPublishing = moment(plan.publish_last_requested_at).diff(plan.published_at) > 0
+    else if plan.published_at? and not plan.publish_last_requested_at?
+      isPublishing = false
     else if plan.publish_last_requested_at?
       recent = moment(TimeStore.getNow()).diff(plan.publish_last_requested_at) < @props.recentTolerance
       isPublishing = isPublishing and recent

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -70,11 +70,13 @@ CoursePlan = React.createClass
   # handles when route changes and modal show/hide needs to sync
   # i.e. when using back or forward on browser
   syncStatsWithState: ->
-    return unless @refs.trigger?
 
     if @_isPlanMatchRouteNotOpen()
-      triggerEl = @refs.trigger.getDOMNode()
-      triggerEl.click()
+      if @refs.trigger?
+        triggerEl = @refs.trigger.getDOMNode()
+        triggerEl.click()
+      else
+        @setIsViewingStats(false)
     else if @_isPlanNotMatchingRouteOpen()
       @refs.trigger.hide()
 
@@ -90,16 +92,23 @@ CoursePlan = React.createClass
         isPublishing: (['working', 'queued'].indexOf(published.state) > -1)
 
       @setState(planState)
+      PlanPublishStore.off('planPublish.*', @checkPublishingStatus) if published.state is 'completed'
 
-  componentWillMount: ->
-    {item} = @props
+  subscribeToPublishing: (item) ->
     {plan} = item
     {id, isPublishing, publish_job_uuid} = plan
 
     if isPublishing and not PlanPublishStore.isPublishing(id)
       PlanPublishActions.published({id, publish_job_uuid}) if publish_job_uuid?
 
-    PlanPublishStore.on('planPublish.*', @checkPublishingStatus) if isPublishing
+    PlanPublishStore.on('planPublish.*', @checkPublishingStatus) if isPublishing or PlanPublishStore.isPublishing(id)
+
+  componentWillMount: ->
+    @subscribeToPublishing(@props.item)
+
+  componentWillReceiveProps: (nextProps) ->
+    @subscribeToPublishing(nextProps.item)
+    @closePlanOnModalHide()
 
   componentWillUnmount: ->
     PlanPublishStore.off('planPublish.*', @checkPublishingStatus)
@@ -182,9 +191,10 @@ CoursePlan = React.createClass
 
   renderOpenPlan: (planStyle, planClasses, label) ->
     {item, courseId} = @props
+    {isPublishing} = @state
     {plan, index} = item
 
-    if plan.isPublishing
+    if isPublishing
       planModal = <CoursePlanPublishingDetails
         plan={plan}
         courseId={courseId}
@@ -264,7 +274,7 @@ CoursePlan = React.createClass
     planClasses.push('is-published') if plan.isPublished or (publishState is 'completed')
     planClasses.push('is-failed') if plan.isFailed
     planClasses.push('is-killed') if plan.isKilled
-    planClasses.push('is-publishing') if plan.isPublishing or isPublishing
+    planClasses.push('is-publishing') if isPublishing
     planClasses.push('is-open') if plan.isOpen
     planClasses.push('is-trouble') if plan.isTrouble
 
@@ -273,7 +283,7 @@ CoursePlan = React.createClass
     label = @renderLabel(rangeDuration, durationLength, plan, index, offset)
 
     renderFn = 'renderEditPlan'
-    renderFn = 'renderOpenPlan' if plan.isOpen and plan.isPublished or (plan.isPublishing or isPublishing)
+    renderFn = 'renderOpenPlan' if plan.isOpen and plan.isPublished or (isPublishing) or (publishState is 'completed')
 
     @[renderFn](planStyle, planClasses, label)
 


### PR DESCRIPTION
## Plan Details for raked plans fixed
![screen shot 2015-08-03 at 2 35 28 pm](https://cloud.githubusercontent.com/assets/2483873/9045978/34172d9c-39ed-11e5-8ada-f6fc237b198a.png)

## Getting ready to publish a new plan
![screen shot 2015-08-03 at 2 36 01 pm](https://cloud.githubusercontent.com/assets/2483873/9045980/34197cb4-39ed-11e5-866c-1fba2ee0e3c6.png)

## Plan shows as publishing as expected
![screen shot 2015-08-03 at 2 36 07 pm](https://cloud.githubusercontent.com/assets/2483873/9045981/3419d416-39ed-11e5-8458-9a0f1478d976.png)

## Plan details shows plan as publishing
![screen shot 2015-08-03 at 2 36 13 pm](https://cloud.githubusercontent.com/assets/2483873/9045982/341a13ae-39ed-11e5-94f9-59b294c033e1.png)

## publishing plan details properly close
![screen shot 2015-08-03 at 2 36 28 pm](https://cloud.githubusercontent.com/assets/2483873/9045983/341c4a20-39ed-11e5-9365-ead3162deeca.png)

## plan updates properly when plan completes publishing
![screen shot 2015-08-03 at 2 37 19 pm](https://cloud.githubusercontent.com/assets/2483873/9045979/3417dc24-39ed-11e5-85ea-a661148827d4.png)

## plan details can be opened as expected after publish is completed
![screen shot 2015-08-03 at 2 37 22 pm](https://cloud.githubusercontent.com/assets/2483873/9045984/3421e6a6-39ed-11e5-9b5f-0b79342da456.png)





# Problems before fix