### PR TITLE
Handling  too many breadcrumbs

### DIFF
--- a/resources/styles/components/task/breadcrumbs.less
+++ b/resources/styles/components/task/breadcrumbs.less
@@ -57,25 +57,6 @@
   margin-left: -2px;
   margin-right: -2px;
 
-  &.coverflow {
-    .task-breadcrumbs-step {
-      .box-shadow(0 1px 6px rgba(0, 0, 0, 0.5));
-
-      &:hover {
-        margin-right: 20px;
-      }
-
-      &:not(:hover) {
-        .rotateY(45deg);
-        margin-left: -16px;
-      }
-
-      &:hover ~ .task-breadcrumbs-step {
-        .rotateY(-45deg);
-      }
-    }
-  }
-
   &.shrink {
     .task-breadcrumbs-step {
       &:not(:hover):not(.active) {

--- a/resources/styles/components/task/breadcrumbs.less
+++ b/resources/styles/components/task/breadcrumbs.less
@@ -56,6 +56,25 @@
 .task-breadcrumbs {
   margin-left: -2px;
   margin-right: -2px;
+
+  &.coverflow {
+    .task-breadcrumbs-step {
+      .box-shadow(0 1px 6px rgba(0, 0, 0, 0.5));
+
+      &:hover {
+        margin-right: 20px;
+      }
+
+      &:not(:hover) {
+        .rotateY(45deg);
+        margin-left: -16px;
+      }
+
+      &:hover ~ .task-breadcrumbs-step {
+        .rotateY(-45deg);
+      }
+    }
+  }
 }
 
 .task-breadcrumbs-step {
@@ -71,7 +90,7 @@
 
   &:hover,
   &.active {
-    .tutor-icon-active();
+    .tutor-icon-active(1.4, 0.5);
   }
 
   &.active {

--- a/resources/styles/components/task/breadcrumbs.less
+++ b/resources/styles/components/task/breadcrumbs.less
@@ -75,6 +75,20 @@
       }
     }
   }
+
+  &.shrink {
+    .task-breadcrumbs-step {
+      &:not(:hover):not(.active) {
+        .scale(.75, .75);
+        margin-left: -16px;
+      }
+      &:hover, &.active {
+        margin-right: 10px;
+        margin-left: -6px;
+        .tutor-icon-active(1.2, 0.12);
+      }
+    }
+  }
 }
 
 .task-breadcrumbs-step {

--- a/resources/styles/mixins.less
+++ b/resources/styles/mixins.less
@@ -97,9 +97,9 @@
   #fonts > .sans(1.2rem, 1.2rem);
 }
 
-.tutor-icon-active(@scale: 1.4) {
+.tutor-icon-active(@scale: 1.4; @shadow: 0.12) {
   .scale(@scale);
-  .box-shadow(0 1px 6px rgba(0, 0, 0, 0.12));
+  .box-shadow(0 1px 6px rgba(0, 0, 0, @shadow));
   border-radius: 50%;
 }
 

--- a/resources/styles/old/global/icons.less
+++ b/resources/styles/old/global/icons.less
@@ -21,7 +21,7 @@
   background-size: @size @size;
   background-repeat: no-repeat;
   background-position: center;
-  .transition(all .1s ease-in);
+  .transition(~"transform .1s ease-in-out, margin .3s ease-in-out");
 }
 
 .x-icon-bg(@name) {

--- a/src/components/breadcrumb/breadcrumb-mixin.cjsx
+++ b/src/components/breadcrumb/breadcrumb-mixin.cjsx
@@ -6,13 +6,14 @@ module.exports =
     crumb: React.PropTypes.object.isRequired
     currentStep: React.PropTypes.number
     goToStep: React.PropTypes.func.isRequired
+    onMouseEnter: React.PropTypes.func
 
   getInitialState: ->
     canReview: true
     step: {}
 
   render: ->
-    {crumb, currentStep, goToStep} = @props
+    {crumb, currentStep, goToStep, onMouseEnter, style, onMouseLeave} = @props
     {canReview, step} = @state
 
     crumbType = step?.type
@@ -54,6 +55,9 @@ module.exports =
 
     <span
       className={classes}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={style}
       title={title}
       onClick={goToStep(crumb.key)}
       data-chapter={crumb.sectionLabel}

--- a/src/components/breadcrumb/index.cjsx
+++ b/src/components/breadcrumb/index.cjsx
@@ -43,6 +43,9 @@ BreadcrumbTaskDynamic = React.createClass
   componentWillUnmount: ->
     @removeListeners()
 
+  componentDidMount: ->
+    @props.onMount?()
+
   setStep: (props) ->
     {crumb} = props
 

--- a/src/components/task/breadcrumbs.cjsx
+++ b/src/components/task/breadcrumbs.cjsx
@@ -22,7 +22,7 @@ module.exports = React.createClass
   getInitialState: ->
     updateOnNext: true
     hoverCrumb: @props.currentStep
-    shouldCoverflow: false
+    shouldCoverflow: null
     coverflowWidth: null
 
   componentWillMount: ->
@@ -45,11 +45,13 @@ module.exports = React.createClass
     crumbs = @getCrumableCrumbs()
     @setState(coverflowWidth: (crumbs.length * 47))
 
-
   componentWillUnmount: ->
     TaskStepStore.setMaxListeners(10)
     TaskStore.off('task.beforeRecovery', @stopUpdate)
     TaskStore.off('task.afterRecovery', @update)
+
+  componentDidUpdate: ->
+    @_resizeListener(@state) if @state.windowEl.width? and not @state.shouldCoverflow?
 
   _resizeListener: (sizes) ->
     shouldCoverflow = @shouldCoverflow(sizes)

--- a/src/components/task/breadcrumbs.cjsx
+++ b/src/components/task/breadcrumbs.cjsx
@@ -69,6 +69,9 @@ module.exports = React.createClass
   componentDidUpdate: (prevProps, prevState) ->
     @_resizeListener(@state) if @state.crumbsWidth isnt prevState.crumbsWidth
 
+  componentWillReceiveProps: (nextProps) ->
+    @setState(hoverCrumb: nextProps.currentStep)
+
   crumbMounted: ->
     @calculateCrumbsWidth() if @state.crumbsWidth?
 

--- a/src/components/task/breadcrumbs.cjsx
+++ b/src/components/task/breadcrumbs.cjsx
@@ -6,12 +6,13 @@ _ = require 'underscore'
 
 CrumbMixin = require './crumb-mixin'
 ChapterSectionMixin = require '../chapter-section-mixin'
+ResizeListenerMixin = require '../resize-listener-mixin'
 {BreadcrumbTaskDynamic} = require '../breadcrumb'
 
 module.exports = React.createClass
   displayName: 'Breadcrumbs'
 
-  mixins: [ChapterSectionMixin, CrumbMixin]
+  mixins: [ChapterSectionMixin, CrumbMixin, ResizeListenerMixin]
 
   propTypes:
     id: React.PropTypes.string.isRequired
@@ -19,8 +20,10 @@ module.exports = React.createClass
     goToStep: React.PropTypes.func.isRequired
 
   getInitialState: ->
-    updateOnNext:
-      true
+    updateOnNext: true
+    hoverCrumb: @props.currentStep
+    shouldCoverflow: false
+    coverflowWidth: null
 
   componentWillMount: ->
     listeners = @getMaxListeners()
@@ -39,10 +42,21 @@ module.exports = React.createClass
     # until the recovery step has been loaded
     TaskStore.on('task.afterRecovery', @update)
 
+    crumbs = @getCrumableCrumbs()
+    @setState(coverflowWidth: (crumbs.length * 47))
+
+
   componentWillUnmount: ->
     TaskStepStore.setMaxListeners(10)
     TaskStore.off('task.beforeRecovery', @stopUpdate)
     TaskStore.off('task.afterRecovery', @update)
+
+  _resizeListener: (sizes) ->
+    shouldCoverflow = @shouldCoverflow(sizes)
+    @setState({shouldCoverflow})
+
+  shouldCoverflow: (sizes) ->
+    sizes.windowEl.width < @state.coverflowWidth
 
   shouldComponentUpdate: (nextProps, nextState) ->
     nextState.updateOnNext
@@ -53,17 +67,29 @@ module.exports = React.createClass
   stopUpdate: ->
     @setState(updateOnNext: false)
 
+  updateHoverCrumb: (hover) ->
+    @setState(hoverCrumb: hover)
+
   render: ->
     crumbs = @getCrumableCrumbs()
     {currentStep, goToStep} = @props
 
-    stepButtons = _.map crumbs, (crumb) ->
+    stepButtons = _.map crumbs, (crumb, crumbIndex) =>
+      crumbStyle =
+        zIndex: crumbs.length - Math.abs(@state.hoverCrumb - crumbIndex)
+
       <BreadcrumbTaskDynamic
+        onMouseEnter={@updateHoverCrumb.bind(@, crumbIndex)}
+        onMouseLeave={@updateHoverCrumb.bind(@, @props.currentStep)}
+        style={crumbStyle}
         crumb={crumb}
         currentStep={currentStep}
         goToStep={goToStep}
         key="breadcrumb-#{crumb.type}-#{crumb.key}"/>
 
-    <div className='task-breadcrumbs'>
+    classes = 'task-breadcrumbs'
+    classes += ' coverflow' if @state.shouldCoverflow
+
+    <div className={classes}>
       {stepButtons}
     </div>

--- a/src/components/task/breadcrumbs.cjsx
+++ b/src/components/task/breadcrumbs.cjsx
@@ -88,7 +88,7 @@ module.exports = React.createClass
         key="breadcrumb-#{crumb.type}-#{crumb.key}"/>
 
     classes = 'task-breadcrumbs'
-    classes += ' coverflow' if @state.shouldCoverflow
+    classes += ' shrink' if @state.shouldCoverflow
 
     <div className={classes}>
       {stepButtons}


### PR DESCRIPTION
## Breadcrumbs shrink when there are too many to fit full-sized on one row
![screen shot 2015-08-07 at 12 03 59 pm](https://cloud.githubusercontent.com/assets/2483873/9141175/6b94a652-3cfc-11e5-9ffb-f23faf1195ff.png)

## Will also adjust as steps get completed:
### Before step completed and new breadcrumb
![screen shot 2015-08-11 at 2 02 24 pm](https://cloud.githubusercontent.com/assets/2483873/9207213/cef26f9e-4031-11e5-97b1-2d6521d52bc6.png)

### After new breadcrumb
![screen shot 2015-08-11 at 2 02 30 pm](https://cloud.githubusercontent.com/assets/2483873/9207215/d1e98ffc-4031-11e5-9f16-7216965e8b83.png)

### self-adjusts as window size changes as well
![screen shot 2015-08-11 at 2 02 34 pm](https://cloud.githubusercontent.com/assets/2483873/9207225/dfd23844-4031-11e5-8c55-f7130e85295c.png)




discussed with @Fredasaurus  and this is our temporary solution