### PR TITLE
Fix changing from individual periods

### DIFF
--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -114,8 +114,44 @@ module.exports = React.createClass
     {id} = @props
     TaskPlanActions.updateDueAt(id, value, period?.id)
 
+  setAllPeriods: ->
+    #save current taskings
+    if @state.showingPeriods
+      saveTaskings = TaskPlanStore.getEnabledTaskings(@props.id)
+      @setState(showingPeriods: false, savedTaskings: saveTaskings)
+
+    #get opens at and due at
+    taskingOpensAt = TaskPlanStore.getOpensAt(@props.id) or TimeStore.getNow()
+    taskingDueAt = TaskPlanStore.getDueAt(@props.id) or TaskPlanStore.getMinDueAt(this.props.id)
+
+    #enable all periods
+    course = CourseStore.get(@props.courseId)
+    periods = _.map course?.periods, (period) -> id: period.id
+    TaskPlanActions.setPeriods(@props.id, periods)
+
+    #set dates for all periods
+    @setOpensAt(taskingOpensAt)
+    @setDueAt(taskingDueAt)
+
+  setIndividualPeriods: ->
+    # if taskings exist in state, then load them
+    if (@state.savedTaskings) then TaskPlanActions.replaceTaskings(@props.id, @state.savedTaskings)
+
+    #clear saved taskings
+    @setState(
+      showingPeriods: true
+      savedTaskings: null
+    )
+
   togglePeriodsDisplay: (ev) ->
-    @setState(showingPeriods: not @state.showingPeriods)
+    if (@state.showingPeriods is not @refs.allPeriodsRadio.props.checked)
+      return
+
+    if (@state.showingPeriods)
+      @setAllPeriods()
+    else
+      @setIndividualPeriods()
+
 
   togglePeriodEnabled: (period, ev) ->
     if ev.target.checked
@@ -181,8 +217,9 @@ module.exports = React.createClass
           <input
             id='hide-periods-radio'
             name='toggle-periods-radio'
+            ref='allPeriodsRadio'
             type='radio'
-            onChange={@togglePeriodsDisplay}
+            onChange={@setAllPeriods}
             disabled={TaskPlanStore.isVisibleToStudents(@props.id)}
             checked={not @state.showingPeriods}/>
           <label className="period" htmlFor='hide-periods-radio'>All Periods</label>
@@ -234,7 +271,7 @@ module.exports = React.createClass
             id='show-periods-radio'
             name='toggle-periods-radio'
             type='radio'
-            onChange={@togglePeriodsDisplay}
+            onChange={@setIndividualPeriods}
             disabled={TaskPlanStore.isVisibleToStudents(@props.id)}
             checked={@state.showingPeriods}/>
           <label className="period" htmlFor='show-periods-radio'>Individual Periods</label>

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -94,6 +94,9 @@ TaskPlanConfig =
 
     @_change(id, {tasking_plans})
 
+  replaceTaskings: (id, taskings) ->
+    @_change(id, {tasking_plans: taskings})
+
   _findTasking: (tasking_plans, periodId) ->
     _.findWhere(tasking_plans, {target_id:periodId, target_type:'period'})
 
@@ -385,6 +388,10 @@ TaskPlanConfig =
     hasAnyTasking: (id) ->
       plan = @_getPlan(id)
       !!plan?.tasking_plans
+
+    getEnabledTaskings: (id) ->
+      plan = @_getPlan(id)
+      plan?.tasking_plans
 
     isStatsLoading: (id) -> @_asyncStatusStats[id] is 'loading'
 


### PR DESCRIPTION
Fix for changing from individual periods to all periods in the task plan builder.  It was not working before.

## Steps to replicate
* save a task plan with only one period selected as the date
* open it  up from the calendar again, try to save it with all periods
  * **Before**: Saves with the original period info
  * **Now**: Saves with all periods as expected

### Save a task plan with only one period selected as the date
![screen shot 2015-08-13 at 4 57 37 pm](https://cloud.githubusercontent.com/assets/2483873/9262734/cabea1d4-41dc-11e5-8d49-0c42d4673aab.png)
### open it  up from the calendar again, try to save it with all periods
![screen shot 2015-08-13 at 4 58 51 pm](https://cloud.githubusercontent.com/assets/2483873/9262737/cfceb830-41dc-11e5-8a28-5bc324dfbb08.png)





## Bugged
![screen shot 2015-08-13 at 4 57 37 pm](https://cloud.githubusercontent.com/assets/2483873/9262748/dc044f52-41dc-11e5-8915-d6eaaab30f07.png)


## Fixed
![screen shot 2015-08-13 at 4 59 44 pm](https://cloud.githubusercontent.com/assets/2483873/9262742/d6a2b9cc-41dc-11e5-8ab1-a16b73d586ab.png)