### PR TITLE
Try one mo' gain if server throws an error

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -79,7 +79,7 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker) ->
       rejected = (jqXhr, statusMessage, err) ->
         setNow(jqXhr)
         statusCode = jqXhr.status
-        AppActions.setServerError(statusCode, jqXhr.responseText, {url, opts}, listenAction.bind(Actions, args...))
+        AppActions.setServerError(statusCode, jqXhr.responseText, {url, opts})
         if statusCode is 400
           CurrentUserActions.logout()
         else if statusMessage is 'parsererror' and statusCode is 200 and IS_LOCAL

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -79,7 +79,7 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker) ->
       rejected = (jqXhr, statusMessage, err) ->
         setNow(jqXhr)
         statusCode = jqXhr.status
-        AppActions.setServerError(statusCode, jqXhr.responseText, {url, opts, attemptedAction: listenAction.bind(Actions, args...)})
+        AppActions.setServerError(statusCode, jqXhr.responseText, {url, opts}, listenAction.bind(Actions, args...))
         if statusCode is 400
           CurrentUserActions.logout()
         else if statusMessage is 'parsererror' and statusCode is 200 and IS_LOCAL

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -79,7 +79,7 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker) ->
       rejected = (jqXhr, statusMessage, err) ->
         setNow(jqXhr)
         statusCode = jqXhr.status
-        AppActions.setServerError(statusCode, jqXhr.responseText)
+        AppActions.setServerError(statusCode, jqXhr.responseText, {url, opts, attemptedAction: listenAction.bind(Actions, args...)})
         if statusCode is 400
           CurrentUserActions.logout()
         else if statusMessage is 'parsererror' and statusCode is 200 and IS_LOCAL

--- a/src/components/navbar/server-error-monitoring.cjsx
+++ b/src/components/navbar/server-error-monitoring.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 BindStoreMixin = require '../bind-store-mixin'
 BS = require 'react-bootstrap'
 
-{AppStore} = require '../../flux/app'
+{AppStore, AppActions} = require '../../flux/app'
 Dialog = require '../tutor-dialog'
 
 module.exports = React.createClass
@@ -15,11 +15,18 @@ module.exports = React.createClass
   bindUpdate: ->
     serverErr = AppStore.getError()
     return unless serverErr
-    {requestDetails} = serverErr
 
-    if AppStore.isOnce(requestDetails)
-      requestDetails.attemptedAction()
+    {request} = serverErr
+    {url} = request
+
+    if AppStore.canRetrigger(url)
+      AppActions.retriggerOnce(url)
     else
+
+      dataMessage =  <span>
+        with <pre>{request.opts.data}</pre>
+      </span> if request.opts.data?
+
       errorMessage =
         <div className='server-error'>
           <h3>An error with code {serverErr.statusCode} has occured</h3>
@@ -27,16 +34,21 @@ module.exports = React.createClass
             href='https://openstaxtutor.zendesk.com/hc/en-us/requests/new'>our support page</a> to file a bug report.
           </p>
           <p>Additional error messages returned from the server is:</p>
-          <div className='response'>{serverErr.message or 'No response was received'}</div>
+          <pre className='response'>{serverErr.message or 'No response was received'}</pre>
           <div className='request'>
-            {requestDetails.url} attempted
+            <kbd>{request.opts.method}</kbd> on {request.url} {dataMessage}
           </div>
         </div>
+
+      dismissError = ->
+        AppActions.resetError(url)
+        Dialog.hide()
+
       Dialog.show(
         title: 'Server Error', body: errorMessage
         buttons: [
           <BS.Button key='ok'
-            onClick={-> Dialog.hide()} bsStyle='primary'>OK</BS.Button>
+            onClick={-> dismissError()} bsStyle='primary'>OK</BS.Button>
         ]
       )
 

--- a/src/components/navbar/server-error-monitoring.cjsx
+++ b/src/components/navbar/server-error-monitoring.cjsx
@@ -55,21 +55,16 @@ module.exports = React.createClass
     serverErr = AppStore.getError()
     return unless serverErr
 
-    errorId = AppStore.getCurrentErrorId()
+    dismissError = ->
+      window.location.reload() if AppStore.shouldReload()
 
