### PR TITLE
New clue attribute with all elements of data

### DIFF
--- a/api/courses/1/guide.json
+++ b/api/courses/1/guide.json
@@ -14,7 +14,14 @@
         3
       ],
       "questions_answered_count": 23,
-      "current_level": 0.9025196157281774,
+      "clue": {
+        "value": 0.9025196157281774,
+        "confidence_interval": [0.48026796534380245, 0.6802679653438024],
+        "confidence_interval_interpretation": "bad",
+        "sample_size": 2,
+        "sample_size_interpretation": "below",
+        "value_interpretation": "medium"
+      },
       "practice_count": 0,
       "page_ids": [
         "2",
@@ -28,7 +35,14 @@
             1
           ],
           "questions_answered_count": 11,
-          "current_level": 0.7216930483524373,
+          "clue": {
+            "value": 0.7216930483524373,
+            "confidence_interval": [0.48026796534380245, 0.6802679653438024],
+            "confidence_interval_interpretation": "bad",
+            "sample_size": 2,
+            "sample_size_interpretation": "below",
+            "value_interpretation": "medium"
+          },
           "practice_count": 0,
           "page_ids": [
             "2"
@@ -41,7 +55,14 @@
             2
           ],
           "questions_answered_count": 12,
-          "current_level": 0.9335832674397897,
+          "clue": {
+            "value": 0.9335832674397897,
+            "confidence_interval": [0.07601666252154723, 0.2760166625215472],
+            "confidence_interval_interpretation": "bad",
+            "sample_size": 4,
+            "sample_size_interpretation": "above",
+            "value_interpretation": "low"
+          },
           "practice_count": 0,
           "page_ids": [
             "3"
@@ -55,7 +76,14 @@
         4
       ],
       "questions_answered_count": 3,
-      "current_level": 0.13278347571119187,
+      "clue":{
+        "value": 0.13278347571119187,
+        "confidence_interval": [0.5331585527121938, 0.7331585527121938],
+        "confidence_interval_interpretation": "bad",
+        "sample_size": 6,
+        "sample_size_interpretation": "above",
+        "value_interpretation": "medium"
+      },
       "practice_count": 0,
       "page_ids": [
         "5",
@@ -69,7 +97,14 @@
             1
           ],
           "questions_answered_count": 1,
-          "current_level": 0.5483725909317109,
+          "clue":{
+            "value": 0.5483725909317109,
+            "confidence_interval": [0.5331585527121938, 0.7331585527121938],
+            "confidence_interval_interpretation": "bad",
+            "sample_size": 6,
+            "sample_size_interpretation": "above",
+            "value_interpretation": "medium"
+          },
           "practice_count": 0,
           "page_ids": [
             "5"
@@ -82,7 +117,14 @@
             2
           ],
           "questions_answered_count": 2,
-          "current_level": 0.35736864708971516,
+          "clue":{
+            "value": 0.35736864708971516,
+            "confidence_interval": [0.5331585527121938, 0.7331585527121938],
+            "confidence_interval_interpretation": "bad",
+            "sample_size": 6,
+            "sample_size_interpretation": "above",
+            "value_interpretation": "medium"
+          },
           "practice_count": 0,
           "page_ids": [
             "6"

--- a/api/user/courses/1/guide.json
+++ b/api/user/courses/1/guide.json
@@ -13,8 +13,14 @@
             "2"
           ],
           "practice_count": 0,
-          "interpretation": "medium",
-          "current_level": 0.41647979570878235,
+          "clue": {
+            "value": 0.41647979570878235,
+            "confidence_interval": [0.48026796534380245, 0.6802679653438024],
+            "confidence_interval_interpretation": "bad",
+            "sample_size": 2,
+            "sample_size_interpretation": "below",
+            "value_interpretation": "medium"
+          },
           "questions_answered_count": 8,
           "chapter_section": [
             1,
@@ -27,8 +33,14 @@
             "3"
           ],
           "practice_count": 0,
-          "interpretation": "medium",
-          "current_level": 0.38865469011386733,
+          "clue": {
+            "value": 0.38865469011386733,
+            "confidence_interval": [0.48026796534380245, 0.6802679653438024],
+            "confidence_interval_interpretation": "bad",
+            "sample_size": 2,
+            "sample_size_interpretation": "below",
+            "value_interpretation": "medium"
+          },
           "questions_answered_count": 2,
           "chapter_section": [
             1,
@@ -42,8 +54,14 @@
         "3"
       ],
       "practice_count": 0,
