### PR TITLE
Change history to only remember selected routes

### DIFF
--- a/src/components/app.cjsx
+++ b/src/components/app.cjsx
@@ -22,8 +22,7 @@ module.exports = React.createClass
     @storeHistory(path: HistoryLocation.getCurrentPath())
 
   storeHistory: (locationChangeEvent) ->
-    if DestinationHelper.shouldRememberRoute(locationChangeEvent, @context.router)
-      TransitionActions.load(locationChangeEvent)
+    TransitionActions.load(locationChangeEvent, @context.router)
 
   getInitialState: ->
     displayDebug: false

--- a/src/components/app.cjsx
+++ b/src/components/app.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 {HistoryLocation, History, RouteHandler} = require 'react-router'
+DestinationHelper = require '../helpers/routes-and-destinations'
 
 Navbar = require './navbar'
 
@@ -7,6 +8,8 @@ Navbar = require './navbar'
 
 module.exports = React.createClass
   displayName: 'App'
+  contextTypes:
+    router: React.PropTypes.func
 
   componentDidMount: ->
     @storeInitial()
@@ -16,12 +19,11 @@ module.exports = React.createClass
     HistoryLocation.removeChangeListener(@storeHistory)
 
   storeInitial: ->
-    if History.length is 1
-      path = HistoryLocation.getCurrentPath()
-      TransitionActions.load({path})
+    @storeHistory(path: HistoryLocation.getCurrentPath())
 
   storeHistory: (locationChangeEvent) ->
-    TransitionActions.load(locationChangeEvent)
+    if DestinationHelper.shouldRememberRoute(locationChangeEvent, @context.router)
+      TransitionActions.load(locationChangeEvent)
 
   getInitialState: ->
     displayDebug: false

--- a/src/components/app.cjsx
+++ b/src/components/app.cjsx
@@ -1,6 +1,5 @@
 React = require 'react'
 {HistoryLocation, History, RouteHandler} = require 'react-router'
-DestinationHelper = require '../helpers/routes-and-destinations'
 
 Navbar = require './navbar'
 

--- a/src/components/buttons/back-button.cjsx
+++ b/src/components/buttons/back-button.cjsx
@@ -9,15 +9,18 @@ BackButton = React.createClass
   displayName: 'BackButton'
 
   propTypes:
+    bsStyle: React.PropTypes.string
     fallbackLink: React.PropTypes.shape(
       to: React.PropTypes.string
       params: React.PropTypes.object
       text: React.PropTypes.string
     ).isRequired
 
+  getDefaultProps: ->
+    bsStyle: 'default'
+
   contextTypes:
     router: React.PropTypes.func
-
 
   render: ->
     # Gets route to last path that was not the same as the current one
@@ -32,8 +35,8 @@ BackButton = React.createClass
       @props.fallbackLink.to, @props.fallbackLink.params
     )
 
-    <BS.Button href={href} className={className} {...@props}>
+    <Link className={"btn btn-#{@props.bsStyle}"} to={href}>
       {backText}
-    </BS.Button>
+    </Link>
 
 module.exports = BackButton

--- a/src/components/buttons/back-button.cjsx
+++ b/src/components/buttons/back-button.cjsx
@@ -18,29 +18,25 @@ BackButton = React.createClass
   contextTypes:
     router: React.PropTypes.func
 
+  navigate: ->
+    historyInfo = TransitionStore.getPrevious(@context.router)
+    if historyInfo.path
+      @context.router.transitionTo(historyInfo.path)
+    else
+      @context.router.transitionTo(@props.fallbackLink.to, @props.fallbackLink.params)
+
   render: ->
     # Gets route to last path that was not the same as the current one
     # See TransitionStore for more detail.
     historyInfo = TransitionStore.getPrevious(@context.router)
-    hasHistory = historyInfo.path?
     {fallbackLink, className} = @props
     {text} = fallbackLink
 