-    if AppStore.isRetriggable(errorId)
-      AppActions.retriggerOnce(errorId)
-    else
-      dismissError = ->
-        AppActions.resetError(errorId)
-
-      Dialog.show(
-        title: 'Server Error', body: <ServerErrorMessage {...serverErr}/>
-        buttons: [
-          <BS.Button key='ok'
-            onClick={-> Dialog.hide()} bsStyle='primary'>OK</BS.Button>
-        ]
-      ).then(dismissError, dismissError)
+    Dialog.show(
+      title: 'Server Error', body: <ServerErrorMessage {...serverErr}/>
+      buttons: [
+        <BS.Button key='ok'
+          onClick={-> Dialog.hide()} bsStyle='primary'>OK</BS.Button>
+      ]
+    ).then(dismissError, dismissError)
 
 
   # We don't actually render anything

--- a/src/components/navbar/server-error-monitoring.cjsx
+++ b/src/components/navbar/server-error-monitoring.cjsx
@@ -5,6 +5,45 @@ BS = require 'react-bootstrap'
 {AppStore, AppActions} = require '../../flux/app'
 Dialog = require '../tutor-dialog'
 
+
+ServerErrorMessage = React.createClass
+  displayName: 'ServerErrorMessage'
+
+  propTypes:
+    statusCode: React.PropTypes.number.isRequired
+    message: React.PropTypes.string.isRequired
+    request: React.PropTypes.object.isRequired
+    supportLink: React.PropTypes.string
+    debug: React.PropTypes.bool
+
+  getDefaultProps: ->
+    supportLink: 'https://openstaxtutor.zendesk.com/hc/en-us/requests/new'
+    debug: true
+
+  render: ->
+    {statusCode, message, request, supportLink, debug} = @props
+    dataMessage =  <span>
+      with <pre>{request.opts.data}</pre>
+    </span> if request.opts.data?
+
+    debugInfo = [
+      <p>Additional error messages returned from the server is:</p>
+      <pre className='response'>{message or 'No response was received'}</pre>
+      <div className='request'>
+        <kbd>{request.opts.method}</kbd> on {request.url} {dataMessage}
+      </div>
+    ] if debug
+
+    errorMessage =
+      <div className='server-error'>
+        <h3>An error with code {statusCode} has occured</h3>
+        <p>Please visit <a target='_blank'
+          href={supportLink}>our support page</a> to file a bug report.
+        </p>
+        {debugInfo}
+      </div>
+
+
 module.exports = React.createClass
   displayName: 'ServerErrorMonitoring'
 
@@ -16,41 +55,21 @@ module.exports = React.createClass
     serverErr = AppStore.getError()
     return unless serverErr
 
-    {request} = serverErr
-    {url} = request
+    errorId = AppStore.getCurrentErrorId()
 
-    if AppStore.canRetrigger(url)
-      AppActions.retriggerOnce(url)
+    if AppStore.isRetriggable(errorId)
+      AppActions.retriggerOnce(errorId)
     else
-
-      dataMessage =  <span>
-        with <pre>{request.opts.data}</pre>
-      </span> if request.opts.data?
-
-      errorMessage =
-        <div className='server-error'>
-          <h3>An error with code {serverErr.statusCode} has occured</h3>
-          <p>Please visit <a target='_blank'
-            href='https://openstaxtutor.zendesk.com/hc/en-us/requests/new'>our support page</a> to file a bug report.
-          </p>
-          <p>Additional error messages returned from the server is:</p>
-          <pre className='response'>{serverErr.message or 'No response was received'}</pre>
-          <div className='request'>
-            <kbd>{request.opts.method}</kbd> on {request.url} {dataMessage}
-          </div>
-        </div>
-
       dismissError = ->
-        AppActions.resetError(url)
-        Dialog.hide()
+        AppActions.resetError(errorId)
 
       Dialog.show(
-        title: 'Server Error', body: errorMessage
+        title: 'Server Error', body: <ServerErrorMessage {...serverErr}/>
         buttons: [
           <BS.Button key='ok'
-            onClick={-> dismissError()} bsStyle='primary'>OK</BS.Button>
+            onClick={-> Dialog.hide()} bsStyle='primary'>OK</BS.Button>
         ]
-      )
+      ).then(dismissError, dismissError)
 
 
   # We don't actually render anything

--- a/src/components/navbar/server-error-monitoring.cjsx
+++ b/src/components/navbar/server-error-monitoring.cjsx
@@ -15,22 +15,30 @@ module.exports = React.createClass
   bindUpdate: ->
     serverErr = AppStore.getError()
     return unless serverErr
