### PR TITLE
Fix plan label not opening details when there's 2 that represent that plan

### DIFF
--- a/resources/styles/components/course-calendar/plan.less
+++ b/resources/styles/components/course-calendar/plan.less
@@ -6,7 +6,7 @@
 @calendar-plan-active-top-offset: @calendar-plan-top-offset - @calendar-plan-top-margin;
 
 @calendar-plan-left-offset: 2px;
-@calendar-plan-left-label-offset: 2 * @calendar-plan-left-offset + 2;
+@calendar-plan-left-label-offset: 2 * @calendar-plan-left-offset;
 
 @calendar-inactive-background: @tutor-neutral;
 
@@ -108,8 +108,7 @@
     // Takes width based on visible width of plan to center label.
     // see CoursePlan component
     label {
-      margin-left: -@calendar-plan-left-label-offset;
-      padding-left: 2 * @calendar-plan-left-label-offset;
+      padding-left: @calendar-plan-left-label-offset;
       text-align: left;
       display: block;
       margin-bottom: 0;
@@ -120,6 +119,7 @@
         &::before {
           content: '...';
           margin-right: @calendar-plan-left-label-offset;
+          margin-left: @calendar-plan-left-label-offset / 2;
           .psuedo-text-label();
         }
 

--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -227,6 +227,8 @@ CourseDuration = React.createClass
             plan: simplePlans[plan.id]
             index: counter[plan.id]
 
+          planForRange.offsetFromPlanStart = planForRange.rangeDuration.start.diff(plan.duration.start, 'days')
+
           # Add plan to plans in range
           rangeData.plansInRange.push(planForRange)
           counter[plan.id] = counter[plan.id] + 1

--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -12,6 +12,7 @@ CourseDuration = React.createClass
 
   propTypes:
     durations: React.PropTypes.array.isRequired
+    courseId: React.PropTypes.string.isRequired
     viewingDuration: React.PropTypes.instanceOf(twix).isRequired
     groupingDurations: React.PropTypes.arrayOf(React.PropTypes.instanceOf(twix)).isRequired
     referenceDate: (props, propName, componentName) ->

--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -41,8 +41,11 @@ CourseDuration = React.createClass
         rangedPlan.plan.id
       )
       .map((groupedPlans) ->
+        # Grab the first plan as representative plan for displays grouped by plan
         {plan} = _.first(groupedPlans)
 
+        # omit the plan on the individual displays since they share one common plan
+        # TODO: clean up so that plan doesn't get duplicated in the first place.
         displays = _.map(groupedPlans, (groupedPlan) ->
           _.omit(groupedPlan, 'plan')
         )
@@ -197,7 +200,10 @@ CourseDuration = React.createClass
       rangeData.dayHeight = calcedHeight
 
   _getSimplePlan: (plan) ->
-    simplePlan = _.omit(plan, 'due_at', 'opens_at', 'duration', 'durationAsWeeks')
+    # Make a simple plan that omits duration/time related information
+    # and adds back in only the relevant time information needed by the
+    # CoursePlan component.
+    simplePlan = _.omit(plan, 'duration', 'tasking_plans', 'openRange')
     earliestOpensAt = @_getEarliestOpensAt(plan)
     simplePlan.opensAt = moment(earliestOpensAt).format('M/D')
     simplePlan.durationLength = plan.duration.length('days')

--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -195,6 +195,14 @@ CourseDuration = React.createClass
     if calcedHeight > rangeData.dayHeight
       rangeData.dayHeight = calcedHeight
 
+  _getSimplePlan: (plan) ->
+    simplePlan = _.omit(plan, 'due_at', 'opens_at', 'duration', 'durationAsWeeks')
+    earliestOpensAt = @_getEarliestOpensAt(plan)
+    simplePlan.opensAt = moment(earliestOpensAt).format('M/D')
+    simplePlan.durationLength = plan.duration.length('days')
+
+    simplePlan
+
   groupByRanges: (durationsInView) ->
     counter = {}
     (range, nthRange) =>
@@ -205,19 +213,17 @@ CourseDuration = React.createClass
         plansByDays: []
         plansInRange: []
 
+      simplePlans = {}
+
       _.each(durationsInView, (plan) =>
         if plan.duration.overlaps(range)
           counter[plan.id] ?= 0
-
-          simplePlan = _.omit(plan, 'due_at', 'opens_at', 'duration', 'durationAsWeeks')
-          earliestOpensAt = @_getEarliestOpensAt(plan)
-          simplePlan.opensAt = moment(earliestOpensAt).format('M/D')
+          simplePlans[plan.id] ?= @_getSimplePlan(plan)
 
           planForRange =
             rangeDuration: plan.duration.intersection(range)
             offset: moment(range.start).twix(plan.duration.start).length('days')
-            duration: plan.duration
-            plan: simplePlan
+            plan: simplePlans[plan.id]
             index: counter[plan.id]
 
           # Add plan to plans in range

--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -36,6 +36,18 @@ CourseDuration = React.createClass
     durationsByStartDate = _.chain(groupedDurations)
       .pluck('plansInRange')
       .flatten()
+      .groupBy((rangedPlan) ->
+        rangedPlan.plan.id
+      )
+      .map((groupedPlans) ->
+        {plan} = _.first(groupedPlans)
+
+        displays = _.map(groupedPlans, (groupedPlan) ->
+          _.omit(groupedPlan, 'plan')
+        )
+
+        {plan, displays}
+      )
       .value()
 
     @setState({ranges: groupedDurations, durationsByStartDate})

--- a/src/components/course-calendar/month.cjsx
+++ b/src/components/course-calendar/month.cjsx
@@ -155,7 +155,7 @@ CourseMonth = React.createClass
             groupingDurations={calendarWeeks}
             courseId={courseId}
             ref='courseDurations'>
-            <CoursePlan/>
+            <CoursePlan courseId={courseId}/>
           </CourseDuration>
 
         </BS.Col>

--- a/src/components/course-calendar/plan-display.cjsx
+++ b/src/components/course-calendar/plan-display.cjsx
@@ -1,0 +1,150 @@
+React = require 'react'
+Router = require 'react-router'
+camelCase = require 'camelcase'
+BS = require 'react-bootstrap'
+
+CoursePlanDetails = require './plan-details'
+CoursePlanPublishingDetails = require './plan-publishing-details'
+
+
+CoursePlanDisplayMixin =
+
+  componentWillReceiveProps: ->
+    @closePlanOnModalHide()
+
+  componentDidMount: ->
+    @closePlanOnModalHide()
+
+  closePlanOnModalHide: ->
+    if @refs.trigger?
+      hide = @refs.trigger.hide
+      syncClosePlan = @props.syncClosePlan
+
+      # alias modal hide to also make plan look un-selected
+      @refs.trigger.hide = ->
+        hide()
+        syncClosePlan()
+
+  buildPlanClasses: ->
+    {plan, publishStatus, isPublishing, isActive} = @props
+
+    planClasses = [
+      'plan'
+      'plan-label-long'
+      "#{plan.type}"
+      "course-plan-#{plan.id}"
+    ]
+
+    planClasses.push('is-published') if plan.isPublished or (publishStatus is 'completed')
+    planClasses.push('is-failed') if publishStatus is 'failed'
+    planClasses.push('is-killed') if publishStatus is 'killed'
+    planClasses.push('is-publishing') if isPublishing
+    planClasses.push('is-open') if plan.isOpen
+    planClasses.push('is-trouble') if plan.isTrouble
+    planClasses.push('active') if isActive
+
+    planClasses.join(' ')
+
+  buildPlanStyles: ->
+    {display, plan} = @props
+    {offset, weekTopOffset, order} = display
+    {durationLength} = plan
+
+    # Adjust width based on plan duration and left position based on offset of plan from start of week
+    # CALENDAR_EVENT_DYNAMIC_WIDTH and CALENDAR_EVENT_DYNAMIC_POSITION
+    # top is calculated by using:
+    #   weekTopOffset -- the distance from the top of the calendar for plans in the same week
+    #   order -- the order the plan should be from the bottom, is an int more than 1 when a plan needs to
+    #       stack on top of other plans that overlap in duration.
+    planStyle =
+      width: durationLength * 100 / 7 + '%'
+      left: offset * 100 / 7 + '%'
+      top: (weekTopOffset + 4 - order * 3) + 'rem'
+
+  renderPlanDisplay: (planModal, planClasses) ->
+    {display, label, syncHover, removeHover, syncOpenPlan} = @props
+    {index} = display
+
+    planStyle = @buildPlanStyles()
+
+    planOnly = <div style={planStyle}
+      className={planClasses}
+      onMouseEnter={syncHover}
+      onMouseLeave={removeHover}
+      onClick={syncOpenPlan}
+      ref='plan'>
+      {label}
+    </div>
+
+    if index is 0
+      # only trigger modal if this is the first component representing the plan
+      planDisplay = <BS.ModalTrigger modal={planModal} ref='trigger'>
+        {planOnly}
+      </BS.ModalTrigger>
+    else
+      # otherwise, if this plan continues into the next week, don't add an additional modal
+      planDisplay = planOnly
+
+    planDisplay
+
+
+CoursePlanDisplayEdit = React.createClass
+  displayName: 'CoursePlanDisplayEdit'
+  mixins: [CoursePlanDisplayMixin]
+  render: ->
+    {plan, display, label, courseId, syncHover, removeHover} = @props
+    {index} = display
+
+    linkTo = camelCase("edit-#{plan.type}")
+    params = {id: plan.id, courseId}
+
+    planStyle = @buildPlanStyles()
+    planClasses = @buildPlanClasses()
+
+    <div
+      style={planStyle}
+      className={planClasses}
+      onMouseEnter={syncHover}
+      onMouseLeave={removeHover}
+      ref='plan'>
+      <Router.Link
+        to={linkTo}
+        params={params}>
+          {label}
+      </Router.Link>
+    </div>
+
+
+CoursePlanDisplayQuickLook = React.createClass
+  displayName: 'CoursePlanDisplayQuickLook'
+  mixins: [CoursePlanDisplayMixin]
+  render: ->
+    {plan, courseId} = @props
+    planClasses = @buildPlanClasses()
+
+    planModal = <CoursePlanDetails
+      plan={plan}
+      courseId={courseId}
+      className={planClasses}
+      ref='details'/>
+
+    @renderPlanDisplay(planModal, planClasses)
+
+
+CoursePlanDisplayPublishing = React.createClass
+  displayName: 'CoursePlanDisplayPublishing'
+  mixins: [CoursePlanDisplayMixin]
+  render: ->
+    {plan, courseId} = @props
+    planClasses = @buildPlanClasses()
+
+    planModal = <CoursePlanPublishingDetails
+      plan={plan}
+      courseId={courseId}
+      className={planClasses}
+      ref='details'/>
+
+    @renderPlanDisplay(planModal, planClasses)
+
+
+module.exports = {CoursePlanDisplayEdit, CoursePlanDisplayQuickLook, CoursePlanDisplayPublishing}

--- a/src/components/course-calendar/plan-display.cjsx
+++ b/src/components/course-calendar/plan-display.cjsx
@@ -8,14 +8,12 @@ DisplayProperties =
   display: React.PropTypes.object.isRequired
   label: React.PropTypes.node.isRequired
   courseId: React.PropTypes.string.isRequired
-  planModal: React.PropTypes.node.isRequired
   planClasses: React.PropTypes.string.isRequired
+  setHover: React.PropTypes.func.isRequired
+  planModal: React.PropTypes.node
   isFirst: React.PropTypes.bool
   isLast: React.PropTypes.bool
-  syncHover: React.PropTypes.func.isRequired
-  removeHover: React.PropTypes.func.isRequired
-  syncOpenPlan: React.PropTypes.func
-  syncClosePlan: React.PropTypes.func
+  setIsViewing: React.PropTypes.func
   spacingMargin: React.PropTypes.number
 
 CoursePlanDisplayMixin =
@@ -68,7 +66,7 @@ CoursePlanDisplayEdit = React.createClass
   displayName: 'CoursePlanDisplayEdit'
   mixins: [CoursePlanDisplayMixin]
   render: ->
-    {plan, planClasses, label, courseId, syncHover, removeHover} = @props
+    {plan, planClasses, label, courseId, setHover} = @props
 
     linkTo = camelCase("edit-#{plan.type}")
     params = {id: plan.id, courseId}
@@ -78,8 +76,8 @@ CoursePlanDisplayEdit = React.createClass
     <div
       style={planStyle}
       className={planClasses}
-      onMouseEnter={syncHover}
-      onMouseLeave={removeHover}
+      onMouseEnter={setHover.bind(null, true)}
+      onMouseLeave={setHover.bind(null, false)}
       ref='plan'>
       <Router.Link
         to={linkTo}
@@ -101,7 +99,7 @@ CoursePlanDisplayQuickLook = React.createClass
 
   closePlanOnModalHide: ->
     hide = @refs.trigger.hide
-    syncClosePlan = @props.syncClosePlan
+    syncClosePlan = @props.setIsViewing.bind(null, false)
 
     # alias modal hide to also make plan look un-selected
     @refs.trigger.hide = ->
@@ -109,15 +107,15 @@ CoursePlanDisplayQuickLook = React.createClass
       syncClosePlan()
 
   render: ->
-    {planClasses, planModal, label, syncHover, removeHover, syncOpenPlan} = @props
+    {planClasses, planModal, label, setHover, setIsViewing} = @props
 
     planStyle = @buildPlanStyles()
 
     planOnly = <div style={planStyle}
       className={planClasses}
-      onMouseEnter={syncHover}
-      onMouseLeave={removeHover}
-      onClick={syncOpenPlan}
+      onMouseEnter={setHover.bind(null, true)}
+      onMouseLeave={setHover.bind(null, false)}
+      onClick={setIsViewing.bind(null, true)}
       ref='plan'>
       {label}
     </div>

--- a/src/components/course-calendar/plan-display.cjsx
+++ b/src/components/course-calendar/plan-display.cjsx
@@ -10,17 +10,43 @@ DisplayProperties =
   courseId: React.PropTypes.string.isRequired
   planModal: React.PropTypes.node.isRequired
   planClasses: React.PropTypes.string.isRequired
+  isFirst: React.PropTypes.bool
+  isLast: React.PropTypes.bool
   syncHover: React.PropTypes.func.isRequired
   removeHover: React.PropTypes.func.isRequired
   syncOpenPlan: React.PropTypes.func
   syncClosePlan: React.PropTypes.func
+  spacingMargin: React.PropTypes.number
 
 CoursePlanDisplayMixin =
 
   propTypes: DisplayProperties
+  getDefaultProps: ->
+    isFirst: false
+    isLast: false
+    spacingMargin: 2
+    rangeLength: 7
+    defaultPlansCount: 3
+
+  calcPercentOfRangeLength: (partLength) ->
+    partLength / @props.rangeLength * 100 + '%'
+
+  adjustPlanSpacing: (planStyle) ->
+    {isFirst, isLast, spacingMargin} = @props
+
+    if isFirst or isLast
+      planStyle.width = "calc(#{planStyle.width} - #{spacingMargin * 3}px)"
+
+    if isFirst
+      planStyle.marginLeft = spacingMargin + 'px'
+
+    unless isFirst or isLast
+      planStyle.marginLeft = -1 * spacingMargin + 'px'
+
+    planStyle
 
   buildPlanStyles: ->
-    {display, plan} = @props
+    {display, plan, spacingMargin, defaultPlansCount} = @props
     {offset, weekTopOffset, order} = display
     {durationLength} = plan
 
@@ -31,9 +57,11 @@ CoursePlanDisplayMixin =
     #   order -- the order the plan should be from the bottom, is an int more than 1 when a plan needs to
     #       stack on top of other plans that overlap in duration.
     planStyle =
-      width: durationLength * 100 / 7 + '%'
-      left: offset * 100 / 7 + '%'
-      top: (weekTopOffset + 4 - order * 3) + 'rem'
+      width: @calcPercentOfRangeLength(durationLength)
+      left: @calcPercentOfRangeLength(offset)
+      top: (weekTopOffset + (spacingMargin * 2) - order * defaultPlansCount) + 'rem'
+
+    @adjustPlanSpacing(planStyle)
 
 
 CoursePlanDisplayEdit = React.createClass

--- a/src/components/course-calendar/plan-display.cjsx
+++ b/src/components/course-calendar/plan-display.cjsx
@@ -3,23 +3,21 @@ Router = require 'react-router'
 camelCase = require 'camelcase'
 BS = require 'react-bootstrap'
 
+DisplayProperties =
+  plan: React.PropTypes.object.isRequired
+  display: React.PropTypes.object.isRequired
+  label: React.PropTypes.node.isRequired
+  courseId: React.PropTypes.string.isRequired
+  planModal: React.PropTypes.node.isRequired
+  planClasses: React.PropTypes.string.isRequired
+  syncHover: React.PropTypes.func.isRequired
+  removeHover: React.PropTypes.func.isRequired
+  syncOpenPlan: React.PropTypes.func
+  syncClosePlan: React.PropTypes.func
+
 CoursePlanDisplayMixin =
 
-  componentWillReceiveProps: ->
-    @closePlanOnModalHide()
-
-  componentDidMount: ->
-    @closePlanOnModalHide()
-
-  closePlanOnModalHide: ->
-    if @refs.trigger?
-      hide = @refs.trigger.hide
-      syncClosePlan = @props.syncClosePlan
-
-      # alias modal hide to also make plan look un-selected
-      @refs.trigger.hide = ->
-        hide()
-        syncClosePlan()
+  propTypes: DisplayProperties
 
   buildPlanStyles: ->
     {display, plan} = @props
@@ -37,32 +35,12 @@ CoursePlanDisplayMixin =
       left: offset * 100 / 7 + '%'
       top: (weekTopOffset + 4 - order * 3) + 'rem'
 
-  renderPlanDisplay: (planModal, planClasses) ->
-    {display, label, syncHover, removeHover, syncOpenPlan} = @props
-    {index} = display
-
-    planStyle = @buildPlanStyles()
-
-    planOnly = <div style={planStyle}
-      className={planClasses}
-      onMouseEnter={syncHover}
-      onMouseLeave={removeHover}
-      onClick={syncOpenPlan}
-      ref='plan'>
-      {label}
-    </div>
-
-    <BS.ModalTrigger modal={planModal} ref='trigger'>
-      {planOnly}
-    </BS.ModalTrigger>
-
 
 CoursePlanDisplayEdit = React.createClass
   displayName: 'CoursePlanDisplayEdit'
   mixins: [CoursePlanDisplayMixin]
   render: ->
-    {plan, planClasses, display, label, courseId, syncHover, removeHover} = @props
-    {index} = display
+    {plan, planClasses, label, courseId, syncHover, removeHover} = @props
 
     linkTo = camelCase("edit-#{plan.type}")
     params = {id: plan.id, courseId}
@@ -86,11 +64,39 @@ CoursePlanDisplayEdit = React.createClass
 CoursePlanDisplayQuickLook = React.createClass
   displayName: 'CoursePlanDisplayQuickLook'
   mixins: [CoursePlanDisplayMixin]
+
+  componentWillReceiveProps: ->
+    @closePlanOnModalHide()
+
+  componentDidMount: ->
+    @closePlanOnModalHide()
+
+  closePlanOnModalHide: ->
+    hide = @refs.trigger.hide
+    syncClosePlan = @props.syncClosePlan
+
+    # alias modal hide to also make plan look un-selected
+    @refs.trigger.hide = ->
+      hide()
+      syncClosePlan()
+
   render: ->
-    {plan, courseId, planClasses, planModal} = @props
+    {planClasses, planModal, label, syncHover, removeHover, syncOpenPlan} = @props
 
-    @renderPlanDisplay(planModal, planClasses)
+    planStyle = @buildPlanStyles()
 
+    planOnly = <div style={planStyle}
+      className={planClasses}
+      onMouseEnter={syncHover}
+      onMouseLeave={removeHover}
+      onClick={syncOpenPlan}
+      ref='plan'>
+      {label}
+    </div>
+
+    <BS.ModalTrigger modal={planModal} ref='trigger'>
+      {planOnly}
+    </BS.ModalTrigger>
 
 
 module.exports = {CoursePlanDisplayEdit, CoursePlanDisplayQuickLook}

--- a/src/components/course-calendar/plan-display.cjsx
+++ b/src/components/course-calendar/plan-display.cjsx
@@ -3,10 +3,6 @@ Router = require 'react-router'
 camelCase = require 'camelcase'
 BS = require 'react-bootstrap'
 
-CoursePlanDetails = require './plan-details'
-CoursePlanPublishingDetails = require './plan-publishing-details'
-
-
 CoursePlanDisplayMixin =
 
   componentWillReceiveProps: ->
@@ -24,26 +20,6 @@ CoursePlanDisplayMixin =
       @refs.trigger.hide = ->
         hide()
         syncClosePlan()
-
-  buildPlanClasses: ->
-    {plan, publishStatus, isPublishing, isActive} = @props
-
-    planClasses = [
-      'plan'
-      'plan-label-long'
-      "#{plan.type}"
-      "course-plan-#{plan.id}"
-    ]
-
-    planClasses.push('is-published') if plan.isPublished or (publishStatus is 'completed')
-    planClasses.push('is-failed') if publishStatus is 'failed'
-    planClasses.push('is-killed') if publishStatus is 'killed'
-    planClasses.push('is-publishing') if isPublishing
-    planClasses.push('is-open') if plan.isOpen
-    planClasses.push('is-trouble') if plan.isTrouble
-    planClasses.push('active') if isActive
-
-    planClasses.join(' ')
 
   buildPlanStyles: ->
     {display, plan} = @props
@@ -65,43 +41,33 @@ CoursePlanDisplayMixin =
     {display, label, syncHover, removeHover, syncOpenPlan} = @props
     {index} = display
 
-    hasModal = index is 0
-
     planStyle = @buildPlanStyles()
 
     planOnly = <div style={planStyle}
       className={planClasses}
       onMouseEnter={syncHover}
       onMouseLeave={removeHover}
-      onClick={syncOpenPlan(hasModal)}
+      onClick={syncOpenPlan}
       ref='plan'>
       {label}
     </div>
 
-    if hasModal
-      # only trigger modal if this is the first component representing the plan
-      planDisplay = <BS.ModalTrigger modal={planModal} ref='trigger'>
-        {planOnly}
-      </BS.ModalTrigger>
-    else
-      # otherwise, if this plan continues into the next week, don't add an additional modal
-      planDisplay = planOnly
-
-    planDisplay
+    <BS.ModalTrigger modal={planModal} ref='trigger'>
+      {planOnly}
+    </BS.ModalTrigger>
 
 
 CoursePlanDisplayEdit = React.createClass
   displayName: 'CoursePlanDisplayEdit'
   mixins: [CoursePlanDisplayMixin]
   render: ->
-    {plan, display, label, courseId, syncHover, removeHover} = @props
+    {plan, planClasses, display, label, courseId, syncHover, removeHover} = @props
     {index} = display
 
     linkTo = camelCase("edit-#{plan.type}")
     params = {id: plan.id, courseId}
 
     planStyle = @buildPlanStyles()
-    planClasses = @buildPlanClasses()
 
     <div
       style={planStyle}
@@ -121,32 +87,10 @@ CoursePlanDisplayQuickLook = React.createClass
   displayName: 'CoursePlanDisplayQuickLook'
   mixins: [CoursePlanDisplayMixin]
   render: ->
-    {plan, courseId} = @props
-    planClasses = @buildPlanClasses()
-
-    planModal = <CoursePlanDetails
-      plan={plan}
-      courseId={courseId}
-      className={planClasses}
-      ref='details'/>
+    {plan, courseId, planClasses, planModal} = @props
 
     @renderPlanDisplay(planModal, planClasses)
 
 
-CoursePlanDisplayPublishing = React.createClass
-  displayName: 'CoursePlanDisplayPublishing'
-  mixins: [CoursePlanDisplayMixin]
-  render: ->
-    {plan, courseId} = @props
-    planClasses = @buildPlanClasses()
 
-    planModal = <CoursePlanPublishingDetails
-      plan={plan}
-      courseId={courseId}
-      className={planClasses}
-      ref='details'/>
-
-    @renderPlanDisplay(planModal, planClasses)
-
-
-module.exports = {CoursePlanDisplayEdit, CoursePlanDisplayQuickLook, CoursePlanDisplayPublishing}
+module.exports = {CoursePlanDisplayEdit, CoursePlanDisplayQuickLook}

--- a/src/components/course-calendar/plan-display.cjsx
+++ b/src/components/course-calendar/plan-display.cjsx
@@ -65,18 +65,20 @@ CoursePlanDisplayMixin =
     {display, label, syncHover, removeHover, syncOpenPlan} = @props
     {index} = display
 
+    hasModal = index is 0
+
     planStyle = @buildPlanStyles()
 
     planOnly = <div style={planStyle}
       className={planClasses}
       onMouseEnter={syncHover}
       onMouseLeave={removeHover}
-      onClick={syncOpenPlan}
+      onClick={syncOpenPlan(hasModal)}
       ref='plan'>
       {label}
     </div>
 
-    if index is 0
+    if hasModal
       # only trigger modal if this is the first component representing the plan
       planDisplay = <BS.ModalTrigger modal={planModal} ref='trigger'>
         {planOnly}

--- a/src/components/course-calendar/plan-label.cjsx
+++ b/src/components/course-calendar/plan-label.cjsx
@@ -1,0 +1,26 @@
+React = require 'react'
+
+CoursePlanLabel = React.createClass
+  displayName: 'CoursePlanLabel'
+  render: ->
+    {rangeDuration, plan, index, offset} = @props
+    {durationLength, opensAt, title} = plan
+
+    # Adjust width based on plan duration, helps with label centering on view...for the most part.
+    # CALENDAR_EVENT_LABEL_DYNAMIC_WIDTH
+    rangeLength = rangeDuration.length('days')
+    planLabelStyle =
+      width: rangeLength / durationLength * 100 + '%'
+
+    # label should float right if the plan is cut off at the beginning of the week
+    if offset < 0
+      planLabelStyle.float = 'right'
+
+    labelClass = 'continued' unless index is 0
+
+    label = <label
+      data-opens-at={opensAt}
+      style={planLabelStyle}
+      className={labelClass}>{title}</label>
+
+module.exports = CoursePlanLabel

--- a/src/components/course-calendar/plan-label.cjsx
+++ b/src/components/course-calendar/plan-label.cjsx
@@ -1,20 +1,27 @@
 React = require 'react'
+twix = require 'twix'
 
 CoursePlanLabel = React.createClass
   displayName: 'CoursePlanLabel'
+  propTypes:
+    rangeDuration: React.PropTypes.instanceOf(twix).isRequired
+    plan: React.PropTypes.object.isRequired
+    index: React.PropTypes.number
+    offset: React.PropTypes.number
+
+  calcPercentOfPlanLength: (partLength) ->
+    partLength / @props.plan.durationLength * 100 + '%'
+
   render: ->
-    {rangeDuration, plan, index, offset} = @props
-    {durationLength, opensAt, title} = plan
+    {rangeDuration, plan, index, offset, offsetFromPlanStart} = @props
+    {opensAt, title} = plan
 
     # Adjust width based on plan duration, helps with label centering on view...for the most part.
     # CALENDAR_EVENT_LABEL_DYNAMIC_WIDTH
-    rangeLength = rangeDuration.length('days')
+    planRangeLength = rangeDuration.length('days')
     planLabelStyle =
-      width: rangeLength / durationLength * 100 + '%'
-
-    # label should float right if the plan is cut off at the beginning of the week
-    if offset < 0
-      planLabelStyle.float = 'right'
+      width: @calcPercentOfPlanLength(planRangeLength)
+      marginLeft: @calcPercentOfPlanLength(offsetFromPlanStart)
 
     labelClass = 'continued' unless index is 0
 

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -21,6 +21,7 @@ CoursePlan = React.createClass
 
   propTypes:
     item: React.PropTypes.object.isRequired
+    courseId: React.PropTypes.string.isRequired
     activeHeight: React.PropTypes.number.isRequired
 
   getDefaultProps: ->
@@ -193,7 +194,7 @@ CoursePlan = React.createClass
         syncClosePlan: @syncClosePlan
       }
 
-      <displayComponent {...displayComponentProps} ref="display#{index}"/>
+      <displayComponent {...displayComponentProps} ref="display#{index}" key="display#{index}"/>
     )
 
     <div>

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -130,8 +130,8 @@ CoursePlan = React.createClass
 
       # alias modal hide to also make plan look un-selected
       @refs.trigger.hide = ->
