### PR TITLE
handle timezones with courses

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "markdown-it": "^4.1.1",
     "mime-types": "^2.1.3",
     "moment": "^2.9.0",
+    "moment-timezone": "^0.4.0",
     "pluralize": "^1.1.2",
     "react": "0.13.1",
     "react-bootstrap": "~0.22.0",

--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -6,7 +6,6 @@ camelCase = require 'camelcase'
 React = require 'react/addons'
 CoursePlan = require './plan'
 {TimeStore} = require '../../flux/time'
-TimeHelper = require '../../helpers/time'
 
 CourseDuration = React.createClass
   displayName: 'CourseDuration'
@@ -58,14 +57,10 @@ CourseDuration = React.createClass
     @setState({ranges: groupedDurations, durationsByStartDate})
 
   componentWillMount: ->
-    TimeHelper.syncCourseTimezone()
     @updateGroupedDurations(@props)
 
   componentWillReceiveProps: (nextProps) ->
     @updateGroupedDurations(nextProps)
-
-  componentWillUnmount: ->
-    TimeHelper.unsyncCourseTimezone()
 
   groupDurations: (durations, viewingDuration, groupingDurations) ->
     durationsInView = _.chain(durations)

--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -6,6 +6,7 @@ camelCase = require 'camelcase'
 React = require 'react/addons'
 CoursePlan = require './plan'
 {TimeStore} = require '../../flux/time'
+TimeHelper = require '../../helpers/time'
 
 CourseDuration = React.createClass
   displayName: 'CourseDuration'
@@ -57,9 +58,14 @@ CourseDuration = React.createClass
     @setState({ranges: groupedDurations, durationsByStartDate})
 
   componentWillMount: ->
+    TimeHelper.syncCourseTimezone()
     @updateGroupedDurations(@props)
+
   componentWillReceiveProps: (nextProps) ->
     @updateGroupedDurations(nextProps)
+
+  componentWillUnmount: ->
+    TimeHelper.unsyncCourseTimezone()
 
   groupDurations: (durations, viewingDuration, groupingDurations) ->
     durationsInView = _.chain(durations)

--- a/src/components/course-calendar/month.cjsx
+++ b/src/components/course-calendar/month.cjsx
@@ -7,6 +7,7 @@ BS = require 'react-bootstrap'
 
 {Calendar, Month, Week, Day} = require 'react-calendar'
 {TimeStore} = require '../../flux/time'
+TimeHelper = require '../../helpers/time'
 
 CourseCalendarHeader = require './header'
 CourseDuration = require './duration'
@@ -30,6 +31,8 @@ CourseMonth = React.createClass
         new Error("#{propName} should be a moment for #{componentName}")
 
   getInitialState: ->
+    # check isCourseTimezone should we need to show a notice
+    isCourseTimezone: TimeHelper.isCourseTimezone()
     activeAddDate: null
 
   getDefaultProps: ->
@@ -43,6 +46,12 @@ CourseMonth = React.createClass
   setDate: (date) ->
     unless moment(date).isSame(@props.date, 'month')
       @setDateParams(date)
+
+  componentWillMount: ->
+    TimeHelper.syncCourseTimezone()
+
+  componentWillUnmount: ->
+    TimeHelper.unsyncCourseTimezone()
 
   componentDidUpdate: ->
     @setDayHeight(@refs.courseDurations.state.ranges) if @refs.courseDurations?

--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -116,6 +116,10 @@ module.exports = React.createClass
 
   componentWillMount: ->
     @setPeriodDefaults()
+    TimeHelper.syncCourseTimezone()
+
+  componentWillUnmount: ->
+    TimeHelper.unsyncCourseTimezone()
 
   setOpensAt: (value, period) ->
     {id} = @props

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -25,6 +25,8 @@ sortTopics = (topics) ->
     TaskHelpers.chapterSectionToNumber(topic.chapter_section)
   )
 
+TutorDateFormat = 'MM/DD/YYYY'
+
 TaskPlanConfig =
 
   _stats: {}
@@ -174,11 +176,10 @@ TaskPlanConfig =
     # the BE to accept.
     if periodId
       tasking = @_findTasking(tasking_plans, periodId)