-      "interpretation": "high",
-      "current_level": 0.8897174467418332,
+      "clue": {
+        "value": 0.8897174467418332,
+        "confidence_interval": [0.48026796534380245, 0.6802679653438024],
+        "confidence_interval_interpretation": "bad",
+        "sample_size": 2,
+        "sample_size_interpretation": "below",
+        "value_interpretation": "high"
+      },
       "questions_answered_count": 10,
       "chapter_section": [
         1

--- a/resources/styles/components/learning-guide.less
+++ b/resources/styles/components/learning-guide.less
@@ -1,6 +1,7 @@
 @import "learning-guide/section-mixin";
 @import "learning-guide/colors-mixin";
 @import "learning-guide/heading";
+@import "learning-guide/statistics";
 @import "learning-guide/teacher";
 @import "learning-guide/teacher-student";
 

--- a/resources/styles/components/learning-guide/statistics.less
+++ b/resources/styles/components/learning-guide/statistics.less
@@ -1,0 +1,6 @@
+.statistics {
+  .clue {
+    font-size: 1rem;
+    color: @tutor-neutral;
+  }
+}

--- a/resources/styles/global/debug-toggle.less
+++ b/resources/styles/global/debug-toggle.less
@@ -1,0 +1,26 @@
+.tutor-app {
+  > .debug-toggle-link {
+    position: fixed;
+    bottom: 0px;
+    left: 0px;
+    z-index: 10; // overlay navbar
+    line-height: 1.5rem;
+    font-size: 1.5rem;
+    color: transparent;
+    &:hover { color: @tutor-neutral; }
+  }
+
+  &.display-debug-content {
+    .debug-toggle-link {
+      color: @tutor-neutral;
+    }
+    .visible-when-debugging {
+      display: block;
+    }
+  }
+
+  .visible-when-debugging {
+    display: none;
+  }
+
+}

--- a/resources/styles/tutor.less
+++ b/resources/styles/tutor.less
@@ -19,6 +19,7 @@
 @import './global/tutor-booksplash-background';
 @import './global/popover';
 @import './global/tooltip';
+@import './global/debug-toggle';
 
 // Component Styling
 @import './components/loadable';

--- a/src/components/app.cjsx
+++ b/src/components/app.cjsx
@@ -23,8 +23,18 @@ module.exports = React.createClass
   storeHistory: (locationChangeEvent) ->
     TransitionActions.load(locationChangeEvent)
 
+  getInitialState: ->
+    displayDebug: false
+
+  toggleDebug: (ev) ->
+    @setState(displayDebug: not @state.displayDebug)
+    ev.preventDefault()
+
   render: ->
-    <div>
-      <Navbar/>
+    classes = ['tutor-app']
+    classes.push 'display-debug-content' if @state.displayDebug
+    <div className={classes.join(' ')}>
+      <a href='#' onClick={@toggleDebug} className='debug-toggle-link'>&pi;</a>
+      <Navbar />
       <RouteHandler/>
     </div>

--- a/src/components/learning-guide/chapter-section-type.coffee
+++ b/src/components/learning-guide/chapter-section-type.coffee
@@ -4,6 +4,6 @@ module.exports = React.PropTypes.shape(
   title:                    React.PropTypes.string
   children:                 React.PropTypes.array
   chapter_section:          React.PropTypes.array
-  current_level:            React.PropTypes.number
+  clue:                     React.PropTypes.object
   questions_answered_count: React.PropTypes.number
 )

--- a/src/components/learning-guide/chapter.cjsx
+++ b/src/components/learning-guide/chapter.cjsx
@@ -6,7 +6,9 @@ ChapterSectionMixin = require '../chapter-section-mixin'
 
 ChapterSectionType = require './chapter-section-type'
 ProgressBar = require './progress-bar'
-Section = require './section'
+Section     = require './section'
+Statistics  = require './statistics'
+
 
 module.exports = React.createClass
 
@@ -27,11 +29,7 @@ module.exports = React.createClass
           <div className='title' title={chapter.title}>{chapter.title}</div>
         </div>
         <ProgressBar {...@props} section={chapter} />
-        <div className='amount-worked'>
-          <span className='count'>
-            {chapter.questions_answered_count} problems worked in this chapter
-          </span>
-        </div>
+        <Statistics  section={chapter} displaying="chapter"/>
       </div>
       <div ref='sections' className='sections'>
         { for section, i in chapter.children

--- a/src/components/learning-guide/guide.cjsx
+++ b/src/components/learning-guide/guide.cjsx
@@ -27,7 +27,7 @@ module.exports = React.createClass
 
   renderWeaker: ->
     # sort sections by current level of understanding
-    sortedSections = _.sortBy(@props.allSections, 'current_level')
+    sortedSections = _.sortBy(@props.allSections, (s) -> s.clue.value )
     # if there are less than 4 sections, use 1/2 of the available ones
     weakStrongCount = Math.min(sortedSections.length / 2, 4)
 

--- a/src/components/learning-guide/progress-bar.cjsx
+++ b/src/components/learning-guide/progress-bar.cjsx
@@ -7,17 +7,21 @@ module.exports = React.createClass
   displayName: 'LearningGuideProgressBar'
 
   propTypes:
-    section: React.PropTypes.object.isRequired
+    section:  React.PropTypes.object.isRequired
     onPractice: React.PropTypes.func
 
   render: ->
     {section, onPractice} = @props
     {clue} = section
 
-    percent = Math.round((clue.value / 1) * 100)
-
-    # always show at least 5% of bar, otherwise it apears empty
-    bar = <BS.ProgressBar className={clue.value_interpretation} now={Math.max(percent, 5)} />
+    bar = if clue.sample_size_interpretation is 'below'
+      <span className="no-data">
+        {if onPractice then 'Practice more to get forecast' else 'Not enough exercises completed'}
+      </span>
+    else
+      percent = Math.round((clue.value / 1) * 100)
+      # always show at least 5% of bar, otherwise it just looks empty
+      <BS.ProgressBar className={clue.value_interpretation} now={Math.max(percent, 5)} />
 
     if onPractice
       tooltip = <BS.Tooltip>Click to practice</BS.Tooltip>

--- a/src/components/learning-guide/progress-bar.cjsx
+++ b/src/components/learning-guide/progress-bar.cjsx
@@ -7,20 +7,17 @@ module.exports = React.createClass
   displayName: 'LearningGuideProgressBar'
 
   propTypes:
-    section:  React.PropTypes.object.isRequired
+    section: React.PropTypes.object.isRequired
     onPractice: React.PropTypes.func
 
   render: ->
-    {section,  onPractice} = @props
+    {section, onPractice} = @props
+    {clue} = section
 
-    bar = if section.current_level
-      percent = Math.round((section.current_level / 1) * 100)
-      # always show at least 5% of bar, otherwise it just looks empty
-      <BS.ProgressBar className={section.interpretation} now={Math.max(percent, 5)} />
-    else
-      <span className="no-data">
-        {if onPractice then 'Practice more to get forecast' else 'Not enough exercises completed'}
-      </span>
+    percent = Math.round((clue.value / 1) * 100)
+
+    # always show at least 5% of bar, otherwise it apears empty
+    bar = <BS.ProgressBar className={clue.value_interpretation} now={Math.max(percent, 5)} />
 
     if onPractice
       tooltip = <BS.Tooltip>Click to practice</BS.Tooltip>

--- a/src/components/learning-guide/section.cjsx
+++ b/src/components/learning-guide/section.cjsx
@@ -2,8 +2,10 @@ React = require 'react'
 BS = require 'react-bootstrap'
 Router = require 'react-router'
 ChapterSectionMixin = require '../chapter-section-mixin'
+ChapterSectionType  = require './chapter-section-type'
 ProgressBar = require './progress-bar'
-ChapterSectionType = require './chapter-section-type'
+Statistics  = require './statistics'
+
 
 module.exports = React.createClass
 
@@ -28,8 +30,6 @@ module.exports = React.createClass
       </div>
 
       <ProgressBar {...@props} />
+      <Statistics section={section} displaying="section" />
 
-      <div className='amount-worked'>
-        <span className='count'>{section.questions_answered_count} problems worked</span>
-      </div>
     </div>

--- a/src/components/learning-guide/statistics.cjsx
+++ b/src/components/learning-guide/statistics.cjsx
@@ -16,7 +16,7 @@ Statistics = React.createClass
       <ul className='clue visible-when-debugging'>
         { for key, value of @props.section.clue
           value = value.join(' ') if _.isArray(value)
-          <li key={key}>{key}: {value}</li>}
+          <li key={key}><strong>{key}</strong>: {value}</li>}
       </ul>
       <div className='amount-worked'>
         <span className='count'>

--- a/src/components/learning-guide/statistics.cjsx
+++ b/src/components/learning-guide/statistics.cjsx
@@ -1,0 +1,29 @@
+React = require 'react'
+BS = require 'react-bootstrap'
+Router = require 'react-router'
+_ = require 'underscore'
+
+ChapterSectionType = require './chapter-section-type'
+
+Statistics = React.createClass
+
+  propTypes:
+    section:  ChapterSectionType.isRequired
+    diplaying: React.PropTypes.string.isRequired
+
+  render: ->
+    <div className='statistics'>
+      <ul className='clue visible-when-debugging'>
+        { for key, value of @props.section.clue
+          value = value.join(' ') if _.isArray(value)
+          <li key={key}>{key}: {value}</li>}
+      </ul>
+      <div className='amount-worked'>
+        <span className='count'>
+          {@props.section.questions_answered_count} problems worked in this {@props.displaying}
+        </span>
+      </div>
+    </div>
+
+
+module.exports = Statistics

--- a/test/components/learning-guide/practice-button.spec.coffee
+++ b/test/components/learning-guide/practice-button.spec.coffee
@@ -24,7 +24,7 @@ describe 'Learning Guide Practice Button', ->
     ).then ({dom}) ->
       Testing.actions.click(dom)
       expect(Testing.router.transitionTo).to.have.been.calledWith( 'viewPractice',
-        { courseId: COURSE_ID }, { page_ids: ['6', '5', '2', '3'] }
+        { courseId: COURSE_ID }, { page_ids: ['2', '3', '5', '6'] }
       )
 
   it 'is disabled if no page ids exist', ->

