### PR TITLE
perf report sort names case-insensitive

### DIFF
--- a/src/components/scores/index.cjsx
+++ b/src/components/scores/index.cjsx
@@ -173,7 +173,7 @@ Scores = React.createClass
           when 'homework' then d.data[index].correct_exercise_count
           when 'reading' then d.data[index].status
       else
-        d.last_name
+        d.last_name.toLowerCase()
     )
     { headings: scores.data_headings, rows: if sort.asc then sortData.reverse() else sortData }
 

--- a/src/components/scores/index.cjsx
+++ b/src/components/scores/index.cjsx
@@ -175,7 +175,7 @@ Scores = React.createClass
       else
         d.last_name.toLowerCase()
     )
-    { headings: scores.data_headings, rows: if sort.asc then sortData.reverse() else sortData }
+    { headings: scores.data_headings, rows: if sort.asc then sortData else sortData.reverse() }
 
   render: ->
     {courseId} = @props


### PR DESCRIPTION
Regarding task: https://www.pivotaltracker.com/story/show/102331780

Performance report was sorting case-sensitive, now will sort properly:

before:
![image](https://cloud.githubusercontent.com/assets/954569/9773210/1b4ab1dc-570f-11e5-8b6b-6eae7d1848b1.png)

after:
![image](https://cloud.githubusercontent.com/assets/954569/9777275/f1596d84-572f-11e5-87c2-7a680a5336a8.png)

