### PR TITLE
Bug/builder external edit restrictions

### DIFF
--- a/src/components/task-plan/external/index.cjsx
+++ b/src/components/task-plan/external/index.cjsx
@@ -45,7 +45,7 @@ ExternalPlan = React.createClass
     if @state?.invalid then formClasses.push('is-invalid-form')
 
     isURLLocked = TaskPlanStore.isOpened(id) and TaskPlanStore.isPublished(id)
-    label = "#{label} (Cannot be changed once plan is opened and published)" if isURLLocked
+    label = "#{label} (Cannot be changed once assignment is opened and published)" if isURLLocked
 
     <div className='external-plan'>
       <BS.Panel bsStyle='primary'

--- a/src/components/task-plan/external/index.cjsx
+++ b/src/components/task-plan/external/index.cjsx
@@ -41,7 +41,11 @@ ExternalPlan = React.createClass
 
     footer = <PlanFooter id={id} courseId={courseId} onPublish={@publish} onSave={@save}/>
     header = [headerText, closeBtn]
+    label = 'Assignment URL'
     if @state?.invalid then formClasses.push('is-invalid-form')
+
+    isURLLocked = TaskPlanStore.isOpened(id) and TaskPlanStore.isPublished(id)
+    label = "#{label} (Cannot be changed once plan is opened and published)" if isURLLocked
 
     <div className='external-plan'>
       <BS.Panel bsStyle='primary'
@@ -55,7 +59,8 @@ ExternalPlan = React.createClass
           <BS.Row>
             <BS.Col xs={12} md={12}>
               <TutorInput
-                label='Assignment URL'
+                disabled={isURLLocked}
+                label={label}
                 className='external-url'
                 id='external-url'
                 default={externalUrl}

--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -47,7 +47,7 @@ PlanFooter = React.createClass
 
     saveable = not TaskPlanStore.isPublished(id)
     isWaiting = TaskPlanStore.isSaving(id)
-    deleteable = not TaskPlanStore.isNew(id) and not TaskPlanStore.isOpened(id) and not isWaiting
+    deleteable = not TaskPlanStore.isNew(id) and not (TaskPlanStore.isOpened(id) and TaskPlanStore.isPublished(id)) and not isWaiting
     isFailed = TaskPlanStore.isFailed(id)
 
     publishButton =

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -57,6 +57,8 @@ TutorInput = React.createClass
       <errorWarning key={error}/>
     )
 
+    inputProps = _.omit(@props, 'label', 'className', 'onChange', 'validate', 'default', 'value')
+
     # Please do not set value={@props.value} on input.
     #
     # Because we are updating the store in some cases on change, and
@@ -67,9 +69,8 @@ TutorInput = React.createClass
     # Instead, use @props.default to set an intial defaul value.
     <div className={wrapperClasses.join(' ')}>
       <input
-        id={@props.id}
+        {...inputProps}
         ref='input'
-        type={@props.type}
         className={classes.join(' ')}
         defaultValue={@props.default}
         onChange={@onChange}


### PR DESCRIPTION
## Allow delete of all draft plans, even if opened
![screen shot 2015-08-03 at 4 59 20 pm](https://cloud.githubusercontent.com/assets/2483873/9048749/2b63aa04-3a01-11e5-8474-b4293c4fc8a1.png)

## Disable URL editing of external after plan is published and opened
![screen shot 2015-08-03 at 4 58 33 pm](https://cloud.githubusercontent.com/assets/2483873/9048762/3c8f5a9e-3a01-11e5-82cd-70f81a7eeb02.png)
