### PR TITLE
prevent trying to load plan that has been requested for deletion -- prevents the 404

### DIFF
--- a/src/components/task-plan/external/index.cjsx
+++ b/src/components/task-plan/external/index.cjsx
@@ -36,6 +36,7 @@ ExternalPlan = React.createClass
       onPublish={@publish}
       onSave={@save}
       onCancel={@cancel}
+      getBackToCalendarParams={@getBackToCalendarParams}
       goBackToCalendar={@goBackToCalendar}/>
 
     header = @builderHeader('external')

--- a/src/components/task-plan/external/index.cjsx
+++ b/src/components/task-plan/external/index.cjsx
@@ -8,7 +8,6 @@ validator = require 'validator'
 {TaskPlanStore, TaskPlanActions} = require '../../../flux/task-plan'
 {TocStore, TocActions} = require '../../../flux/toc'
 PlanFooter = require '../footer'
-Close = require '../../close'
 PlanMixin = require '../plan-mixin'
 TaskPlanBuilder = require '../builder'
 
@@ -29,15 +28,7 @@ ExternalPlan = React.createClass
     plan = TaskPlanStore.get(id)
     externalUrl = plan?.settings?.external_url
 
-    headerText = <span key='header-text'>
-      {if TaskPlanStore.isNew(id) then 'Add External Assignment' else 'Edit External Assignment'}
-    </span>
-
     formClasses = ['edit-external', 'dialog']
-    closeBtn = <Close
-      key='close-button'
-      className='pull-right'
-      onClick={@cancel}/>
 
     footer = <PlanFooter
       id={id}
@@ -47,7 +38,7 @@ ExternalPlan = React.createClass
       onCancel={@cancel}
       goBackToCalendar={@goBackToCalendar}/>
 
-    header = [headerText, closeBtn]
+    header = @builderHeader('external')
     label = 'Assignment URL'
     if @state?.invalid then formClasses.push('is-invalid-form')
 

