### PR TITLE
Prevent text wrapping on exercise images

### DIFF
--- a/resources/styles/book-content/questions.less
+++ b/resources/styles/book-content/questions.less
@@ -9,6 +9,7 @@
   .question-stem {
     float: left;
     width: 96%;
+    img { display: block; }
   }
 }
 .answers-answer {


### PR DESCRIPTION
Before:

<img width="720" alt="screen shot 2015-08-12 at 7 43 45 pm" src="https://cloud.githubusercontent.com/assets/79566/9240363/d08b73b0-412a-11e5-86fd-32598690f24f.png">


After:

<img width="716" alt="screen shot 2015-08-12 at 7 43 16 pm" src="https://cloud.githubusercontent.com/assets/79566/9240365/d64b749e-412a-11e5-9014-09442991dfa5.png">
