### PR TITLE
Fix grasp-check answers

### DIFF
--- a/resources/styles/components/question.less
+++ b/resources/styles/components/question.less
@@ -18,7 +18,6 @@
 .answer() {
   .flex-display();
   .align-items(center);
-  width: 100%;
   margin: @answer-vertical-spacing 0;
 }
 

--- a/resources/styles/components/question.less
+++ b/resources/styles/components/question.less
@@ -130,6 +130,7 @@
       counter-increment: answer 1;
       .answer();
       margin: 0;
+      width: initial;
 
       .answer-letter {
         display: table-cell;


### PR DESCRIPTION
Change the answers-answer to fit within a grasp-check. 

Removed width: 100% from the answer(); mixin. 

Fixes the grasp check answers overflowing
![2015-09-01_12-00-43](https://cloud.githubusercontent.com/assets/8514591/9610752/15323064-50a1-11e5-9f4b-dabc75327cbe.png)


Shouldn't impact:
![2015-09-02_14-07-49](https://cloud.githubusercontent.com/assets/8514591/9643827/b3cd4de2-5189-11e5-902d-28e664f5fd58.png)
![2015-09-02_14-05-53](https://cloud.githubusercontent.com/assets/8514591/9643833/b6463660-5189-11e5-9b39-8dc03f236d38.png)