-    if hasHistory
-      backText = if historyInfo.name then "Back to #{historyInfo.name}"  else 'Back'
-      backButton = <BS.Button className={className}
-        onClick={=> @context.router.transitionTo(historyInfo.path)}>
-        {backText}
-      </BS.Button>
-    else
-      fallbackLink = _.omit(fallbackLink, 'text')
-      classes = 'btn btn-default'
-      classes += " #{className}" if className?
+    backText = if historyInfo.name then "Back to #{historyInfo.name}"  else fallbackLink.text
 
-      backButton = <Link {...fallbackLink} className={classes}>
-        {text}
-      </Link>
-
-    backButton
+    <BS.Button className={className} {...@props}
+      onClick={@navigate}>
+      {backText}
+    </BS.Button>
 
 module.exports = BackButton

--- a/src/components/buttons/back-button.cjsx
+++ b/src/components/buttons/back-button.cjsx
@@ -18,24 +18,18 @@ BackButton = React.createClass
   contextTypes:
     router: React.PropTypes.func
 
-  getInitialState: ->
-    historyInfo = {}
-    hasHistory = (History.length > 1)
-    # Only gets previous route transitioned to. Routes from router.replaceWith are ignored.
-    # See TransitionStore for more detail.
-    historyInfo = TransitionStore.getPrevious(@context.router.match) if hasHistory
-
-    {hasHistory, historyInfo}
-
   render: ->
-    {hasHistory, historyInfo} = @state
+    # Gets route to last path that was not the same as the current one
+    # See TransitionStore for more detail.
+    historyInfo = TransitionStore.getPrevious(@context.router)
+    hasHistory = historyInfo.path?
     {fallbackLink, className} = @props
     {text} = fallbackLink
 
     if hasHistory
-      backText = 'Back'
-      backText = "Back to #{historyInfo.name}" if historyInfo.name
-      backButton = <BS.Button className={className} onClick={@context.router.goBack}>
+      backText = if historyInfo.name then "Back to #{historyInfo.name}"  else 'Back'
+      backButton = <BS.Button className={className}
+        onClick={=> @context.router.transitionTo(historyInfo.path)}>
         {backText}
       </BS.Button>
     else

--- a/src/components/buttons/back-button.cjsx
+++ b/src/components/buttons/back-button.cjsx
@@ -18,12 +18,6 @@ BackButton = React.createClass
   contextTypes:
     router: React.PropTypes.func
 
-  navigate: ->
-    historyInfo = TransitionStore.getPrevious(@context.router)
-    if historyInfo.path
-      @context.router.transitionTo(historyInfo.path)
-    else
-      @context.router.transitionTo(@props.fallbackLink.to, @props.fallbackLink.params)
 
   render: ->
     # Gets route to last path that was not the same as the current one
@@ -32,10 +26,13 @@ BackButton = React.createClass
     {fallbackLink, className} = @props
     {text} = fallbackLink
 
-    backText = if historyInfo.name then "Back to #{historyInfo.name}"  else fallbackLink.text
+    backText = if historyInfo.name then "Back to #{historyInfo.name}" else fallbackLink.text
 
-    <BS.Button className={className} {...@props}
-      onClick={@navigate}>
+    href =  historyInfo.path or @context.router.makeHref(
+      @props.fallbackLink.to, @props.fallbackLink.params
+    )
+
+    <BS.Button href={href} className={className} {...@props}>
       {backText}
     </BS.Button>
 

--- a/src/components/task-step/ends.cjsx
+++ b/src/components/task-step/ends.cjsx
@@ -46,20 +46,10 @@ PracticeEnd = React.createClass
       params: {courseId}
       text: 'Back to Performance Forecast'
 
-    backButton = <BackButton fallbackLink={fallbackLink} />
-
     # custom footer for practices
     footer =
       <div className='-practice-end'>
-        <PracticeButton
-          courseId={courseId}
-          loadedTaskId={taskId}
-          reloadPractice={reloadPractice}
-          pageIds={pageIds}
-          forceCreate={true}>
-          Do more practice
-        </PracticeButton>
-        {backButton}
+        <BackButton bsStyle="primary" fallbackLink={fallbackLink} />
       </div>
 
     completeSteps = TaskStore.getCompletedStepsCount(taskId)

