### PR TITLE
Intro pages, chapter titles, key terms, show teacher content

### DIFF
--- a/resources/styles/book-content/ap-bio/ap-connection.less
+++ b/resources/styles/book-content/ap-bio/ap-connection.less
@@ -24,10 +24,6 @@
   p {
     #fonts > .sans(1.8rem, 1.75em);
     color: @tutor-neutral-dark;
-   [data-type="term" ]{
-      font-weight: bold;
-      font-style: italic;
-    }
     .ost-standards-name {
         display: block;
       }

--- a/resources/styles/book-content/ap-bio/ap-connection.less
+++ b/resources/styles/book-content/ap-bio/ap-connection.less
@@ -20,10 +20,14 @@
   border-top: solid 8px @tutor-neutral-lighter;
   border-bottom: solid 8px @tutor-neutral-lighter;
   padding: 20px 40px;
+
   p {
     #fonts > .sans(1.8rem, 1.75em);
     color: @tutor-neutral-dark;
-    span {
+   [data-type="term" ]{
+      font-weight: bold;
+    }
+    span:not(data-type="term") {
         display: block;
       }
     }

--- a/resources/styles/book-content/ap-bio/ap-connection.less
+++ b/resources/styles/book-content/ap-bio/ap-connection.less
@@ -26,6 +26,7 @@
     color: @tutor-neutral-dark;
    [data-type="term" ]{
       font-weight: bold;
+      font-style: italic;
     }
     span:not(data-type="term") {
         display: block;

--- a/resources/styles/book-content/ap-bio/ap-connection.less
+++ b/resources/styles/book-content/ap-bio/ap-connection.less
@@ -15,7 +15,7 @@
   min-height: auto;
 }
   background: @tutor-neutral-lightest;
-  margin: 40px 0 32px 0;
+  margin: 0 0 32px 0;
   clear: both;
   border-top: solid 8px @tutor-neutral-lighter;
   border-bottom: solid 8px @tutor-neutral-lighter;

--- a/resources/styles/book-content/ap-bio/ap-connection.less
+++ b/resources/styles/book-content/ap-bio/ap-connection.less
@@ -28,7 +28,7 @@
       font-weight: bold;
       font-style: italic;
     }
-    span:not(data-type="term") {
+    .ost-standards-name {
         display: block;
       }
     }

--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -4,6 +4,10 @@
 .summary,
 [data-type=abstract] {
 }
+[data-type=term]{
+  font-weight: bold;
+  font-style: italic;
+}
 table {
   width: 100%;
   margin-bottom: 32px;

--- a/resources/styles/book-content/index.less
+++ b/resources/styles/book-content/index.less
@@ -39,7 +39,7 @@
 
   .tutor-book-theme-first-letter(@tutor-book-hs-physics-secondary);
   .tutor-book-theme-typography(@tutor-book-hs-physics-primary);
-  .tutor-book-theme-learning-objectives(@tutor-book-hs-physics-primary);
+  .tutor-book-theme-learning-objectives(@tutor-book-hs-physics-primary; rgba(255,255,255,.8));
   .tutor-book-theme-splash-image(@tutor-book-hs-physics-primary);
   .tutor-book-theme-note(@tutor-book-hs-physics-primary; @tutor-book-hs-physics-secondary);
   .tutor-bullet-lists(@tutor-book-hs-physics-secondary);

--- a/resources/styles/book-content/learning-objectives.less
+++ b/resources/styles/book-content/learning-objectives.less
@@ -3,6 +3,7 @@
   #fonts > .sans(1.8rem, 1.8rem);
   width: 100%;
   min-height: 100px;
+  margin-bottom: 40px;
   .book-content-full-width();
   .flex-display(inline-flex);
   margin-top: -@tutor-card-body-padding-vertical;

--- a/resources/styles/book-content/learning-objectives.less
+++ b/resources/styles/book-content/learning-objectives.less
@@ -13,7 +13,7 @@
     display: none;
   }
   p {
-    #fonts > .sans(1.5rem, 1.8em);
+    #fonts > .sans(1.4rem, 1.8em);
     width: 220px; // keep line length consistent
     text-transform: uppercase;
     text-align: right;

--- a/resources/styles/book-content/note.less
+++ b/resources/styles/book-content/note.less
@@ -47,7 +47,7 @@
 > section > .note:not(.learning-objectives),
 section > section > .note {
   background: @tutor-neutral-lightest;
-  margin: 68px 0 32px 0;
+  margin: 38px 0 32px 0;
   clear: both;
   border-top: solid 8px @tutor-neutral-lighter;
   border-bottom: solid 8px @tutor-neutral-lighter;

--- a/resources/styles/book-content/splash-image.less
+++ b/resources/styles/book-content/splash-image.less
@@ -13,15 +13,13 @@
 
   + p {
     clear: both;
-    padding-top: 40px;
+    padding-top: 20px;
   }
   .tutor-ui-overlay {
     position: relative;
-    margin-top: -100px;
     font-size: 3rem;
-    line-height: 100px;
-    height: 100px;
-    padding: 0 20px;
-    text-overflow: ellipsis;
+    line-height: 3rem;
+    font-weight: 600;
+    padding: 30px 20px;
   }
 }

--- a/resources/styles/book-content/theming-mixins.less
+++ b/resources/styles/book-content/theming-mixins.less
@@ -49,7 +49,7 @@
 .tutor-book-theme-splash-image(@overlay: @tutor-book-splash-overlay; @text-color: @tutor-book-splash-text) {
   .splash {
     .tutor-ui-overlay {
-      background-color: fade(@overlay, 80%);
+      background-color: @overlay;
       color: @text-color;
     }
   }

--- a/resources/styles/components/reference-book/navbar.less
+++ b/resources/styles/components/reference-book/navbar.less
@@ -25,7 +25,7 @@
       }
     }
     .teacher-edition  {
-      margin: 10px;
+      margin: 12px 0;
     }
     .menu-toggle:before{ content: @fa-var-list; }
     // don't collapse navbar when screen is narrow

--- a/resources/styles/components/reference-book/navbar.less
+++ b/resources/styles/components/reference-book/navbar.less
@@ -13,7 +13,8 @@
       font-size: 2.8rem;
       padding: 18px 16px 14px 16px;
     }