-        syncClosePlan()
         hide()
+        syncClosePlan()
 
   syncOpenPlan: ->
     @setIsViewingStats(true) unless @state.isViewingStats
@@ -169,7 +169,7 @@ CoursePlan = React.createClass
     {isPublishing} = @state
     {plan} = item
 
-    if isPublishing
+    if isPublishing and not plan.isPublished
       planModal = <CoursePlanPublishingDetails
         plan={plan}
         courseId={courseId}
@@ -267,7 +267,7 @@ CoursePlan = React.createClass
       label = @renderLabel(rangeDuration, durationLength, plan, index, offset)
 
       renderFn = 'renderEditPlan'
-      renderFn = 'renderOpenPlan' if plan.isOpen and plan.isPublished or (isPublishing) or (publishStatus is 'completed')
+      renderFn = 'renderOpenPlan' if plan.isPublished or (isPublishing) or (publishStatus is 'completed')
 
       @[renderFn](planStyle, planClasses, label, index)
     )

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -147,18 +147,7 @@ CoursePlan = React.createClass
     {durationLength} = plan
 
     planDisplays = _.map(displays, (display) =>
-      {rangeDuration, offset, index, weekTopOffset, order} = display
-
-      # Adjust width based on plan duration and left position based on offset of plan from start of week
-      # CALENDAR_EVENT_DYNAMIC_WIDTH and CALENDAR_EVENT_DYNAMIC_POSITION
-      # top is calculated by using:
-      #   weekTopOffset -- the distance from the top of the calendar for plans in the same week
-      #   order -- the order the plan should be from the bottom, is an int more than 1 when a plan needs to
-      #       stack on top of other plans that overlap in duration.
-      planStyle =
-        width: durationLength * 100 / 7 + '%'
-        left: offset * 100 / 7 + '%'
-        top: (weekTopOffset + 4 - order * 3) + 'rem'
+      {rangeDuration, offset, index} = display
 
       labelProps = {rangeDuration, plan, index, offset}
       label = <CoursePlanLabel {...labelProps} ref='label'/>

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -172,9 +172,9 @@ CoursePlan = React.createClass
         ref='details'/>
 
     planDisplays = _.map(displays, (display) =>
-      {rangeDuration, offset, index} = display
+      {rangeDuration, offset, offsetFromPlanStart, index} = display
 
-      labelProps = {rangeDuration, plan, index, offset}
+      labelProps = {rangeDuration, plan, index, offset, offsetFromPlanStart}
       label = <CoursePlanLabel {...labelProps} ref="label#{index}"/>
 
       displayComponent = CoursePlanDisplayEdit
@@ -187,6 +187,8 @@ CoursePlan = React.createClass
         courseId,
         planModal,
         planClasses,
+        isFirst: (index is 0),
+        isLast: (index is displays.length - 1),
         syncHover: @syncHover,
         removeHover: @removeHover,
         syncOpenPlan: @syncOpenPlan

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -39,12 +39,13 @@ CoursePlan = React.createClass
     planId is @props.item.plan.id
 
   _isPlanNotMatchingRouteOpen: ->
-    {planId} = @context.router.getCurrentParams()
-    not @_doesPlanMatchesRoute() and @refs.display0.details?
+    not (@_doesPlanMatchesRoute() or @state.isViewingStats) and @refs.display0.details?
 
   _isPlanMatchRouteNotOpen: ->
+    console.info('_doesPlanMatchesRoute')
+    console.info((@_doesPlanMatchesRoute() or @state.isViewingStats))
     {planId} = @context.router.getCurrentParams()
-    @_doesPlanMatchesRoute() and not @refs.display0.details?
+    (@_doesPlanMatchesRoute() or @state.isViewingStats) and not @refs.display0.details?
 
   _getExpectedRoute: (isViewingStats) ->
     closedRouteName = 'calendarByDate'
@@ -73,8 +74,9 @@ CoursePlan = React.createClass
   syncStatsWithState: ->
     if @_isPlanMatchRouteNotOpen()
       if @refs.display0.refs.trigger?
-        triggerEl = @refs.display0.refs.trigger.getDOMNode()
-        triggerEl.click()
+        console.info('hello')
+        # triggerEl = @refs.display0.refs.trigger.getDOMNode()
+        # triggerEl.click()
       else
         @setIsViewingStats(false)
     else if @_isPlanNotMatchingRouteOpen()
@@ -84,6 +86,7 @@ CoursePlan = React.createClass
   setIsViewingStats: (isViewingStats) ->
     @_updateRoute(isViewingStats)
     @setState({isViewingStats})
+    # @syncStatsWithState()
 
   checkPublishingStatus: (published) ->
     if published.publishFor is @props.item.plan.id
@@ -115,8 +118,8 @@ CoursePlan = React.createClass
   componentDidMount: ->
     @syncStatsWithState()
 
-  componentWillUpdate: ->
-    @syncStatsWithState()
+  componentDidUpdate: (prevProps, prevState) ->
+    @syncStatsWithState() if prevState.isViewingStats isnt @state.isViewingStats
 
   syncOpenPlan: ->
     @setIsViewingStats(true) unless @state.isViewingStats

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -164,8 +164,7 @@ CoursePlan = React.createClass
         courseId={courseId}
         className={planClasses}
         ref='details'/>
-
-    if isPublishing
+    else if isPublishing
       planModal = <CoursePlanPublishingDetails
         plan={plan}
         courseId={courseId}
@@ -194,7 +193,10 @@ CoursePlan = React.createClass
         syncClosePlan: @syncClosePlan
       }
 
-      <displayComponent {...displayComponentProps} ref="display#{index}" key="display#{index}"/>
+      <displayComponent
+        {...displayComponentProps}
+        ref="display#{index}"
+        key="display#{index}"/>
     )
 
     <div>

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -12,7 +12,7 @@ CoursePlanPublishingDetails = require './plan-publishing-details'
 
 # TODO drag and drop, and resize behavior
 CoursePlan = React.createClass
