### PR TITLE
textarea shows textarea values right on open for builder, as opposed to waiting till a change

### DIFF
--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -197,10 +197,18 @@ TutorTextArea = React.createClass
     id: React.PropTypes.string
     className: React.PropTypes.string
     onChange: React.PropTypes.func
+    heightBuffer: React.PropTypes.number
+
+  getDefaultProps: ->
+    heightBuffer: 28
 
   resize: (event) ->
-    event.target.style.height = ''
-    event.target.style.height = "#{event.target.scrollHeight}px"
+    textarea = @refs.textarea.getDOMNode()
+    textarea.style.height = ''
+    textarea.style.height = "#{textarea.scrollHeight + @props.heightBuffer}px"
+
+  componentDidMount: ->
+    @resize() if @props.default.length > 0
 
   onChange: (event) ->
     @props.onChange(event.target?.value, event.target)


### PR DESCRIPTION
# Before
## Builder on load
* Only shows part of the content.
![screen shot 2015-08-07 at 11 07 58 am](https://cloud.githubusercontent.com/assets/2483873/9140170/ca37ebb8-3cf4-11e5-8f78-4e456969ad51.png)

## Textarea on focus
* Still only shows part of the content
![screen shot 2015-08-07 at 11 08 01 am](https://cloud.githubusercontent.com/assets/2483873/9140150/9e1cc81e-3cf4-11e5-870d-05135f421f41.png)

## Textarea after a keypress
* Surprise!  You do have a description here
![screen shot 2015-08-07 at 11 08 03 am](https://cloud.githubusercontent.com/assets/2483873/9140151/9e1dc250-3cf4-11e5-9d21-9bfccfbb56a3.png)

# Now
## Builder on load
* Shows all content on load
* textarea height updates as change happens still
![screen shot 2015-08-07 at 11 02 21 am](https://cloud.githubusercontent.com/assets/2483873/9140167/bd19fb56-3cf4-11e5-8062-a2814ee9c82a.png)
