### PR TITLE
ignore router default scroll behavior when viewing plan stats on calendar

### DIFF
--- a/src/router.cjsx
+++ b/src/router.cjsx
@@ -43,8 +43,15 @@ routes = (
 
           <Route path='calendar/?' name='taskplans'>
             <Router.DefaultRoute handler={TeacherTaskPlans} />
-            <Route path='months/:date/?' name='calendarByDate' handler={TeacherTaskPlans} >
-              <Route path='plans/:planId/?' name='calendarViewPlanStats'/>
+            <Route
+              path='months/:date/?'
+              name='calendarByDate'
+              handler={TeacherTaskPlans}
+              ignoreScrollBehavior>
+              <Route
+                path='plans/:planId/?'
+                name='calendarViewPlanStats'
+                ignoreScrollBehavior/>
             </Route>
           </Route>
           <Route path='homeworks/new/?' name='createHomework' handler={HomeworkShell} />


### PR DESCRIPTION
Calendar now preserves scroll position as expected

## Scroll position perserved
![screen shot 2015-08-05 at 10 38 17 am](https://cloud.githubusercontent.com/assets/2483873/9090113/410b7a7c-3b5e-11e5-86a6-262a005868ca.png)
![screen shot 2015-08-05 at 10 38 21 am](https://cloud.githubusercontent.com/assets/2483873/9090114/410d7304-3b5e-11e5-97f6-45dd73c7b44e.png)

## Before
![screen shot 2015-08-05 at 10 38 58 am](https://cloud.githubusercontent.com/assets/2483873/9090117/4112199a-3b5e-11e5-8067-b455dc20edd4.png)
![screen shot 2015-08-05 at 10 39 02 am](https://cloud.githubusercontent.com/assets/2483873/9090115/410da5d6-3b5e-11e5-8bcb-ccabfaa7b048.png)
