### PR TITLE
Match title displayed to selected entry from ToC

### DIFF
--- a/resources/styles/components/course-calendar/month.less
+++ b/resources/styles/components/course-calendar/month.less
@@ -44,7 +44,7 @@
 
   .calendar-loading {
     .rc-Month {
-      .tutor-subtle-loading('Loading Calendar...');
+      .tutor-subtle-load(loading);
     }
   }
 
@@ -62,6 +62,7 @@
       display: inline-block;
       vertical-align: top;
       position: relative;
+      .tutor-subtle-load(will-load; 'Loading Calendar...');
 
       &-weekdays {
         width: 100%;

--- a/resources/styles/components/course-calendar/month.less
+++ b/resources/styles/components/course-calendar/month.less
@@ -43,20 +43,8 @@
   }
 
   .calendar-loading {
-    .rc-Month:after {
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      content: 'Loading Calendar...';
-      // TODO update colors
-      background: rgba(255, 255, 255, 0.75);
-      top: 0;
-      text-align: center;
-      font-size: 3rem;
-      line-height: 10em;
-      opacity: 1;
-
-      .transition(opacity .25s ease-in-out);
+    .rc-Month {
+      .tutor-subtle-loading('Loading Calendar...');
     }
   }
 

--- a/resources/styles/components/reference-book/page.less
+++ b/resources/styles/components/reference-book/page.less
@@ -62,6 +62,22 @@
   .page-wrapper {
     transition: margin-left 0.2s linear;
   }
+
+  .page-loading {
+    text-align: center;
+    .page {
+      position: relative;
+      .tutor-subtle-loading('Loading page...');
+  
+      &::after {
+        left: 0;
+        top: -8px;
+        background: rgba(255, 255, 255, 0.9);
+      }
+    }
+  }
+
+
   // when menu is open and the screen is wide enough, slide everything to the right so it's still visible
   &.menu-open {
     @media screen and (min-width: (@reference-book-page-width + @reference-book-menu-width + 50px) ) {

--- a/resources/styles/components/reference-book/page.less
+++ b/resources/styles/components/reference-book/page.less
@@ -61,23 +61,27 @@
 
   .page-wrapper {
     transition: margin-left 0.2s linear;
-  }
-
-  .page-loading {
-    text-align: center;
     .page {
       position: relative;
-      .tutor-subtle-loading('Loading page...');
-  
+      .tutor-subtle-load(will-load; 'Loading page...'; 0.1s);
+
       &::after {
         left: 0;
         top: -8px;
-        background: rgba(255, 255, 255, 0.9);
+      }
+    }
+
+    &.page-loading {
+      .refresh-button {
+        position: absolute;
+        left: 50%;
+        z-index: 2;
+      }
+      .page {
+        .tutor-subtle-load(loading);
       }
     }
   }
-
-
   // when menu is open and the screen is wide enough, slide everything to the right so it's still visible
   &.menu-open {
     @media screen and (min-width: (@reference-book-page-width + @reference-book-menu-width + 50px) ) {

--- a/resources/styles/mixins.less
+++ b/resources/styles/mixins.less
@@ -126,6 +126,24 @@
 }
 
 
+.tutor-subtle-loading(@loading-text: 'Loading...') {
+  &::after{
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    content: @loading-text;
+    // TODO update colors
+    background: rgba(255, 255, 255, 0.75);
+    top: 0;
+    text-align: center;
+    font-size: 3rem;
+    line-height: 10em;
+    opacity: 1;
+
+    .transition(opacity .25s ease-in-out);
+  }
+}
+
 // If you want to use these please uncomment.
 //
 // .tutor-shadow(3) {

--- a/resources/styles/mixins.less
+++ b/resources/styles/mixins.less
@@ -126,21 +126,26 @@
 }
 
 
-.tutor-subtle-loading(@loading-text: 'Loading...') {
-  &::after{
+.tutor-subtle-load(will-load; @loading-text: 'Loading...'; @trans-time: 0.25s; @bg-fade: 90%; @bg-base: @tutor-white;) {
+  &::after {
     position: absolute;
     width: 100%;
     height: 100%;
     content: @loading-text;
-    // TODO update colors
-    background: rgba(255, 255, 255, 0.75);
+    background: fade(@bg-base, @bg-fade);
     top: 0;
     text-align: center;
     font-size: 3rem;
     line-height: 10em;
-    opacity: 1;
+    opacity: 0;
 
-    .transition(opacity .25s ease-in-out);
+    .transition(opacity @trans-time ease-in-out);
+  }
+}
+
+.tutor-subtle-load(loading) {
+  &::after {
+    opacity: 1;
   }
 }
 

--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -39,7 +39,7 @@ module.exports =
       else
         img.onload = sizeImage
 
-  getCNXIdOfHref: (href) ->
+  getCnxIdOfHref: (href) ->
     beforeHash = _.first(href.split('#'))
     _.last(beforeHash.split('/'))
 
@@ -50,7 +50,7 @@ module.exports =
 
   buildReferenceBookLink: (cnxId) ->
     referenceBookParams = _.clone(@context.router.getCurrentParams())
-    referenceBookParams.cnxId = cnxId or @getCNXId()
+    referenceBookParams.cnxId = cnxId or @getCnxId()
     pageUrl = @context.router.makeHref('viewReferenceBookPage', referenceBookParams)
 
     pageUrl
@@ -86,7 +86,7 @@ module.exports =
       return link
 
   linkToAnotherPage: (link) ->
-    mediaCNXId = @getCNXIdOfHref(link.getAttribute('href')) or @getCNXId()
+    mediaCNXId = @getCnxIdOfHref(link.getAttribute('href')) or @getCnxId()
     @linkMediaElsewhere(mediaCNXId, link) if mediaCNXId?
 
   linkToThisPage: (link) ->

--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -86,7 +86,7 @@ module.exports =
       return link
 
   linkToAnotherPage: (link) ->
-    mediaCNXId = @getCnxIdOfHref(link.getAttribute('href')) or @getCnxId()
+    mediaCNXId = @getCnxIdOfHref(link.getAttribute('href')) or @props.cnxId or @getCnxId?()
     @linkMediaElsewhere(mediaCNXId, link) if mediaCNXId?
 
   linkToThisPage: (link) ->

--- a/src/components/chapter-section-mixin.cjsx
+++ b/src/components/chapter-section-mixin.cjsx
@@ -18,6 +18,8 @@ module.exports =
     # ignore 0 in chapter sections
     sectionArray.pop() if skipZeros and _.last(sectionArray) is 0
 
+    console.info('sectionArray')
+    console.info(sectionArray)
     if sectionArray instanceof Array
       sectionArray.join(separator or sectionSeparator)
     else

--- a/src/components/chapter-section-mixin.cjsx
+++ b/src/components/chapter-section-mixin.cjsx
@@ -18,8 +18,6 @@ module.exports =
     # ignore 0 in chapter sections
     sectionArray.pop() if skipZeros and _.last(sectionArray) is 0
 
-    console.info('sectionArray')
-    console.info(sectionArray)
     if sectionArray instanceof Array
       sectionArray.join(separator or sectionSeparator)
     else

--- a/src/components/chapter-section-mixin.cjsx
+++ b/src/components/chapter-section-mixin.cjsx
@@ -4,14 +4,21 @@ module.exports =
   getInitialState: ->
     sectionSeparator: '.'
     skipZeros: true
+    inputStringSeparator: '.'
 
   sectionFormat: (section, separator) ->
-    # prevent mutation
-    section = _.clone(section)
-    # ignore 0 in chapter sections
-    section.pop() if @state.skipZeros and _.last(section) is 0
+    {inputStringSeparator, skipZeros, sectionSeparator} = @state
 
-    if section instanceof Array
-      section.join(separator or @state.sectionSeparator)
+    if _.isString(section)
+      sectionArray = section.split(inputStringSeparator)
+
+    sectionArray = section if _.isArray(section)
+    # prevent mutation
+    sectionArray = _.clone(sectionArray)
+    # ignore 0 in chapter sections
+    sectionArray.pop() if skipZeros and _.last(sectionArray) is 0
+
+    if sectionArray instanceof Array
+      sectionArray.join(separator or sectionSeparator)
     else
       section

--- a/src/components/reference-book/index.cjsx
+++ b/src/components/reference-book/index.cjsx
@@ -14,31 +14,16 @@ ReferenceBookPage = require './page'
 
 ReferenceBookPageShell = React.createClass
   displayName: 'ReferenceBookPageShell'
-  contextTypes:
-    router: React.PropTypes.func
-
-  getProps: ->
-    params = {courseId, cnxId, section} = @context.router.getCurrentParams()
-    return params if courseId? and cnxId? and section?
-
-    if section?
-      page = ReferenceBookStore.getChapterSectionPage({courseId, section})
-    else
-      section = ReferenceBookStore.getFirstSection(courseId)
-      page = _.first ReferenceBookStore.getPages(courseId)
-
-    cnxId ?= page.cnx_id
-
-    {cnxId, section, courseId}
-
+  propTypes:
+    courseId: React.PropTypes.string.isRequired
+    cnxId: React.PropTypes.string.isRequired
   render: ->
-    pageProps = @getProps()
-    if pageProps.cnxId?
+    if @props.cnxId?
       <LoadableItem
-        id={pageProps.cnxId}
+        id={@props.cnxId}
         store={ReferenceBookPageStore}
         actions={ReferenceBookPageActions}
-        renderItem={ -> <ReferenceBookPage {...pageProps}/> }
+        renderItem={ => <ReferenceBookPage {...@props}/> }
       />
     else
       <Invalid />

--- a/src/components/reference-book/index.cjsx
+++ b/src/components/reference-book/index.cjsx
@@ -27,14 +27,18 @@ ReferenceBookPageShell = React.createClass
   renderLoading: (previousPageProps, currentProps) ->
     (refreshButton) ->
       if previousPageProps? and not _.isEqual(previousPageProps, currentProps)
-        loading = <div className='page-loading loadable is-loading'>
+        loading = <ReferenceBookPage
+          {...previousPageProps}
+          className='page-loading loadable is-loading'>
           {refreshButton}
-          <ReferenceBookPage {...previousPageProps}/>
-        </div>
+        </ReferenceBookPage>
       else
         loading = <div className='loadable is-loading'>Loading... {refreshButton}</div>
 
       loading
+
+  renderLoaded: ->
+    <ReferenceBookPage {...@props}/>
 
   render: ->
     if @props.cnxId?
@@ -43,7 +47,7 @@ ReferenceBookPageShell = React.createClass
         store={ReferenceBookPageStore}
         actions={ReferenceBookPageActions}
         renderLoading={@renderLoading(@state?.previousPageProps, @props)}
-        renderItem={ => <ReferenceBookPage {...@props}/> }
+        renderItem={@renderLoaded}
       />
     else
       <Invalid />

--- a/src/components/reference-book/index.cjsx
+++ b/src/components/reference-book/index.cjsx
@@ -17,12 +17,32 @@ ReferenceBookPageShell = React.createClass
   propTypes:
     courseId: React.PropTypes.string.isRequired
     cnxId: React.PropTypes.string.isRequired
+
+  getDefaultState: ->
+    previousPageProps: null
+
+  componentWillReceiveProps: ->
+    @setState(previousPageProps: @props)
+
+  renderLoading: (previousPageProps, currentProps) ->
+    (refreshButton) ->
+      if previousPageProps? and not _.isEqual(previousPageProps, currentProps)
+        loading = <div className='page-loading loadable is-loading'>
+          {refreshButton}
+          <ReferenceBookPage {...previousPageProps}/>
+        </div>
+      else
+        loading = <div className='loadable is-loading'>Loading... {refreshButton}</div>
+
+      loading
+
   render: ->
     if @props.cnxId?
       <LoadableItem
         id={@props.cnxId}
         store={ReferenceBookPageStore}
         actions={ReferenceBookPageActions}
+        renderLoading={@renderLoading(@state?.previousPageProps, @props)}
         renderItem={ => <ReferenceBookPage {...@props}/> }
       />
     else

--- a/src/components/reference-book/index.cjsx
+++ b/src/components/reference-book/index.cjsx
@@ -12,38 +12,33 @@ moment = require 'moment'
 ReferenceBook = require './reference-book'
 ReferenceBookPage = require './page'
 
-ReferenceBookFirstPage  = React.createClass
-  displayName: 'ReferenceBookPageFirstPage'
-  contextTypes:
-    router: React.PropTypes.func
-  render: ->
-    {courseId} = @context.router.getCurrentParams()
-    page = _.first ReferenceBookStore.getPages(courseId)
-    <LoadableItem
-      id={page.cnx_id}
-      store={ReferenceBookPageStore}
-      actions={ReferenceBookPageActions}
-      renderItem={ -> <ReferenceBookPage courseId={courseId} cnxId={page.cnx_id}/> }
-    />
-
-
-
 ReferenceBookPageShell = React.createClass
   displayName: 'ReferenceBookPageShell'
   contextTypes:
     router: React.PropTypes.func
 
-  render: ->
-    {courseId, cnxId, section} = @context.router.getCurrentParams()
-    if section and not cnxId
+  getProps: ->
+    params = {courseId, cnxId, section} = @context.router.getCurrentParams()
+    return params if courseId? and cnxId? and section?
+
+    if section?
       page = ReferenceBookStore.getChapterSectionPage({courseId, section})
-      cnxId = page?.cnx_id
-    if cnxId
+    else
+      section = ReferenceBookStore.getFirstSection(courseId)
+      page = _.first ReferenceBookStore.getPages(courseId)
+
+    cnxId ?= page.cnx_id
+
+    {cnxId, section, courseId}
+
+  render: ->
+    pageProps = @getProps()
+    if pageProps.cnxId?
       <LoadableItem
-        id={cnxId}
+        id={pageProps.cnxId}
         store={ReferenceBookPageStore}
         actions={ReferenceBookPageActions}
-        renderItem={ -> <ReferenceBookPage courseId=courseId cnxId={cnxId}/> }
+        renderItem={ -> <ReferenceBookPage {...pageProps}/> }
       />
     else
       <Invalid />
@@ -64,4 +59,4 @@ ReferenceBookShell = React.createClass
     />
 
 
-module.exports = {ReferenceBookShell, ReferenceBookPageShell, ReferenceBookFirstPage}
+module.exports = {ReferenceBookShell, ReferenceBookPageShell}

--- a/src/components/reference-book/navbar.cjsx
+++ b/src/components/reference-book/navbar.cjsx
@@ -21,16 +21,10 @@ module.exports = React.createClass
 
   renderSectionTitle: ->
     params = @context.router.getCurrentParams()
-    {cnxId, section} = params
-    if cnxId
-      page = ReferenceBookStore.getPageInfo(params)
-      section = page?.chapter_section
-    else if section
-      page = ReferenceBookStore.getChapterSectionPage(params)
-    section = section.split('.') if section and _.isString(section)
+    title = ReferenceBookStore.getPageTitle(params)
     <BS.Nav navbar className="section-title">
-        <ChapterSection section={section} />
-        {page?.title}
+        <ChapterSection section={params.section.split('.')} />
+        {title}
     </BS.Nav>
 
 

--- a/src/components/reference-book/navbar.cjsx
+++ b/src/components/reference-book/navbar.cjsx
@@ -18,8 +18,6 @@ module.exports = React.createClass
     showTeacherEdition: React.PropTypes.func
     courseId: React.PropTypes.string.isRequired
     section: React.PropTypes.string.isRequired
-  contextTypes:
-    router: React.PropTypes.func
 
   renderSectionTitle: ->
     {section, courseId} = @props
@@ -39,8 +37,6 @@ module.exports = React.createClass
     </BS.Nav>
 
   render: ->
-    {cnxId} = @context.router.getCurrentParams()
-
     <BS.Navbar fixedTop fluid>
       <BS.Nav navbar>
         <BS.NavItem onClick={@props.toggleTocMenu}>

--- a/src/components/reference-book/navbar.cjsx
+++ b/src/components/reference-book/navbar.cjsx
@@ -16,12 +16,13 @@ module.exports = React.createClass
     teacherLinkText: React.PropTypes.string
     toggleTocMenu: React.PropTypes.func.isRequired
     showTeacherEdition: React.PropTypes.func
+    courseId: React.PropTypes.string.isRequired
+    section: React.PropTypes.string.isRequired
   contextTypes:
     router: React.PropTypes.func
 
   renderSectionTitle: ->
-    {section, courseId} = @context.router.getCurrentParams()
-    section ?= ReferenceBookStore.getFirstSection(courseId)
+    {section, courseId} = @props
     title = ReferenceBookStore.getPageTitle({section, courseId})
 
     <BS.Nav navbar className="section-title">

--- a/src/components/reference-book/navbar.cjsx
+++ b/src/components/reference-book/navbar.cjsx
@@ -20,11 +20,13 @@ module.exports = React.createClass
     router: React.PropTypes.func
 
   renderSectionTitle: ->
-    params = @context.router.getCurrentParams()
-    title = ReferenceBookStore.getPageTitle(params)
+    {section, courseId} = @context.router.getCurrentParams()
+    section ?= ReferenceBookStore.getFirstSection(courseId)
+    title = ReferenceBookStore.getPageTitle({section, courseId})
+
     <BS.Nav navbar className="section-title">
-        <ChapterSection section={params.section.split('.')} />
-        {title}
+      <ChapterSection section={section} />
+      {title}
     </BS.Nav>
 
 

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -26,9 +26,7 @@ module.exports = React.createClass
     @props.cnxId or @context.router.getCurrentParams().cnxId
 
   getSplashTitle: ->
-    cnxId = @getCnxId()
-    page = ReferenceBookStore.getPageInfo({courseId: @props.courseId, cnxId})
-    page?.title
+    ReferenceBookStore.getPageTitle(@context.router.getCurrentParams())
 
   prevLink: (info) ->
     <Router.Link className='nav prev' to='viewReferenceBookSection'

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -18,12 +18,10 @@ module.exports = React.createClass
   displayName: 'ReferenceBookPage'
   propTypes:
     courseId: React.PropTypes.string.isRequired
+    cnxId: React.PropTypes.string.isRequired
   contextTypes:
     router: React.PropTypes.func
   mixins: [BookContentMixin, GetPositionMixin]
-
-  getCnxId: ->
-    @props.cnxId or @context.router.getCurrentParams().cnxId
 
   getSplashTitle: ->
     ReferenceBookStore.getPageTitle(@props)
@@ -98,9 +96,8 @@ module.exports = React.createClass
     _.each(@_exerciseNodes, @unmountExerciseComponent)
 
   render: ->
-    {courseId} = @context.router.getCurrentParams()
+    {courseId, cnxId} = @props
     # read the id from props, or failing that the url
-    cnxId = @getCnxId()
     page = ReferenceBookPageStore.get(cnxId)
     info = ReferenceBookStore.getPageInfo({courseId, cnxId})
 

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -99,7 +99,7 @@ module.exports = React.createClass
     _.each(@_exerciseNodes, @unmountExerciseComponent)
 
   render: ->
-    {courseId, cnxId} = @props
+    {courseId, cnxId, className} = @props
     # read the id from props, or failing that the url
     page = ReferenceBookPageStore.get(cnxId)
     info = ReferenceBookStore.getPageInfo({courseId, cnxId})
@@ -111,7 +111,13 @@ module.exports = React.createClass
       .replace(/^[\s\S]*<body[\s\S]*?>/, '')
       .replace(/<\/body>[\s\S]*$/, '')
 
-    <div className='page-wrapper'>
+    if className?
+      className += ' page-wrapper'
+    else
+      className = 'page-wrapper'
+
+    <div className={className}>
+      {@props.children}
       {@prevLink(info) if info.prev}
       <ArbitraryHtmlAndMath className='page' block html={html} />
       {@nextLink(info) if info.next}

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -26,7 +26,7 @@ module.exports = React.createClass
     @props.cnxId or @context.router.getCurrentParams().cnxId
 
   getSplashTitle: ->
-    ReferenceBookStore.getPageTitle(@context.router.getCurrentParams())
+    ReferenceBookStore.getPageTitle(@props)
 
   prevLink: (info) ->
     <Router.Link className='nav prev' to='viewReferenceBookSection'

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -7,6 +7,8 @@ HTML = require '../html'
 ArbitraryHtmlAndMath = require '../html'
 BookContentMixin = require '../book-content-mixin'
 GetPositionMixin = require '../get-position-mixin'
+ChapterSectionMixin = require '../chapter-section-mixin'
+
 {ReferenceBookExerciseShell} = require './exercise'
 
 {ReferenceBookPageStore} = require '../../flux/reference-book-page'
@@ -19,22 +21,21 @@ module.exports = React.createClass
   propTypes:
     courseId: React.PropTypes.string.isRequired
     cnxId: React.PropTypes.string.isRequired
-  contextTypes:
-    router: React.PropTypes.func
-  mixins: [BookContentMixin, GetPositionMixin]
-
+  mixins: [BookContentMixin, GetPositionMixin, ChapterSectionMixin]
+  componentWillMount: ->
+    @setState(skipZeros: false)
   getSplashTitle: ->
     ReferenceBookStore.getPageTitle(@props)
 
   prevLink: (info) ->
     <Router.Link className='nav prev' to='viewReferenceBookSection'
-      params={courseId: @props.courseId, section: info.prev.chapter_section.join('.')}>
+      params={courseId: @props.courseId, section: @sectionFormat(info.prev.chapter_section)}>
       <div className='triangle' />
     </Router.Link>
 
   nextLink: (info) ->
     <Router.Link className='nav next' to='viewReferenceBookSection'
-      params={courseId: @props.courseId, section: info.next.chapter_section.join('.')}>
+      params={courseId: @props.courseId, section: @sectionFormat(info.next.chapter_section)}>
       <div className='triangle' />
     </Router.Link>
 

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -22,6 +22,8 @@ module.exports = React.createClass
     courseId: React.PropTypes.string.isRequired
     cnxId: React.PropTypes.string.isRequired
   mixins: [BookContentMixin, GetPositionMixin, ChapterSectionMixin]
+  contextTypes:
+    router: React.PropTypes.func
   componentWillMount: ->
     @setState(skipZeros: false)
   getSplashTitle: ->

--- a/src/components/reference-book/reference-book.cjsx
+++ b/src/components/reference-book/reference-book.cjsx
@@ -10,6 +10,7 @@ Menu = require './slide-out-menu'
 
 {CourseListingStore} = require '../../flux/course-listing'
 {CourseStore} = require '../../flux/course'
+{ReferenceBookActions, ReferenceBookStore} = require '../../flux/reference-book'
 
 # menu width (300) + page width (1000) + 50 px padding
 # corresponds to @reference-book-page-width and @reference-book-menu-width in variables.less
@@ -24,7 +25,28 @@ module.exports = React.createClass
   bindEvent: 'loaded'
 
   componentWillMount: ->
+    {courseId, cnxId, section} = @context.router.getCurrentParams()
+
+    unless cnxId? or section?
+      section = ReferenceBookStore.getFirstSection(courseId)
+      @context.router.transitionTo('viewReferenceBookSection', {courseId, section})
+      return
+
     CourseListingStore.ensureLoaded()
+
+  getPageProps: ->
+    params = {courseId, cnxId, section} = @context.router.getCurrentParams()
+    return params if courseId? and cnxId? and section?
+
+    if section?
+      page = ReferenceBookStore.getChapterSectionPage({courseId, section})
+    else if cnxId?
+      page = ReferenceBookStore.getPageInfo({courseId, cnxId})
+      section = page.chapter_section
+
+    cnxId ?= page?.cnx_id
+
+    {cnxId, section, courseId}
 
   getInitialState: ->
     {cnxId} = @context.router.getCurrentParams()
@@ -45,6 +67,7 @@ module.exports = React.createClass
   render: ->
     {courseId} = @context.router.getCurrentParams()
     courseDataProps = @getCourseDataProps(courseId)
+    pageProps = @getPageProps()
 
     course = CourseStore.get(courseId)
     classnames = ["reference-book"]
@@ -59,12 +82,12 @@ module.exports = React.createClass
 
     <div {...courseDataProps} className={classnames.join(' ')}>
       <NavBar
+        {...pageProps}
         toggleTocMenu={@toggleMenuState}
         teacherLinkText={teacherLinkText}
-        showTeacherEdition={toggleTeacher}
-        courseId={courseId}/>
+        showTeacherEdition={toggleTeacher} />
       <div className="content">
-        <Menu onMenuSelection={@onMenuClick} />
-        <Router.RouteHandler courseId={courseId} />
+        <Menu {...pageProps} onMenuSelection={@onMenuClick} />
+        <Router.RouteHandler {...pageProps} />
       </div>
     </div>

--- a/src/components/reference-book/reference-book.cjsx
+++ b/src/components/reference-book/reference-book.cjsx
@@ -65,9 +65,9 @@ module.exports = React.createClass
     ev?.preventDefault() # needed to prevent scrolling to top
 
   render: ->
-    {courseId} = @context.router.getCurrentParams()
-    courseDataProps = @getCourseDataProps(courseId)
     pageProps = @getPageProps()
+    {courseId} = pageProps
+    courseDataProps = @getCourseDataProps(courseId)
 
     course = CourseStore.get(courseId)
     classnames = ["reference-book"]

--- a/src/components/reference-book/slide-out-menu.cjsx
+++ b/src/components/reference-book/slide-out-menu.cjsx
@@ -10,7 +10,5 @@ module.exports = React.createClass
 
   render: ->
     <div className='menu'>
-      <ReferenceBookTOC visible={@props.visible}
-        courseId={@props.courseId}
-        onMenuSelection={@props.onMenuSelection} />
+      <ReferenceBookTOC {...@props} visible={@props.visible} />
     </div>

--- a/src/components/task-plan/chapter-section.cjsx
+++ b/src/components/task-plan/chapter-section.cjsx
@@ -1,10 +1,15 @@
 React = require 'react'
 ChapterSectionMixin = require '../chapter-section-mixin'
+_ = require 'underscore'
 
 module.exports = React.createClass
   displayName: 'ChapterSection'
   propTypes:
-    section: React.PropTypes.array.isRequired
+    section: React.PropTypes.oneOfType(
+      React.PropTypes.array
+      React.PropTypes.string
+    ).isRequired
+
   componentWillMount: ->
     @setState(skipZeros: false)
   mixins: [ChapterSectionMixin]

--- a/src/components/task-step/all-steps.cjsx
+++ b/src/components/task-step/all-steps.cjsx
@@ -34,7 +34,7 @@ Reading = React.createClass
   getSplashTitle: ->
     TaskStepStore.get(@props.id)?.title or ''
 
-  getCNXId: ->
+  getCnxId: ->
     {id} = @props
     {content_url} = TaskStepStore.get(id)
     _.last(content_url.split('contents/'))

--- a/src/flux/reference-book.coffee
+++ b/src/flux/reference-book.coffee
@@ -39,6 +39,11 @@ ReferenceBookConfig = {
       else
         null
 
+    getPageTitle: ({courseId, section}) ->
+      toc = @_get(courseId)?['0']
+      section = _.map(section.split('.'), (n) -> parseInt(n))
+      findChapterSection(toc, section)?.title
+
     getPages: (courseId) ->
       toc = @_get(courseId)?['0']
       return [] unless toc

--- a/src/flux/reference-book.coffee
+++ b/src/flux/reference-book.coffee
@@ -25,6 +25,18 @@ ReferenceBookConfig = {
     getToc: (courseId) ->
       @_get(courseId)['0']
 
+    getFirstSection: (courseId) ->
+      toc = @_get(courseId)?['0']
+      return null unless toc?.children?
+
+      {children} = toc
+      _.chain(children)
+        .sortBy((child) ->
+          child.chapter_section
+        )
+        .first()
+        .value()?.chapter_section
+
     # Takes a courseId and a chapter_section specifier
     # which is a string joined with dots i.e. "1.2.3"
     getChapterSectionPage: ({courseId, section}) ->
@@ -40,8 +52,10 @@ ReferenceBookConfig = {
         null
 
     getPageTitle: ({courseId, section}) ->
+      return null unless section?
+      section = section.split('.') unless _.isArray(section)
       toc = @_get(courseId)?['0']
-      section = _.map(section.split('.'), (n) -> parseInt(n))
+      section = _.map(section, (n) -> parseInt(n))
       findChapterSection(toc, section)?.title
 
     getPages: (courseId) ->

--- a/src/router.cjsx
+++ b/src/router.cjsx
@@ -74,7 +74,7 @@ routes = (
       <Route path='sandbox/?' name='sandbox' handler={Sandbox} />
     </Route> # end of App route
     <Route path='/books/:courseId' name='viewReferenceBook' handler={ReferenceBookShell}>
-      <Router.DefaultRoute name="viewReferenceBookFirstPage" handler={ReferenceBookFirstPage}/>
+      <Router.DefaultRoute name="viewReferenceBookFirstPage" handler={ReferenceBookPageShell}/>
 
       <Route path='section/:section'
         name='viewReferenceBookSection' handler={ReferenceBookPageShell} />


### PR DESCRIPTION
This way the title will always match the selected entry

With chapter 7 selected, before:
<img width="1360" alt="screen shot 2015-08-03 at 9 26 55 pm" src="https://cloud.githubusercontent.com/assets/79566/9051885/9013540c-3a26-11e5-9f8c-3cc1b7e88da5.png">


After:
<img width="1352" alt="screen shot 2015-08-03 at 9 27 36 pm" src="https://cloud.githubusercontent.com/assets/79566/9051887/970a24b6-3a26-11e5-8538-e8e2403d72a1.png">


## linked by page will also show title and can show active TOC item
![screen shot 2015-08-04 at 3 58 54 pm](https://cloud.githubusercontent.com/assets/2483873/9073200/6448f79c-3ac5-11e5-84d3-6072132fd68c.png)

## Subtle loading
![screen shot 2015-08-05 at 10 04 54 am](https://cloud.githubusercontent.com/assets/2483873/9089866/f774e534-3b5c-11e5-9271-fbbc7d438d1b.png)
![screen shot 2015-08-05 at 10 04 58 am](https://cloud.githubusercontent.com/assets/2483873/9089867/f7773f96-3b5c-11e5-90f6-4e90cefbebfd.png)

