### PR TITLE
Render blank cell when no assignment data is present

### DIFF
--- a/src/components/performance/absent-cell.cjsx
+++ b/src/components/performance/absent-cell.cjsx
@@ -1,0 +1,7 @@
+React    = require 'react'
+
+module.exports = React.createClass
+  displayName: 'AbsentCell'
+
+  render: ->
+    <span/>

--- a/src/components/performance/index.cjsx
+++ b/src/components/performance/index.cjsx
@@ -6,9 +6,9 @@ Time   = require '../time'
 ReadingCell  = require './reading-cell'
 HomeworkCell = require './homework-cell'
 NameCell     = require './name-cell'
+AbsentCell   = require './absent-cell'
 ExternalCell = require './external-cell'
 SortingHeader = require './sorting-header'
-
 FixedDataTable = require 'fixed-data-table'
 Table = FixedDataTable.Table
 Column = FixedDataTable.Column
@@ -122,8 +122,9 @@ Performance = React.createClass
     ]
     for task in student_data.data
       props.task = task
-      columns.push switch task.type
-        when 'reading' then  <ReadingCell  key='reading'  {...props} />
+      columns.push switch task?.type or 'null'
+        when 'null'     then <AbsentCell   key='absent'   {...props} />
+        when 'reading'  then <ReadingCell  key='reading'  {...props} />
         when 'homework' then <HomeworkCell key='homework' {...props} />
         when 'external' then <ExternalCell key='extern'   {...props} />
     columns


### PR DESCRIPTION
When a student is dropped or transfered to a different period, future
assignements will not have any data.  The student should still
appear in the report but not display any information for the assignments
they didn't participate in.

BE PR: https://github.com/openstax/tutor-server/pull/608

Note the assignments "No Atticus" and "No Lily"  They were assigned after Atticus was dropped from the period, and Lily was transferred to it.
<img width="1266" alt="screen shot 2015-08-19 at 8 36 26 pm" src="https://cloud.githubusercontent.com/assets/79566/9373631/33dce0ca-46b2-11e5-92ae-1153c74dbb36.png">

