### PR TITLE
fix the reading covers links on a reading step

### DIFF
--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -7,7 +7,16 @@ dom = require '../helpers/dom'
 # According to the tagging legend exercises with a link should have `a.os-embed`
 # but in the content they are just a vanilla link.
 EXERCISE_LINK_SELECTOR = '.os-exercise > [data-type="problem"] > p > a[href]'
-MEDIA_LINK_SELECTOR = 'a:not(.nav):not([data-type=footnote-number]):not([data-type=footnote-ref])'
+MEDIA_LINK_EXCLUDES = [
+  '.nav'
+  '.view-reference-guide'
+  '[data-type=footnote-number]'
+  '[data-type=footnote-ref]'
+]
+
+MEDIA_LINK_SELECTOR = _.reduce(MEDIA_LINK_EXCLUDES, (current, exclude) ->
+  "#{current}:not(#{exclude})"
+, 'a')
 
 module.exports =
   componentDidMount:  ->


### PR DESCRIPTION
Fixes [21](https://docs.google.com/spreadsheets/d/1P0eq49e7u1uM3SUI9pULo7EQYZIJt1KLOOfBidHdFSY/edit#gid=620238128)

## Bug
* reference link is wrong for reading step of reading task
![screen shot 2015-08-20 at 4 12 08 pm](https://cloud.githubusercontent.com/assets/2483873/9395797/3d2c13e0-4756-11e5-9c84-548107b13af3.png)

## With fix
![screen shot 2015-08-20 at 4 11 03 pm](https://cloud.githubusercontent.com/assets/2483873/9395801/3ff92a18-4756-11e5-984e-148f5fb73366.png)


