### PR TITLE
Use sample size for choosing weaker sections

### DIFF
--- a/src/components/learning-guide/progress-bar.cjsx
+++ b/src/components/learning-guide/progress-bar.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 BS = require 'react-bootstrap'
 
 ChapterSectionType = require './chapter-section-type'
+LearningGuide = require '../../flux/learning-guide'
 
 module.exports = React.createClass
   displayName: 'LearningGuideProgressBar'
@@ -14,16 +15,15 @@ module.exports = React.createClass
 
   render: ->
     {section, onPractice} = @props
-    {clue} = section
 
-    bar = if clue.sample_size < @props.sampleSizeThreshold and clue.sample_size_interpretation is 'below'
+    bar = if LearningGuide.Helpers.canDisplayForecast(section.clue, @props.sampleSizeThreshold)
+      percent = Math.round((section.clue.value / 1) * 100)
+      # always show at least 5% of bar, otherwise it just looks empty
+      <BS.ProgressBar className={section.clue.value_interpretation} now={Math.max(percent, 5)} />
+    else
       <span className="no-data">
         {if onPractice then 'Practice more to get forecast' else 'Not enough exercises completed'}
       </span>
-    else
-      percent = Math.round((clue.value / 1) * 100)
-      # always show at least 5% of bar, otherwise it just looks empty
-      <BS.ProgressBar className={clue.value_interpretation} now={Math.max(percent, 5)} />
 
     if onPractice
       tooltip = <BS.Tooltip>Click to practice</BS.Tooltip>

--- a/src/components/learning-guide/weaker-sections.cjsx
+++ b/src/components/learning-guide/weaker-sections.cjsx
@@ -21,7 +21,7 @@ WeakerSections = React.createClass
     <div className='lacking-data'>{@props.weakerEmptyMessage}</div>
 
   renderSections: ->
-    for section, i in LearningGuide.Helpers.weakestSections(@props.sections)
+    for section, i in LearningGuide.Helpers.weakestSections(@props.sections, @props.sampleSizeThreshold)
       <Section key={i} section={section} {...@props} />
 
   render: ->

--- a/src/components/student-dashboard/dashboard.cjsx
+++ b/src/components/student-dashboard/dashboard.cjsx
@@ -63,7 +63,7 @@ module.exports = React.createClass
           </BS.Col>
 
           <BS.Col xs=12 md=4 lg=3>
-            <ProgressGuideShell courseId={courseId} />
+            <ProgressGuideShell courseId={courseId} sampleSizeThreshold=3 />
             <div className='actions-box'>
               <BrowseBookButton unstyled courseId={courseId}>
                 <div>Browse the Book</div>

--- a/src/components/student-dashboard/progress-guide.cjsx
+++ b/src/components/student-dashboard/progress-guide.cjsx
@@ -23,6 +23,7 @@ ProgressGuide = React.createClass
 
   propTypes:
     courseId: React.PropTypes.string.isRequired
+    sampleSizeThreshold: React.PropTypes.number.isRequired
 
   onPractice: (section) ->
     @context.router.transitionTo('viewPractice', {courseId: @props.courseId}, {page_ids: section.page_ids})
@@ -37,7 +38,6 @@ ProgressGuide = React.createClass
       <div className='guide-group'>
         <div className='chapter-panel'>
         <WeakerSections {...@props}
-          sampleSizeThreshold={3}
           onPractice={@onPractice}
           sections={LearningGuide.Student.store.getAllSections(courseId)}
           weakerEmptyMessage="You haven't worked enough problems for Tutor to predict your weakest topics."
@@ -54,6 +54,7 @@ ProgressGuidePanels = React.createClass
 
   propTypes:
     courseId: React.PropTypes.string.isRequired
+    sampleSizeThreshold: React.PropTypes.number.isRequired
 
   viewGuide: ->
     @context.router.transitionTo('viewGuide', {courseId: @props.courseId})
@@ -73,21 +74,21 @@ ProgressGuidePanels = React.createClass
     </div>
 
   render: ->
-    return @renderEmpty() unless LearningGuide.Helpers.canPractice(
-      sections:LearningGuide.Student.store.getAllSections(@props.courseId)
-    )
+    return @renderEmpty() unless LearningGuide.Helpers.canPractice({
+      @props, sections:LearningGuide.Student.store.getAllSections(@props.courseId)
+    })
 
     sections = LearningGuide.Helpers.weakestSections(
-      LearningGuide.Student.store.getAllSections(@props.courseId)
+      LearningGuide.Student.store.getAllSections(@props.courseId), @props.sampleSizeThreshold
     )
 
     <div className='progress-guide'>
       <div className='actions-box'>
 
-        <ProgressGuide courseId={@props.courseId} />
+        <ProgressGuide {...@props} />
 
         <PracticeButton title='Practice my weakest topics'
-            courseId={@props.courseId} sections={sections} />
+          {...@props} sections={sections} />
 
         <BS.Button
           onClick={@viewGuide}
@@ -104,6 +105,7 @@ module.exports = React.createClass
 
   propTypes:
     courseId: React.PropTypes.string.isRequired
+    sampleSizeThreshold: React.PropTypes.number.isRequired
 
   renderLoading: (refreshButton) ->
     <div className='actions-box loadable is-loading'>

--- a/src/flux/learning-guide.coffee
+++ b/src/flux/learning-guide.coffee
@@ -97,11 +97,14 @@ TeacherStudent = makeSimpleStore extendConfig {
 
 Helpers = {
 
-  filterForecastedSections: (sections) ->
-    _.filter(sections, (s) -> s.clue.sample_size_interpretation isnt 'below')
+  canDisplayForecast: (clue, sampleSizeThreshold) ->
+    clue.sample_size >= sampleSizeThreshold or clue.sample_size_interpretation isnt 'below'
 
-  weakestSections: (sections, displayCount = 4) ->
-    validSections = @filterForecastedSections(sections)
+  filterForecastedSections: (sections, sampleSizeThreshold) ->
+    _.filter(sections, (s) -> Helpers.canDisplayForecast(s.clue, sampleSizeThreshold) )
+
+  weakestSections: (sections, sampleSizeThreshold, displayCount = 4) ->
+    validSections = @filterForecastedSections(sections, sampleSizeThreshold)
     displayCount = Math.min(Math.floor(validSections.length / 2), displayCount)
 
     # Sort by value and pick 'displayCount' of the weakest
@@ -110,10 +113,10 @@ Helpers = {
       .first(displayCount)
       .value()
 
-  canPractice: ({sections, displayCount, minimumSectionCount}) ->
+  canPractice: ({sections, sampleSizeThreshold, displayCount, minimumSectionCount}) ->
     displayCount ||= 4
     minimumSectionCount ||= 2
-    @weakestSections(sections, displayCount).length >= minimumSectionCount
+    @weakestSections(sections, sampleSizeThreshold, displayCount).length >= minimumSectionCount
 
   pagesForSections: (sections) ->
     _.chain(sections).pluck('page_ids').flatten().uniq().value()


### PR DESCRIPTION
Previously sections were discarded from appearing in the weaker areas of the performance forecast if the `sample_size_interpretation == 'below'`.  We then changed the section to also use the sample_size but failed to update the logic for picking weaker sections.

This moves the logic into the LearningGuide store and uses that for the sections as well.  Now sections should be more likely to appear in the "weaker areas" panel.