### PR TITLE
Enlarge student dashboard progress column

### DIFF
--- a/src/components/student-dashboard/event-row.cjsx
+++ b/src/components/student-dashboard/event-row.cjsx
@@ -32,13 +32,13 @@ module.exports = React.createClass
       <BS.Col xs={2}  sm={1} className={"column-icon"}>
         <i className={"icon icon-lg icon-#{@props.className}"}/>
       </BS.Col>
-      <BS.Col xs={10} sm={7} className='title'>
+      <BS.Col xs={10} sm={6} className='title'>
         {@props.children}
         <Instructions
           task={@props.event}
           popverClassName='student-dashboard-instructions-popover'/>
       </BS.Col>
-      <BS.Col xs={5}  sm={2} className='feedback'>
+      <BS.Col xs={5}  sm={3} className='feedback'>
         <span>{@props.feedback}</span><EventInfoIcon event={@props.event} />
       </BS.Col>
       <BS.Col xs={5}  sm={2} className='due-at'>

--- a/src/components/student-dashboard/events-panel.cjsx
+++ b/src/components/student-dashboard/events-panel.cjsx
@@ -42,8 +42,8 @@ module.exports = React.createClass
   render: ->
     <BS.Panel className={@props.className}>
       <div className="row labels">
-        <BS.Col xs={12} sm={8}>{@renderTitle()}</BS.Col>
-        <BS.Col xs={5} xsOffset={2} smOffset={0} sm={2} className='progress-label'>
+        <BS.Col xs={12} sm={7}>{@renderTitle()}</BS.Col>
+        <BS.Col xs={5} xsOffset={2} smOffset={0} sm={3} className='progress-label'>
           Progress
         </BS.Col>
         <BS.Col xs={5} sm={2} className='due-at-label'>Due (7:00am)</BS.Col>


### PR DESCRIPTION
When screen was between 1,000 & 800px wide, The expanded status's like "10/12 answered (I)" take up too much space,
while the description always seems to have space to spare

Before:
![screen shot 2015-09-07 at 10 58 26 am](https://cloud.githubusercontent.com/assets/79566/9720006/8e909696-554f-11e5-9766-402fc716678b.png)

After:
![screen shot 2015-09-07 at 10 57 55 am](https://cloud.githubusercontent.com/assets/79566/9720008/956c8c9a-554f-11e5-8872-0dacce950ef4.png)


