### PR TITLE
don't using router go back.  manually build out calendar return route from plan info

### DIFF
--- a/src/components/task-plan/external/index.cjsx
+++ b/src/components/task-plan/external/index.cjsx
@@ -39,7 +39,14 @@ ExternalPlan = React.createClass
       className='pull-right'
       onClick={@cancel}/>
 
-    footer = <PlanFooter id={id} courseId={courseId} onPublish={@publish} onSave={@save}/>
+    footer = <PlanFooter
+      id={id}
+      courseId={courseId}
+      onPublish={@publish}
+      onSave={@save}
+      onCancel={@cancel}
+      goBackToCalendar={@goBackToCalendar}/>
+
     header = [headerText, closeBtn]
     label = 'Assignment URL'
     if @state?.invalid then formClasses.push('is-invalid-form')

--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -11,6 +11,11 @@ PlanFooter = React.createClass
   propTypes:
     id: React.PropTypes.string.isRequired
     courseId: React.PropTypes.string.isRequired
+    goBackToCalendar: React.PropTypes.func
+
+  getDefaultProps: ->
+    goBackToCalendar: =>
+      @context.router.transitionTo('taskplans', {courseId})
 
   getInitialState: ->
     isEditable: TaskPlanStore.isEditable(@props.id)
@@ -18,13 +23,13 @@ PlanFooter = React.createClass
   saved: ->
     courseId = @props.courseId
     TaskPlanStore.removeChangeListener(@saved)
-    @context.router.transitionTo('taskplans', {courseId})
+    @props.goBackToCalendar()
 
   onDelete: ->
     {id, courseId} = @props
     if confirm('Are you sure you want to delete this?')
       TaskPlanActions.delete(id)
-      @context.router.transitionTo('taskplans', {courseId})
+      @props.goBackToCalendar()
 
   onSave: ->
     @setState({saving: true, publishing: false})
@@ -35,10 +40,7 @@ PlanFooter = React.createClass
     @props.onPublish()
 
   onCancel: ->
-    {id, courseId} = @props
-    if confirm('Are you sure you want to cancel?')
-      TaskPlanActions.reset(id)
-      @context.router.transitionTo('taskplans', {courseId})
+    @props.onCancel()
 
   onViewStats: ->
     {id, courseId} = @props

--- a/src/components/task-plan/homework.cjsx
+++ b/src/components/task-plan/homework.cjsx
@@ -97,7 +97,9 @@ HomeworkPlan = React.createClass
     footer = <PlanFooter id={id}
       courseId={courseId}
       onPublish={@publish}
-      onSave={@save}/>
+      onSave={@save}
+      onCancel={@cancel}
+      goBackToCalendar={@goBackToCalendar}/>
 
     formClasses = ['edit-homework dialog']
     if @state?.showSectionTopics then formClasses.push('hide')

--- a/src/components/task-plan/plan-mixin.coffee
+++ b/src/components/task-plan/plan-mixin.coffee
@@ -2,6 +2,8 @@ React = require 'react'
 {TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
 {TimeStore} = require '../../flux/time'
 moment = require 'moment'
+# we should gather things somewhere nice.
+CALENDAR_DATE_FORMAT = 'YYYY-MM-DD'
 
 module.exports =
   contextTypes:
@@ -69,8 +71,11 @@ module.exports =
   goBackToCalendar: ->
     {id, courseId} = @props
     calendarRoute = 'calendarByDate'
-    dueAt = TaskPlanStore.getFirstDueDate(id) or @context?.router?.getCurrentQuery()?.due_at
-    date = moment(dueAt).format('YYYY-MM-DD')
+    dueAt = TaskPlanStore.getFirstDueDate(id) or @context.router.getCurrentQuery().due_at
+    if dueAt?
+      date = moment(dueAt).format(CALENDAR_DATE_FORMAT)
+    else
+      date = moment(TimeStore.getNow()).format(CALENDAR_DATE_FORMAT)
 
     unless TaskPlanStore.isNew(id) or not TaskPlanStore.isPublishing(id)
       calendarRoute = 'calendarViewPlanStats'

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -130,7 +130,13 @@ ReadingPlan = React.createClass
       className='pull-right'
       onClick={@cancel}/>
 
-    footer = <PlanFooter id={id} courseId={courseId} onPublish={@publish} onSave={@save}/>
+    footer = <PlanFooter
+      id={id}
+      courseId={courseId}
+      onPublish={@publish}
+      onSave={@save}
+      onCancel={@cancel}
+      goBackToCalendar={@goBackToCalendar}/>
     header = [headerText, closeBtn]
 
     addReadingText = if topics?.length then 'Add More Readings' else 'Add Readings'

--- a/src/flux/toc.coffee
+++ b/src/flux/toc.coffee
@@ -40,6 +40,8 @@ TocConfig =
         throw new Error('BUG: Invalid section')
 
     getSectionInfo: (sectionId) ->
+      console.info('sectionId')
+      console.info(sectionId)
       if (@_toc and @_sections)
         @_sections[sectionId] or throw new Error('BUG: Invalid section')
     getSectionLabel: (key) ->

--- a/src/flux/toc.coffee
+++ b/src/flux/toc.coffee
@@ -40,8 +40,6 @@ TocConfig =
         throw new Error('BUG: Invalid section')
 
     getSectionInfo: (sectionId) ->
-      console.info('sectionId')
-      console.info(sectionId)
       if (@_toc and @_sections)
         @_sections[sectionId] or throw new Error('BUG: Invalid section')
     getSectionLabel: (key) ->


### PR DESCRIPTION
trying to use router.goBack would cause problems sometimes in edge cases where:

1. teacher deletes a plan
1. teacher then creates a new plan
1. teacher publishes or cancels
  * sometimes would cause a 404 as it attempts to go back to calendar, but to the deleted planId's route
  * for whatever reason, go back is tracked to the wrong route.

This PR aims to fix this issue by:

1. building calendar back route manually from due_at and plan id information
1. pulling leaving builder functions from publish, save, delete, cancel, etc. to use the central `@goBackToCalendar` function
1. using same cancel function for both X close button and Cancel button in builder footer
1. fixing the resets to be plan specific and use a copy of the plan initially loaded from the server since plan local store gets manipulated directly by the builder
  * cancel and delete used to complete reset the full task plan store, which had unintended effects.
  * to test behavior now
    1. edit a plan
    1. cancel edit
    1. click to edit it again
        * note that changes are reverted properly

