### PR TITLE
Only display dialog once

### DIFF
--- a/src/components/navbar/server-error-monitoring.cjsx
+++ b/src/components/navbar/server-error-monitoring.cjsx
@@ -54,14 +54,15 @@ module.exports = React.createClass
 
   bindUpdate: ->
     serverErr = AppStore.getError()
-    return unless serverErr
+    return unless serverErr and -1 is window.location.search.indexOf('reloaded')
 
     dismissError = ->
       navigation = AppStore.errorNavigation()
       return if _.isEmpty navigation
       if navigation.shouldReload
-        window.location.reload()
-      else
+        join = if window.location.search then '&' else '?'
+        window.location.href = window.location.href + join + 'reloaded'
+      else if navigation.href
         window.location.href = navigation.href
 
     Dialog.show(

--- a/src/flux/app.coffee
+++ b/src/flux/app.coffee
@@ -28,7 +28,7 @@ AppConfig =
       else
         isGET404 = statusCode is 404 and request.method is 'GET'
         isInRange = 400 <= statusCode < 600
-        {shouldRedirect: isInRange and not isGET404}
+        {shouldReload: isInRange and not isGET404}
 
 {actions, store} = makeSimpleStore(AppConfig)
 module.exports = {AppActions:actions, AppStore:store}


### PR DESCRIPTION
Sets a "reloaded" query parameter after the dialog is displayed and
dismissed.

That paramter is checked when a server error is encounterd and skipped
if present



First show:

<img width="1252" alt="screen shot 2015-08-20 at 10 52 03 pm" src="https://cloud.githubusercontent.com/assets/79566/9401138/3ec8c538-4790-11e5-90cd-b9eac9610098.png">

Second time:

<img width="1261" alt="screen shot 2015-08-20 at 11 09 31 pm" src="https://cloud.githubusercontent.com/assets/79566/9401155/8ceff34e-4790-11e5-93c9-0a96526dbf2d.png">

