### PR TITLE
Move buttons to left and show OK first

### DIFF
--- a/resources/styles/components/tutor-dialog.less
+++ b/resources/styles/components/tutor-dialog.less
@@ -6,5 +6,8 @@
       overflow: scroll;
     }
   }
-
+  .modal-footer {
+    text-align: left;
+    padding: @modal-inner-padding;
+  }
 }

--- a/src/components/tutor-dialog.cjsx
+++ b/src/components/tutor-dialog.cjsx
@@ -36,10 +36,10 @@ DetachedTutorDialog = React.createClass
   render: ->
     return null unless @state.show
     buttons = @props.buttons or [
-        <BS.Button key='cancel' className='cancel'
-          onClick={_.compose(@props.onCancel,  @_hide)}>Cancel</BS.Button>
         <BS.Button key='ok'     className='ok'
           onClick={_.compose(@props.onOk, @_hide)} bsStyle='primary'>OK</BS.Button>
+        <BS.Button key='cancel' className='cancel'
+          onClick={_.compose(@props.onCancel,  @_hide)}>Cancel</BS.Button>
     ]
     classes = ['tutor-dialog']
     classes.push @props.className if @props.className
@@ -48,7 +48,7 @@ DetachedTutorDialog = React.createClass
       <div className='modal-body'>
         {@props.body}
       </div>
-      <div className='modal-footer'>
+      <div className='modal-footer pull-left'>
         {buttons}
       </div>
     </BS.Modal>

--- a/src/components/tutor-dialog.cjsx
+++ b/src/components/tutor-dialog.cjsx
@@ -48,7 +48,7 @@ DetachedTutorDialog = React.createClass
       <div className='modal-body'>
         {@props.body}
       </div>
-      <div className='modal-footer pull-left'>
+      <div className='modal-footer'>
         {buttons}
       </div>
     </BS.Modal>


### PR DESCRIPTION
As discussed in #644 this moves the buttons to the left and switches their order so that the OK button appears first

![screen shot 2015-08-17 at 10 49 29 am](https://cloud.githubusercontent.com/assets/79566/9309214/be5cdd22-44cd-11e5-89d2-7cba3cd8a585.png)