-    .section-title, .teacher-edition {
+
+    .section-title {
       font-size: 1.8rem;
       margin: 0 0 0 40px;
       padding-top: 14px;
@@ -22,6 +23,9 @@
         margin-right: 0.5rem;
         text-align: center;
       }
+    }
+    .teacher-edition  {
+      margin: 10px;
     }
     .menu-toggle:before{ content: @fa-var-list; }
     // don't collapse navbar when screen is narrow

--- a/resources/styles/global/navbar.less
+++ b/resources/styles/global/navbar.less
@@ -28,7 +28,7 @@
 
   .ui-rice-logo {
     display: inline-block;
-    margin-top: 15px;
+    margin: 15px 0 15px 20px;
     height: 30px;
     width: 84px;
     .tutor-background-image('rice-logo.png');

--- a/resources/styles/old/global/buttons.less
+++ b/resources/styles/old/global/buttons.less
@@ -57,7 +57,7 @@
 
   &.btn-sm {
     font-size: 1.2rem;
-    //padding: unsure at this time
+    padding: 6px 12px;
   }
 
   &.btn-default {

--- a/src/components/reference-book/navbar.cjsx
+++ b/src/components/reference-book/navbar.cjsx
@@ -31,9 +31,9 @@ module.exports = React.createClass
 
   renderTeacher: ->
     <BS.Nav navbar right>
-      <BS.NavItem className="teacher-edition" onClick={@props.showTeacherEdition}>
+      <BS.Button className="teacher-edition" onClick={@props.showTeacherEdition}>
         {@props.teacherLinkText}
-      </BS.NavItem>
+      </BS.Button>
     </BS.Nav>
 
   render: ->

--- a/src/components/reference-book/navbar.cjsx
+++ b/src/components/reference-book/navbar.cjsx
@@ -31,7 +31,7 @@ module.exports = React.createClass
 
   renderTeacher: ->
     <BS.Nav navbar right>
-      <BS.Button className="teacher-edition" onClick={@props.showTeacherEdition}>
+      <BS.Button className="btn-sm teacher-edition" onClick={@props.showTeacherEdition}>
         {@props.teacherLinkText}
       </BS.Button>
     </BS.Nav>


### PR DESCRIPTION
A grab bag of reference view and interactive reading styles. Apologies for the breadth.

1. Moving the title overlay below the image. Also now accommodates two line titles.
<img width="1410" alt="screen shot 2015-08-18 at 11 31 15 am" src="https://cloud.githubusercontent.com/assets/2372608/9336484/7d0a63c6-459f-11e5-8ea2-7902668d4f3e.png">

2. Changing the alpha of Physics LOs to make them easier to read on blue background.

3. Making the spacing after the Chapter intro sections consistent.
<img width="1103" alt="screen shot 2015-08-18 at 11 31 52 am" src="https://cloud.githubusercontent.com/assets/2372608/9336521/a8c5179a-459f-11e5-8f8e-de5d6681611a.png">

4. Creating styles for key terms.
<img width="887" alt="screen shot 2015-08-18 at 11 32 24 am" src="https://cloud.githubusercontent.com/assets/2372608/9336552/cee1719e-459f-11e5-95c0-23cded4d0ea5.png">

5. Styling the show teacher content into button.
<img width="1416" alt="screen shot 2015-08-18 at 11 32 45 am" src="https://cloud.githubusercontent.com/assets/2372608/9336589/0e24eeb2-45a0-11e5-980b-3f5b446456ee.png">

6. Adding Key Terms styles for all content
![2015-08-18_11-15-18](https://cloud.githubusercontent.com/assets/8514591/9336703/970d14c0-45a0-11e5-9e48-039aa85ed021.png)


