### PR TITLE
course listing listeners werent binding due to return

### DIFF
--- a/src/components/reference-book/reference-book.cjsx
+++ b/src/components/reference-book/reference-book.cjsx
@@ -29,8 +29,7 @@ module.exports = React.createClass
 
     unless cnxId? or section?
       section = ReferenceBookStore.getFirstSection(courseId)
-      @context.router.transitionTo('viewReferenceBookSection', {courseId, section})
-      return
+      @context.router.replaceWith('viewReferenceBookSection', {courseId, section})
 
     CourseListingStore.ensureLoaded()
 


### PR DESCRIPTION
show/hide teacher edition link will now show even when transitioning from `/book/:courseId`