### PR TITLE
fixes when we would accidentally submit a moment date obj to BE

### DIFF
--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -169,12 +169,15 @@ TaskPlanConfig =
     throw new Error('id is required') unless id
     throw new Error("#{attr} is required") unless date
 
+    # use of moment(date).toDate() will make sure to convert
+    # any type of date (string, js date, moment, etc) to date for
+    # the BE to accept.
     if periodId
       tasking = @_findTasking(tasking_plans, periodId)
-      tasking[attr] = date
+      tasking[attr] = moment(date).toDate()
     else
       for tasking in tasking_plans
-        tasking[attr] = date
+        tasking[attr] = moment(date).toDate()
 
     @_change(id, {tasking_plans})
 
@@ -427,7 +430,7 @@ TaskPlanConfig =
       opensAt = moment(@exports.getOpensAt.call(@, id, periodId))
       if opensAt.isBefore(TimeStore.getNow())
         opensAt = moment(TimeStore.getNow())
-      opensAt.startOf('day').add(1, 'day')
+      opensAt.startOf('day').add(1, 'day').toDate()
 
     hasTasking: (id, periodId) ->
       plan = @_getPlan(id)


### PR DESCRIPTION
## How to replicate
1. start adding a brand **new** plan
1. select to make due dates different periods
1. change due date for at least one of the periods
1. switch back to "All periods"
  * this calls the `TaskPlanStore.getMinDueAt` which was the culprit
1. try to save as draft or publish
  * BE yells at you with a `422`
  * you'll see in the modal that FE is trying to submit a moment obj as due_at

should be fixed with this PR.
