### PR TITLE
update recovered status only when the newly generated recovery step is loaded

### DIFF
--- a/src/components/task-step/exercise/modes.cjsx
+++ b/src/components/task-step/exercise/modes.cjsx
@@ -11,6 +11,7 @@ BindStoreMixin = require '../../bind-store-mixin'
 Question = require '../../question'
 FreeResponse = require './free-response'
 ExerciseGroup = require './group'
+AsyncButton = require '../../buttons/async-button'
 
 {TaskStepActions, TaskStepStore} = require '../../../flux/task-step'
 {TaskActions, TaskStore} = require '../../../flux/task'
@@ -150,7 +151,7 @@ ExerciseReview = React.createClass
   isContinueEnabled: ->
     {id} = @props
     {answer_id} = TaskStepStore.get(id)
-    !!answer_id
+    !!answer_id and not TaskStepStore.isRecovering(id)
 
   onContinue: ->
     @props.onNextStep()
@@ -181,13 +182,16 @@ ExerciseReview = React.createClass
   renderFooterButtons: ->
     {id, review} = @props
     task = TaskStore.get(TaskStepStore.getTaskId(id))
-    if TaskStepStore.canTryAnother(id, task) then tryAnotherButton =
-      <BS.Button
+
+    if TaskStepStore.canTryAnother(id, task)
+      tryAnotherButton = <AsyncButton
         bsStyle='primary'
         className='-try-another'
-        onClick={@tryAnother}>
+        onClick={@tryAnother}
+        isWaiting={TaskStepStore.isRecovering(id)}
+        waitingText='Loading…'>
         Try Another
-      </BS.Button>
+      </AsyncButton>
 
     # "Refresh my Memory" button is disabled until BE gets it working properly.
     # See corresponding comment in tests.

--- a/src/components/task-step/exercise/modes.cjsx
+++ b/src/components/task-step/exercise/modes.cjsx
@@ -189,7 +189,7 @@ ExerciseReview = React.createClass
         className='-try-another'
         onClick={@tryAnother}
         isWaiting={TaskStepStore.isRecovering(id)}
-        waitingText='Loading…'>
+        waitingText='Loading Another…'>
         Try Another
       </AsyncButton>
 

--- a/src/flux/task-step.coffee
+++ b/src/flux/task-step.coffee
@@ -11,11 +11,14 @@ RECOVERY = 'recovery'
 
 TaskStepConfig =
   _asyncStatus: {}
+  _recoveryTarget: {}
 
   _loaded: (obj, id) ->
     if not obj.task_id
       obj.task_id = @_local[id]?.task_id
     @emit("step.loaded", id)
+    _.each(@_recoveryTarget, _.partial(@_updateRecoveredFor, id), @)
+
     obj
 
   _saved: (obj, id) ->
@@ -46,10 +49,14 @@ TaskStepConfig =
     @emit('change', id)
 
   loadedRecovery: (obj, id) ->
-    delete @_asyncStatus[id]
+    @_recoveryTarget[id] = obj.id
     @clearChanged()
     @emit('change', id)
     @emit('step.recovered', obj)
+
+  _updateRecoveredFor: (loadedId, recoverTarget, recoveredFor) ->
+    delete @_asyncStatus[recoveredFor] if recoverTarget is loadedId
+    delete @_recoveryTarget[recoveredFor]
 
   exports:
     isRecovering: (id) -> @_asyncStatus[id] is RECOVERY

--- a/src/flux/task-step.coffee
+++ b/src/flux/task-step.coffee
@@ -50,13 +50,14 @@ TaskStepConfig =
 
   loadedRecovery: (obj, id) ->
     @_recoveryTarget[id] = obj.id
-    @clearChanged()
-    @emit('change', id)
     @emit('step.recovered', obj)
 
   _updateRecoveredFor: (loadedId, recoverTarget, recoveredFor) ->
-    delete @_asyncStatus[recoveredFor] if recoverTarget is loadedId
-    delete @_recoveryTarget[recoveredFor]
+    if recoverTarget is loadedId
+      @emit('change', recoveredFor)
+      @clearChanged(recoveredFor)
+      delete @_asyncStatus[recoveredFor]
+      delete @_recoveryTarget[recoveredFor]
 
   exports:
     isRecovering: (id) -> @_asyncStatus[id] is RECOVERY
@@ -108,7 +109,6 @@ TaskStepConfig =
       step? and
         (step.has_recovery and step.correct_answer_id isnt step.answer_id) and
         not Durations.isPastDue(task) and
-        not @exports.isRecovering.call(@, id) and
         not @exports.isLoading.call(@, id) and
         not @exports.isSaving.call(@, id)
 

--- a/test/task-step-store.spec.coffee
+++ b/test/task-step-store.spec.coffee
@@ -55,10 +55,13 @@ describe 'Task Step Store', ->
       @task.due_at = moment(TimeStore.getNow()).subtract(1, 'minute').toDate()
       expect(TaskStepStore.canTryAnother(step.id, @task)).to.be.false
 
-    it 'doesnt work when recovering a task', ->
+    it 'isRecovering updates when recovering a task', ->
       step = LoadStepData()
+      expect(TaskStepStore.isRecovering(step.id)).to.be.false
       TaskStepActions.loadRecovery(step.id)
       expect(TaskStepStore.isRecovering(step.id)).to.be.true
-      expect(TaskStepStore.canTryAnother(step.id, @task)).to.be.false
-      TaskStepActions.loadedRecovery({}, step.id)
       expect(TaskStepStore.canTryAnother(step.id, @task)).to.be.true
+      TaskStepActions.loadedRecovery({id: 'RECOVERED_STEP'}, step.id)
+      expect(TaskStepStore.isRecovering(step.id)).to.be.true
+      TaskStepActions.loaded({id: 'RECOVERED_STEP'}, 'RECOVERED_STEP')
+      expect(TaskStepStore.isRecovering(step.id)).to.be.false


### PR DESCRIPTION
![screen shot 2015-08-25 at 2 33 54 pm](https://cloud.githubusercontent.com/assets/2483873/9477164/654f1e38-4b36-11e5-975b-3730f7512fcb.png)
![screen shot 2015-08-25 at 2 34 03 pm](https://cloud.githubusercontent.com/assets/2483873/9477165/655974aa-4b36-11e5-9112-615061e2ccca.png)

Actually says, "Loading another..." as opposed to just "Loading..."
