### PR TITLE
Disable continue button when saving

### DIFF
--- a/src/components/task-step/step-mixin.cjsx
+++ b/src/components/task-step/step-mixin.cjsx
@@ -13,20 +13,24 @@ module.exports =
 
   renderContinueButton: ->
     return null if @hideContinueButton?()
-    isWaiting = TaskStepStore.isLoading(@props.id)
-    isSaving = TaskStepStore.isSaving(@props.id)
-    isFailed = TaskStepStore.isFailed(@props.id)
+
     # if this is the last step completed and the view is read-only,
     # then you cannot continue, and this will override @isContinueEnabled
-    cannotContinue = not StepPanel.canContinue(@props.id)
+    waitingText = switch
+      when TaskStepStore.isLoading(@props.id) then "Loading…"
+      when TaskStepStore.isSaving(@props.id)  then "Saving…"
+      else null
+
+    cannotContinue = not StepPanel.canContinue(@props.id) or not @isContinueEnabled?()
 
     <AsyncButton
       bsStyle='primary'
       className='continue'
       onClick={@onContinue}
-      disabled={not @isContinueEnabled?() or cannotContinue}
-      isWaiting={isWaiting}
-      isFailed={isFailed}
+      disabled={cannotContinue}
+      isWaiting={!!waitingText}
+      waitingText={waitingText}
+      isFailed={TaskStepStore.isFailed(@props.id)}
       >
       {@continueButtonText?() or 'Continue'}
     </AsyncButton>


### PR DESCRIPTION
A task step should not be continued while it's state is saving or
loading. The earlier code was checking the isSaving state, but wasn't
passing it onto the AsyncButton.

This should prevent the sequence that occurs occasionally where:

 1. user clicks on a choice
  * An async save is initiated, but due to network conditions, phase of the moon, etc. it's delayed
 2. a short time later, user clicks continue button
  * A async save to mark step completed is sent.
  * Due to the save from step 1 being delayed this arrives before the answer is recorded.
 3. Server error occurs.

With this code, the continue button will be disabled until each network request completes, which will disallow further network requests to be initiated.