### PR TITLE
Set figure's that contain an appropriate sized image to 100% width

### DIFF
--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -74,44 +74,31 @@ div[data-type="document-title"] ~ p:first-of-type {
 }
 
 figure {
-  max-width: 100%;
   display: table;
   text-align: left;
   margin-right: 30px;
   margin-bottom: 20px;
   padding: 0;
   float: left;
-  &.full-width { width: 100%; }
-  &.tutor-ui-vertical-img {
-    @media (min-width: @screen-sm-min) {
-      width: 50%;
-      float: left;
-    }
-  }
   img {
     max-width: 100%;
     border: 1px solid @border-color;
     margin: 10px 0 0 0;
     padding: 0;
   }
-  .tutor-ui-horizontal-img {
-    display:block;
-
+  &.full-width:not(.splash) {
+    width: 100%;
+  }
+  &.tutor-ui-vertical-img {
+    @media (min-width: @screen-sm-min) {
+      width: 50%;
+      float: left;
+    }
+  }
+  &.tutor-ui-horizontal-img {
     &.full-width {
       img { width: 100%; }
     }
-  }
-
-  // splash images are always full width without margin or surrounding padding
-  &.splash {
-    margin-bottom: 40px;
-    // .splash is wider than other elements on the page since it has 0 surrounding padding
-    // This means child elements that normally have a fixed pixel width will not expand to fit
-    // unless their widths are set to be 100%
-    .tutor-ui-horizontal-img {
-      .book-content-full-width();
-    }
-    img { width: 100%; }
   }
   figcaption {
     display: table-caption;

--- a/resources/styles/book-content/splash-image.less
+++ b/resources/styles/book-content/splash-image.less
@@ -1,6 +1,6 @@
+// splash images are always full width without margin or surrounding padding
 .splash {
-  width: 100%;
-  margin: -@tutor-book-padding-vertical 0 40px 0;
+  .book-content-full-width();
 
   img {
     border: 0;
@@ -8,7 +8,6 @@
   }
 
   figcaption {
-    .book-content-full-width();
     padding: 20px;
   }
 

--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -1,5 +1,6 @@
 _ = require 'underscore'
 S = require '../helpers/string'
+dom = require '../helpers/dom'
 
 # According to the tagging legend exercises with a link should have `a.os-embed`
 # but in the content they are just a vanilla link.
@@ -109,13 +110,13 @@ module.exports =
     @renderOtherLinks?(otherLinks)
     @renderExercises?(exerciseLinks)
 
-
 # called with the context set to the image
 sizeImage = ->
-  return unless @parentNode
+  figure = dom.closest(@, 'figure')
+  return unless figure
   if @naturalWidth > @naturalHeight
-    @parentNode.classList.add('tutor-ui-horizontal-img')
+    figure.classList.add('tutor-ui-horizontal-img')
     if @naturalWidth > 450
-      @parentNode.classList.add('full-width')
+      figure.classList.add('full-width')
   else
-    @parentNode.classList.add('tutor-ui-vertical-img')
+    figure.classList.add('tutor-ui-vertical-img')

--- a/src/helpers/dom.coffee
+++ b/src/helpers/dom.coffee
@@ -7,7 +7,7 @@ module.exports = {
 
   closest: (el, selector) ->
     return null unless el
-    if @matches(el, selector) then el else (el.querySelector(selector) or @closest(el.parentNode, selector))
+    if @matches(el, selector) then el else @closest(el.parentNode, selector)
 
 
 }

--- a/src/helpers/dom.coffee
+++ b/src/helpers/dom.coffee
@@ -1,0 +1,13 @@
+module.exports = {
+
+  matches: (el, selector) ->
+    method = el.matches or el.mozMatchesSelector or el.msMatchesSelector or el.oMatchesSelector or el.webkitMatchesSelector
+    method?.call(el, selector)
+
+
+  closest: (el, selector) ->
+    return null unless el
+    if @matches(el, selector) then el else (el.querySelector(selector) or @closest(el.parentNode, selector))
+
+
+}

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -41,6 +41,7 @@ require './time.spec'
 require './current-user-store.spec'
 require './course-listing-store.spec'
 require './task-helpers.spec'
+require './dom-helpers.spec'
 
 # This should be done **last** because it starts up the whole app
 require './router.spec'

--- a/test/dom-helpers.spec.coffee
+++ b/test/dom-helpers.spec.coffee
@@ -1,0 +1,38 @@
+{expect} = require 'chai'
+_ = require 'underscore'
+
+DOM  = require '../src/helpers/dom'
+
+HTML = """
+<div class="dc">
+  <h1>heading</h1>
+  <p class="para">
+    first paragraph.
+  </p>
+  <div class="wfig">
+    <figure>a figure</figure>
+  </div>
+</div>
+"""
+
+describe 'DOM Helpers', ->
+
+  beforeEach ->
+    @root = document.createElement('div')
+    @root.innerHTML = HTML
+    @p = @root.querySelector('p.para')
+    @figure = @root.querySelector('figure')
+
+  it 'can query using closest', ->
+    expect( DOM.closest( @p, '.dc' ).tagName ).to.equal('DIV')
+    expect( DOM.closest( @figure, '.dc' ).tagName ).to.equal('DIV')
+    expect( DOM.closest( @figure, 'div' ).className ).to.equal('wfig')
+
+  it 'can find using closest when same element matches', ->
+    expect( DOM.closest( @p, '.para' ).className ).to.equal('para')
+
+  it 'returns null when not found', ->
+    expect( DOM.closest( @p, 'img' ) ).to.be.null
+
+  it 'does not find siblings', ->
+    expect( DOM.closest( @p, '.wfig' ) ).to.be.null


### PR DESCRIPTION
Somewhere along the line the figure's stopped automatically being 100% wide.  This broke the image expansion since their 100% width would be constrained by the size of the figure.

This changes the JS logic to walk up the tree to the figure and apply the full-width classes to it, and then sets the styles to match.

It does so by adding a new "DOM" helper with an implementation of jQueries `.closest`

![screen shot 2015-08-06 at 4 25 13 pm](https://cloud.githubusercontent.com/assets/79566/9124188/8355df42-3c5a-11e5-8a3e-76b5753d0baf.png)