-      tasking[attr] = moment(date).toDate()
+      tasking[attr] = moment(date, [TutorDateFormat]).toDate()
     else
       for tasking in tasking_plans
-        tasking[attr] = moment(date).toDate()
-
+        tasking[attr] = moment(date, [TutorDateFormat]).toDate()
     @_change(id, {tasking_plans})
 
   updateOpensAt: (id, opens_at, periodId) ->

--- a/src/helpers/time.coffee
+++ b/src/helpers/time.coffee
@@ -1,5 +1,34 @@
 moment = require 'moment-timezone'
 
+# Using tzdetect until https://github.com/moment/moment-timezone/issues/138
+# gets straightened out.
+#
+# A small public domain library detecting the user's timezone using moment.js
+# Repository : https://github.com/Canop/tzdetect.js
+# Usage :
+#   tzdetect.matches()     : array of all timezones matching the user's one
+#   tzdetect.matches(base) : array of all timezones matching the supplied one
+tzdetect =
+  names: moment.tz.names()
+  matches: (base) ->
+    results = []
+    now = Date.now()
+
+    makekey = (id) ->
+      [0, 4, 8, -5 * 12, 4 - 5 * 12, 8 - 5 * 12, 4 - 2 * 12, 8 - 2 * 12].map((months) ->
+        m = moment(now + months * 30 * 24 * 60 * 60 * 1000)
+        m.tz(id) if id
+        m.format('DDHHmm')
+      ).join(' ')
+
+    lockey = makekey(base)
+
+    tzdetect.names.forEach (id) ->
+      results.push(id) if makekey(id) is lockey
+
+    return results
+
+
 TimeHelper =
   getCurrentLocales: ->
     currentLocale = moment.localeData()
@@ -13,5 +42,11 @@ TimeHelper =
 
   unsyncCourseTimezone: ->
     moment.defaultZone = null
+
+  getLocalTimezone: ->
+    tzdetect.matches()
+
+  isCourseTimezone: (courseTimezone = 'US/Central') ->
+    TimeHelper.getLocalTimezone().indexOf(courseTimezone) > -1
 
 module.exports = TimeHelper

--- a/src/helpers/time.coffee
+++ b/src/helpers/time.coffee
@@ -1,4 +1,4 @@
-moment = require 'moment'
+moment = require 'moment-timezone'
 
 TimeHelper =
   getCurrentLocales: ->
@@ -7,5 +7,11 @@ TimeHelper =
     abbr: currentLocale._abbr
     week: currentLocale._week
     weekdaysMin: currentLocale._weekdaysMin
+
+  syncCourseTimezone: (courseTimezone = 'US/Central') ->
+    moment.tz.setDefault(courseTimezone)
+
+  unsyncCourseTimezone: ->
+    moment.defaultZone = null
 
 module.exports = TimeHelper

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -60,6 +60,7 @@ require './task-helpers.spec'
 require './dom-helpers.spec'
 require './helpers/string.spec'
 require './helpers/period.spec'
+require './helpers/time.spec'
 
 # The whole Boom Boom.
 # This should be done **last** because it starts up the whole app

--- a/test/helpers/time.spec.coffee
+++ b/test/helpers/time.spec.coffee
@@ -28,8 +28,20 @@ describe 'Time Helpers', ->
     expect(moment.defaultZone).to.deep.equal(moment.tz.zone(TEST_TIMEZONE))
     expect(moment().startOf('day').format()).to.not.equal(TODAY_IN_CURRENT_ZONE)
 
+
   it 'will reset the default timezone to user time', ->
 
     TimeHelper.unsyncCourseTimezone()
     expect(moment.defaultZone).to.not.exist
     expect(moment().startOf('day').format()).to.equal(TODAY_IN_CURRENT_ZONE)
+
+
+  it 'can check the default timezone', ->
+
+    isCourseTimezone = TimeHelper.isCourseTimezone(TEST_TIMEZONE)
+    expect(isCourseTimezone).to.be.false
+
+    TimeHelper.syncCourseTimezone(TEST_TIMEZONE)
+    isCourseTimezone = TimeHelper.isCourseTimezone(TEST_TIMEZONE)
+    expect(isCourseTimezone).to.be.true
+    TimeHelper.unsyncCourseTimezone()

