### PR TITLE
Add sampleSizeThreshold property to progress bar

### DIFF
--- a/src/components/learning-guide/chapter.cjsx
+++ b/src/components/learning-guide/chapter.cjsx
@@ -18,6 +18,7 @@ module.exports = React.createClass
     courseId: React.PropTypes.string.isRequired
     chapter:  ChapterSectionType.isRequired
     onPractice: React.PropTypes.func
+    sampleSizeThreshold: React.PropTypes.number.isRequired
 
   render: ->
     {chapter, courseId} = @props

--- a/src/components/learning-guide/guide.cjsx
+++ b/src/components/learning-guide/guide.cjsx
@@ -24,6 +24,7 @@ module.exports = React.createClass
     onReturn:    React.PropTypes.func.isRequired
     weakerTitle: React.PropTypes.string.isRequired
     weakerExplanation: React.PropTypes.element
+    sampleSizeThreshold: React.PropTypes.number.isRequired
 
   render: ->
     {courseId} = @props

--- a/src/components/learning-guide/progress-bar.cjsx
+++ b/src/components/learning-guide/progress-bar.cjsx
@@ -6,15 +6,21 @@ ChapterSectionType = require './chapter-section-type'
 module.exports = React.createClass
   displayName: 'LearningGuideProgressBar'
 
+  getDefaultProps: ->
+    # specify a threshold just in case a parent component fails to pass it on
+    sampleSizeThreshold: 3
+
   propTypes:
     section:  React.PropTypes.object.isRequired
     onPractice: React.PropTypes.func
+    courseId:    React.PropTypes.string.isRequired
+    sampleSizeThreshold: React.PropTypes.number.isRequired
 
   render: ->
     {section, onPractice} = @props
     {clue} = section
 
-    bar = if clue.sample_size_interpretation is 'below'
+    bar = if @props.sampleSizeThreshold <= clue.sample_size and clue.sample_size_interpretation is 'below'
       <span className="no-data">
         {if onPractice then 'Practice more to get forecast' else 'Not enough exercises completed'}
       </span>

--- a/src/components/learning-guide/section.cjsx
+++ b/src/components/learning-guide/section.cjsx
@@ -15,6 +15,7 @@ module.exports = React.createClass
     courseId: React.PropTypes.string.isRequired
     section:  ChapterSectionType.isRequired
     onPractice: React.PropTypes.func
+    sampleSizeThreshold: React.PropTypes.number.isRequired
 
   mixins: [ChapterSectionMixin]
 

--- a/src/components/learning-guide/student.cjsx
+++ b/src/components/learning-guide/student.cjsx
@@ -64,6 +64,7 @@ module.exports = React.createClass
         weakerExplanation={@renderWeakerExplanation()}
         weakerEmptyMessage="You haven't worked enough problems for Tutor to predict your weakest topics."
         heading={@renderHeading()}
+        sampleSizeThreshold={3}
         emptyMessage={@renderEmptyMessage()}
         onReturn={@returnToDashboard}
         allSections={LearningGuide.Student.store.getAllSections(courseId)}

--- a/src/components/learning-guide/teacher-student.cjsx
+++ b/src/components/learning-guide/teacher-student.cjsx
@@ -70,6 +70,7 @@ module.exports = React.createClass
         emptyMessage={@renderEmptyMessage()}
         weakerTitle="Their weakest topics"
         weakerEmptyMessage="Your student hasn't worked enough problems for Tutor to predict their weakest topics."
+        sampleSizeThreshold={3}
         onReturn={@returnToDashboard}
         allSections={LearningGuide.TeacherStudent.store.getAllSections(courseId, {roleId})}
         chapters={LearningGuide.TeacherStudent.store.getChapters(courseId, {roleId}) }

--- a/src/components/learning-guide/teacher.cjsx
+++ b/src/components/learning-guide/teacher.cjsx
@@ -76,6 +76,7 @@ module.exports = React.createClass
         weakerEmptyMessage="Your students haven't worked enough problems for Tutor to predict their weakest topics."
         emptyMessage={@renderEmptyMessage()}
         onReturn={@returnToDashboard}
+        sampleSizeThreshold={20}
         allSections={LearningGuide.Teacher.store.getSectionsForPeriod(courseId, @state.periodId)}
         chapters={LearningGuide.Teacher.store.getChaptersForPeriod(courseId, @state.periodId)}
       />

--- a/src/components/learning-guide/weaker-panel.cjsx
+++ b/src/components/learning-guide/weaker-panel.cjsx
@@ -17,6 +17,7 @@ WeakerPanel = React.createClass
     onPractice:          React.PropTypes.func
     sectionCount:        React.PropTypes.number
     minimumSectionCount: React.PropTypes.number
+    sampleSizeThreshold: React.PropTypes.number.isRequired
 
   renderLackingData: ->
     <div className='lacking-data'>{@props.weakerEmptyMessage}</div>

--- a/src/components/learning-guide/weaker-sections.cjsx
+++ b/src/components/learning-guide/weaker-sections.cjsx
@@ -15,6 +15,7 @@ WeakerSections = React.createClass
     sectionCount: React.PropTypes.number
     weakerEmptyMessage:  React.PropTypes.string.isRequired
     minimumSectionCount: React.PropTypes.number
+    sampleSizeThreshold: React.PropTypes.number.isRequired
 
   renderLackingData: ->
     <div className='lacking-data'>{@props.weakerEmptyMessage}</div>

--- a/src/components/student-dashboard/progress-guide.cjsx
+++ b/src/components/student-dashboard/progress-guide.cjsx
@@ -37,6 +37,8 @@ ProgressGuide = React.createClass
       <div className='guide-group'>
         <div className='chapter-panel'>
         <WeakerSections {...@props}
+          sampleSizeThreshold={3}
+          onPractice={@onPractice}
           sections={LearningGuide.Student.store.getAllSections(courseId)}
           weakerEmptyMessage="You haven't worked enough problems for Tutor to predict your weakest topics."
         />

--- a/test/components/learning-guide/progress-bar.spec.coffee
+++ b/test/components/learning-guide/progress-bar.spec.coffee
@@ -7,7 +7,8 @@ describe 'Learning Guide Progress Bar', ->
   beforeEach ->
     @props = {
       onPractice: sinon.spy()
-      section: { clue: { value: 0.82, sample_size_interpretation: 'high', magic: true } }
+      sampleSizeThreshold: 1
+      section: { clue: { value: 0.82, sample_size: 2, sample_size_interpretation: 'high', magic: true } }
     }
 
   it 'calls practice callback', ->
@@ -22,6 +23,14 @@ describe 'Learning Guide Progress Bar', ->
 
   it 'does not render the bar when sample_size_interpretation is below', ->
     @props.section.clue.sample_size_interpretation = 'below'
+    Testing.renderComponent( Bar, props: @props).then ({dom}) =>
+      expect(dom.querySelector('.progress-bar')).to.be.null
+      Testing.actions.click(dom)
+      expect(@props.onPractice).to.have.been.calledWith(@props.section)
+
+  it 'renders if sample size threshold is reached even when sample_size_interpretation is below', ->
+    @props.section.clue.sample_size_interpretation = 'below'
+    @props.sampleSizeThreshold = 2 # same as clue value - should use <= to evaluate
     Testing.renderComponent( Bar, props: @props).then ({dom}) =>
       expect(dom.querySelector('.progress-bar')).to.be.null
       Testing.actions.click(dom)


### PR DESCRIPTION
Allow the teacher and student components to set a value for the # of samples needed to render the progress bar.  If the value given is exceeded the bar will render regardless of what the clue's sample_size_interpretation value is.