### PR TITLE
yay sort by average step number

### DIFF
--- a/src/components/task-teacher-review/crumb-mixin.cjsx
+++ b/src/components/task-teacher-review/crumb-mixin.cjsx
@@ -140,7 +140,10 @@ module.exports =
 
   generateCrumbs: ->
     {id, period} = @props
-    @_generateCrumbs id, period
+    periodCrumbs = @_generateCrumbs id, period
+    _.sortBy(periodCrumbs, (crumb) ->
+      crumb.data.average_step_number
+    )
 
   getContents: ->
     {id, period} = @props


### PR DESCRIPTION
yay we get step number now!  FE sorts before displaying...and things seem to work!  BE openstax/tutor-server#597


## Bug
* question order in review does not match assign order.  it is sorted by page, and then assign order
![screen shot 2015-08-20 at 12 41 52 pm](https://cloud.githubusercontent.com/assets/2483873/9390799/f35a7d00-4738-11e5-8783-75908772e515.png)


## Fixed

![screen shot 2015-08-20 at 12 40 22 pm](https://cloud.githubusercontent.com/assets/2483873/9390749/aed23ae2-4738-11e5-8acd-f2bb9610681e.png)