--- a/test/components/learning-guide/progress-bar.spec.coffee
+++ b/test/components/learning-guide/progress-bar.spec.coffee
@@ -7,7 +7,7 @@ describe 'Learning Guide Progress Bar', ->
   beforeEach ->
     @props = {
       onPractice: sinon.spy()
-      section: { clue: { value: 0.82, magic: true } }
+      section: { clue: { value: 0.82, sample_size_interpretation: 'high', magic: true } }
     }
 
   it 'calls practice callback', ->
@@ -18,3 +18,11 @@ describe 'Learning Guide Progress Bar', ->
   it 'renders the progress bar with correct level', ->
     Testing.renderComponent( Bar, props: @props ).then ({dom}) ->
       expect(dom.querySelector('.progress-bar').style.width).to.equal('82%')
+
+
+  it 'does not render the bar when sample_size_interpretation is below', ->
+    @props.section.clue.sample_size_interpretation = 'below'
+    Testing.renderComponent( Bar, props: @props).then ({dom}) =>
+      expect(dom.querySelector('.progress-bar')).to.be.null
+      Testing.actions.click(dom)
+      expect(@props.onPractice).to.have.been.calledWith(@props.section)

--- a/test/components/learning-guide/progress-bar.spec.coffee
+++ b/test/components/learning-guide/progress-bar.spec.coffee
@@ -7,7 +7,7 @@ describe 'Learning Guide Progress Bar', ->
   beforeEach ->
     @props = {
       onPractice: sinon.spy()
-      section: { current_level: 0.82, magic: true }
+      section: { clue: { value: 0.82, magic: true } }
     }
 
   it 'calls practice callback', ->
