### PR TITLE
Fixing cancel on select problems/readings

### DIFF
--- a/src/components/task-plan/homework.cjsx
+++ b/src/components/task-plan/homework.cjsx
@@ -31,7 +31,7 @@ ChooseExercises = React.createClass
     })
 
   render: ->
-    {courseId, planId, selected, hide} = @props
+    {courseId, planId, selected, hide, cancel} = @props
 
     header = <span>Add Problems</span>
     selected = TaskPlanStore.getTopics(planId)
@@ -51,7 +51,7 @@ ChooseExercises = React.createClass
       exerciseSummary = <ExerciseSummary
           canReview={true}
           reviewClicked={hide}
-          onCancel={hide}
+          onCancel={cancel}
           planId={planId}/>
 
       addExercises = <AddExercises
@@ -66,6 +66,7 @@ ChooseExercises = React.createClass
         courseId={courseId}
         planId={planId}
         selected={selected}
+        cancel={cancel}
         hide={hide} />
 
       <PinnedHeaderFooterCard
@@ -114,6 +115,7 @@ HomeworkPlan = React.createClass
       chooseExercises = <ChooseExercises
         courseId={courseId}
         planId={id}
+        cancel={@cancelSelection}
         hide={@hideSectionTopics}
         selected={topics}/>
 

--- a/src/components/task-plan/plan-mixin.coffee
+++ b/src/components/task-plan/plan-mixin.coffee
@@ -28,7 +28,6 @@ module.exports =
     })
 
   cancelSelection: ->
-    console.log(@state.savedTopics)
     TaskPlanActions.updateTopics(@props.id, @state.savedTopics)
     TaskPlanActions.updateExercises(@props.id, @state.savedExercises)
     @hideSectionTopics()

--- a/src/components/task-plan/plan-mixin.coffee
+++ b/src/components/task-plan/plan-mixin.coffee
@@ -22,8 +22,16 @@ module.exports =
 
   showSectionTopics: ->
     @setState({
-      showSectionTopics: true
+      showSectionTopics: true,
+      savedTopics: TaskPlanStore.getTopics(@props.id),
+      savedExercises: TaskPlanStore.getExercises(@props.id)
     })
+
+  cancelSelection: ->
+    console.log(@state.savedTopics)
+    TaskPlanActions.updateTopics(@props.id, @state.savedTopics)
+    TaskPlanActions.updateExercises(@props.id, @state.savedExercises)
+    @hideSectionTopics()
 
   hideSectionTopics: ->
     @setState({

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -109,6 +109,7 @@ ChooseReadings = React.createClass
       courseId={@props.courseId}
       planId={@props.planId}
       selected={@props.selected}
+      cancel={@props.cancel}
       hide={@hide} />
 
 ReadingPlan = React.createClass
@@ -139,6 +140,7 @@ ReadingPlan = React.createClass
       formClasses.push('hide')
       selectReadings = <ChooseReadings
                         hide={@hideSectionTopics}
+                        cancel={@cancelSelection}
                         courseId={courseId}
                         planId={id}
                         selected={topics}/>

--- a/src/components/task-plan/select-topics.cjsx
+++ b/src/components/task-plan/select-topics.cjsx
@@ -121,7 +121,7 @@ SelectTopics = React.createClass
     <ChapterAccordion {...@props} expanded={expanded} chapter={chapter}/>
 
   renderDialog: ->
-    {courseId, planId, selected, hide, header, primary} = @props
+    {courseId, planId, selected, hide, header, primary, cancel} = @props
 
     selected = TaskPlanStore.getTopics(planId)
     chapters = _.map(TocStore.get(), @renderChapterPanels)
@@ -133,7 +133,7 @@ SelectTopics = React.createClass
       confirmMsg='Are you sure you want to close?'
       cancel='Cancel'
       isChanged={-> true}
-      onCancel={hide}>
+      onCancel={cancel}>
 
       <div className='select-reading-chapters'>
         {chapters}

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -200,6 +200,11 @@ TaskPlanConfig =
     exercise_ids = ExerciseStore.removeTopicExercises(exercise_ids, topicId)
     @_change(id, {settings: {page_ids, exercise_ids, exercises_count_dynamic}})
 
+  updateTopics: (id, page_ids) ->
+    plan = @_getPlan(id)
+    {exercise_ids, exercises_count_dynamic} = plan.settings
+    @_change(id, {settings: {page_ids, exercise_ids, exercises_count_dynamic}})
+
   addExercise: (id, exercise) ->
     plan = @_getPlan(id)
     {page_ids, exercise_ids, exercises_count_dynamic} = plan.settings
@@ -220,6 +225,11 @@ TaskPlanConfig =
 
     @_change(id, {settings: {page_ids, exercise_ids, exercises_count_dynamic}})
 
+  updateExercises: (id, exercise_ids) ->
+    plan = @_getPlan(id)
+    {page_ids, exercises_count_dynamic} = plan.settings
+    @_change(id, {settings: {page_ids, exercise_ids, exercises_count_dynamic}})
+    
   moveReading: (id, topicId, step) ->
     plan = @_getPlan(id)
     {page_ids, exercises_count_dynamic} = plan.settings


### PR DESCRIPTION
No UI changes, just allows for cancel when selection problems or readings.

From testing previous to this sprint: https://www.pivotaltracker.com/story/show/101136084

## Without Fix
Homework problems and reading selections do not clear upon cancel
### Homework
1. Selection
  ![screen shot 2015-08-17 at 6 45 17 pm](https://cloud.githubusercontent.com/assets/2483873/9319116/813ef054-4510-11e5-89dc-fec756d44402.png)
1. After cancel
  ![screen shot 2015-08-17 at 6 45 29 pm](https://cloud.githubusercontent.com/assets/2483873/9319117/814515b0-4510-11e5-8270-27b7217f9498.png)

### Reading
1. Selection
  ![screen shot 2015-08-17 at 6 44 02 pm](https://cloud.githubusercontent.com/assets/2483873/9319119/8e5d357a-4510-11e5-9dfc-5123c25aab9b.png)
1. After cancel
  ![screen shot 2015-08-17 at 6 44 08 pm](https://cloud.githubusercontent.com/assets/2483873/9319120/8e5f01f2-4510-11e5-878b-ed5dde9d1642.png)





## With Fix

### Homework
1. Selection
  ![screen shot 2015-08-17 at 6 51 39 pm](https://cloud.githubusercontent.com/assets/2483873/9319193/46545ee2-4511-11e5-9d5d-b5ffc2822822.png)
1. After cancel
  ![screen shot 2015-08-17 at 6 51 42 pm](https://cloud.githubusercontent.com/assets/2483873/9319192/4651a85a-4511-11e5-9ead-9a6fdf9f4644.png)


### Reading
1. Selection
  ![screen shot 2015-08-17 at 6 52 06 pm](https://cloud.githubusercontent.com/assets/2483873/9319199/61a734f8-4511-11e5-9a27-27cf5f205085.png)

1. After cancel
  ![screen shot 2015-08-17 at 6 52 11 pm](https://cloud.githubusercontent.com/assets/2483873/9319200/61a7fa96-4511-11e5-8009-d4be6672da9d.png)