### PR TITLE
Plan editability

### DIFF
--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -26,16 +26,8 @@ module.exports = React.createClass
   getInitialState: ->
     isNewPlan = TaskPlanStore.isNew(@props.id)
 
-    # Whether date/periods inputs are disabled should only depend on the whether
-    # the **saved** version of the plan is visible to students.  During edit, the ability to
-    # update a plan should not suddenly be disabled if the teacher picks today to be
-    # an open date.
-    isSavedPlanVisibleToStudent = TaskPlanStore.isVisibleToStudents(@props.id)
-
     showingPeriods: not isNewPlan
     currentLocale: TimeHelper.getCurrentLocales()
-    isVisibleToStudents: isSavedPlanVisibleToStudent
-    isEditable: TaskPlanStore.isEditable(@props.id)
 
   # Called by the UnsavedStateMixin to detect if anything needs to be persisted
   # This logic could be improved, all it checks is if a title is set on a new task plan
@@ -117,23 +109,13 @@ module.exports = React.createClass
 
     {taskingOpensAt, taskingDueAt}
 
-  updateIsVisibleAndIsEditable: ->
-    isVisibleToStudents = TaskPlanStore.isVisibleToStudents(@props.id)
-    isEditable = TaskPlanStore.isEditable(@props.id)
-    @setState({isVisibleToStudents, isEditable})
-
   # this will be called whenever the course store loads, but won't if
   # the store has already finished loading by the time the component mounts
   bindUpdate: ->
     @setPeriodDefaults()
-    @updateIsVisibleAndIsEditable()
 
   componentWillMount: ->
     @setPeriodDefaults()
-    TaskPlanStore.on('publishing', @updateIsVisibleAndIsEditable)
-
-  componentWillUnmount: ->
-    TaskPlanStore.off('publishing', @updateIsVisibleAndIsEditable)
 
   setOpensAt: (value, period) ->
     {id} = @props

--- a/src/components/task-plan/homework.cjsx
+++ b/src/components/task-plan/homework.cjsx
@@ -23,6 +23,7 @@ ChooseExercises = React.createClass
     courseId: React.PropTypes.string.isRequired
     selected: React.PropTypes.array.isRequired
     hide: React.PropTypes.func.isRequired
