### PR TITLE
Links in ref book and iReadings need some updates

### DIFF
--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -1,6 +1,7 @@
 _ = require 'underscore'
 S = require '../helpers/string'
 dom = require '../helpers/dom'
+{CourseStore} = require '../flux/course'
 
 # According to the tagging legend exercises with a link should have `a.os-embed`
 # but in the content they are just a vanilla link.
@@ -50,14 +51,17 @@ module.exports =
     S.capitalize(tag)
 
   buildReferenceBookLink: (cnxId) ->
-    referenceBookParams = _.clone(@context.router.getCurrentParams())
-    referenceBookParams.cnxId = cnxId or @getCnxId()
+    {courseId} = @context.router.getCurrentParams()
+    course = CourseStore.get(courseId)
+    referenceBookParams =
+      bookId: course.book_id
+      cnxId: cnxId or @getCnxId()
     pageUrl = @context.router.makeHref('viewReferenceBookPage', referenceBookParams)
 
     pageUrl
 
   isMediaLink: (link) ->
-    link.innerText is '[link]' and link.hash.length > 0 and link.hash.search('/') is -1
+    link.hash.length > 0 and link.hash.search('/') is -1
 
   hasCNXId: (link) ->
     trueHref = link.getAttribute('href')
@@ -94,7 +98,8 @@ module.exports =
     root = @getDOMNode()
     media = root.querySelector(link.hash)
     tag = @getMediaTag(media)
-    link.innerText = tag if tag?
+    link.innerText = tag if link.innerText is '[link]' and tag?
+    link.target = '_self'
 
   processLinks: ->
     root = @getDOMNode()


### PR DESCRIPTION
- [X] links that are linking to a figure found in itself should have target='_self'
- [X] check link that are not [link] text for media linking as well
- [X] update to use book_id

## With fix
### links that are linking to a figure found in itself should have target='_self'
1. Clicking on link
  ![screen shot 2015-08-17 at 7 33 37 pm](https://cloud.githubusercontent.com/assets/2483873/9319738/58cba4da-4517-11e5-8fd5-d67f583b2bc6.png)
1. After link is clicked, focuses on targeted figure, on same page/tab
  ![screen shot 2015-08-17 at 7 33 27 pm](https://cloud.githubusercontent.com/assets/2483873/9319737/58c9d948-4517-11e5-90af-27ee430ccecf.png)

### check links that are not "[link]" as link text for media linking as well
![screen shot 2015-08-17 at 7 31 36 pm](https://cloud.githubusercontent.com/assets/2483873/9319741/6257d7c6-4517-11e5-8bb8-f49ba311cfa9.png)
### update to use book_id
  * see link in bottom right hand corner of previous SS.  shows properly formed reference book link

## Without fix
### links linking to a figure within page can open in new window
1. Clicking on link
  ![screen shot 2015-08-17 at 7 43 00 pm](https://cloud.githubusercontent.com/assets/2483873/9319818/75e09944-4518-11e5-82ab-7375423fdd47.png)
1. After link is clicked, opens to figure in new tab
  ![screen shot 2015-08-17 at 7 43 03 pm](https://cloud.githubusercontent.com/assets/2483873/9319817/75e07b94-4518-11e5-8469-e8c2f0fe34db.png)

### ignores links that don't have "[link]" as link text
* not properly linked because link does not get processed
   ![screen shot 2015-08-17 at 7 42 18 pm](https://cloud.githubusercontent.com/assets/2483873/9319849/bd7d9270-4518-11e5-94b2-53f6b33d8ff6.png)

### Errors on links that aren't in step, but in reference book
![screen shot 2015-08-17 at 7 48 17 pm](https://cloud.githubusercontent.com/assets/2483873/9319880/00de64c2-4519-11e5-9c5d-1d13e908a7d0.png)

