### PR TITLE
Fix for issues in AP Connection 

### DIFF
--- a/resources/styles/book-content/ap-bio/ap-connection.less
+++ b/resources/styles/book-content/ap-bio/ap-connection.less
@@ -1,7 +1,10 @@
 .ap-connection {
+  h1 {
+    border-top: 0;
+  }
   h1 + p:first-of-type{
   &::first-letter{
-    float: left;
+    float: none;
     #fonts > .sans(1.75rem, 3.15rem); //setting line-height in em to scale on browser zoom
     font-weight: 400;
     color: @tutor-neutral-dark;


### PR DESCRIPTION
Remove the top border on in AP Connection on title that was still displaying. 

Fixed an alignment issue in Firefox for the first letter of the paragraph
![2015-08-06_11-47-47](https://cloud.githubusercontent.com/assets/8514591/9117595/f92b128e-3c30-11e5-88bb-bc1ddbb8585c.png)
