### PR TITLE
Use first and last name if name field isn't present

### DIFF
--- a/src/components/course-settings/drop-student.cjsx
+++ b/src/components/course-settings/drop-student.cjsx
@@ -3,6 +3,7 @@ BS = require 'react-bootstrap'
 
 {RosterActions} = require '../../flux/roster'
 Icon = require '../icon'
+Name = require '../name'
 
 module.exports = React.createClass
   displayName: 'DropStudentLink'
@@ -13,7 +14,8 @@ module.exports = React.createClass
     RosterActions.delete(@props.student.id)
 
   confirmPopOver: ->
-    <BS.Popover title={"Drop #{@props.student.full_name}?"} {...@props}>
+    title = <span>Drop <Name {...@props.student} />?</span>
+    <BS.Popover title={title} {...@props}>
       <BS.Button onClick={@performDeletion} bsStyle="danger">
         <Icon type='ban' /> Drop
       </BS.Button>

--- a/src/components/learning-guide/teacher-student.cjsx
+++ b/src/components/learning-guide/teacher-student.cjsx
@@ -3,6 +3,7 @@ BS = require 'react-bootstrap'
 Router = require 'react-router'
 _ = require 'underscore'
 
+Name = require '../name'
 BindStoreMixin = require '../bind-store-mixin'
 LearningGuide = require '../../flux/learning-guide'
 {PerformanceStore} = require '../../flux/performance'
@@ -27,14 +28,16 @@ module.exports = React.createClass
     students = PerformanceStore.getAllStudents(@props.courseId)
     selected = PerformanceStore.getStudent(@props.courseId, @props.roleId)
     return null unless selected
-
+    name = <Name {...selected} />
     <div className='guide-heading'>
       <div className='guide-group-title'>
         Performance Forecast for:
-        <BS.DropdownButton bzSize='large' className='student-selection' title={selected.name}
+        <BS.DropdownButton bzSize='large' className='student-selection' title={name}
           bsStyle='link' onSelect={@onSelectStudent}>
             { for student in _.sortBy(students, 'name') when student.role isnt selected.role
-              <BS.MenuItem key={student.role} eventKey={student.role}>{student.name}</BS.MenuItem> }
+              <BS.MenuItem key={student.role} eventKey={student.role}>
+                <Name {...student} />
+              </BS.MenuItem> }
         </BS.DropdownButton>
         <InfoLink type='teacher_student'/>
       </div>

--- a/src/components/name.cjsx
+++ b/src/components/name.cjsx
@@ -1,0 +1,19 @@
+_ = require 'underscore'
+React = require 'react'
+
+Name = React.createClass
+
+  propTypes:
+    first_name:  React.PropTypes.string
+    last_name:   React.PropTypes.string
+    name:        React.PropTypes.string
+
+  render: ->
+    name = if _.isEmpty(@props.name)
+      "#{@props.first_name} #{@props.last_name}"
+    else
+      @props.name
+
+    <span className="name">{name}</span>
+
+module.exports = Name

--- a/src/components/name.cjsx
+++ b/src/components/name.cjsx
@@ -14,6 +14,6 @@ Name = React.createClass
     else
       @props.name
 
-    <span className="name">{name}</span>
+    <span className="-name">{name}</span>
 
 module.exports = Name

--- a/src/components/performance/name-cell.cjsx
+++ b/src/components/performance/name-cell.cjsx
@@ -1,5 +1,6 @@
 React    = require 'react'
 Router = require 'react-router'
+Name = require '../name'
 
 module.exports = React.createClass
   displayName: 'NameCell'
@@ -14,5 +15,5 @@ module.exports = React.createClass
   render: ->
     <Router.Link className={"student-name #{@props.className}"} to='viewStudentTeacherGuide'
       params={roleId: @props.roleId, courseId: @props.courseId}>
-      {@props.student.first_name} {@props.student.last_name}
+      <Name {...@props.student} />
     </Router.Link>

--- a/src/components/task/viewing-as-student-name.cjsx
+++ b/src/components/task/viewing-as-student-name.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 LoadableItem = require '../loadable-item'
-
+Name = require '../name'
 {PerformanceStore, PerformanceActions} = require '../../flux/performance'
 
 ViewingAsStudentName = React.createClass
@@ -18,7 +18,7 @@ ViewingAsStudentName = React.createClass
     student = PerformanceStore.getStudentOfTask(courseId, taskId)
 
     studentName = <div className={className}>
-      {student.first_name} {student.last_name}
+      <Name {...student} />
     </div> if student?
 
     studentName

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -39,6 +39,7 @@ require './components/buttons/browse-the-book.spec'
 require './components/book-content-mixin.spec'
 require './components/performance/reading-cell.spec'
 require './components/performance/homework-cell.spec'
+require './components/name.spec'
 
 require './crud-store.spec'
 require './task-store.spec'

--- a/test/components/name.spec.coffee
+++ b/test/components/name.spec.coffee
@@ -1,0 +1,31 @@
+{Testing, expect, _} = require './helpers/component-testing'
+
+Name = require '../../src/components/name'
+
+describe 'Name Component', ->
+
+  beforeEach ->
+    @props =
+      name: 'Prince Humperdinck'
+      first_name: 'Vincent'
+      last_name: 'Adultman'
+
+  it 'renders using name if present and ignores first and last name', ->
+    Testing.renderComponent( Name, props: @props ).then ({dom}) ->
+      expect(dom.innerText).to.equal('Prince Humperdinck')
+
+  describe 'when missing name', ->
+    it 'doesn\'t use a undefined name', ->
+      delete @props.name
+      Testing.renderComponent( Name, props: @props ).then ({dom}) ->
+        expect(dom.innerText).to.equal('Vincent Adultman')
+
+    it 'doesn\'t use a null name', ->
+      @props.name = null
+      Testing.renderComponent( Name, props: @props ).then ({dom}) ->
+        expect(dom.innerText).to.equal('Vincent Adultman')
+
+    it 'doesn\'t use an empty name', ->
+      @props.name = ''
+      Testing.renderComponent( Name, props: @props ).then ({dom}) ->
+        expect(dom.innerText).to.equal('Vincent Adultman')


### PR DESCRIPTION
When student's are created, their name field (which contains the combined name), may be blank. If it is we need to display the first and last name fields.

Prevents uglyness like:
![screen shot 2015-08-24 at 4 27 55 pm](https://cloud.githubusercontent.com/assets/79566/9453008/34f89afc-4a7d-11e5-9821-7397ef9663c9.png)
