### PR TITLE
plan is only editable if no due date is before today

### DIFF
--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -173,6 +173,7 @@ CourseDuration = React.createClass
     plan.isPublished = (plan.published_at? and plan.published_at)
     plan.isPublishing = @isPlanPublishing(plan)
     plan.isTrouble = plan.is_trouble
+    plan.isEditable = not plan.duration.start.isBefore(referenceDate, 'day')
 
   # TODO see how to pull out plan specific logic to show that this
   # can be reused for units, for example

--- a/src/components/course-calendar/plan-details.cjsx
+++ b/src/components/course-calendar/plan-details.cjsx
@@ -37,6 +37,9 @@ CoursePlanDetails = React.createClass
     editLinkName = camelCase("edit-#{type}")
 
     reviewButton = @renderReviewButton()
+    editButton = <Router.Link to={editLinkName} params={linkParams}>
+      <BS.Button>Edit Assignment</BS.Button>
+    </Router.Link> if plan.isEditable
 
     <BS.Modal
       {...@props}
@@ -47,9 +50,7 @@ CoursePlanDetails = React.createClass
       </div>
       <div className='modal-footer'>
         {reviewButton}
-        <Router.Link to={editLinkName} params={linkParams}>
-          <BS.Button>Edit Assignment</BS.Button>
-        </Router.Link>
+        {editButton}
       </div>
     </BS.Modal>
 


### PR DESCRIPTION
## Before
![screen shot 2015-08-14 at 2 01 55 pm](https://cloud.githubusercontent.com/assets/2483873/9281771/1acc3870-428d-11e5-9197-fa7864275dea.png)
![screen shot 2015-08-14 at 2 02 06 pm](https://cloud.githubusercontent.com/assets/2483873/9281770/1aca3836-428d-11e5-8492-4a55508dee5c.png)

## Now
### Don't show edit button for plans with due date before today
![screen shot 2015-08-14 at 1 59 11 pm](https://cloud.githubusercontent.com/assets/2483873/9281780/283f8980-428d-11e5-9822-2019681070c8.png)

### Show edit button if due in future
![screen shot 2015-08-14 at 1 59 21 pm](https://cloud.githubusercontent.com/assets/2483873/9281779/283cf7d8-428d-11e5-92cf-1541d18125fd.png)


@Fredasaurus  would this work?