+    canEdit: React.PropTypes.bool
 
   selectProblems: ->
     @setState({
@@ -49,6 +50,7 @@ ChooseExercises = React.createClass
     if shouldShowExercises
       exerciseSummary = <ExerciseSummary
           canReview={true}
+          canEdit={@props.canEdit}
           reviewClicked={hide}
           onCancel={cancel}
           planId={planId}/>
@@ -119,13 +121,14 @@ HomeworkPlan = React.createClass
         planId={id}
         cancel={@cancelSelection}
         hide={@hideSectionTopics}
+        canEdit={not @state.isVisibleToStudents}
         selected={topics}/>
 
     if shouldShowExercises
       exerciseSummary = <ExerciseSummary
         onCancel={@cancel}
         onPublish={@publish}
-        canAdd={not TaskPlanStore.isVisibleToStudents(id)}
+        canAdd={not @state.isVisibleToStudents}
         addClicked={@showSectionTopics}
         planId={id}/>
 
@@ -137,6 +140,7 @@ HomeworkPlan = React.createClass
       reviewExercises = <ReviewExercises
         courseId={courseId}
         pageIds={topics}
+        canEdit={not @state.isVisibleToStudents}
         planId={id}/>
 
       reviewExercisesSummary = <PinnedHeaderFooterCard
@@ -149,7 +153,7 @@ HomeworkPlan = React.createClass
 
     header = @builderHeader('homework')
 
-    if not TaskPlanStore.isVisibleToStudents(id)
+    if not @state.isVisibleToStudents
       addProblemsButton = <BS.Button id='problems-select'
         onClick={@showSectionTopics}
         bsStyle='default'>+ Select Problems

--- a/src/components/task-plan/homework/exercise-summary.cjsx
+++ b/src/components/task-plan/homework/exercise-summary.cjsx
@@ -8,6 +8,7 @@ ExerciseSummary = React.createClass
   propTypes:
     planId: React.PropTypes.string.isRequired
     canAdd: React.PropTypes.bool
+    canEdit: React.PropTypes.bool
     canReview: React.PropTypes.bool
     addClicked: React.PropTypes.func
     reviewClicked: React.PropTypes.func
@@ -48,17 +49,18 @@ ExerciseSummary = React.createClass
         className="-add-exercises" 
         onClick={@props.addClicked}>Add More...</BS.Button>
 
-    if TaskPlanStore.canDecreaseTutorExercises(@props.planId)
-      removeSelection =
-        <BS.Button onClick={@removeTutorSelection} className="btn-xs -move-exercise-down">
-          <i className="fa fa-arrow-down"/>
-        </BS.Button>
+    if @props.canEdit or @props.canAdd
+      if TaskPlanStore.canDecreaseTutorExercises(@props.planId)
+        removeSelection =
+          <BS.Button onClick={@removeTutorSelection} className="btn-xs -move-exercise-down">
+            <i className="fa fa-arrow-down"/>
+          </BS.Button>
 
-    if TaskPlanStore.canIncreaseTutorExercises(@props.planId)
-      addSelection =
-        <BS.Button onClick={@addTutorSelection} className="btn-xs -move-exercise-up">
-          <i className="fa fa-arrow-up"/>
-        </BS.Button>
+      if TaskPlanStore.canIncreaseTutorExercises(@props.planId)
+        addSelection =
+          <BS.Button onClick={@addTutorSelection} className="btn-xs -move-exercise-up">
+            <i className="fa fa-arrow-up"/>
+          </BS.Button>
 
     <BS.Panel className="exercise-summary" bsStyle="default">
       <BS.Grid>

--- a/src/components/task-plan/homework/exercises.cjsx
+++ b/src/components/task-plan/homework/exercises.cjsx
@@ -59,6 +59,7 @@ ReviewExerciseCard = React.createClass
   propTypes:
     planId: React.PropTypes.string.isRequired
     exercise: React.PropTypes.object.isRequired
+    canEdit: React.PropTypes.bool
     index: React.PropTypes.number
 
   mixins: [ExerciseCardMixin]
@@ -86,7 +87,7 @@ ReviewExerciseCard = React.createClass
         <i className="fa fa-arrow-down"/>
       </BS.Button>
 
-    if not TaskPlanStore.isVisibleToStudents(@props.planId)
+    if @props.canEdit
       <span className="pull-right card-actions">
         {moveUp}
         {moveDown}
@@ -161,12 +162,17 @@ ReviewExercises = React.createClass
   propTypes:
     planId: React.PropTypes.string.isRequired
     courseId: React.PropTypes.string.isRequired
+    canEdit: React.PropTypes.bool
     pageIds: React.PropTypes.array
 
   mixins: [ExercisesRenderMixin]
 
   renderExercise: (exercise, i) ->
-    <ReviewExerciseCard index={i} planId={@props.planId} exercise={exercise}/>
+    <ReviewExerciseCard
+      index={i}
+      planId={@props.planId}
+      canEdit={@props.canEdit}
+      exercise={exercise}/>
 
   render: ->
     load = @renderLoading()

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -20,6 +20,7 @@ ReviewReadingLi = React.createClass
   propTypes:
     planId: React.PropTypes.string.isRequired
     topicId: React.PropTypes.string.isRequired
+    canEdit: React.PropTypes.bool
 
   moveReadingUp: ->
     TaskPlanActions.moveReading(@props.planId, @props.topicId, -1)
@@ -36,7 +37,7 @@ ReviewReadingLi = React.createClass
         <i className="fa fa-arrow-up"/>
       </BS.Button>
 
-    if not TaskPlanStore.isVisibleToStudents(@props.planId)
+    if @props.canEdit
       <span className='section-buttons'>
         {moveUpButton}
         <BS.Button onClick={@moveReadingDown} className="btn-xs move-reading-down">
@@ -65,9 +66,14 @@ ReviewReadings = React.createClass
   propTypes:
     planId: React.PropTypes.string.isRequired
     selected: React.PropTypes.array
+    canEdit: React.PropTypes.bool
 
   renderSection: (topicId, index) ->
-    <ReviewReadingLi topicId={topicId} planId={@props.planId} index={index}/>
+    <ReviewReadingLi
+      topicId={topicId}
+      planId={@props.planId}
+      canEdit={@props.canEdit}
+      index={index}/>
 
   renderSelected: ->
     if @props.selected.length
@@ -146,7 +152,7 @@ ReadingPlan = React.createClass
 
     if @state?.invalid then formClasses.push('is-invalid-form')
 
-    if not TaskPlanStore.isVisibleToStudents(id)
+    if not @state.isVisibleToStudents
       addReadingsButton = <BS.Button id='reading-select'
         onClick={@showSectionTopics}
         bsStyle='default'>+ {addReadingText}
@@ -169,7 +175,11 @@ ReadingPlan = React.createClass
 
           <BS.Row>
             <BS.Col xs={12} md={12}>
-              <ReviewReadings courseId={courseId} planId={id} selected={topics}/>
+              <ReviewReadings
+                canEdit={not @state.isVisibleToStudents}
+                courseId={courseId}
+                planId={id}
+                selected={topics}/>
               {addReadingsButton}
               {readingsRequired}
             </BS.Col>

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -7,7 +7,7 @@ validator = require 'validator'
 {TocStore} = require './toc'
 {TimeStore} = require './time'
 {ExerciseStore} = require './exercise'
-{PlanPublishActions} = require './plan-publish'
+{PlanPublishActions, PlanPublishStore} = require './plan-publish'
 TaskHelpers = require '../helpers/task'
 
 TUTOR_SELECTIONS =
@@ -303,7 +303,9 @@ TaskPlanConfig =
     @_change(id, {is_publish_requested: true})
 
   _saved: (obj, id) ->
-    PlanPublishActions.published(obj, id) if obj.is_publish_requested
+    if obj.is_publish_requested
+      PlanPublishActions.published(obj, id)
+      @emit('publish-queued', id)
     obj
 
   resetPlan: (id) ->
@@ -389,8 +391,7 @@ TaskPlanConfig =
       not ((isPublishedOrPublishing and isPastDue) or @_isDeleteRequested(id))
 
     isPublishing: (id) ->
-      plan = @_getPlan(id)
-      plan?.is_publish_requested
+      PlanPublishStore.isPublishing(id)
 
     canDecreaseTutorExercises: (id) ->
       plan = @_getPlan(id)


### PR DESCRIPTION
## To trigger bug
1. start building a new homework or reading
1. change start date to today
1. click publish
  * at this point, the "Add Reading" or "Select Problems" disappear
  * errors show up as well
  * start date picker becomes disabled
  * this gets you stuck

* There was another bug as well, hidden within.  If you click "Publish", and later finish building your assignment, and click "Save as Draft", your plan will actually publish instead.

## Fix
On step 3,
* you should be able to edit all aspects on the plan, despite open date being past

#### For plans that are already published and opened,
* will be unable to change plan details, except for
  * Name
  * Description
  * Due dates

#### For plans that are in draft mode, regardless of dates,
* everything editable

#### For plans that are published, but not yet open
* everything editable

#### Plans past due,
* should not let you edit anything
* should have a back to calendar button
