### PR TITLE
Fix performance report homework status

### DIFF
--- a/src/components/late-icon.cjsx
+++ b/src/components/late-icon.cjsx
@@ -10,6 +10,7 @@ module.exports = React.createClass
       due_at:          React.PropTypes.string
       last_worked_at:  React.PropTypes.string
       type:            React.PropTypes.string
+      status:          React.PropTypes.string
     ).isRequired
 
     buildLateMessage: React.PropTypes.func
@@ -21,14 +22,13 @@ module.exports = React.createClass
   render: ->
     {task, className, buildLateMessage} = @props
     status = TaskHelper.getLateness(task)
-    return null unless status.is_late
 
-    msg = buildLateMessage(task, status)
+    return null if task.status is 'not_started' or not status.is_late
 
     classes = 'late'
     classes += " #{className}" if className?
 
-    tooltip = <BS.Tooltip>{msg}</BS.Tooltip>
+    tooltip = <BS.Tooltip>{buildLateMessage(task, status)}</BS.Tooltip>
     <BS.OverlayTrigger placement='top' overlay={tooltip}>
       <i className={classes}/>
     </BS.OverlayTrigger>

--- a/src/components/performance/cell-status-mixin.cjsx
+++ b/src/components/performance/cell-status-mixin.cjsx
@@ -15,11 +15,6 @@ module.exports = {
       type:            React.PropTypes.string
     ).isRequired
 
-    student: React.PropTypes.shape(
-      name: React.PropTypes.string
-      role: React.PropTypes.number
-    ).isRequired
-
   renderLink: ({message}) ->
     <Router.Link className={"task-result #{@props.task.type} #{@props.className}"} to='viewTaskStep'
       params={courseId: @props.courseId, id: @props.task.id, stepIndex: 1}>

--- a/src/components/performance/homework-cell.cjsx
+++ b/src/components/performance/homework-cell.cjsx
@@ -7,11 +7,13 @@ module.exports = React.createClass
   mixins: [CellStatusMixin] # handles rendering
 
   render: ->
-    status = TaskHelper.getLateness(@props.task)
-
-    message = if status.is_late
-      'Incomplete'
-    else
+    message = if @props.task.status is 'not_started'
+      'Not started'
+    else if TaskHelper.isDue(@props.task)
       "#{@props.task.correct_exercise_count}/#{@props.task.exercise_count}"
+    else if @props.task.status is 'completed'
+      'Complete'
+    else
+      'In progress'
 
     @renderLink({message})

--- a/src/helpers/task.coffee
+++ b/src/helpers/task.coffee
@@ -1,9 +1,10 @@
 moment = require 'moment'
 _ = require 'underscore'
