### PR TITLE
fix mis-sizing of component from resize listener

### DIFF
--- a/src/components/resize-listener-mixin.cjsx
+++ b/src/components/resize-listener-mixin.cjsx
@@ -19,7 +19,7 @@ module.exports =
     @resizeListener = _.throttle(@resizeEffect, @state.resizeThrottle or @props.resizeThrottle)
 
   componentDidMount: ->
-    _.delay(@setInitialSize, 0)
+    _.defer(@setInitialSize)
     window.addEventListener('resize', @resizeListener)
 
   componentWillUnmount: ->

--- a/src/components/resize-listener-mixin.cjsx
+++ b/src/components/resize-listener-mixin.cjsx
@@ -19,7 +19,7 @@ module.exports =
     @resizeListener = _.throttle(@resizeEffect, @state.resizeThrottle or @props.resizeThrottle)
 
   componentDidMount: ->
-    @setInitialSize()
+    _.delay(@setInitialSize, 0)
     window.addEventListener('resize', @resizeListener)
 
   componentWillUnmount: ->

--- a/src/components/task/breadcrumbs.cjsx
+++ b/src/components/task/breadcrumbs.cjsx
@@ -67,7 +67,8 @@ module.exports = React.createClass
     TaskStore.off('task.afterRecovery', @update)
 
   componentDidUpdate: (prevProps, prevState) ->
-    @_resizeListener(@state) if @state.crumbsWidth isnt prevState.crumbsWidth
+    if @didWidthsChange(prevState, @state)
+      @setShouldShrink(@state)
 
   componentWillReceiveProps: (nextProps) ->
     @setState(hoverCrumb: nextProps.currentStep)
@@ -75,12 +76,12 @@ module.exports = React.createClass
   crumbMounted: ->
     @calculateCrumbsWidth() if @state.crumbsWidth?
 
-  _resizeListener: (sizes) ->
-    shouldShrink = @shouldShrink(sizes)
-    @setState({shouldShrink})
+  didWidthsChange: (prevState, currentState) ->
+    currentState.crumbsWidth isnt prevState.crumbsWidth or currentState.componentEl.width isnt prevState.componentEl.width
 
-  shouldShrink: (sizes) ->
-    sizes.componentEl.width < @state.crumbsWidth
+  setShouldShrink: (sizes) ->
+    shouldShrink = sizes.componentEl.width < @state.crumbsWidth
+    @setState({shouldShrink})
 
   shouldComponentUpdate: (nextProps, nextState) ->
     nextState.updateOnNext

--- a/src/components/task/breadcrumbs.cjsx
+++ b/src/components/task/breadcrumbs.cjsx
@@ -67,7 +67,7 @@ module.exports = React.createClass
     TaskStore.off('task.afterRecovery', @update)
 
   componentDidUpdate: (prevProps, prevState) ->
-    if @didWidthsChange(prevState, @state)
+    if @didWidthChange(prevState, @state)
       @setShouldShrink(@state)
 
   componentWillReceiveProps: (nextProps) ->
@@ -76,7 +76,7 @@ module.exports = React.createClass
   crumbMounted: ->
     @calculateCrumbsWidth() if @state.crumbsWidth?
 
-  didWidthsChange: (prevState, currentState) ->
+  didWidthChange: (prevState, currentState) ->
     currentState.crumbsWidth isnt prevState.crumbsWidth or currentState.componentEl.width isnt prevState.componentEl.width
 
   setShouldShrink: (sizes) ->


### PR DESCRIPTION
Component was confused about it's size, so it would sometimes shrink things initially when it didn't need to.  It would size appropriate on window resize or next crumb update.

## Proper initial sizing
![screen shot 2015-08-11 at 5 58 39 pm](https://cloud.githubusercontent.com/assets/2483873/9212905/af597742-4052-11e5-8e81-e9c15f5995ed.png)



## Bug/before -- confused initial sizing
![screen shot 2015-08-11 at 5 58 14 pm](https://cloud.githubusercontent.com/assets/2483873/9212902/ac771bba-4052-11e5-8dc1-2015148c113e.png)