--- a/test/helpers/time.spec.coffee
+++ b/test/helpers/time.spec.coffee
@@ -1,0 +1,35 @@
+{expect} = require 'chai'
+_ = require 'underscore'
+moment = require 'moment-timezone'
+
+TimeHelper = require '../../src/helpers/time'
+
+TEST_TIMEZONE = 'Pacific/Midway'
+TODAY_IN_CURRENT_ZONE = moment().startOf('day').format()
+
+describe 'Time Helpers', ->
+
+  it 'can get current locale', ->
+
+    currentLocale = TimeHelper.getCurrentLocales()
+
+    # check on the essential properties for being able to use
+    # currentLocale to fix calendar's locale changing
+    expect(currentLocale).to.have.property('abbr').and.to.be.a('string')
+    expect(currentLocale).to.have.property('week').and.to.be.an('object')
+    expect(currentLocale).to.have.deep.property('week.dow').and.to.be.a('number')
+    expect(currentLocale).to.have.deep.property('week.doy').and.to.be.a('number')
+    expect(currentLocale).to.have.property('weekdaysMin').and.to.be.an('array')
+
+
+  it 'will set the default timezone', ->
+
+    TimeHelper.syncCourseTimezone(TEST_TIMEZONE)
+    expect(moment.defaultZone).to.deep.equal(moment.tz.zone(TEST_TIMEZONE))
+    expect(moment().startOf('day').format()).to.not.equal(TODAY_IN_CURRENT_ZONE)
+
+  it 'will reset the default timezone to user time', ->
+
+    TimeHelper.unsyncCourseTimezone()
+    expect(moment.defaultZone).to.not.exist
+    expect(moment().startOf('day').format()).to.equal(TODAY_IN_CURRENT_ZONE)


### PR DESCRIPTION
sync the teacher calendar and builder to one timezone that may not the teacher's local timezone -- now defaulted to US/Central

Talked to BE briefly about providing us the "course timezone" even though it's always central right now.  It will be good preparation for when course timezone can be changed.  However, this PR will be an improvement even without a BE change.


# Test case timezone change
![screen shot 2015-09-05 at 7 58 02 am](https://cloud.githubusercontent.com/assets/2483873/9693364/f47fafbc-53a3-11e5-8afd-48f22bf455cf.png)

## Bug
### Plans on wrong date
![screen shot 2015-09-05 at 8 01 35 am](https://cloud.githubusercontent.com/assets/2483873/9693453/aecc451a-53a4-11e5-9b17-0da81c183dcc.png)
### Date input says 12 instead of 11
![screen shot 2015-09-05 at 8 01 52 am](https://cloud.githubusercontent.com/assets/2483873/9693449/aec6ed68-53a4-11e5-8524-52b38f6f0dcd.png)
![screen shot 2015-09-05 at 8 02 05 am](https://cloud.githubusercontent.com/assets/2483873/9693451/aecb13e8-53a4-11e5-8de8-0db8b24072b0.png)
![screen shot 2015-09-05 at 8 02 44 am](https://cloud.githubusercontent.com/assets/2483873/9693452/aecb35c6-53a4-11e5-8881-1fd5170be8ae.png)
### Changing timezone back to central -- homework actually got assigned to be due on the day before
![screen shot 2015-09-04 at 3 03 15 pm](https://cloud.githubusercontent.com/assets/2483873/9693450/aec75690-53a4-11e5-8abd-dbf9453ebcbf.png)

## With Fix
![screen shot 2015-09-05 at 7 56 36 am](https://cloud.githubusercontent.com/assets/2483873/9693371/fade4d64-53a3-11e5-9b72-80e6384ce331.png)
![screen shot 2015-09-05 at 7 57 13 am](https://cloud.githubusercontent.com/assets/2483873/9693373/faedb13c-53a3-11e5-83cd-14d1e1a67b39.png)
![screen shot 2015-09-05 at 7 57 22 am](https://cloud.githubusercontent.com/assets/2483873/9693372/faea99b6-53a3-11e5-8c64-dee7e16e6bd5.png)
### Changing timezone back to central, date preserved.
![screen shot 2015-09-04 at 3 08 27 pm](https://cloud.githubusercontent.com/assets/2483873/9693547/5bcbe2e8-53a5-11e5-9d31-da402d2611eb.png)

