### PR TITLE
Wait for DOMContentLoaded before running app

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -24,16 +24,16 @@ window._STORES =
   TOC: require './src/flux/toc'
 
 
-api.start(dom.readBootstrapData())
 
-startMathJax()
-TransitionAssistant.startMonitoring()
-
-
-# This is added because MathJax puts in extra divs on initial load.
-# Moves the React Root to be an element inside a div
-# instead of the only element in the body.
-mainDiv = document.createElement('div')
-mainDiv.id = 'react-root-container'
-document.body.appendChild(mainDiv)
-router.start(mainDiv)
+document.addEventListener("DOMContentLoaded", ->
+  api.start(dom.readBootstrapData())
+  startMathJax()
+  TransitionAssistant.startMonitoring()
+  # This is added because MathJax puts in extra divs on initial load.
+  # Moves the React Root to be an element inside a div
+  # instead of the only element in the body.
+  mainDiv = document.createElement('div')
+  mainDiv.id = 'react-root-container'
+  document.body.appendChild(mainDiv)
+  router.start(mainDiv)
+)


### PR DESCRIPTION
This is the main bug that prevented IE 9 from running.  `document.body.appendChild` was being called before the document was ready, causing an exception.

While I know we don't want to support IE9, I'm wondering if we should wait for the document to be ready before we startup?  It seems like it'd be good practice and I'm mildly surprised it hasn't bitten us in other browsers as well.