### PR TITLE
Fix error when clicking on individual periods

### DIFF
--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -141,8 +141,8 @@ module.exports = React.createClass
     TaskPlanActions.setPeriods(@props.id, periods)
 
     #set dates for all periods
-    taskingDueAt = TaskPlanStore.getDueAt(@props.id) or TaskPlanStore.getMinDueAt(this.props.id)
-    @setDueAt(taskingDueAt)
+    taskingDueAt = TaskPlanStore.getDueAt(@props.id)
+    @setDueAt(taskingDueAt) if taskingDueAt
 
   setIndividualPeriods: ->
     # if taskings exist in state, then load them

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -12,6 +12,7 @@ chai.use(sinonChai)
 require './components/course-listing.spec'
 require './components/navbar.spec'
 require './components/navbar/account-link.spec'
+require './components/task-plan/builder.spec'
 require './components/task-plan/homework-plan.spec'
 require './components/task-plan/homework/exercise-summary.spec'
 require './components/task-plan/footer.spec'
@@ -42,7 +43,6 @@ require './components/book-content-mixin.spec'
 require './components/performance/reading-cell.spec'
 require './components/performance/homework-cell.spec'
 require './components/name.spec'
-
 # Flux your muscle
 require './crud-store.spec'
 require './task-store.spec'
@@ -64,3 +64,4 @@ require './helpers/period.spec'
 # The whole Boom Boom.
 # This should be done **last** because it starts up the whole app
 require './router.spec'
+###

--- a/test/components/helpers/task-plan.coffee
+++ b/test/components/helpers/task-plan.coffee
@@ -15,6 +15,7 @@ ExtendBasePlan = (props, taskingProps = {}) ->
   baseTaskingPlan =
     opens_at: tomorrow
     due_at: dayAfter
+    target_type: 'period'
 
   baseModel = _.extend({}, baseModel, props)
 

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -14,9 +14,10 @@ tomorrow = (new Date(Date.now() + 1000 * 3600 * 24)).toString()
 COURSES = require '../../../api/user/courses.json'
 NEW_READING = ExtendBasePlan({id: "_CREATING_1", settings: {page_ids: []}})
 PUBLISHED_MODEL = ExtendBasePlan({
+  id: '1'
   title: 'hello',
   description: 'description',
-  published_at: yesterday}, {opens_at: yesterday})
+  published_at: yesterday}, {opens_at: yesterday, due_at: yesterday, target_id: COURSES[0].periods[0].id})
 
 helper = (model) -> PlanRenderHelper(model, Builder)
 
@@ -45,7 +46,6 @@ describe 'Task Plan Builder', ->
 
   it 'should not allow editable open date if plan is visible', ->
     helper(PUBLISHED_MODEL).then ({dom, element}) ->
-      expect(dom.querySelectorAll('.tasking-plan.disabled').length).to.equal(COURSES[0].periods.length)
       element.setAllPeriods()
       expect(element.refs.openDate.props.disabled).to.be.true
 

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -45,3 +45,11 @@ describe 'Task Plan Builder', ->
   it 'hides periods by default', ->
     helper(NEW_READING).then ({dom, element}) ->
       expect(dom.querySelector('.tasking-plan.tutor-date-input')).to.be.null
+
+  it 'does not load a default due at for all periods', ->
+    helper(NEW_READING).then ({dom, element}) ->
+      element.setIndividualPeriods()
+      expect(dom.querySelector('#hide-periods-radio').checked).to.be.false
+      element.setAllPeriods()
+      expect(dom.querySelector('#hide-periods-radio').checked).to.be.true
+      

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -5,9 +5,13 @@ Builder = require '../../../src/components/task-plan/builder'
 {Testing, sinon, expect, _, React} = require '../helpers/component-testing'
 {ExtendBasePlan, PlanRenderHelper} = require '../helpers/task-plan'
 
+{CourseListingActions, CourseListingStore} = require '../../../src/flux/course-listing'
+{CourseStore} = require '../../../src/flux/course'
+
 yesterday = (new Date(Date.now() - 1000 * 3600 * 24)).toString()
 tomorrow = (new Date(Date.now() + 1000 * 3600 * 24)).toString()
 
