### PR TITLE
shows when plan opens on plan label

### DIFF
--- a/resources/styles/components/course-calendar/index.less
+++ b/resources/styles/components/course-calendar/index.less
@@ -14,9 +14,10 @@
 }
 
 .is-not-open() {
-  content: @fa-var-eye-slash;
-  .fa-icon();
-  color: @tutor-neutral;
+  font-weight: 400;
+  font-style: italic;
+  content: 'opens ' attr(data-opens-at);
+  color: @tutor-neutral-darker;
 }
 
 .is-draft() {

--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -124,6 +124,12 @@ CourseDuration = React.createClass
 
     @_getDurationFromMoments(rangeDates)
 
+  _getEarliestOpensAt: (plan) ->
+    openDates = _.pluck(plan.tasking_plans, 'opens_at')
+    rangeDates = _.union(openDates)
+    openRange = @_getDurationFromMoments(rangeDates)
+    openRange.start
+
   # For displaying ranges for units in the future
   setDurationRange: (plan) ->
     plan.duration = @_getDurationRange(plan)
@@ -187,15 +193,19 @@ CourseDuration = React.createClass
         plansByDays: []
         plansInRange: []
 
-      _.each(durationsInView, (plan) ->
+      _.each(durationsInView, (plan) =>
         if plan.duration.overlaps(range)
           counter[plan.id] ?= 0
+
+          simplePlan = _.omit(plan, 'due_at', 'opens_at', 'duration', 'durationAsWeeks')
+          earliestOpensAt = @_getEarliestOpensAt(plan)
+          simplePlan.opensAt = moment(earliestOpensAt).format('M/D')
 
           planForRange =
             rangeDuration: plan.duration.intersection(range)
             offset: moment(range.start).twix(plan.duration.start).length('days')
             duration: plan.duration
-            plan: _.omit(plan, 'due_at', 'opens_at', 'duration', 'durationAsWeeks')
+            plan: simplePlan
             index: counter[plan.id]
 
           # Add plan to plans in range

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -1,5 +1,3 @@
-moment = require 'moment'
-twix = require 'twix'
 _ = require 'underscore'
 
 React = require 'react'
@@ -187,7 +185,11 @@ CoursePlan = React.createClass
 
     labelClass = 'continued' unless index is 0
 
-    label = <label style={planLabelStyle} ref='label' className={labelClass}>{plan.title}</label>
+    label = <label
+      data-opens-at={plan.opensAt}
+      style={planLabelStyle}
+      ref='label'
+      className={labelClass}>{plan.title}</label>
 
   renderOpenPlan: (planStyle, planClasses, label) ->
     {item, courseId} = @props


### PR DESCRIPTION
![screen shot 2015-08-05 at 5 24 27 pm](https://cloud.githubusercontent.com/assets/2483873/9099527/08cd9cec-3b97-11e5-9f06-e0178f0cc5c6.png)

no more eye-slash