### PR TITLE
Fix the notes not wrapping properly in moving man + IE11 note text wrap issues

### DIFF
--- a/resources/styles/book-content/note.less
+++ b/resources/styles/book-content/note.less
@@ -52,6 +52,7 @@ section > section > .note {
   border-top: solid 8px @tutor-neutral-lighter;
   border-bottom: solid 8px @tutor-neutral-lighter;
   padding: 20px 40px;
+  width: 100%;
   .tutor-book-note-style();
 
   &:not(.os-teacher) {


### PR DESCRIPTION
Fix wrapping issues within moving man. This also fixes wrapping issues within notes in IE11

![2015-08-11_16-08-41](https://cloud.githubusercontent.com/assets/8514591/9210672/3d09f6f8-4043-11e5-8dbb-78e448bd7e51.png)
![capture](https://cloud.githubusercontent.com/assets/8514591/9210769/c835877e-4043-11e5-8d90-acf9523ed9f9.PNG)