-    errorMessage =
-      <div className='server-error'>
-        <h3>An error with code {serverErr.statusCode} has occured</h3>
-        <p>Please visit <a target='_blank'
-          href='https://openstaxtutor.zendesk.com/hc/en-us/requests/new'>our support page</a> to file a bug report.
-        </p>
-        <p>Additional error messages returned from the server is:</p>
-        <div className='response'>{serverErr.message or 'No response was received'}</div>
-      </div>
-    Dialog.show(
-      title: 'Server Error', body: errorMessage
-      buttons: [
-        <BS.Button key='ok'
-          onClick={-> Dialog.hide()} bsStyle='primary'>OK</BS.Button>
-      ]
-    )
+    {requestDetails} = serverErr
+
+    if AppStore.isOnce(requestDetails)
+      requestDetails.attemptedAction()
+    else
+      errorMessage =
+        <div className='server-error'>
+          <h3>An error with code {serverErr.statusCode} has occured</h3>
+          <p>Please visit <a target='_blank'
+            href='https://openstaxtutor.zendesk.com/hc/en-us/requests/new'>our support page</a> to file a bug report.
+          </p>
+          <p>Additional error messages returned from the server is:</p>
+          <div className='response'>{serverErr.message or 'No response was received'}</div>
+          <div className='request'>
+            {requestDetails.url} attempted
+          </div>
+        </div>
+      Dialog.show(
+        title: 'Server Error', body: errorMessage
+        buttons: [
+          <BS.Button key='ok'
+            onClick={-> Dialog.hide()} bsStyle='primary'>OK</BS.Button>
+        ]
+      )
 
 
   # We don't actually render anything

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -93,6 +93,8 @@ module.exports = React.createClass
   shouldComponentUpdate: (nextProps, nextState) ->
     {id} = @props
 
+    console.info(TaskStore.getAsyncStatus(id))
+
     # if a step needs to be recovered, load a recovery step for it
     if @_stepRecoveryQueued(nextState)
       TaskStepActions.loadRecovery(nextState.recoverForStepId)
@@ -116,6 +118,9 @@ module.exports = React.createClass
     #   redirect to the step after the step we triggered refresh from.
     if @_leavingRefreshingStep(nextState)
       @continueAfterRefreshStep()
+      return false
+
+    if TaskStore.isSaving(id)
       return false
 
     # if we reach this point, assume that we should go ahead and do a normal component update

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -93,8 +93,6 @@ module.exports = React.createClass
   shouldComponentUpdate: (nextProps, nextState) ->
     {id} = @props
 
-    console.info(TaskStore.getAsyncStatus(id))
-
     # if a step needs to be recovered, load a recovery step for it
     if @_stepRecoveryQueued(nextState)
       TaskStepActions.loadRecovery(nextState.recoverForStepId)
@@ -118,9 +116,6 @@ module.exports = React.createClass
     #   redirect to the step after the step we triggered refresh from.
     if @_leavingRefreshingStep(nextState)
       @continueAfterRefreshStep()
-      return false
-
-    if TaskStore.isSaving(id)
       return false
 
     # if we reach this point, assume that we should go ahead and do a normal component update

--- a/src/flux/app.coffee
+++ b/src/flux/app.coffee
@@ -6,16 +6,23 @@ flux = require 'flux-react'
 {makeSimpleStore} = require './helpers'
 
 AppConfig =
+  _counts: {}
 
-  setServerError: (statusCode, message) ->
-    @_currentServerError = {statusCode, message}
-    @emit('server-error', statusCode, message)
+  setServerError: (statusCode, message, requestDetails) ->
+    @_currentServerError = {statusCode, message, requestDetails}
+    @_counts[requestDetails.url] ?= 0
+    @_counts[requestDetails.url] = @_counts[requestDetails.url] + 1
+    @emit('server-error', statusCode, message, requestDetails)
 
   clearError: ->
+    @_counts[@_currentServerError.requestDetails.url] = null
     @_currentServerError = null
 
   exports:
     getError: -> @_currentServerError
+
+    isOnce: (url) ->
+      @_counts[@_currentServerError.requestDetails.url] < 2
 
 {actions, store} = makeSimpleStore(AppConfig)
 module.exports = {AppActions:actions, AppStore:store}

