### PR TITLE
Bug/plan publishing and delete details

### DIFF
--- a/resources/styles/components/course-calendar/plan-details.less
+++ b/resources/styles/components/course-calendar/plan-details.less
@@ -31,13 +31,11 @@ body.modal-open {
     &.external-modal     { .x-plan-modal(@external-color); }
   }
 
-  &:not(.is-published) {
-    &.is-publishing {
-      .modal-title::before {
-        .is-publishing();
-        margin-right: @modal-padding/2;
-        margin-left: -@modal-padding/2;
-      }
+  &.is-publishing {
+    .modal-title::before {
+      .is-publishing();
+      margin-right: @modal-padding/2;
+      margin-left: -@modal-padding/2;
     }
   }
 

--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -5,6 +5,7 @@ camelCase = require 'camelcase'
 
 React = require 'react/addons'
 CoursePlan = require './plan'
+PlanHelper = require '../../helpers/plan'
 {TimeStore} = require '../../flux/time'
 
 CourseDuration = React.createClass
@@ -151,17 +152,7 @@ CourseDuration = React.createClass
     plan.duration = @_getDurationRange(plan)
 
   isPlanPublishing: (plan) ->
-    isPublishing = (plan.is_publish_requested? and plan.is_publish_requested) or plan.publish_last_requested_at?
-    if plan.published_at? and plan.publish_last_requested_at?
-      # is the last requested publishing after the last completed publish?
-      isPublishing = moment(plan.publish_last_requested_at).diff(plan.published_at) > 0
-    else if plan.published_at? and not plan.publish_last_requested_at?
-      isPublishing = false
-    else if plan.publish_last_requested_at?
-      recent = moment(TimeStore.getNow()).diff(plan.publish_last_requested_at) < @props.recentTolerance
-      isPublishing = isPublishing and recent
-
-    isPublishing
+    PlanHelper.isPublishing(plan, @props.recentTolerance)
 
   setDurationDay: (plan) ->
     {referenceDate} = @props

--- a/src/components/course-calendar/index.cjsx
+++ b/src/components/course-calendar/index.cjsx
@@ -9,11 +9,17 @@ displayAs =
 CourseCalendar = React.createClass
   displayName: 'CourseCalendar'
 
+  propTypes:
+    loadPlansList: React.PropTypes.func
+
   getInitialState: ->
     displayAs: 'month'
 
   render: ->
     Handler = displayAs[@state.displayAs]
-    <Handler {...@props} ref='calendarHandler'/>
+    {loadPlansList} = @props
+    plansList = loadPlansList?()
+
+    <Handler {...@props} plansList={plansList} ref='calendarHandler'/>
 
 module.exports = CourseCalendar

--- a/src/components/course-calendar/month.cjsx
+++ b/src/components/course-calendar/month.cjsx
@@ -7,6 +7,7 @@ BS = require 'react-bootstrap'
 
 {Calendar, Month, Week, Day} = require 'react-calendar'
 {TimeStore} = require '../../flux/time'
+{TeacherTaskPlanActions} = require '../../flux/teacher-task-plan'
 
 CourseCalendarHeader = require './header'
 CourseDuration = require './duration'
@@ -43,6 +44,8 @@ CourseMonth = React.createClass
   setDate: (date) ->
     unless moment(date).isSame(@props.date, 'month')
       @setDateParams(date)
+      # sync local copy with server again when we change date in view.
+      TeacherTaskPlanActions.load(@props.courseId)
 
   componentDidUpdate: ->
     @setDayHeight(@refs.courseDurations.state.ranges) if @refs.courseDurations?

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -24,9 +24,9 @@ CoursePlan = React.createClass
   propTypes:
     courseId: React.PropTypes.string.isRequired
     item: React.PropTypes.shape(
-        plan: React.PropTypes.object
-        displays: React.PropTypes.array
-      )
+      plan: React.PropTypes.object
+      displays: React.PropTypes.array
+    )
     activeHeight: React.PropTypes.number
 
   getDefaultProps: ->

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -31,7 +31,7 @@ CoursePlan = React.createClass
   getInitialState: ->
     isViewingStats: @_doesPlanMatchesRoute()
     publishStatus: PlanPublishStore.getAsyncStatus(@props.item.plan.id)
-    isPublishing: false
+    isPublishing: PlanPublishStore.isPublishing(@props.item.plan.id)
     isHovered: false
 
   # utility functions for functions called in lifecycle methods
@@ -85,10 +85,10 @@ CoursePlan = React.createClass
     {id, isPublishing, publish_job_uuid} = plan
     publishStatus = PlanPublishStore.getAsyncStatus(id)
 
-    if isPublishing and not PlanPublishStore.isPublishing(id) and not PlanPublishStore.isPublished(id)
+    if isPublishing and not @state.isPublishing and not PlanPublishStore.isPublished(id)
       PlanPublishActions.published({id, publish_job_uuid}) if publish_job_uuid?
 
-    isPublishing = isPublishing or PlanPublishStore.isPublishing(id)
+    isPublishing = isPublishing or @state.isPublishing
 
     if isPublishing
       PlanPublishActions.startChecking(id, publish_job_uuid)

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -22,9 +22,12 @@ CoursePlan = React.createClass
     router: React.PropTypes.func
 
   propTypes:
-    item: React.PropTypes.object.isRequired
     courseId: React.PropTypes.string.isRequired
-    activeHeight: React.PropTypes.number.isRequired
+    item: React.PropTypes.shape(
+        plan: React.PropTypes.object
+        displays: React.PropTypes.array
+      )
+    activeHeight: React.PropTypes.number
 
   getDefaultProps: ->
     # CALENDAR_EVENT_LABEL_ACTIVE_STATIC_HEIGHT
@@ -75,13 +78,13 @@ CoursePlan = React.createClass
 
   checkPublishingStatus: (published) ->
     planId = @props.item.plan.id
-    if published.publishFor is planId
+    if published.for is planId
       planStatus =
         publishStatus: published.status
         isPublishing: PlanPublishStore.isPublishing(planId)
 
       @setState(planStatus)
-      PlanPublishStore.removeAllListeners("planPublish.#{planId}.*", @checkPublishingStatus) if PlanPublishStore.isDone(planId)
+      PlanPublishStore.removeAllListeners("progress.#{planId}.*", @checkPublishingStatus) if PlanPublishStore.isDone(planId)
 
   subscribeToPublishing: (plan) ->
     publishState = PlanHelper.subscribeToPublishing(plan, @checkPublishingStatus)
@@ -106,7 +109,7 @@ CoursePlan = React.createClass
 
   stopCheckingPlan: (plan) ->
     PlanPublishActions.stopChecking(plan.id) if @state.isPublishing
-    PlanPublishStore.removeAllListeners("planPublish.#{plan.id}.*")
+    PlanPublishStore.removeAllListeners("progress.#{plan.id}.*")
 
   setIsViewing: (isViewingStats) ->
     @syncIsViewingStats(isViewingStats) if @state.isViewingStats isnt isViewingStats

--- a/src/components/course-calendar/plan.cjsx
+++ b/src/components/course-calendar/plan.cjsx
@@ -11,6 +11,8 @@ CoursePlanLabel = require './plan-label'
 {CoursePlanDisplayEdit, CoursePlanDisplayQuickLook} = require './plan-display'
 
 {PlanPublishStore, PlanPublishActions} = require '../../flux/plan-publish'
+PlanHelper = require '../../helpers/plan'
+
 
 # TODO drag and drop, and resize behavior
 CoursePlan = React.createClass
@@ -82,19 +84,8 @@ CoursePlan = React.createClass
       PlanPublishStore.removeAllListeners("planPublish.#{planId}.*", @checkPublishingStatus) if PlanPublishStore.isDone(planId)
 
   subscribeToPublishing: (plan) ->
-    {id, isPublishing, publish_job_uuid} = plan
-    publishStatus = PlanPublishStore.getAsyncStatus(id)
-
-    if isPublishing and not @state.isPublishing and not PlanPublishStore.isPublished(id)
-      PlanPublishActions.published({id, publish_job_uuid}) if publish_job_uuid?
-
-    isPublishing = isPublishing or @state.isPublishing
-
-    if isPublishing
-      PlanPublishActions.startChecking(id, publish_job_uuid)
-      PlanPublishStore.on("planPublish.#{id}.*", @checkPublishingStatus)
-
-    @setState({publishStatus, isPublishing})
+    publishState = PlanHelper.subscribeToPublishing(plan, @checkPublishingStatus)
+    @setState(publishState)
 
   componentWillMount: ->
     @subscribeToPublishing(@props.item.plan)

--- a/src/components/performance/export.cjsx
+++ b/src/components/performance/export.cjsx
@@ -41,7 +41,7 @@ PerformanceExport = React.createClass
 
   handleCompletedExport: (exportData) ->
     {courseId} = @props
-    if @isUpdateValid(exportData.exportFor)
+    if @isUpdateValid(exportData.for)
       PerformanceExportActions.load(courseId)
       @setState(tryToDownload: true)
 
@@ -109,12 +109,14 @@ PerformanceExport = React.createClass
     @setState(tryToDownload: true, downloadedSinceLoad: true)
 
   addBindListener: ->
-    PerformanceExportStore.on('performanceExport.completed', @handleCompletedExport)
-    PerformanceExportStore.on('performanceExport.loaded', @handleLoadedExport)
+    {courseId} = @props
+    PerformanceExportStore.on("progress.#{courseId}.completed", @handleCompletedExport)
+    PerformanceExportStore.on('loaded', @handleLoadedExport)
 
   removeBindListener: ->
-    PerformanceExportStore.off('performanceExport.completed', @handleCompletedExport)
-    PerformanceExportStore.off('performanceExport.loaded', @handleLoadedExport)
+    {courseId} = @props
+    PerformanceExportStore.off("progress.#{courseId}.completed", @handleCompletedExport)
+    PerformanceExportStore.off('loaded', @handleLoadedExport)
 
   render: ->
     {courseId, className} = @props

--- a/src/components/performance/export.cjsx
+++ b/src/components/performance/export.cjsx
@@ -136,6 +136,7 @@ PerformanceExport = React.createClass
         isWaiting={PerformanceExportStore.isExporting(courseId) or tryToDownload}
         isFailed={PerformanceExportStore.isFailed(courseId) or downloadHasError}
         failedProps={failedProps}
+        timeout={3600000}
         waitingText='Generating Export…'>
         Generate Export
       </AsyncButton>

--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -27,14 +27,14 @@ PlanFooter = React.createClass
 
   checkPublishingStatus: (published) ->
     planId = @props.id
-    if published.publishFor is planId
+    if published.for is planId
       planStatus =
         publishing: PlanPublishStore.isPublishing(planId)
 
       @setState(planStatus)
       if PlanPublishStore.isDone(planId)
-        PlanPublishStore.removeAllListeners("planPublish.#{planId}.*", @checkPublishingStatus)
-        TaskPlanStore.load(planId)
+        PlanPublishStore.removeAllListeners("progress.#{planId}.*", @checkPublishingStatus)
+        TaskPlanActions.load(planId)
 
   componentWillMount: ->
     plan = TaskPlanStore.get(@props.id)

--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -2,6 +2,8 @@ React = require 'react'
 BS = require 'react-bootstrap'
 Router = require 'react-router'
 {TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
+{PlanPublishStore, PlanPublishActions} = require '../../flux/plan-publish'
+PlanHelper = require '../../helpers/plan'
 AsyncButton = require '../buttons/async-button'
 BackButton = require '../buttons/back-button'
 
@@ -20,6 +22,25 @@ PlanFooter = React.createClass
 
   getInitialState: ->
     isEditable: TaskPlanStore.isEditable(@props.id)
+    publishing: TaskPlanStore.isPublishing(@props.id)
+    saving: TaskPlanStore.isSaving(@props.id)
+
+  checkPublishingStatus: (published) ->
+    planId = @props.id
+    if published.publishFor is planId
+      planStatus =
+        publishing: PlanPublishStore.isPublishing(planId)
+
+      @setState(planStatus)
+      if PlanPublishStore.isDone(planId)
+        PlanPublishStore.removeAllListeners("planPublish.#{planId}.*", @checkPublishingStatus)
+        TaskPlanStore.load(planId)
+
+  componentWillMount: ->
+    plan = TaskPlanStore.get(@props.id)
+    publishState = PlanHelper.subscribeToPublishing(plan, @checkPublishingStatus)
+
+    @setState(publishing: publishState.isPublishing)
 
   saved: ->
     courseId = @props.courseId
@@ -53,8 +74,8 @@ PlanFooter = React.createClass
 
     plan = TaskPlanStore.get(id)
 
-    saveable = not TaskPlanStore.isPublished(id)
-    isWaiting = TaskPlanStore.isSaving(id)
+    saveable = not (TaskPlanStore.isPublished(id) or TaskPlanStore.isPublishing(id))
+    isWaiting = TaskPlanStore.isSaving(id) or TaskPlanStore.isPublishing(id) or TaskPlanStore.isDeleteRequested(id)
     deleteable = not TaskPlanStore.isNew(id) and not (TaskPlanStore.isOpened(id) and TaskPlanStore.isPublished(id)) and not isWaiting
     isFailed = TaskPlanStore.isFailed(id)
 
@@ -82,6 +103,7 @@ PlanFooter = React.createClass
           isFailed={isFailed}
           waitingText='Publishing…'
           disabled={isWaiting}
+          timeout={3600000}
           >
           {'Publish'}
         </AsyncButton>

--- a/src/components/task-plan/plan-mixin.coffee
+++ b/src/components/task-plan/plan-mixin.coffee
@@ -101,7 +101,7 @@ PlanMixin =
     else
       date = moment(TimeStore.getNow()).format(CALENDAR_DATE_FORMAT)
 
-    unless TaskPlanStore.isNew(id) or not TaskPlanStore.isPublishing(id) or TaskPlanStore.isDeleteRequested(id)
+    unless TaskPlanStore.isNew(id) or TaskPlanStore.isPublishing(id) or TaskPlanStore.isDeleteRequested(id)
       calendarRoute = 'calendarViewPlanStats'
       planId = id
 

--- a/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -65,18 +65,6 @@ TeacherTaskPlanListing = React.createClass
 
   mixins: [CourseDataMixin]
 
-  componentDidMount: ->
-    {courseId} = @context.router.getCurrentParams()
-
-    # Bypass loading if plan is already loaded, as is the case in testing.
-    if not TeacherTaskPlanStore.isLoaded(courseId)
-      TeacherTaskPlanActions.load( courseId )
-
-  componentWillMount: -> TeacherTaskPlanStore.addChangeListener(@update)
-  componentWillUnmount: -> TeacherTaskPlanStore.removeChangeListener(@update)
-
-  update: -> @setState({})
-
   statics:
     willTransitionTo: (transition, params, query, callback) ->
       {date, planId} = params

--- a/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -92,9 +92,9 @@ TeacherTaskPlanListing = React.createClass
 
     date = @getDateFromParams()
 
-    plansList = TeacherTaskPlanStore.getActiveCoursePlans(courseId)
+    loadPlansList = TeacherTaskPlanStore.getActiveCoursePlans.bind(TeacherTaskPlanStore, courseId)
 
-    loadedCalendarProps = {plansList, courseId, date}
+    loadedCalendarProps = {loadPlansList, courseId, date}
 
     <div {...courseDataProps} className="tutor-booksplash-background">
 

--- a/src/flux/job.coffee
+++ b/src/flux/job.coffee
@@ -29,8 +29,12 @@ JobConfig = {
     jobData
 
   checkUntil: (id, checkJob, interval = 1000, maxRepeats = 50, finalStatus = ['completed', 'failed', 'killed']) ->
-    @_checkUntil[id] = {checkJob, finalStatus, interval, maxRepeats, count: 0}
-    checkJob()
+    unless @_checkUntil[id]?
+      @_checkUntil[id] = {checkJob, finalStatus, interval, maxRepeats, count: 0}
+      checkJob()
+
+  stopChecking: (id) ->
+    delete @_checkUntil[id]
 
   exports:
 

--- a/src/flux/performance-export.coffee
+++ b/src/flux/performance-export.coffee
@@ -1,31 +1,14 @@
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
 {JobActions, JobStore} = require './job'
+{JobListenerConfig} = require '../helpers/job'
+
 _ = require 'underscore'
 moment = require 'moment'
 
-EXPORT_REQUESTING = 'export_requesting'
-EXPORT_REQUESTED = 'export_queued'
-EXPORTING = 'working'
-EXPORT_QUEUED = 'queued'
-EXPORTED = 'completed'
-EXPORT_FAILED = 'failed'
-EXPORT_KILLED = 'killed'
-
 PerformanceExportConfig = {
 
-  _job: {}
-
   _loaded: (obj, id) ->
-    @emit('performanceExport.loaded', id)
-
-  _updateExportStatusFor: (id) ->
-    (jobData) =>
-      exportData = _.clone(jobData)
-      exportData.exportFor = id
-
-      @_asyncStatus[id] = exportData.status
-      @emit("performanceExport.#{exportData.status}", exportData)
-      @emitChange()
+    @emit('loaded', id)
 
   getJobIdFromJobUrl: (jobUrl) ->
     jobUrlSegments = jobUrl.split('/api/jobs/')
@@ -33,61 +16,13 @@ PerformanceExportConfig = {
 
     jobId
 
-  saveJob: (jobId, id) ->
-    @_job[id] ?= []
-    @_job[id].push(jobId)
-
-  export: (id) ->
-    @_asyncStatus[id] = EXPORT_REQUESTING
-    @emitChange()
-
-  exported: (obj, id) ->
+  _getId: (obj, id) ->
     {job} = obj
     jobId = @getJobIdFromJobUrl(job)
 
-    # export job has been queued
-    @emit('performanceExport.queued', {jobId, id})
-    @_asyncStatus[id] = EXPORT_REQUESTED
-    @saveJob(jobId, id)
-
-    # checks job until final status is reached
-    checkJob = ->
-      JobActions.load(jobId)
-    JobActions.checkUntil(jobId, checkJob)
-
-    # whenever this job status is updated, emit the status for performance export
-    updateExportStatus = @_updateExportStatusFor(id)
-    JobStore.on("job.#{jobId}.*", updateExportStatus)
-    JobStore.off("job.#{jobId}.final", updateExportStatus)
-
-  _getJobs: (id) ->
-    _.clone(@_job[id])
+    {jobId, id}
 
   exports:
-    isExporting: (id) ->
-      exportingStates = [
-        EXPORT_REQUESTING
-        EXPORT_REQUESTED
-        EXPORT_QUEUED
-        EXPORTING
-      ]
-
-      exportingStates.indexOf(@_asyncStatus[id]) > -1
-
-    isFailed: (id) ->
-      failedStates = [
-        EXPORT_FAILED
-        EXPORT_KILLED
-      ]
-
-      failedStates.indexOf(@_asyncStatus[id]) > -1
-
-    isExported: (id, jobId) ->
-      jobId ?= _.last(@_getJobs(id))
-      job = JobStore.get(jobId)
-      {status} = job if job?
-      status is EXPORTED
-
     getLatestExport: (id) ->
       perfExports = @_get(id)
 
@@ -96,9 +31,22 @@ PerformanceExportConfig = {
           perfExport.created_at
         ).last().value()
 
-
 }
 
-extendConfig(PerformanceExportConfig, new CrudConfig())
+JobCrudConfig = extendConfig(new JobListenerConfig(), new CrudConfig())
+extendConfig(PerformanceExportConfig, JobCrudConfig)
+
+PerformanceExportConfig.exports.isExported = PerformanceExportConfig.exports.isCompleted
+PerformanceExportConfig.exports.isExporting = PerformanceExportConfig.exports.isProgressing
+
+PerformanceExportConfig.export = (args...) ->
+  @que.call(@, args...)
+  @emitChange()
+
+PerformanceExportConfig.exported = (args...) ->
+  @queued.call(@, args...)
+  {id, jobId} = @_getId(args...)
+  @startChecking.call(@, id, jobId)
+
 {actions, store} = makeSimpleStore(PerformanceExportConfig)
 module.exports = {PerformanceExportActions:actions, PerformanceExportStore:store}

--- a/src/flux/plan-publish.coffee
+++ b/src/flux/plan-publish.coffee
@@ -10,8 +10,7 @@ PlanPublishConfig =
     jobId = publish_job_uuid
     {id, jobId}
 
-JobCrudConfig = extendConfig(new JobListenerConfig(), new CrudConfig())
-extendConfig(PlanPublishConfig, JobCrudConfig)
+extendConfig(PlanPublishConfig, new JobListenerConfig(2000, 100))
 
 PlanPublishConfig.exports.isPublishing = PlanPublishConfig.exports.isProgressing
 PlanPublishConfig.exports.isPublished = PlanPublishConfig.exports.isCompleted

--- a/src/flux/plan-publish.coffee
+++ b/src/flux/plan-publish.coffee
@@ -44,6 +44,12 @@ PlanPublishConfig = {
     @_asyncStatus[id] = PUBLISH_REQUESTED
     @saveJob(jobId, id)
 
+  startChecking: (id, jobId) ->
+    lastestJob = @_getLatestJob(id)
+    @saveJob(jobId, id) if jobId? and jobId isnt lastestJob
+    jobId ?= lastestJob
+    return unless jobId?
+
     # checks job until final status is reached
     checkJob = ->
       JobActions.load(jobId)
@@ -54,8 +60,17 @@ PlanPublishConfig = {
     JobStore.on("job.#{jobId}.*", updatePublishStatus)
     JobStore.off("job.#{jobId}.final", updatePublishStatus)
 
+  stopChecking: (id) ->
+    jobId = @_getLatestJob(id)
+    console.info('stopChecking')
+    console.info(jobId)
+    JobActions.stopChecking(jobId) if jobId?
+
   _getJobs: (id) ->
     _.clone(@_job[id])
+
+  _getLatestJob: (id) ->
+    _.last(@_getJobs(id))
 
   exports:
     isPublishing: (id) ->

--- a/src/flux/plan-publish.coffee
+++ b/src/flux/plan-publish.coffee
@@ -1,111 +1,20 @@
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
 {JobActions, JobStore} = require './job'
+{JobListenerConfig} = require '../helpers/job'
 _ = require 'underscore'
 moment = require 'moment'
 
-PUBLISH_REQUESTING = 'publish_requesting'
-PUBLISH_REQUESTED = 'publish_queued'
-PUBLISHING = 'working'
-PUBLISH_QUEUED = 'queued'
-PUBLISHED = 'completed'
-PUBLISH_FAILED = 'failed'
-PUBLISH_KILLED = 'killed'
-
-PlanPublishConfig = {
-
-  _job: {}
-
-  _loaded: (obj, id) ->
-    @emit("planPublish.#{id}.loaded", id)
-
-  _updatePublishStatusFor: (id) ->
-    (jobData) =>
-      publishData = _.clone(jobData)
-      publishData.publishFor = id
-
-      @_asyncStatus[id] = publishData.status
-      @emit("planPublish.#{id}.#{publishData.status}", publishData)
-      @emitChange()
-
-  saveJob: (jobId, id) ->
-    @_job[id] ?= []
-    @_job[id].push(jobId)
-
-  publish: (id) ->
-    @_asyncStatus[id] = PUBLISH_REQUESTING
-    @emitChange()
-
-  published: (obj) ->
+PlanPublishConfig =
+  _getIds: (obj) ->
     {publish_job_uuid, id} = obj
     jobId = publish_job_uuid
+    {id, jobId}
 
-    # publish job has been queued
-    @emit("planPublish.#{id}.queued", {jobId, id})
-    @_asyncStatus[id] = PUBLISH_REQUESTED
-    @saveJob(jobId, id)
+JobCrudConfig = extendConfig(new JobListenerConfig(), new CrudConfig())
+extendConfig(PlanPublishConfig, JobCrudConfig)
 
-  startChecking: (id, jobId) ->
-    lastestJob = @_getLatestJob(id)
-    @saveJob(jobId, id) if jobId? and jobId isnt lastestJob
-    jobId ?= lastestJob
-    return unless jobId?
+PlanPublishConfig.exports.isPublishing = PlanPublishConfig.exports.isProgressing
+PlanPublishConfig.exports.isPublished = PlanPublishConfig.exports.isCompleted
 
-    # checks job until final status is reached
-    checkJob = ->
-      JobActions.load(jobId)
-    JobActions.checkUntil(jobId, checkJob, 2000, 100)
-
-    # whenever this job status is updated, emit the status for plan publish
-    updatePublishStatus = @_updatePublishStatusFor(id)
-    JobStore.on("job.#{jobId}.*", updatePublishStatus)
-    JobStore.off("job.#{jobId}.final", updatePublishStatus)
-
-  stopChecking: (id) ->
-    jobId = @_getLatestJob(id)
-    JobActions.stopChecking(jobId) if jobId?
-
-  _getJobs: (id) ->
-    _.clone(@_job[id])
-
-  _getLatestJob: (id) ->
-    _.last(@_getJobs(id))
-
-  exports:
-    isPublishing: (id) ->
-      publishingStates = [
-        PUBLISH_REQUESTING
-        PUBLISH_REQUESTED
-        PUBLISH_QUEUED
-        PUBLISHING
-      ]
-
-      publishingStates.indexOf(@_asyncStatus[id]) > -1
-
-    isFailed: (id) ->
-      failedStates = [
-        PUBLISH_FAILED
-        PUBLISH_KILLED
-      ]
-
-      failedStates.indexOf(@_asyncStatus[id]) > -1
-
-    isDone: (id) ->
-      doneStates = [
-        PUBLISHED
-        PUBLISH_FAILED
-        PUBLISH_KILLED
-      ]
-
-      doneStates.indexOf(@_asyncStatus[id]) > -1
-
-    isPublished: (id, jobId) ->
-      jobId ?= _.last(@_getJobs(id))
-      job = JobStore.get(jobId)
-      {status} = job if job?
-      status is PUBLISHED
-
-}
-
-extendConfig(PlanPublishConfig, new CrudConfig())
 {actions, store} = makeSimpleStore(PlanPublishConfig)
 module.exports = {PlanPublishActions:actions, PlanPublishStore:store}

--- a/src/flux/plan-publish.coffee
+++ b/src/flux/plan-publish.coffee
@@ -62,8 +62,6 @@ PlanPublishConfig = {
 
   stopChecking: (id) ->
     jobId = @_getLatestJob(id)
-    console.info('stopChecking')
-    console.info(jobId)
     JobActions.stopChecking(jobId) if jobId?
 
   _getJobs: (id) ->

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -391,7 +391,7 @@ TaskPlanConfig =
       not ((isPublishedOrPublishing and isPastDue) or @_isDeleteRequested(id))
 
     isPublishing: (id) ->
-      @_changed[id].is_publish_requested or PlanPublishStore.isPublishing(id)
+      @_changed[id]?.is_publish_requested or PlanPublishStore.isPublishing(id)
 
     canDecreaseTutorExercises: (id) ->
       plan = @_getPlan(id)

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -304,7 +304,7 @@ TaskPlanConfig =
 
   _saved: (obj, id) ->
     if obj.is_publish_requested
-      PlanPublishActions.published(obj, id)
+      PlanPublishActions.queued(obj, id)
       @emit('publish-queued', id)
     obj
 
@@ -391,7 +391,7 @@ TaskPlanConfig =
       not ((isPublishedOrPublishing and isPastDue) or @_isDeleteRequested(id))
 
     isPublishing: (id) ->
-      PlanPublishStore.isPublishing(id)
+      @_changed[id].is_publish_requested or PlanPublishStore.isPublishing(id)
 
     canDecreaseTutorExercises: (id) ->
       plan = @_getPlan(id)

--- a/src/helpers/job.coffee
+++ b/src/helpers/job.coffee
@@ -11,9 +11,9 @@ JOBBED = 'completed'
 JOB_FAILED = 'failed'
 JOB_KILLED = 'killed'
 
-JobListenerConfig = ->
+JobListenerConfig = (checkIntervals, checkRepeats) ->
   {
-
+    _asyncStatus: {}
     _job: {}
 
     _updateJobStatusFor: (id) ->
@@ -54,7 +54,7 @@ JobListenerConfig = ->
       # checks job until final status is reached
       checkJob = ->
         JobActions.load(jobId)
-      JobActions.checkUntil(jobId, checkJob, 2000, 100)
+      JobActions.checkUntil(jobId, checkJob, checkIntervals, checkRepeats)
 
       # whenever this job status is updated, emit the status for this wrapper
       updateJobStatus = @_updateJobStatusFor(id)
@@ -72,6 +72,8 @@ JobListenerConfig = ->
       _.last(@_getJobs(id))
 
     exports:
+      getAsyncStatus: (id) -> @_asyncStatus[id]
+
       isProgressing: (id) ->
         jobbingStates = [
           JOB_REQUESTING

--- a/src/helpers/job.coffee
+++ b/src/helpers/job.coffee
@@ -16,6 +16,11 @@ JobListenerConfig = (checkIntervals, checkRepeats) ->
     _asyncStatus: {}
     _job: {}
 
+    reset: ->
+      @_asyncStatus = {}
+      @_job = {}
+      @emitChange()
+
     _updateJobStatusFor: (id) ->
       (jobData) =>
         progress = _.clone(jobData)
@@ -41,6 +46,7 @@ JobListenerConfig = (checkIntervals, checkRepeats) ->
 
       if jobId?
         # job has been queued
+        # TODO fix this inconsistency between status and emit.
         @emit("progress.#{id}.queued", {jobId, id})
         @_asyncStatus[id] = JOB_REQUESTED
         @saveJob(jobId, id)

--- a/src/helpers/job.coffee
+++ b/src/helpers/job.coffee
@@ -1,0 +1,110 @@
+{JobActions, JobStore} = require '../flux/job'
+_ = require 'underscore'
+moment = require 'moment'
+
+JOB_REQUESTING = 'job_requesting'
+JOB_REQUESTED = 'job_queued'
+JOB_UNSTARTED = 'unknown'
+JOBBING = 'working'
+JOB_QUEUED = 'queued'
+JOBBED = 'completed'
+JOB_FAILED = 'failed'
+JOB_KILLED = 'killed'
+
+JobListenerConfig = ->
+  {
+
+    _job: {}
+
+    _updateJobStatusFor: (id) ->
+      (jobData) =>
+        progress = _.clone(jobData)
+        progress.for = id
+
+        @_asyncStatus[id] = progress.status
+        @emit("progress.#{id}.#{progress.status}", progress)
+
+    saveJob: (jobId, id) ->
+      @_job[id] ?= []
+      @_job[id].push(jobId)
+
+    que: (id) ->
+      @_asyncStatus[id] = JOB_REQUESTING
+
+    queued: (obj, id) ->
+      if @_getIds?
+        {jobId, id} = @_getIds(obj)
+      else
+        jobId = obj.jobId
+        id = obj.id or id
+
+      if jobId?
+        # job has been queued
+        @emit("progress.#{id}.queued", {jobId, id})
+        @_asyncStatus[id] = JOB_REQUESTED
+        @saveJob(jobId, id)
+
+    startChecking: (id, jobId) ->
+      lastestJob = @_getLatestJob(id)
+      @saveJob(jobId, id) if jobId? and jobId isnt lastestJob
+      jobId ?= lastestJob
+      return unless jobId?
+
+      # checks job until final status is reached
+      checkJob = ->
+        JobActions.load(jobId)
+      JobActions.checkUntil(jobId, checkJob, 2000, 100)
+
+      # whenever this job status is updated, emit the status for this wrapper
+      updateJobStatus = @_updateJobStatusFor(id)
+      JobStore.on("job.#{jobId}.*", updateJobStatus)
+      JobStore.off("job.#{jobId}.final", updateJobStatus)
+
+    stopChecking: (id) ->
+      jobId = @_getLatestJob(id)
+      JobActions.stopChecking(jobId) if jobId?
+
+    _getJobs: (id) ->
+      _.clone(@_job[id])
+
+    _getLatestJob: (id) ->
+      _.last(@_getJobs(id))
+
+    exports:
+      isProgressing: (id) ->
+        jobbingStates = [
+          JOB_REQUESTING
+          JOB_REQUESTED
+          JOB_QUEUED
+          JOBBING
+        ]
+
+        jobbingStates.indexOf(@_asyncStatus[id]) > -1
+
+      isFailed: (id) ->
+        failedStates = [
+          JOB_FAILED
+          JOB_KILLED
+        ]
+
+        failedStates.indexOf(@_asyncStatus[id]) > -1
+
+      isDone: (id) ->
+        doneStates = [
+          JOBBED
+          JOB_FAILED
+          JOB_KILLED
+        ]
+
+        doneStates.indexOf(@_asyncStatus[id]) > -1
+
+      isCompleted: (id, jobId) ->
+        jobId ?= _.last(@_getJobs(id))
+        job = JobStore.get(jobId)
+        {status} = job if job?
+        status is JOBBED
+  }
+
+JobHelper = {JobListenerConfig}
+
+module.exports = JobHelper

--- a/src/helpers/job.coffee
+++ b/src/helpers/job.coffee
@@ -30,6 +30,7 @@ JobListenerConfig = ->
 
     que: (id) ->
       @_asyncStatus[id] = JOB_REQUESTING
+      @emit("progress.#{id}.#{JOB_REQUESTING}")
 
     queued: (obj, id) ->
       if @_getIds?

--- a/src/helpers/plan.coffee
+++ b/src/helpers/plan.coffee
@@ -26,13 +26,13 @@ PlanHelper =
     isPublishingInStore = PlanPublishStore.isPublishing(id)
 
     if isPublishing and not isPublishingInStore and not PlanPublishStore.isPublished(id)
-      PlanPublishActions.published({id, publish_job_uuid}) if publish_job_uuid?
+      PlanPublishActions.queued({id, publish_job_uuid}) if publish_job_uuid?
 
     isPublishing = isPublishing or isPublishingInStore
 
     if isPublishing
       PlanPublishActions.startChecking(id, publish_job_uuid)
-      PlanPublishStore.on("planPublish.#{id}.*", callback) if callback? and _.isFunction(callback)
+      PlanPublishStore.on("progress.#{id}.*", callback) if callback? and _.isFunction(callback)
 
     {isPublishing, publishStatus}
 

--- a/src/helpers/plan.coffee
+++ b/src/helpers/plan.coffee
@@ -1,0 +1,40 @@
+moment = require 'moment'
+_ = require 'underscore'
+
+{PlanPublishStore, PlanPublishActions} = require '../flux/plan-publish'
+{TimeStore, TimeActions} = require '../flux/time'
+
+PlanHelper =
+  isPublishing: (plan, recentTolerance = 3600000) ->
+    isPublishing = (plan.is_publish_requested? and plan.is_publish_requested) or plan.publish_last_requested_at?
+    if plan.published_at? and plan.publish_last_requested_at?
+      # is the last requested publishing after the last completed publish?
+      isPublishing = moment(plan.publish_last_requested_at).diff(plan.published_at) > 0
+    else if plan.published_at? and not plan.publish_last_requested_at?
+      isPublishing = false
+    else if plan.publish_last_requested_at?
+      recent = moment(TimeStore.getNow()).diff(plan.publish_last_requested_at) < recentTolerance
+      isPublishing = isPublishing and recent
+
+    isPublishing
+
+  subscribeToPublishing: (plan, callback) ->
+    {id, publish_job_uuid} = plan
+    isPublishing = PlanHelper.isPublishing(plan)
+
+    publishStatus = PlanPublishStore.getAsyncStatus(id)
+    isPublishingInStore = PlanPublishStore.isPublishing(id)
+
+    if isPublishing and not isPublishingInStore and not PlanPublishStore.isPublished(id)
+      PlanPublishActions.published({id, publish_job_uuid}) if publish_job_uuid?
+
+    isPublishing = isPublishing or isPublishingInStore
+
+    if isPublishing
+      PlanPublishActions.startChecking(id, publish_job_uuid)
+      PlanPublishStore.on("planPublish.#{id}.*", callback) if callback? and _.isFunction(callback)
+
+    {isPublishing, publishStatus}
+
+
+module.exports = PlanHelper

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -58,6 +58,7 @@ require './dom-helpers.spec'
 
 
 require './helpers/job.spec'
+require './flux/plan-publish.spec'
 
 # This should be done **last** because it starts up the whole app
 require './router.spec'

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -54,5 +54,10 @@ require './course-listing-store.spec'
 require './task-helpers.spec'
 require './dom-helpers.spec'
 
+
+
+
+require './helpers/job.spec'
+
 # This should be done **last** because it starts up the whole app
 require './router.spec'

--- a/test/flux/plan-publish.spec.coffee
+++ b/test/flux/plan-publish.spec.coffee
@@ -1,0 +1,63 @@
+{expect} = require 'chai'
+sinon = require 'sinon'
+_ = require 'underscore'
+
+{PlanPublishActions, PlanPublishStore} = require '../../src/flux/plan-publish'
+
+expectedActions = [
+  'reset'
+  'saveJob'
+  'que'
+  'queued'
+  'startChecking'
+  'stopChecking'
+  '_getIds'
+]
+
+expectedStore = [
+  'getAsyncStatus'
+  'isProgressing'
+  'isCompleted'
+  'isDone'
+  'isFailed'
+  'isPublishing'
+  'isPublished'
+]
+
+JOB_CHECK_INTERVAL = 2000
+JOB_CHECK_REPEATS = 3
+
+JOB_DATA_ID = 'job-id-yay!'
+JOB_FOR_ID = 'a-plan-publish-or-something-like-that'
+
+JOB_DATA =
+  id: JOB_DATA_ID
+
+JOB_QUEUED_RESPONSE =
+  id: JOB_FOR_ID
+  jobId: JOB_DATA_ID
+
+JOB_STATUSES = [
+  'job_requesting'
+  'job_queued'
+  'unknown'
+  'working'
+  'queued'
+  'completed'
+  'failed'
+  'killed'
+]
+
+describe 'Plan Publish flux', ->
+
+  it 'should have expected functions and publish-specific aliases', ->
+
+    _.each(expectedActions, (action) ->
+      expect(PlanPublishActions)
+        .to.have.property(action).that.is.a('function')
+    )
+
+    _.each(expectedStore, (storeAsker) ->
+      expect(PlanPublishStore)
+        .to.have.property(storeAsker).that.is.a('function')
+    )

--- a/test/helpers/job.spec.coffee
+++ b/test/helpers/job.spec.coffee
@@ -1,0 +1,110 @@
+{expect} = require 'chai'
+sinon = require 'sinon'
+_ = require 'underscore'
+
+JobHelper = require '../../src/helpers/job'
+
+expectedActions = [
+  'reset'
+  'saveJob'
+  'que'
+  'queued'
+  'startChecking'
+  'stopChecking'
+]
+
+expectedStore = [
+  'getAsyncStatus'
+  'isProgressing'
+  'isCompleted'
+  'isDone'
+  'isFailed'
+]
+
+JOB_CHECK_INTERVAL = 2000
+JOB_CHECK_REPEATS = 3
+
+JOB_DATA_ID = 'job-id-yay!'
+JOB_FOR_ID = 'a-plan-publish-or-something-like-that'
+
+JOB_DATA =
+  id: JOB_DATA_ID
+
+JOB_QUEUED_RESPONSE =
+  id: JOB_FOR_ID
+  jobId: JOB_DATA_ID
+
+JOB_STATUSES = [
+  'job_requesting'
+  'job_queued'
+  'unknown'
+  'working'
+  'queued'
+  'completed'
+  'failed'
+  'killed'
+]
+jobListenerConfig = null
+
+describe 'Job Helper', ->
+
+  before ->
+    jobListenerConfig = new JobHelper.JobListenerConfig()
+    jobListenerConfig.emit = sinon.spy()
+    jobListenerConfig.emitChange = sinon.spy()
+
+    _.each(jobListenerConfig.exports, (store, index) ->
+      jobListenerConfig.exports[index] = store.bind(_.omit(jobListenerConfig, 'exports'))
+    )
+
+  it 'should be able to make a new job listener config', ->
+
+    _.each(expectedActions, (action) ->
+      expect(jobListenerConfig)
+        .to.have.property(action).that.is.a('function')
+    )
+
+    _.each(expectedStore, (storeAsker) ->
+      expect(jobListenerConfig.exports)
+        .to.have.property(storeAsker).that.is.a('function')
+    )
+
+  it 'should be able to save a job', ->
+    jobListenerConfig.saveJob('first-job', JOB_FOR_ID)
+
+    expect(jobListenerConfig._job[JOB_FOR_ID]).to.contain('first-job')
+    expect(jobListenerConfig._getJobs(JOB_FOR_ID)).to.contain('first-job')
+
+  it 'should be able to save another job', ->
+    jobListenerConfig.saveJob('another-job', JOB_FOR_ID)
+
+    expect(jobListenerConfig._job[JOB_FOR_ID]).to.contain('another-job')
+    expect(jobListenerConfig._getJobs(JOB_FOR_ID)).to.contain('another-job')
+
+  it 'should be able to get most recently saved job', ->
+    expect(jobListenerConfig._getLatestJob(JOB_FOR_ID)).to.equal('another-job')
+
+  it 'should be able to que a job for something', ->
+    expect(jobListenerConfig._asyncStatus[JOB_FOR_ID]).to.not.equal(JOB_STATUSES[0])
+    jobListenerConfig.que(JOB_FOR_ID)
+    expect(jobListenerConfig._asyncStatus[JOB_FOR_ID]).to.equal(JOB_STATUSES[0])
+    expect(jobListenerConfig.exports.getAsyncStatus(JOB_FOR_ID)).to.equal(JOB_STATUSES[0])
+    expect(jobListenerConfig.emit).to.have.been.calledWith("progress.#{JOB_FOR_ID}.#{JOB_STATUSES[0]}")
+    expect(jobListenerConfig.exports.isProgressing(JOB_FOR_ID)).to.be.true
+
+  it 'should be able to receive track a queued job', ->
+    jobListenerConfig.queued(JOB_QUEUED_RESPONSE, JOB_FOR_ID)
+    expect(jobListenerConfig.emit).to.have.been.calledWith("progress.#{JOB_FOR_ID}.queued", JOB_QUEUED_RESPONSE)
+    expect(jobListenerConfig._getLatestJob(JOB_FOR_ID)).to.equal(JOB_DATA_ID)
+    expect(jobListenerConfig.exports.isProgressing(JOB_FOR_ID)).to.be.true
+
+  it 'should be able update job status', ->
+    jobWorking = _.clone(JOB_DATA)
+    jobWorking.status = JOB_STATUSES[3]
+    jobListenerConfig._updateJobStatusFor(JOB_FOR_ID)(jobWorking)
+    jobWorking.for = JOB_FOR_ID
+
+    expect(jobListenerConfig.exports.getAsyncStatus(JOB_FOR_ID)).to.equal(JOB_STATUSES[3])
+    expect(jobListenerConfig.exports.isProgressing(JOB_FOR_ID)).to.be.true
+    expect(jobListenerConfig.emit).to.have.been.calledWith("progress.#{JOB_FOR_ID}.#{JOB_STATUSES[3]}", jobWorking)
+

--- a/test/helpers/job.spec.coffee
+++ b/test/helpers/job.spec.coffee
@@ -108,3 +108,4 @@ describe 'Job Helper', ->
     expect(jobListenerConfig.exports.isProgressing(JOB_FOR_ID)).to.be.true
     expect(jobListenerConfig.emit).to.have.been.calledWith("progress.#{JOB_FOR_ID}.#{JOB_STATUSES[3]}", jobWorking)
 
+  # TODO add tests for start and stop checking


### PR DESCRIPTION
## Bug
1. publish a plan
  * you will be taken back to the calendar
1. change your month
1. change back
  * plan shows as draft and not as publishing
  * also, if you click to edit, "Save as Draft" and "Delete" are still options

## With Fix
* publishing status will show even if you change your month view, and then change back
![screen shot 2015-08-26 at 2 15 11 pm](https://cloud.githubusercontent.com/assets/2483873/9503799/b81d4a4a-4bfe-11e5-9fd6-083e2b28500b.png)
![screen shot 2015-08-26 at 2 15 14 pm](https://cloud.githubusercontent.com/assets/2483873/9503800/b81f416a-4bfe-11e5-9d31-f29160c908f0.png)
![screen shot 2015-08-26 at 2 15 20 pm](https://cloud.githubusercontent.com/assets/2483873/9503798/b81d19f8-4bfe-11e5-8521-a8e35e1e3a0c.png)
* Even if you do get to the edit page for a publishing plan, you will be prevented from doing anything
![screen shot 2015-08-26 at 3 19 02 pm](https://cloud.githubusercontent.com/assets/2483873/9505149/45fcd8a6-4c06-11e5-9b6f-ccb8dce607b5.png)
* After publishing is done, you get to do stuff again
![screen shot 2015-08-26 at 3 47 19 pm](https://cloud.githubusercontent.com/assets/2483873/9505922/9f029ab8-4c0a-11e5-9f7d-eb6171e5316b.png)


## To Do
- [x] fix calendar publishing state
- [x] disable builder footer when publishing
- [x] some code clean up
- [ ] Specs for
  - [x] Job helper
  - [x] Plan publish store
  - [ ] Plan component
  * job store, probably later