--- a/src/flux/transition.coffee
+++ b/src/flux/transition.coffee
@@ -34,14 +34,16 @@ TransitionStore = flux.createStore
     @_local
 
   exports:
-    getPrevious: (matchRoutes) ->
+    getPrevious: (router) ->
+      matchRoutes = router.match
+      currentPath = DestinationHelper.destinationFromPath(router.getCurrentPath(), matchRoutes)
       history = @_get()
-      backPath = history[history.length - 2]
-      matchedRoute = matchRoutes(backPath) if backPath?
-      deepestRouteName = _.last(matchedRoute.routes).name if matchedRoute?.routes?.length
+      pathIndex = _.findLastIndex(history, (path) ->
+        currentPath isnt DestinationHelper.destinationFromPath(path, matchRoutes)
+      )
+      return {} if -1 is pathIndex
 
       # Both path and name will be undefined if history does not have a previous entry.
-      path: backPath
-      name: DestinationHelper.getDestination(deepestRouteName)
+      {path: history[pathIndex], name: DestinationHelper.destinationFromPath(history[pathIndex], matchRoutes)}
 
 module.exports = {TransitionActions, TransitionStore}

--- a/src/flux/transition.coffee
+++ b/src/flux/transition.coffee
@@ -10,7 +10,9 @@ TransitionActions = flux.createActions [
 
 
 # Transition Store only loads into memory paths that are 'pushed'
-# onto the react-router history.
+# onto the react-router history and are reported as rememberable by
+# DestinationHelper
+#
 # This means that the back button will only track the routes that are
 # 'transitioned' to and not those that 'replace' location,
 # as is the case with router.replaceWith
@@ -23,9 +25,9 @@ TransitionStore = flux.createStore
   actions: _.values(TransitionActions)
   _local: []
 
-  load: ({path, type}) ->
-    type ?= 'push'
-    @_local.push(path) if type is 'push'
+  load: (change, router) ->
+    change.type ?= 'push'
+    @_local.push(change.path) if change.type is 'push' and DestinationHelper.shouldRememberRoute(change, router)
 
   reset: ->
     @_local = []

--- a/src/flux/transition.coffee
+++ b/src/flux/transition.coffee
@@ -26,8 +26,9 @@ TransitionStore = flux.createStore
   _local: []
 
   load: (change, router) ->
-    change.type ?= 'push'
-    @_local.push(change.path) if change.type is 'push' and DestinationHelper.shouldRememberRoute(change, router)
+    {type, path} = change
+    type ?= 'push'
+    @_local.push(path) if type is 'push' and DestinationHelper.shouldRememberRoute(change, router)
 
   reset: ->
     @_local = []

--- a/src/helpers/routes-and-destinations.coffee
+++ b/src/helpers/routes-and-destinations.coffee
@@ -1,3 +1,4 @@
+_ = require 'underscore'
 COURSE_SETTINGS = 'Course Settings'
 COURSES = 'Courses'
 DASHBOARD = 'Dashboard'
@@ -12,12 +13,9 @@ READING_BUILDER = 'Reading Builder'
 STEP = 'Step'
 TASK = 'Task'
 
-routesAndDestinations =
+REMEMBERED_ROUTES =
   dashboard: COURSES
   viewStudentDashboard: DASHBOARD
-  viewTask: TASK
-  viewTaskStep: STEP
-  viewPractice: PRACTICE
   viewGuide: LEARNING_GUIDE
   viewTeacherDashboard: DASHBOARD
   viewPerformance: PERFORMANCE_REPORT
@@ -25,13 +23,6 @@ routesAndDestinations =
   viewStudentTeacherGuide: LEARNING_GUIDE
   taskplans: DASHBOARD
   calendarByDate: DASHBOARD
-  calendarViewPlanStats: DASHBOARD
-  createHomework: HOMEWORK_BUILDER
-  editHomework: HOMEWORK_BUILDER
-  createReading: READING_BUILDER
-  editReading: READING_BUILDER
-  createExternal: EXTERNAL_BUILDER
-  editExternal: EXTERNAL_BUILDER
   courseSettings: COURSE_SETTINGS
   viewStats: PLAN_STATS
   reviewTask: PLAN_REVIEW
@@ -39,7 +30,15 @@ routesAndDestinations =
   reviewTaskStep: PLAN_REVIEW
 
 destinationHelpers =
-  getDestination: (routeName) ->
-    routesAndDestinations[routeName]
+  getDestinationName: (routeName) ->
+    REMEMBERED_ROUTES[routeName]
+
+  destinationFromPath: (path, matchRoutes) ->
+    matchedRoute = matchRoutes(path)
+    deepestRouteName = _.last(matchedRoute.routes).name if matchedRoute?.routes?.length
+    @getDestinationName(deepestRouteName)
+
+  shouldRememberRoute: (routeName, router) ->
+    !!@destinationFromPath(routeName.path, router.match)
 
 module.exports = destinationHelpers

--- a/test/components/helpers/component-testing.coffee
+++ b/test/components/helpers/component-testing.coffee
@@ -10,6 +10,7 @@ ReactTestUtils = React.addons.TestUtils
 sandbox = null
 ROUTER = null
 CURRENT_ROUTER_PARAMS = null
+CURRENT_ROUTER_PATH   = null
 # Mock a router for the context
 beforeEach ->
   sandbox = sinon.sandbox.create()
@@ -17,6 +18,8 @@ beforeEach ->
   ROUTER.makeHref = sandbox.spy()
   ROUTER.isActive = sandbox.spy()
   ROUTER.transitionTo = sandbox.spy()
+  ROUTER.getCurrentPath = sandbox.spy( -> CURRENT_ROUTER_PATH )
+  ROUTER.match = sandbox.spy()
   ROUTER.getCurrentParams = sandbox.spy( -> CURRENT_ROUTER_PARAMS )
 afterEach ->
   sandbox.restore()
@@ -37,6 +40,7 @@ Testing = {
   renderComponent: (component, options = {}) ->
     options.props ||= {}
     CURRENT_ROUTER_PARAMS = options.routerParams or {}
+    CURRENT_ROUTER_PATH   = options.routerPath   or '/'
     root = document.createElement('div')
     promise = new Promise( (resolve, reject) ->
       props = _.clone(options.props)
@@ -52,6 +56,7 @@ Testing = {
     # defer adding the then callback so it'll be called after whatever is attached after the return
     _.defer -> promise.then ->
       React.unmountComponentAtNode(root)
+      CURRENT_ROUTER_PATH   = '/'
       CURRENT_ROUTER_PARAMS = {}
       return arguments
     promise

--- a/test/components/task-plan/footer.spec.coffee
+++ b/test/components/task-plan/footer.spec.coffee
@@ -57,7 +57,6 @@ VISIBLE_HW = extendBasePlan({
 
 helper = (model) ->
   {id} = model
-  console.info(model)
   # Load the plan into the store
   TaskPlanActions.loaded(model, id)
   Testing.renderComponent( PlanFooter, props: {id, courseId: "1"} )


### PR DESCRIPTION
This changes the history to only remember routes that can be safely
returned to.

The Back button's helper methods are also modified so that it will only
load the last paths from history that was for a screen other than the
current one.

<img width="1284" alt="screen shot 2015-08-19 at 8 04 11 pm" src="https://cloud.githubusercontent.com/assets/79566/9373272/1daa39be-46ae-11e5-9536-e08bdc2fd907.png">


<img width="1281" alt="screen shot 2015-08-19 at 8 07 29 pm" src="https://cloud.githubusercontent.com/assets/79566/9373260/fd7a35ea-46ad-11e5-9d58-7b03ccb724e9.png">