+{TimeStore} = require '../flux/time'
 
 module.exports = {
 
-  getLateness: ({due_at, last_worked_at}) ->
+  getLateness: ({due_at, last_worked_at, status}) ->
 
     result =
       is_late: false
@@ -11,10 +12,12 @@ module.exports = {
       how_late: null
 
     result.last_worked_at = moment(last_worked_at)
-    result.is_late = moment(due_at).isBefore(result.last_worked_at)
+    result.is_late  = moment(due_at).isBefore(result.last_worked_at)
     result.how_late = moment(due_at).from(result.last_worked_at, true) if result.is_late
     result
 
+  isDue: ({due_at}) ->
+    moment(due_at).isBefore(TimeStore.getNow())
 
   # Convert each number to base 10 with it's position based on index.
   # If section is not present, 0 is set for it

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -37,6 +37,8 @@ require './components/tutor-dialog.spec'
 require './components/unsaved-state.spec'
 require './components/buttons/browse-the-book.spec'
 require './components/book-content-mixin.spec'
+require './components/performance/reading-cell.spec'
+require './components/performance/homework-cell.spec'
 
 require './crud-store.spec'
 require './task-store.spec'

--- a/test/components/performance/homework-cell.spec.coffee
+++ b/test/components/performance/homework-cell.spec.coffee
@@ -1,0 +1,76 @@
+{Testing, expect, _} = require '../helpers/component-testing'
+
+{TimeActions, TimeStore} = require '../../../src/flux/time'
+
+Cell = require '../../../src/components/performance/homework-cell'
+
+describe 'Performance Report Homework Cell', ->
+
+  beforeEach ->
+    @props =
+      courseId: '1'
+      student:
+        name: 'Molly Bloom'
+        role: 'student'
+      task:
+        status:          'in_progress'
+        type:            'homework'
+        exercise_count: 11
+        correct_exercise_count: 9
+
+  describe 'before due date', ->
+    beforeEach ->
+      _.extend @props.task,
+        due_at:          '2015-10-14T12:00:00.000Z'
+        last_worked_at:  '2015-10-13T12:00:00.000Z'
+
+    it 'renders as in progress', ->
+      Testing.renderComponent( Cell, props: @props ).then ({dom}) ->
+        expect(dom.innerText).to.equal('In progress')
+        expect(dom.querySelector('i.late')).to.be.null
+
+    it 'renders as not started', ->
+      @props.task.status = 'not_started'
+      Testing.renderComponent( Cell, props: @props ).then ({dom}) ->
+        expect(dom.innerText).to.equal('Not started')
+        expect(dom.querySelector('i.late')).to.be.null
+
+    it 'renders as complete', ->
+      @props.task.status = 'completed'
+      Testing.renderComponent( Cell, props: @props ).then ({dom}) ->
+        expect(dom.innerText).to.equal('Complete')
+        expect(dom.querySelector('i.late')).to.be.null
+
+    it 'renders as in progress if status is garbage', ->
+      @props.task.status = 'jfdsafa'
+      Testing.renderComponent( Cell, props: @props ).then ({dom}) ->
+        expect(dom.innerText).to.equal('In progress')
+        expect(dom.querySelector('i.late')).to.be.null
+
+  describe 'after due date', ->
+    beforeEach ->
+      now = new Date()
+      iso_string = 'Fri Nov 11 2015 00:00:00 GMT+0000 (UTC)'
+      TimeActions.setFromString(iso_string, now)
+
+      _.extend @props.task,
+        due_at:          '2015-10-14T12:00:00.000Z'
+        last_worked_at:  '2015-10-13T12:00:00.000Z'
+
+    it 'renders as not started', ->
+      @props.task.status = 'not_started'
+      Testing.renderComponent( Cell, props: @props ).then ({dom}) ->
+        expect(dom.innerText).to.equal('Not started')
+        expect(dom.querySelector('i.late')).to.be.null
+
+    it 'shows scores when completed', ->
+      @props.task.status = 'completed'
+      Testing.renderComponent( Cell, props: @props ).then ({dom}) ->
+        expect(dom.innerText).to.equal('9/11')
+        expect(dom.querySelector('i.late')).to.be.null
+
+    it 'displays late icon when worked late', ->
+      @props.task.last_worked_at = '2015-10-15T12:00:00.000Z'
+      Testing.renderComponent( Cell, props: @props ).then ({dom}) ->
+        expect(dom.innerText).to.equal('9/11')
+        expect(dom.querySelector('i.late')).to.not.be.null

--- a/test/components/performance/homework-cell.spec.coffee
+++ b/test/components/performance/homework-cell.spec.coffee
@@ -57,8 +57,9 @@ describe 'Performance Report Homework Cell', ->
         due_at:          '2015-10-14T12:00:00.000Z'
         last_worked_at:  '2015-10-13T12:00:00.000Z'
 
-    it 'renders as not started', ->
+    it 'renders as not started, without icon', ->
       @props.task.status = 'not_started'
+      @props.task.last_worked_at = '2015-10-15T12:00:00.000Z'
       Testing.renderComponent( Cell, props: @props ).then ({dom}) ->
         expect(dom.innerText).to.equal('Not started')
         expect(dom.querySelector('i.late')).to.be.null

--- a/test/components/performance/homework-cell.spec.coffee
+++ b/test/components/performance/homework-cell.spec.coffee
@@ -20,6 +20,9 @@ describe 'Performance Report Homework Cell', ->
 
   describe 'before due date', ->
     beforeEach ->
+      now = new Date()
+      iso_string = 'Fri Jun 11 2015 00:00:00 GMT+0000 (UTC)'
+      TimeActions.setFromString(iso_string, now)
       _.extend @props.task,
         due_at:          '2015-10-14T12:00:00.000Z'
         last_worked_at:  '2015-10-13T12:00:00.000Z'

--- a/test/components/performance/reading-cell.spec.coffee
+++ b/test/components/performance/reading-cell.spec.coffee
@@ -1,0 +1,40 @@
+{Testing, expect, _} = require '../helpers/component-testing'
+
+{TimeActions, TimeStore} = require '../../../src/flux/time'
+
+Cell = require '../../../src/components/performance/reading-cell'
+
+describe 'Performance Report Reading Cell', ->
+
+  beforeEach ->
+    @props =
+      courseId: '1'
+      student:
+        name: 'Molly Bloom'
+        role: 'student'
+      task:
+        status:          'in_progress'
+        due_at:          '2015-10-14T12:00:00.000Z'
+        last_worked_at:  '2015-10-13T12:00:00.000Z'
+        type:            'reading'
+
+  it 'renders as in progress', ->
+    Testing.renderComponent( Cell, props: @props ).then ({dom}) ->
+      expect(dom.innerText).to.equal('In progress')
+      expect(dom.querySelector('i.late')).to.be.null
+
+  it 'renders as not started', ->
+    @props.task.status = 'not_started'
+    Testing.renderComponent( Cell, props: @props ).then ({dom}) ->
+      expect(dom.innerText).to.equal('Not started')
+      expect(dom.querySelector('i.late')).to.be.null
+
+  it 'renders as complete', ->
+    @props.task.status = 'completed'
+    Testing.renderComponent( Cell, props: @props ).then ({dom}) ->
+      expect(dom.innerText).to.equal('Complete')
+
+  it 'renders with late icon', ->
+    @props.task.last_worked_at = '2015-10-15T12:00:00.000Z'
+    Testing.renderComponent( Cell, props: @props ).then ({dom}) ->
+      expect(dom.querySelector('i.late')).not.to.be.null


### PR DESCRIPTION
The homework cells in the performance report had a bug where they would display "Incomplete" if the task was worked late, regardless of the completion status.

Note the display for Alden, Isobel, and Bernhard in the HW column

Before:
<img width="1236" alt="screen shot 2015-08-22 at 10 52 59 pm" src="https://cloud.githubusercontent.com/assets/79566/9426861/ecfa8b5a-4920-11e5-9410-be4a0417647b.png">

After:
<img width="1218" alt="screen shot 2015-08-22 at 11 12 24 pm" src="https://cloud.githubusercontent.com/assets/79566/9426895/48887b42-4923-11e5-823e-133e63eae3ac.png">