--- a/src/flux/app.coffee
+++ b/src/flux/app.coffee
@@ -6,46 +6,58 @@ _ = require 'underscore'
 
 {makeSimpleStore} = require './helpers'
 
+getErrorId = (error) ->
+  "#{error?.request?.opts?.method}#{error?.request?.url}"
+
+shouldRetrigger = (error) ->
+  400 <= error.statusCode < 500
+
+RETRIGGER_ERROR_DELAY = 0
+
 AppConfig =
   _retriggered: {}
   _triggers: {}
 
   setServerError: (statusCode, message, requestDetails, triggerAction) ->
     {url, opts} = requestDetails
-
     sparseOpts = _.pick(opts, 'method', 'data')
     request = {url, opts: sparseOpts}
-
     @_currentServerError = {statusCode, message, request}
 
-    @_triggers[url] = triggerAction unless @_retriggered[url]
+    id = getErrorId(@_currentServerError)
+
+    @_triggers[id] = triggerAction if @_isRetriggable(id)
 
     @emit('server-error', statusCode, message)
 
-  retriggered: (url) ->
-    @_retriggered[url] = true
-    delete @_triggers[url]
+  retriggered: (id) ->
+    @_retriggered[id] = true
+    # make extra sure to remove trigger.
+    delete @_triggers[id]
 
-  retriggerOnce: (url) ->
-    unless @_retriggered[url]
-      # retrigger
-      @_triggers[url]?()
+  retriggerOnce: (id) ->
+    if @_isRetriggable(id)
+      # retrigger, with delay if needed.
+      _.delay(@_triggers[id], RETRIGGER_ERROR_DELAY)
       # and mark as retriggered
-      @retriggered(url)
+      @retriggered(id)
 
-  resetError: (url) ->
-    @_triggers[url] = null
-    @_retriggered[url] = null
+  resetError: (id) ->
+    @_triggers[id] = null
+    @_retriggered[id] = null
     @_currentServerError = null
 
-  clearError: ->
-    @_currentServerError = null
+  _isRetriggable: (id) ->
+    shouldRetrigger(@_currentServerError) and not (@_retriggered[id]? and @_retriggered[id])
 
   exports:
     getError: -> @_currentServerError
 
-    canRetrigger: (url) ->
-      not @_retriggered[url]
+    getCurrentErrorId: ->
+      getErrorId(@_currentServerError)
+
+    isRetriggable: (id) ->
+      @_isRetriggable(id)
 
 {actions, store} = makeSimpleStore(AppConfig)
 module.exports = {AppActions:actions, AppStore:store}

--- a/src/flux/app.coffee
+++ b/src/flux/app.coffee
@@ -8,7 +8,10 @@ _ = require 'underscore'
 
 
 shouldReload = (error) ->
-  (400 <= error.statusCode < 600) and not (error.statusCode is 404)
+  {statusCode, request} = error
+  isGET404 = statusCode is 404 and request.method is 'GET'
+  isInRange = 400 <= statusCode < 600
+  isInRange and not isGET404
 
 
 AppConfig =


### PR DESCRIPTION
so we take it and flip and reverse it.  just once though.  targeted at [69](https://docs.google.com/spreadsheets/d/1P0eq49e7u1uM3SUI9pULo7EQYZIJt1KLOOfBidHdFSY/edit#gid=1446311939) wherein `422` happens and the last attempted action needs to be repeated before student can continue task

also, captures info about the request.  SS shows spoofed url to force error

1. Before error trigger
  ![screen shot 2015-08-20 at 11 54 29 am](https://cloud.githubusercontent.com/assets/2483873/9389791/80721c2c-4732-11e5-9631-9fa693abc08a.png)
1. Spoofed error
  ![screen shot 2015-08-20 at 11 54 15 am](https://cloud.githubusercontent.com/assets/2483873/9389790/80700c52-4732-11e5-92c7-19e5ec5e9e07.png)
1. after closing modal, page reloads and app state is consistent with fresh server load
  * In this example, the multiple answer choice patch caused the server error, and so the answer was never saved.  The FE reflects that after the forced reload.
  ![screen shot 2015-08-20 at 11 54 09 am](https://cloud.githubusercontent.com/assets/2483873/9389792/8073c4d2-4732-11e5-932e-f58fc01a0d80.png)

Also, I have yet to achieve the same `422` during an exercise as during doomsday to try this with that.