--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 BS = require 'react-bootstrap'
+Router = require 'react-router'
 {TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
 AsyncButton = require '../buttons/async-button'
 BackButton = require '../buttons/back-button'
@@ -47,8 +48,9 @@ PlanFooter = React.createClass
     @context.router.transitionTo('viewStats', {courseId, id})
 
   render: ->
-    {id, courseId, clickedSelectProblem, onPublish, onSave} = @props
+    {id, courseId, clickedSelectProblem, onPublish, onSave, getBackToCalendarParams} = @props
     {isEditable} = @state
+    backToCalendarParams = getBackToCalendarParams()
 
     plan = TaskPlanStore.get(id)
 
@@ -81,12 +83,11 @@ PlanFooter = React.createClass
           </BS.Button>
         </BS.OverlayTrigger>
     else
-      fallbackLink =
-        to: 'taskplans'
-        params: {courseId}
-        text: 'Back to Calendar'
-
-      backButton = <BackButton fallbackLink={fallbackLink} />
+      backButton = <Router.Link
+        {...backToCalendarParams}
+        className='btn btn-default'>
+          Back to Calendar
+      </Router.Link>
 
 
     if deleteable

--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -50,7 +50,6 @@ PlanFooter = React.createClass
   render: ->
     {id, courseId, clickedSelectProblem, onPublish, onSave, getBackToCalendarParams} = @props
     {isEditable} = @state
-    backToCalendarParams = getBackToCalendarParams()
 
     plan = TaskPlanStore.get(id)
 
@@ -97,6 +96,7 @@ PlanFooter = React.createClass
           </BS.Button>
         </BS.OverlayTrigger>
     else
+      backToCalendarParams = getBackToCalendarParams()
       backButton = <Router.Link
         {...backToCalendarParams}
         className='btn btn-default'>

--- a/src/components/task-plan/homework.cjsx
+++ b/src/components/task-plan/homework.cjsx
@@ -4,7 +4,6 @@ _ = require 'underscore'
 BS = require 'react-bootstrap'
 Router = require 'react-router'
 PlanFooter = require './footer'
-Close = require '../close'
 SelectTopics = require './select-topics'
 ExerciseSummary = require './homework/exercise-summary'
 PlanMixin = require './plan-mixin'
@@ -85,8 +84,7 @@ HomeworkPlan = React.createClass
   render: ->
     {id, courseId} = @props
     plan = TaskPlanStore.get(id)
-    headerText = if TaskPlanStore.isNew(id) then 'Add Homework Assignment' else 'Edit Homework Assignment'
-    closeBtn = <Close onClick={@cancel}/>
+
     topics = TaskPlanStore.getTopics(id)
     hasExercises = TaskPlanStore.getExercises(id)?.length
     shouldShowExercises = hasExercises and not @state?.showSectionTopics
@@ -147,7 +145,7 @@ HomeworkPlan = React.createClass
         {reviewExercises}
       </PinnedHeaderFooterCard>
 
-    header = [headerText, closeBtn]
+    header = @builderHeader('homework')
 
     if not TaskPlanStore.isVisibleToStudents(id)
       addProblemsButton = <BS.Button id='problems-select'

--- a/src/components/task-plan/homework.cjsx
+++ b/src/components/task-plan/homework.cjsx
@@ -97,7 +97,9 @@ HomeworkPlan = React.createClass
       onPublish={@publish}
       onSave={@save}
       onCancel={@cancel}
-      goBackToCalendar={@goBackToCalendar}/>
+      getBackToCalendarParams={@getBackToCalendarParams}
+      goBackToCalendar={@goBackToCalendar}
+      />
 
     formClasses = ['edit-homework dialog']
     if @state?.showSectionTopics then formClasses.push('hide')

--- a/src/components/task-plan/index.cjsx
+++ b/src/components/task-plan/index.cjsx
@@ -77,6 +77,10 @@ PlanShell = React.createClass
     Type = @getType()
     {courseId} = @context.router.getCurrentParams()
     id = @getId()
+
+    if TaskPlanStore.isDeleteRequested(id)
+      return <Type id={id} courseId={courseId} />
+
     <LoadableItem
       id={id}
       store={TaskPlanStore}

--- a/src/components/task-plan/plan-mixin.coffee
+++ b/src/components/task-plan/plan-mixin.coffee
@@ -71,7 +71,7 @@ module.exports =
       TaskPlanActions.resetPlan(id)
       @goBackToCalendar()
 
-  goBackToCalendar: ->
+  getBackToCalendarParams: ->
     {id, courseId} = @props
     calendarRoute = 'calendarByDate'
     dueAt = TaskPlanStore.getFirstDueDate(id) or @context.router.getCurrentQuery().due_at
@@ -84,7 +84,12 @@ module.exports =
       calendarRoute = 'calendarViewPlanStats'
       planId = id
 
-    @context.router.transitionTo(calendarRoute, {courseId, date, planId})
+    to: calendarRoute
+    params: {courseId, date, planId}
+
+  goBackToCalendar: ->
+    {to, params} = @getBackToCalendarParams()
+    @context.router.transitionTo(to, params)
 
   builderHeader: (type) ->
     {id} = @props

--- a/src/components/task-plan/plan-mixin.coffee
+++ b/src/components/task-plan/plan-mixin.coffee
@@ -71,6 +71,7 @@ module.exports =
       TaskPlanActions.resetPlan(id)
       @goBackToCalendar()
 
+  # TODO move to helper type thing.
   getBackToCalendarParams: ->
     {id, courseId} = @props
     calendarRoute = 'calendarByDate'

--- a/src/components/task-plan/plan-mixin.coffee
+++ b/src/components/task-plan/plan-mixin.coffee
@@ -1,6 +1,9 @@
 React = require 'react'
 {TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
 {TimeStore} = require '../../flux/time'
+Close = require '../close'
+S = require '../../helpers/string'
+
 moment = require 'moment'
 # we should gather things somewhere nice.
 CALENDAR_DATE_FORMAT = 'YYYY-MM-DD'
@@ -77,9 +80,29 @@ module.exports =
     else
       date = moment(TimeStore.getNow()).format(CALENDAR_DATE_FORMAT)
 
-    unless TaskPlanStore.isNew(id) or not TaskPlanStore.isPublishing(id)
+    unless TaskPlanStore.isNew(id) or not TaskPlanStore.isPublishing(id) or TaskPlanStore.isDeleteRequested(id)
       calendarRoute = 'calendarViewPlanStats'
       planId = id
 
     @context.router.transitionTo(calendarRoute, {courseId, date, planId})
+
+  builderHeader: (type) ->
+    {id} = @props
+    type = S.capitalize(type)
+
+    if TaskPlanStore.isNew(id)
+      headerText = "Add #{type} Assignment"
+    else if TaskPlanStore.isDeleteRequested(id)
+      headerText = "#{type} is being deleted"
+    else
+      headerText = "Edit #{type} Assignment"
+
+    headerSpan = <span key='header-text'>{headerText}</span>
+
+    closeBtn = <Close
+      key='close-button'
+      className='pull-right'
+      onClick={@cancel}/>
+
+    [headerSpan, closeBtn]
 

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -128,6 +128,7 @@ ReadingPlan = React.createClass
       onPublish={@publish}
       onSave={@save}
       onCancel={@cancel}
+      getBackToCalendarParams={@getBackToCalendarParams}
       goBackToCalendar={@goBackToCalendar}/>
     header = @builderHeader('reading')
 

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -9,7 +9,6 @@ Router = require 'react-router'
 {TocStore, TocActions} = require '../../flux/toc'
 SelectTopics = require './select-topics'
 PlanFooter = require './footer'
-Close = require '../close'
 ChapterSection = require './chapter-section'
 PlanMixin = require './plan-mixin'
 LoadableItem = require '../loadable-item'
@@ -120,15 +119,8 @@ ReadingPlan = React.createClass
     {id, courseId} = @props
     plan = TaskPlanStore.get(id)
 
-    headerText = <span key='header-text'>
-      {if TaskPlanStore.isNew(id) then 'Add Reading Assignment' else 'Edit Reading Assignment'}
-    </span>
     topics = TaskPlanStore.getTopics(id)
     formClasses = ['edit-reading', 'dialog']
-    closeBtn = <Close
-      key='close-button'
-      className='pull-right'
-      onClick={@cancel}/>
 
     footer = <PlanFooter
       id={id}
@@ -137,7 +129,7 @@ ReadingPlan = React.createClass
       onSave={@save}
       onCancel={@cancel}
       goBackToCalendar={@goBackToCalendar}/>
-    header = [headerText, closeBtn]
+    header = @builderHeader('reading')
 
     addReadingText = if topics?.length then 'Add More Readings' else 'Add Readings'
 

--- a/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -2,9 +2,11 @@ React = require 'react'
 moment = require 'moment'
 BS = require 'react-bootstrap'
 Router = require 'react-router'
+_ = require 'underscore'
 
 LoadableItem = require '../loadable-item'
 {TeacherTaskPlanStore, TeacherTaskPlanActions} = require '../../flux/teacher-task-plan'
+{TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
 {CourseStore} = require '../../flux/course'
 {TimeStore} = require '../../flux/time'
 
@@ -77,14 +79,18 @@ TeacherTaskPlanListing = React.createClass
 
   statics:
     willTransitionTo: (transition, params, query, callback) ->
-      {date} = params
-      if date? and moment(date, DATE_FORMAT).isValid()
-        callback()
-      else
+      {date, planId} = params
+      unless date? and moment(date, DATE_FORMAT).isValid()
         date = moment(TimeStore.getNow())
         params.date = date.format(DATE_FORMAT)
         transition.redirect('calendarByDate', params)
-        callback()
+        return callback()
+
+      if planId? and TaskPlanStore.isDeleteRequested(planId)
+        transition.redirect('calendarByDate', _.omit(params, 'planId'))
+        return callback()
+
+      callback()
 
   getDateFromParams: ->
     {date} = @context.router.getCurrentParams()

--- a/test/components/task-plan/footer.spec.coffee
+++ b/test/components/task-plan/footer.spec.coffee
@@ -2,8 +2,11 @@
 
 React = require 'react'
 _ = require 'underscore'
+moment = require 'moment'
 
 {TaskPlanActions, TaskPlanStore} = require '../../../src/flux/task-plan'
+{TimeActions, TimeStore} = require '../../../src/flux/time'
+
 PlanFooter = require '../../../src/components/task-plan/footer'
 {Testing, sinon, expect, _, React} = require '../helpers/component-testing'
 
@@ -54,12 +57,17 @@ VISIBLE_HW = extendBasePlan({
   opens_at: yesterday
 })
 
+# Stub the function, TODO - bring in helper
+getBackToCalendarParams = ->
+  to: 'calendarByDate'
+  params:
+    date: moment(TimeStore.getNow()).format('YYYY-MM-DD')
 
 helper = (model) ->
   {id} = model
   # Load the plan into the store
   TaskPlanActions.loaded(model, id)
-  Testing.renderComponent( PlanFooter, props: {id, courseId: "1"} )
+  Testing.renderComponent( PlanFooter, props: {id, courseId: "1", getBackToCalendarParams} )
 
 
 describe 'Task Plan Footer', ->


### PR DESCRIPTION
the older, calmer sister PR to #660 ![calmer?](http://ak-hdl.buzzfed.com/static/enhanced/terminal05/2012/10/11/16/anigif_enhanced-buzz-18508-1349987162-9.gif)

## How to reproduce
1. publish a plan that opens in the future
1. view and edit
1. click delete
  * at this point, the previous PR neglected to take the user back to the calendar without plan id in route
    * It only accounted for drafts, and drafts that were being deleted, and avoided the plan id route for those specific cases, as intended
  * this really aint no thang since it doesn't cause any 404's though since loading the deleted plan and plan stats is not actually triggered
1. click browser back
  * **this is where things start to go wrong.** back to plan edit route will trigger an api hit for the deleted plan
  * another back will trigger an api hit for the deleted plan's stats
  * locally, it takes awhile for both to return 404 and show the modal, since the single thread is still working on actually deleting the plan

## With fix
### Back once to plan editor
* Doesn't re-fetch plan that's been recently requested for deletion
* not my fave UI ever, but for something that a user shouldn't be seeing, should be okay for now?
  ![screen shot 2015-08-20 at 1 42 36 am](https://cloud.githubusercontent.com/assets/2483873/9377458/da3841f4-46de-11e5-9d7c-b1d16ff0bc53.png)

### Back twice to calendar that had plan modal open
* Prevents route for plan that's been deleted
  ![screen shot 2015-08-20 at 1 42 42 am](https://cloud.githubusercontent.com/assets/2483873/9377457/da37ac08-46de-11e5-90d3-e81a7f345619.png)

