### PR TITLE
Refactor/browse the book new tab link cleanup

### DIFF
--- a/src/components/course-calendar/header.cjsx
+++ b/src/components/course-calendar/header.cjsx
@@ -8,7 +8,7 @@ Router = require 'react-router'
 
 CourseAddMenuMixin = require './add-menu-mixin'
 PracticeButton = require '../buttons/practice-button'
-BrowseBookButton = require '../buttons/browse-the-book'
+BrowseTheBook = require '../buttons/browse-the-book'
 
 {TimeStore} = require '../../flux/time'
 
@@ -62,7 +62,7 @@ CourseCalendarHeader = React.createClass
     {courseId} = @context.router.getCurrentParams()
     <div className='calendar-header'>
       <BS.Row className='calendar-actions'>
-        <BrowseBookButton bsStyle='default' courseId={courseId} />
+        <BrowseTheBook bsStyle='default' courseId={courseId} />
         <Router.Link className='btn btn-default' to='viewTeacherGuide' params={{courseId}}>
           Performance Forecast
         </Router.Link>

--- a/src/components/new-tab-link.cjsx
+++ b/src/components/new-tab-link.cjsx
@@ -1,0 +1,35 @@
+React = require 'react'
+_ = require 'underscore'
+
+NewTabLink = React.createClass
+  displayName: 'NewTabLink'
+
+  contextTypes:
+    router: React.PropTypes.func
+
+  getDefaultProps: ->
+    target: '_blank'
+
+  propTypes:
+    to: React.PropTypes.string.isRequired
+    children: React.PropTypes.node.isRequired
+    params: React.PropTypes.object
+    query: React.PropTypes.object
+    target: React.PropTypes.string
+
+  getLinkProps: (link) ->
+    linkProps =
+      href: link
+
+    # most props should transfer, such as onClick, className, etc.
+    transferProps = _.omit(@props, ['to', 'params', 'query', 'children'])
+    _.extend({}, transferProps, linkProps)
+
+  render: ->
+    {to, params, query, children} = @props
+    link = @context.router.makeHref(to, params, query)
+    linkProps = @getLinkProps(link)
+
+    <a {...linkProps}>{children}</a>
+
+module.exports = NewTabLink

--- a/src/components/student-dashboard/dashboard.cjsx
+++ b/src/components/student-dashboard/dashboard.cjsx
@@ -10,7 +10,7 @@ ThisWeekPanel   = require './this-week-panel'
 
 PracticeButton = require '../buttons/practice-button'
 ProgressGuideShell = require './progress-guide'
-BrowseBookButton = require '../buttons/browse-the-book'
+BrowseTheBook = require '../buttons/browse-the-book'
 
 CourseDataMixin = require '../course-data-mixin'
 
@@ -65,9 +65,9 @@ module.exports = React.createClass
           <BS.Col xs=12 md=4 lg=3>
             <ProgressGuideShell courseId={courseId} sampleSizeThreshold=3 />
             <div className='actions-box'>
-              <BrowseBookButton unstyled courseId={courseId}>
+              <BrowseTheBook unstyled courseId={courseId}>
                 <div>Browse the Book</div>
-              </BrowseBookButton>
+              </BrowseTheBook>
             </div>
           </BS.Col>
 

--- a/src/components/task-plan/reading.cjsx
+++ b/src/components/task-plan/reading.cjsx
@@ -95,13 +95,14 @@ ChooseReadings = React.createClass
     @props.hide()
 
   render: ->
-    buttonStyle = if @props.selected?.length then 'primary' else 'disabled'
+    buttonStyle = if @props.selected?.length then 'primary' else 'default'
     header = <span>Select Readings</span>
 
     primary =
       <BS.Button
         className='-show-problems'
         bsStyle={buttonStyle}
+        disabled={@props.selected?.length is 0}
         onClick={@hide}>Add Readings
       </BS.Button>
 


### PR DESCRIPTION
No UI changes, `BrowseTheBook` links and buttons throughout, still look as expected

![screen shot 2015-09-08 at 1 18 50 pm](https://cloud.githubusercontent.com/assets/2483873/9743485/4c94402a-562c-11e5-8832-f8a76e4113de.png)
![screen shot 2015-09-08 at 1 19 19 pm](https://cloud.githubusercontent.com/assets/2483873/9743488/4c97f7e2-562c-11e5-9278-a29be2e495fb.png)
![screen shot 2015-09-08 at 1 19 25 pm](https://cloud.githubusercontent.com/assets/2483873/9743487/4c960414-562c-11e5-937c-1a169e149c96.png)
![screen shot 2015-09-08 at 1 19 42 pm](https://cloud.githubusercontent.com/assets/2483873/9743486/4c94b97e-562c-11e5-836c-e7b7dd07ac12.png)
![screen shot 2015-09-08 at 1 20 46 pm](https://cloud.githubusercontent.com/assets/2483873/9743520/6cd9938a-562c-11e5-8aa6-ae01e32809d8.png)