+COURSES = require '../../../api/user/courses.json'
 NEW_READING = ExtendBasePlan({id: "_CREATING_1", settings: {page_ids: []}})
 PUBLISHED_MODEL = ExtendBasePlan({
   title: 'hello',
@@ -20,13 +24,13 @@ helper = (model) -> PlanRenderHelper(model, Builder)
 describe 'Task Plan Builder', ->
   beforeEach ->
     TaskPlanActions.reset()
+    CourseListingActions.loaded(COURSES)
 
   it 'should load expected plan', ->
     helper(PUBLISHED_MODEL).then ({dom}) ->
       expect(dom.querySelector('#reading-title').value).to.equal(PUBLISHED_MODEL.title)
       descriptionValue = dom.querySelector('.assignment-description textarea').value
       expect(descriptionValue).to.equal(PUBLISHED_MODEL.description)
-
 
   it 'should allow editable periods radio if plan is not visible', ->
     helper(NEW_READING).then ({dom}) ->
@@ -42,10 +46,17 @@ describe 'Task Plan Builder', ->
   it 'should not allow editable open date if plan is visible', ->
     helper(PUBLISHED_MODEL).then ({dom, element}) ->
       expect(element.refs.openDate.props.disabled).to.be.true
-      
+
+
   it 'hides periods by default', ->
     helper(NEW_READING).then ({dom, element}) ->
       expect(dom.querySelector('.tasking-plan.tutor-date-input')).to.be.null
+
+  it 'can show individual periods', ->
+    helper(NEW_READING).then ({dom}) ->
+      element.setIndividualPeriods()
+      expect(dom.querySelectorAll('.tasking-plan.tutor-date-input').length).to.equal(COURSES.periods.length)
+
 
   it 'does not load a default due at for all periods', ->
     helper(NEW_READING).then ({dom, element}) ->

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -6,6 +6,7 @@ Builder = require '../../../src/components/task-plan/builder'
 {ExtendBasePlan, PlanRenderHelper} = require '../helpers/task-plan'
 
 yesterday = (new Date(Date.now() - 1000 * 3600 * 24)).toString()
+tomorrow = (new Date(Date.now() + 1000 * 3600 * 24)).toString()
 
 NEW_READING = ExtendBasePlan({id: "_CREATING_1", settings: {page_ids: []}})
 PUBLISHED_MODEL = ExtendBasePlan({
@@ -49,7 +50,6 @@ describe 'Task Plan Builder', ->
   it 'does not load a default due at for all periods', ->
     helper(NEW_READING).then ({dom, element}) ->
       element.setIndividualPeriods()
-      expect(dom.querySelector('#hide-periods-radio').checked).to.be.false
       element.setAllPeriods()
-      expect(dom.querySelector('#hide-periods-radio').checked).to.be.true
-      
+      dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
+      expect(dueAt).to.be.falsy

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -45,6 +45,8 @@ describe 'Task Plan Builder', ->
 
   it 'should not allow editable open date if plan is visible', ->
     helper(PUBLISHED_MODEL).then ({dom, element}) ->
+      expect(dom.querySelectorAll('.tasking-plan.disabled').length).to.equal(COURSES[0].periods.length)
+      element.setAllPeriods()
       expect(element.refs.openDate.props.disabled).to.be.true
 
 
@@ -53,10 +55,9 @@ describe 'Task Plan Builder', ->
       expect(dom.querySelector('.tasking-plan.tutor-date-input')).to.be.null
 
   it 'can show individual periods', ->
-    helper(NEW_READING).then ({dom}) ->
+    helper(NEW_READING).then ({dom, element}) ->
       element.setIndividualPeriods()
-      expect(dom.querySelectorAll('.tasking-plan.tutor-date-input').length).to.equal(COURSES.periods.length)
-
+      expect(dom.querySelectorAll('.tasking-plan.tutor-date-input').length).to.equal(COURSES[0].periods.length)
 
   it 'does not load a default due at for all periods', ->
     helper(NEW_READING).then ({dom, element}) ->


### PR DESCRIPTION
To reproduce on master:
1. Create a new reading
2. Click on individual periods (note that no due dates are set)
3. Click on all periods (note that due date is now set to minimum due date)
4. Save (will not save as due date in the store is not set), and will not show a validation message

Fixed functionality:
1. Create new reading
2. Click on individual periods (note that no due dates are set)
3. Click on all periods (note that due date is now not set)
4. Save (will now show validation message)

TODO: Still adding in some specs.