### PR TITLE
Fix performance report back button overlapping with heading

### DIFF
--- a/resources/styles/components/learning-guide/heading.less
+++ b/resources/styles/components/learning-guide/heading.less
@@ -10,6 +10,7 @@
     .flex-display();
     .justify-content(flex-start);
     .align-items(center);
+
     .guide-group-title {
       .flex(1);
     }
@@ -20,7 +21,7 @@
     }
   }
   .guide-group-title {
-    font-size: 3.5rem;
+    font-size: 3rem;
     display: inline-block;
   }
   .info-link:after {

--- a/resources/styles/components/learning-guide/responsive.less
+++ b/resources/styles/components/learning-guide/responsive.less
@@ -1,13 +1,5 @@
 .learning-guide {
 
-  .guide-heading {
-    @media (max-width: @screen-md-min) {
-      .flex-direction(column);
-      .align-items(stretch);
-      .btn.back { position: relative; top: -40px; }
-    }
-  }
-
   @media (max-width: @screen-md-min) {
     .weaker .explanation {
       p {

--- a/resources/styles/components/learning-guide/teacher-student.less
+++ b/resources/styles/components/learning-guide/teacher-student.less
@@ -1,10 +1,13 @@
 .learning-guide.teacher-student {
+  .guide-group-title .preamble { margin-right: 1rem; }
+
   .student-selection {
     #fonts > .sans(3rem);
+    margin: 0;
     display: inline-block;
     box-shadow: none;
     .dropdown-toggle  {
-      padding: 0 0 0.5rem 1rem;
+      padding: 0 0 0.5rem 0;
       text-transform: none;
       #fonts > .sans(3rem);
     }

--- a/src/components/learning-guide/teacher-student.cjsx
+++ b/src/components/learning-guide/teacher-student.cjsx
@@ -43,7 +43,7 @@ module.exports = React.createClass
     name = <Name {...selected} />
     <div className='guide-heading'>
       <div className='guide-group-title'>
-        Performance Forecast for:
+        <span className='preamble'>Performance Forecast for:</span>
         <BS.DropdownButton bzSize='large' className='student-selection' title={name}
           bsStyle='link' onSelect={@onSelectStudent}>
             { for student in _.sortBy(students, 'name') when student.role isnt selected.role


### PR DESCRIPTION
before:
![screen shot 2015-09-07 at 10 05 31 am](https://cloud.githubusercontent.com/assets/79566/9719711/b2bebc12-554c-11e5-84dc-dc96b0b9df79.png)

after:
![screen shot 2015-09-07 at 10 40 27 am](https://cloud.githubusercontent.com/assets/79566/9719726/e53c0690-554c-11e5-8199-92564d9e2392.png)
