### PR TITLE
Customize student dashboard styles for narrow screens

### DIFF
--- a/resources/styles/components/student-dashboard/panel.less
+++ b/resources/styles/components/student-dashboard/panel.less
@@ -18,13 +18,18 @@
       font-weight: 900;
       color: @tutor-neutral-darker;
     }
-    
+
     .date-range {
       #fonts .sans(1.4rem, @student-dashboard-row-height);
       color: @tutor-neutral-darker;
       text-transform: uppercase;
     }
-
+    // Adjust height for when the columns collapse and progress appears below task title
+    @media screen and ( max-width: @screen-sm-min ){
+      // don't take up as much vertical space when collapsed
+      .panel-title { height: @student-dashboard-row-height / 2; }
+      .progress-label { padding-left: 0; }
+    }
   }
 
   .panel > .panel-body {

--- a/resources/styles/components/student-dashboard/task.less
+++ b/resources/styles/components/student-dashboard/task.less
@@ -35,13 +35,17 @@
       }
     }
 
-    // The first panel inside a tab should be positioned at the top with no margin
+    // Adjust height for when the columns collapse and progress appears below task title
     @media screen and ( max-width: @screen-sm-min ){
-      .column-icon { height: @student-dashboard-row-height*2; }
-      .icon {
-        margin-top: (@student-dashboard-row-height * 2 - @icon-size-lg * 10)/2;
-        margin-bottom: (@student-dashboard-row-height * 2 - @icon-size-lg * 10)/2;
+      .column-icon {
+        text-align: center;
+        height: @student-dashboard-row-height;
       }
+      .title, .feedback, .due-at {
+        line-height: @student-dashboard-row-height / 2;
+      }
+      // match the 0 left padding of the description
+      .feedback { padding-left: 0; }
     }
 
     // A task that is workable can be clicked
@@ -60,4 +64,3 @@
 .student-dashboard-instructions-popover {
   .tutor-popover();
 }
-


### PR DESCRIPTION
Fixes a few styling issues I noticed when working on #720.

When the screen is narrow, the progress and due columns collapse under
the description.  In that case the line height needs to be adjusted so
it doesn't double the row height

Before:
![screen shot 2015-09-07 at 12 13 51 pm](https://cloud.githubusercontent.com/assets/79566/9720997/ee0afac6-5559-11e5-98ca-a60cffb550ec.png)


After:
![screen shot 2015-09-07 at 12 09 17 pm](https://cloud.githubusercontent.com/assets/79566/9721007/04fe2e56-555a-11e5-934e-70657c8bb910.png)