@@ -18,9 +18,3 @@ describe 'Learning Guide Progress Bar', ->
   it 'renders the progress bar with correct level', ->
     Testing.renderComponent( Bar, props: @props ).then ({dom}) ->
       expect(dom.querySelector('.progress-bar').style.width).to.equal('82%')
-
-  it 'does not render the bar when no data is available', ->
-    Testing.renderComponent( Bar, props: {onPractice: @props.onPractice, section: {foo:'bar'} } ).then ({dom}) =>
-      expect(dom.querySelector('.progress-bar')).to.be.null
-      Testing.actions.click(dom)
-      expect(@props.onPractice).to.have.been.calledWith({foo: 'bar'})

--- a/test/components/learning-guide/section.spec.coffee
+++ b/test/components/learning-guide/section.spec.coffee
@@ -20,4 +20,4 @@ describe 'Learning Guide Section Panel', ->
 
   it 'reports how many problems were worked', ->
     Testing.renderComponent( Section, props: @props ).then ({dom}) ->
-      expect(dom.querySelector('.amount-worked').textContent).to.equal('8 problems worked')
+      expect(dom.querySelector('.amount-worked .count span:first-child').textContent).to.equal('8')


### PR DESCRIPTION
This updates the FE to handle the additional CLUE values that the BE is now sending.

The Performance Forecast will now only hide the bar if the `sample_size_interpretation` is `below`.  

It now has a secret debug option that will display all the values for debugging.  The option is an invisible pi symbol [ [background](https://www.google.com/search?client=safari&rls=en&q=the+net+pi+symbol&ie=UTF-8&oe=UTF-8) ] at the bottom left corner of the screen.  It's normally transparent, but turns grey when the mouse is hovered over it.  When clicked, display of all CLUE values is toggled.

@Fredasaurus any thoughts on the debug option?

![screen shot 2015-08-11 at 1 24 51 pm](https://cloud.githubusercontent.com/assets/79566/9206391/1e848aec-402d-11e5-9d6a-24c54b87cdbe.png)