### PR TITLE
Fix JS exception when navigating reference book

### DIFF
--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -1,3 +1,4 @@
+React = require 'react'
 _ = require 'underscore'
 S = require '../helpers/string'
 dom = require '../helpers/dom'
@@ -19,10 +20,10 @@ module.exports =
     @detectImgAspectRatio()
     @processLinks()
 
-  insertOverlays: ->
   contextTypes:
     router: React.PropTypes.func
 
+  insertOverlays: ->
     title = @getSplashTitle()
     return unless title
     root = @getDOMNode()
@@ -54,14 +55,12 @@ module.exports =
     S.capitalize(tag)
 
   buildReferenceBookLink: (cnxId) ->
-    {courseId} = @context.router.getCurrentParams()
-    course = CourseStore.get(courseId)
-    referenceBookParams =
-      bookId: course.book_id
-      cnxId: cnxId or @getCnxId()
-    pageUrl = @context.router.makeHref('viewReferenceBookPage', referenceBookParams)
-
-    pageUrl
+    {courseId, bookId} = @context.router.getCurrentParams()
+    if courseId and not bookId
+      bookId = CourseStore.get(courseId)?.book_id
+    @context.router.makeHref( 'viewReferenceBookPage',
+      { bookId, cnxId: cnxId or @getCnxId() }
+    )
 
   isMediaLink: (link) ->
     link.hash.length > 0 and link.hash.search('/') is -1

--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -20,6 +20,9 @@ module.exports =
     @processLinks()
 
   insertOverlays: ->
+  contextTypes:
+    router: React.PropTypes.func
+
     title = @getSplashTitle()
     return unless title
     root = @getDOMNode()

--- a/src/components/task-plan/chapter-section.cjsx
+++ b/src/components/task-plan/chapter-section.cjsx
@@ -5,10 +5,10 @@ _ = require 'underscore'
 module.exports = React.createClass
   displayName: 'ChapterSection'
   propTypes:
-    section: React.PropTypes.oneOfType(
+    section: React.PropTypes.oneOfType([
       React.PropTypes.array
       React.PropTypes.string
-    ).isRequired
+    ]).isRequired
 
   componentWillMount: ->
     @setState(skipZeros: false)

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -36,6 +36,7 @@ require './components/tutor-input.spec'
 require './components/tutor-dialog.spec'
 require './components/unsaved-state.spec'
 require './components/buttons/browse-the-book.spec'
+require './components/book-content-mixin.spec'
 
 require './crud-store.spec'
 require './task-store.spec'

--- a/test/components/book-content-mixin.spec.coffee
+++ b/test/components/book-content-mixin.spec.coffee
@@ -1,0 +1,35 @@
+{React, Testing, expect, sinon} = require './helpers/component-testing'
+
+CNX_ID    = '128@3'
+COURSE_ID = '1'
+COURSE    = require '../../api/user/courses/1.json'
+
+{CourseActions} = require '../../src/flux/course'
+
+TestComponent = React.createClass
+  mixins: [ require('../../src/components/book-content-mixin') ]
+  getCnxId: sinon.spy -> CNX_ID
+  getSplashTitle: sinon.spy -> 'Test Title'
+  render: ->
+    React.createElement('div', {}, @buildReferenceBookLink())
+
+describe 'Book content mixin', ->
+
+  beforeEach ->
+    CourseActions.loaded(COURSE, COURSE_ID)
+
+  describe 'building reference book links', ->
+
+    it 'looks up book id from course store', ->
+      Testing.renderComponent( TestComponent, routerParams: {courseId: '1'} ).then ({element, dom}) ->
+        expect(Testing.router.makeHref).to.have.been.calledWith('viewReferenceBookPage', {
+          bookId: COURSE.book_id, cnxId: CNX_ID
+        })
+        console.log dom
+
+    it 'uses book id if provided', ->
+      Testing.renderComponent( TestComponent, routerParams: {bookId: '459'} )
+        .then ({element}) ->
+          expect(Testing.router.makeHref).to.have.been.calledWith('viewReferenceBookPage', {
+            bookId: '459', cnxId: CNX_ID
+          })


### PR DESCRIPTION
Sometimes the when ref book router params do not have courseId, they just have bookId.  

No need to look it up in that case.