### PR TITLE
fix where draft was not linking to edit from calendar

### DIFF
--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -141,7 +141,7 @@ CoursePlan = React.createClass
     label = <CoursePlanLabel {...labelProps} ref="label#{index}"/>
 
     displayComponent = CoursePlanDisplayEdit
-    displayComponent = CoursePlanDisplayQuickLook if hasQuickLook?
+    displayComponent = CoursePlanDisplayQuickLook if hasQuickLook
 
     displayComponentProps = {
       plan,

--- a/test/components/course-calendar.spec.coffee
+++ b/test/components/course-calendar.spec.coffee
@@ -15,11 +15,16 @@ COURSE = require '../../api/user/courses/1.json'
 {CourseActions} = require '../../src/flux/course'
 
 planId = '1'
+draftPlanId = '3'
 courseId = '1'
 
 VALID_MODEL = require '../../api/courses/1/dashboard.json'
 # pin plan 1 to one month ago for testing
 _.each VALID_MODEL.plans[0].tasking_plans, (tasking) ->
+  tasking.due_at = moment(TimeStore.getNow()).subtract(1, 'month').toDate()
+
+# pin draft plan to one month ago for testing
+_.each VALID_MODEL.plans[1].tasking_plans, (tasking) ->
   tasking.due_at = moment(TimeStore.getNow()).subtract(1, 'month').toDate()
 
 VALID_PLAN_MODEL = require '../../api/plans/1/stats.json'
@@ -30,6 +35,7 @@ describe 'Course Calendar', ->
     CourseActions.loaded(COURSE, courseId)
     TeacherTaskPlanActions.loaded(VALID_MODEL, courseId)
     plan = TaskPlanStatsStore.get(planId)
+    draftPlan = TaskPlanStatsStore.get(draftPlanId)
 
     calendarTests
       .goToCalendar("/courses/#{courseId}/t/calendar", courseId)
@@ -88,6 +94,22 @@ describe 'Course Calendar', ->
       .clickPrevious(@result)
       .then(calendarChecks.checkIsLabelPreviousMonth)
       .then(calendarChecks.checkDoesViewHavePlans)
+      .then( ->
+        done()
+      , done)
+
+  it 'should show plan edit link when plan is a draft', (done) ->
+    calendarActions
+      .clickPrevious(@result)
+      .then(calendarChecks.checkIsEditPlanLink(draftPlanId))
+      .then( ->
+        done()
+      , done)
+
+  it 'should have plan details onClick when plan is published', (done) ->
+    calendarActions
+      .clickPrevious(@result)
+      .then(calendarChecks.checkIsViewPlanElement(planId))
       .then( ->
         done()
       , done)

--- a/test/components/helpers/calendar/checks.coffee
+++ b/test/components/helpers/calendar/checks.coffee
@@ -12,6 +12,7 @@ React = require 'react/addons'
 {TimeActions, TimeStore} = require '../../../../src/flux/time'
 
 Add = require '../../../../src/components/course-calendar/add'
+{CoursePlanDisplayEdit, CoursePlanDisplayQuickLook} = require '../../../../src/components/course-calendar/plan-display'
 
 checks =
 
@@ -221,6 +222,42 @@ checks._checkDoesViewShowPlan = (planId, {div, component, state, router, history
 checks.checkDoesViewShowPlan = (planId) ->
   (args...) ->
     Promise.resolve(checks._checkDoesViewShowPlan(planId, args...))
+
+checks._checkIsEditPlanLink = (planId, {div, component, state, router, history, courseId}) ->
+  plansList = TeacherTaskPlanStore.getActiveCoursePlans(courseId)
+  plan = _.findWhere(plansList, {id: planId})
+
+  planEditRoute = "edit-#{plan.type}"
+
+  targetEditLink = router.makeHref(camelCase(planEditRoute), {courseId, id: planId})
+  planEdits = React.addons.TestUtils.scryRenderedComponentsWithType(component, CoursePlanDisplayEdit)
+  thisPlanEdit = _.find(planEdits, (planEdit) ->
+    planEdit.props.plan.id is planId
+  )
+
+  # checks that there's a link, and that the href matches
+  expect(div.querySelector(".course-plan-#{planId} a").href).to.contain(targetEditLink)
+  # checks that a CoursePlanDisplayEdit component was rendered for this plan
+  expect(thisPlanEdit).to.not.be.null
+
+checks.checkIsEditPlanLink = (planId) ->
+  (args...) ->
+    Promise.resolve(checks._checkIsEditPlanLink(planId, args...))
+
+checks._checkIsViewPlanElement = (planId, {div, component, state, router, history, courseId}) ->
+  planQuickLooks = React.addons.TestUtils.scryRenderedComponentsWithType(component, CoursePlanDisplayQuickLook)
+  thisPlanQuickLook = _.find(planQuickLooks, (planQuickLook) ->
+    planQuickLook.props.plan.id is planId
+  )
+
+  # checks that there's not a link.
+  expect(div.querySelector(".course-plan-#{planId} a")).to.be.null
+  # checks that a CoursePlanDisplayQuickLook component was rendered for this plan
+  expect(thisPlanQuickLook).to.not.be.null
+
+checks.checkIsViewPlanElement = (planId) ->
+  (args...) ->
+    Promise.resolve(checks._checkIsViewPlanElement(planId, args...))
 
 checks._checkDoesViewShowPlanStats = (planId, {div, component, state, router, history, courseId}) ->
   plan = TaskPlanStatsStore.get(planId)


### PR DESCRIPTION
Also, update specs to prevent this regression

1. make a plan
1. save as draft
1. click on plan from calendar
  * bugged: doesn't do anything, updates route
  * fixed: takes you to edit page for plan