### PR TITLE
Fix date range on dashboard this week panel

### DIFF
--- a/src/components/student-dashboard/this-week-panel.cjsx
+++ b/src/components/student-dashboard/this-week-panel.cjsx
@@ -12,7 +12,7 @@ module.exports = React.createClass
     courseId: React.PropTypes.string.isRequired
 
   render: ->
-    startAt = moment(TimeStore.getNow())
+    startAt = moment(TimeStore.getNow()).startOf('isoweek')
     events  = StudentDashboardStore.weeklyEventsForDay(@props.courseId, startAt)
     if events.length
       <Events

--- a/src/components/student-dashboard/this-week-panel.cjsx
+++ b/src/components/student-dashboard/this-week-panel.cjsx
@@ -20,7 +20,7 @@ module.exports = React.createClass
         courseId={@props.courseId}
         events=events
         startAt={startAt}
-        endAt={startAt.clone().add(1, 'week')}
+        endAt={startAt.clone().add(1, 'week').subtract(1, 'second')}
       />
     else
       <EmptyPanel/>


### PR DESCRIPTION
Luckily the store grabs all events for the week so at least this was
showing all the events, but was confusing for the title to be incorrect.

Snapshot taken on Aug 6th:

![screen shot 2015-08-06 at 1 56 36 pm](https://cloud.githubusercontent.com/assets/79566/9120656/1346eb68-3c43-11e5-8380-175a2be38d62.png)
