### PR TITLE
dont try to set a min due date for all periods before a common opens_at is set for all periods

### DIFF
--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -133,7 +133,7 @@ module.exports = React.createClass
 
     #get opens at and due at
     taskingOpensAt = TaskPlanStore.getOpensAt(@props.id) or TimeStore.getNow()
-    taskingDueAt = TaskPlanStore.getDueAt(@props.id) or TaskPlanStore.getMinDueAt(this.props.id)
+    @setOpensAt(taskingOpensAt)
 
     #enable all periods
     course = CourseStore.get(@props.courseId)
@@ -141,7 +141,7 @@ module.exports = React.createClass
     TaskPlanActions.setPeriods(@props.id, periods)
 
     #set dates for all periods
-    @setOpensAt(taskingOpensAt)
+    taskingDueAt = TaskPlanStore.getDueAt(@props.id) or TaskPlanStore.getMinDueAt(this.props.id)
     @setDueAt(taskingDueAt)
 
   setIndividualPeriods: ->


### PR DESCRIPTION
## How to replicate
1. create a new assignment
1. choose to set individual period dates
1. change a open date
1. change a due date
1. switch to all periods again
1. fill out whatever else is needed, but don't touch any of the dates stuff
1. try to save or publish
  * you should get a 422

Steps 3 and 4's order does not matter

## Why?
* The FE attempts to create a minimum due date from the common open date, but there was no common open date at the time we try to create the minimum due date.