### PR TITLE
fixes trying to load without cnxId as props on ref book page

### DIFF
--- a/src/components/reference-book/index.cjsx
+++ b/src/components/reference-book/index.cjsx
@@ -26,7 +26,7 @@ ReferenceBookPageShell = React.createClass
 
   renderLoading: (previousPageProps, currentProps) ->
     (refreshButton) ->
-      if previousPageProps? and not _.isEqual(previousPageProps, currentProps)
+      if previousPageProps? and previousPageProps.cnxId? and not _.isEqual(previousPageProps, currentProps)
         loading = <ReferenceBookPage
           {...previousPageProps}
           className='page-loading loadable is-loading'>


### PR DESCRIPTION
When trying to renderLoading, it was trying to render the page despite not having received cnxId as a prop from it's parent yet