-  displaysName: 'CoursePlan'
+  displayName: 'CoursePlan'
 
   contextTypes:
     router: React.PropTypes.func


### PR DESCRIPTION
## Clicking on first half
![screen shot 2015-08-12 at 12 53 43 pm](https://cloud.githubusercontent.com/assets/2483873/9232088/4e3167d2-40f1-11e5-87c6-3aac10bc901f.png)

## Clicking on second half
![screen shot 2015-08-12 at 12 53 47 pm](https://cloud.githubusercontent.com/assets/2483873/9232089/51293b22-40f1-11e5-9082-bda7e663fc02.png)

Order does not matter

## Handles multiple week beyond 2 weeks properly
![screen shot 2015-08-12 at 5 25 17 pm](https://cloud.githubusercontent.com/assets/2483873/9238341/36cf1000-4117-11e5-8412-effba2a434dd.png)

Spacing tweaked and improved as well


Changes are based on the idea that the plan should be one component, even if it's being displayed by 2 or more elements due to splitting over weeks.  Displays are then their own component, concerned only with handling the display of the plan.

Before, there could be multiple plan components per actual plan, and this required syncing hover and clicked state across components with [janky direct element maniputation](https://github.com/openstax/tutor-js/blob/master/src/components/course-calendar/plan.cjsx#L149-L173)  as opposed to now with [a shared state update on the plan which passes down to the displays](https://github.com/openstax/tutor-js/blob/bug/calendar-plan-details-mistrigger/src/components/course-calendar/plan.cjsx#L122-L132). 

Also, before, clicking on one chunk of a plan sometimes meant triggering the click on another part of the plan to open the modal, which led to problems.  Now, all displays for a plan are triggers for the same plan modal.

If a plan is published, will show quicklook.  If a plan is publishing for the first time, will show publishing modal.  If a plan is in draft, will link to edit page.