### PR TITLE
Refactor/improve exercise loading

### DIFF
--- a/src/components/bind-store-mixin.cjsx
+++ b/src/components/bind-store-mixin.cjsx
@@ -2,7 +2,7 @@ module.exports =
 
   # can modify which event you want to bind on as needed.
   _bindEvent: ->
-    @bindEvent or 'change'
+    @bindEvent or @props.bindEvent or 'change'
 
   # @bindStore may need to be a function in some cases, i.e. when the store is being passed in as a prop.
   _bindStore: ->

--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -22,10 +22,10 @@ MEDIA_LINK_SELECTOR = _.reduce(MEDIA_LINK_EXCLUDES, (current, exclude) ->
 
 LinkContentMixin =
   componentDidMount:  ->
-    _.defer(@processLinks)
+    @processLinks()
 
   componentDidUpdate: ->
-    _.defer(@processLinks)
+    @processLinks()
 
   contextTypes:
     router: React.PropTypes.func
@@ -99,6 +99,10 @@ LinkContentMixin =
     link.dataset.targeted = 'media'
 
   processLinks: ->
+    _.defer(@_processLinks)
+
+  _processLinks: ->
+    return unless @isMounted()
     root = @getDOMNode()
     mediaLinks = root.querySelectorAll(MEDIA_LINK_SELECTOR)
     exerciseLinks = root.querySelectorAll(EXERCISE_LINK_SELECTOR)
@@ -116,12 +120,12 @@ ReadingContentMixin =
   componentDidMount:  ->
     @insertOverlays()
     @detectImgAspectRatio()
-    _.defer(@processLinks)
+    @processLinks()
 
   componentDidUpdate: ->
     @insertOverlays()
     @detectImgAspectRatio()
-    _.defer(@processLinks)
+    @processLinks()
 
   contextTypes:
     router: React.PropTypes.func

--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -22,10 +22,10 @@ MEDIA_LINK_SELECTOR = _.reduce(MEDIA_LINK_EXCLUDES, (current, exclude) ->
 
 LinkContentMixin =
   componentDidMount:  ->
-    @processLinks()
+    _.defer(@processLinks)
 
   componentDidUpdate: ->
-    @processLinks()
+    _.defer(@processLinks)
 
   contextTypes:
     router: React.PropTypes.func
@@ -116,12 +116,12 @@ ReadingContentMixin =
   componentDidMount:  ->
     @insertOverlays()
     @detectImgAspectRatio()
-    @processLinks()
+    _.defer(@processLinks)
 
   componentDidUpdate: ->
     @insertOverlays()
     @detectImgAspectRatio()
-    @processLinks()
+    _.defer(@processLinks)
 
   contextTypes:
     router: React.PropTypes.func

--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -109,8 +109,8 @@ LinkContentMixin =
       .uniq()
       .value()
 
-    @renderOtherLinks?(otherLinks)
-    @renderExercises?(exerciseLinks)
+    @renderOtherLinks?(otherLinks) if otherLinks?.length
+    @renderExercises?(exerciseLinks) if exerciseLinks?.length
 
 ReadingContentMixin =
   componentDidMount:  ->

--- a/src/components/loadable-item.cjsx
+++ b/src/components/loadable-item.cjsx
@@ -22,6 +22,10 @@ module.exports = React.createClass
     renderLoading: React.PropTypes.func
     renderError: React.PropTypes.func
     update: React.PropTypes.func
+    bindEvent: React.PropTypes.string
+
+  getDefaultProps: ->
+    bindEvent: 'change'
 
   componentDidMount: -> @reload({})
   componentDidUpdate: (oldProps) -> @reload(oldProps)
@@ -40,7 +44,7 @@ module.exports = React.createClass
 
   render: ->
     { id, store, actions, load, isLoaded, isLoading, renderItem,
-      saved, renderLoading, renderError, renderBug, update, options} = @props
+      saved, renderLoading, renderError, renderBug, update, options, bindEvent} = @props
 
     load ?= actions.load
     isLoaded ?= store.isLoaded
@@ -74,5 +78,6 @@ module.exports = React.createClass
       render={renderItem}
       renderLoading={renderLoading}
       update={update}
+      bindEvent={bindEvent}
       {renderModes}
     />

--- a/src/components/reference-book/exercise.cjsx
+++ b/src/components/reference-book/exercise.cjsx
@@ -34,11 +34,20 @@ ReferenceBookExercise = React.createClass
 
 ReferenceBookExerciseShell = React.createClass
   displayName: 'ReferenceBookExerciseShell'
+  isLoading: ->
+    {exerciseAPIUrl} = @props
+    ReferenceBookExerciseStore.isLoading(exerciseAPIUrl) or ReferenceBookExerciseStore.isQueued(exerciseAPIUrl)
+  load: ->
+    {exerciseAPIUrl} = @props
+    ReferenceBookExerciseActions.load(exerciseAPIUrl) unless @isLoading()
   render: ->
     {exerciseAPIUrl} = @props
 
     <LoadableItem
       id={exerciseAPIUrl}
+      bindEvent={"loaded.#{exerciseAPIUrl}"}
+      isLoading={@isLoading}
+      load={@load}
       store={ReferenceBookExerciseStore}
       actions={ReferenceBookExerciseActions}
       renderItem={=> <ReferenceBookExercise {...@props} />}

--- a/src/components/reference-book/exercise.cjsx
+++ b/src/components/reference-book/exercise.cjsx
@@ -4,6 +4,7 @@ React = require 'react'
 
 Question = require '../question'
 LoadableItem = require '../loadable-item'
+ArbitraryHtml = require '../html'
 
 ReferenceBookMissingExercise = React.createClass
   displayName: 'ReferenceBookMissingExercise'
@@ -40,6 +41,9 @@ ReferenceBookExerciseShell = React.createClass
   load: ->
     {exerciseAPIUrl} = @props
     ReferenceBookExerciseActions.load(exerciseAPIUrl) unless @isLoading()
+  renderExercise: ->
+    exerciseHtml = React.renderToStaticMarkup(<ReferenceBookExercise {...@props} />)
+    <ArbitraryHtml html={exerciseHtml}/>
   render: ->
     {exerciseAPIUrl} = @props
 
@@ -50,7 +54,7 @@ ReferenceBookExerciseShell = React.createClass
       load={@load}
       store={ReferenceBookExerciseStore}
       actions={ReferenceBookExerciseActions}
-      renderItem={=> <ReferenceBookExercise {...@props} />}
+      renderItem={@renderExercise}
       renderLoading={-> <span className='loading-exercise'>Loading exercise...</span>}
       renderError={-> <ReferenceBookMissingExercise/>}
     />

--- a/src/components/reference-book/index.cjsx
+++ b/src/components/reference-book/index.cjsx
@@ -22,21 +22,23 @@ ReferenceBookPageShell = React.createClass
   getDefaultState: ->
     previousPageProps: null
 
-  componentWillReceiveProps: ->
+  componentWillReceiveProps: (nextProps) ->
     @setState(previousPageProps: @props)
 
-  renderLoading: (previousPageProps, currentProps) ->
-    (refreshButton) ->
-      if previousPageProps? and previousPageProps.cnxId? and not _.isEqual(previousPageProps, currentProps)
-        loading = <ReferenceBookPage
-          {...previousPageProps}
-          className='page-loading loadable is-loading'>
-          {refreshButton}
-        </ReferenceBookPage>
-      else
-        loading = <div className='loadable is-loading'>Loading... {refreshButton}</div>
+  isAnotherPage: (previousPageProps, currentProps) ->
+    previousPageProps? and previousPageProps.cnxId? and not _.isEqual(previousPageProps, currentProps)
 
-      loading
+  renderLoading: (previousPageProps, currentProps, refreshButton) ->
+    if @isAnotherPage(previousPageProps, currentProps)
+      loading = <ReferenceBookPage
+        {...previousPageProps}
+        className='page-loading loadable is-loading'>
+        {refreshButton}
+      </ReferenceBookPage>
+    else
+      loading = <div className='loadable is-loading'>Loading... {refreshButton}</div>
+
+    loading
 
   renderLoaded: ->
     <ReferenceBookPage {...@props}/>
@@ -47,7 +49,7 @@ ReferenceBookPageShell = React.createClass
         id={@props.cnxId}
         store={ReferenceBookPageStore}
         actions={ReferenceBookPageActions}
-        renderLoading={@renderLoading(@state?.previousPageProps, @props)}
+        renderLoading={_.partial(@renderLoading, @state?.previousPageProps, @props)}
         renderItem={@renderLoaded}
       />
     else
@@ -58,17 +60,31 @@ ReferenceBookShell = React.createClass
   displayName: 'ReferenceBookShell'
   contextTypes:
     router: React.PropTypes.func
+  getInitialState: ->
+    @getIds()
+
   componentWillMount: ->
     {courseId} = @context.router.getCurrentParams()
+    @setIds()
 
     unless CourseStore.isLoaded(courseId)
       CourseActions.load(courseId)
-      CourseStore.once('course.loaded', @setState.bind(@, {}))
+      CourseStore.once('course.loaded', @setIds.bind(@))
 
-  render: ->
+  componentWillReceiveProps: ->
+    @setIds()
+
+  getIds: ->
     {courseId} = @context.router.getCurrentParams()
     {ecosystemId} = @context.router.getCurrentQuery()
     ecosystemId ?= CourseStore.get(courseId)?.ecosystem_id
+    {courseId, ecosystemId}
+
+  setIds: ->
+    @setState(@getIds())
+
+  render: ->
+    {courseId, ecosystemId} = @state
 
     <LoadableItem
       id={ecosystemId}

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -13,7 +13,7 @@ ChapterSectionMixin = require '../chapter-section-mixin'
 
 {ReferenceBookPageStore} = require '../../flux/reference-book-page'
 {ReferenceBookStore} = require '../../flux/reference-book'
-{ReferenceBookExerciseStore} = require '../../flux/reference-book-exercise'
+{ReferenceBookExerciseActions, ReferenceBookExerciseStore} = require '../../flux/reference-book-exercise'
 
 module.exports = React.createClass
   _exerciseNodes: []
@@ -88,6 +88,10 @@ module.exports = React.createClass
 
   renderExercises: (exerciseLinks) ->
     ReferenceBookExerciseStore.setMaxListeners(exerciseLinks.length)
+    allExercises = _.pluck(exerciseLinks, 'href')
+    multipleUrl = ReferenceBookExerciseStore.getMultipleUrl(allExercises)
+    ReferenceBookExerciseActions.load(multipleUrl) unless ReferenceBookExerciseStore.isLoaded(multipleUrl)
+
     _.each(exerciseLinks, @renderExercise)
 
   renderExercise: (link) ->

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -105,7 +105,7 @@ module.exports = React.createClass
     React.unmountComponentAtNode(node) if node?
     @_exerciseNodes.splice(nodeIndex, 1)
 
-  componentWillUnmount: ->
+  componentWillReceiveProps: ->
     _.each(@_exerciseNodes, @unmountExerciseComponent)
 
   render: ->

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -16,7 +16,6 @@ ChapterSectionMixin = require '../chapter-section-mixin'
 {ReferenceBookExerciseActions, ReferenceBookExerciseStore} = require '../../flux/reference-book-exercise'
 
 module.exports = React.createClass
-  _exerciseNodes: []
   displayName: 'ReferenceBookPage'
   propTypes:
     courseId: React.PropTypes.string.isRequired
@@ -96,17 +95,8 @@ module.exports = React.createClass
 
   renderExercise: (link) ->
     exerciseAPIUrl = link.href
-
-    if link.parentNode.parentNode?
-      @_exerciseNodes.push(link.parentNode.parentNode)
-      React.render(<ReferenceBookExerciseShell exerciseAPIUrl={exerciseAPIUrl}/>, link.parentNode.parentNode)
-
-  unmountExerciseComponent: (node, nodeIndex) ->
-    React.unmountComponentAtNode(node) if node?
-    @_exerciseNodes.splice(nodeIndex, 1)
-
-  componentWillReceiveProps: ->
-    _.each(@_exerciseNodes, @unmountExerciseComponent)
+    exerciseNode = link.parentNode.parentNode
+    React.render(<ReferenceBookExerciseShell exerciseAPIUrl={exerciseAPIUrl}/>, exerciseNode) if exerciseNode?
 
   render: ->
     {courseId, cnxId, className, ecosystemId} = @props

--- a/src/components/reference-book/reference-book.cjsx
+++ b/src/components/reference-book/reference-book.cjsx
@@ -24,6 +24,21 @@ module.exports = React.createClass
   bindStore: CourseListingStore
   bindEvent: 'loaded'
 
+  getPageState: ->
+    {cnxId} = @context.router.getCurrentParams()
+    # Pop open the menu unless the page was explicitly navigated to
+    isMenuVisible: not cnxId
+    pageProps: @getPageProps()
+
+  setPageState: ->
+    @setState(@getPageState())
+
+  getInitialState: ->
+    @getPageState()
+
+  componentWillReceiveProps: (nextProps) ->
+    @setPageState()
+
   componentWillMount: ->
     {courseId, cnxId, section} = @context.router.getCurrentParams()
     query = {ecosystemId} = @context.router.getCurrentQuery()
@@ -52,11 +67,6 @@ module.exports = React.createClass
 
     {cnxId, section, courseId, ecosystemId, query}
 
-  getInitialState: ->
-    {cnxId} = @context.router.getCurrentParams()
-    # Pop open the menu unless the page was explicitly navigated to
-    {isMenuVisible: not cnxId}
-
   toggleTeacherEdition: (ev) ->
     @setState(showTeacherEdition: not @state.showTeacherEdition)
     ev?.preventDefault() # stops react-router from scrolling to top
@@ -69,7 +79,7 @@ module.exports = React.createClass
     ev?.preventDefault() # needed to prevent scrolling to top
 
   render: ->
-    pageProps = @getPageProps()
+    {pageProps} = @state
     {courseId} = pageProps
     courseDataProps = @getCourseDataProps(courseId)
 

--- a/src/flux/reference-book-exercise.coffee
+++ b/src/flux/reference-book-exercise.coffee
@@ -48,7 +48,7 @@ ReferenceBookExerciseConfig = {
       )
 
       delete @_toSeparate[id]
-      return
+      @emit('loaded.multiple')
     else
       @emit("loaded.#{id}")
 

--- a/src/flux/reference-book-exercise.coffee
+++ b/src/flux/reference-book-exercise.coffee
@@ -1,8 +1,75 @@
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
 _ = require 'underscore'
 
-ReferenceBookExerciseConfig = {
+LOADING = 'loading'
+QUERY_START_STRING = '?q='
 
+combineQueries = (multipleUrls) ->
+  params = {}
+  tags = _.map(multipleUrls, (url) ->
+    queryString = decodeURIComponent(url.split(QUERY_START_STRING)[1])
+    [param, value] = queryString.split(':')
+    params[param] ?= []
+    params[param].push(value)
+
+    return value if param is 'tag'
+  )
+  urlsAndTags = _.object(multipleUrls, tags)
+  queryStrings = _.map(params, (values, paramKey) ->
+    "#{paramKey}:#{values.join(',')}"
+  )
+  queryString = queryStrings.join(' ')
+
+  {queryString, urlsAndTags}
+
+getMultipleUrl = (multipleUrls, baseUrl) ->
+  {queryString} = combineQueries(multipleUrls)
+
+  "#{baseUrl}?q=#{queryString}"
+
+ReferenceBookExerciseConfig = {
+  _toSeparate: {}
+
+  loadMultiple: (multipleUrls, baseUrl) ->
+    {queryString, urlsAndTags} = combineQueries(multipleUrls, baseUrl)
+    url = "#{baseUrl}?q=#{queryString}"
+
+    @_toSeparate[url] = urlsAndTags
+
+  _loaded: (obj, id) ->
+    if @_toSeparate[id]?
+      _.each(@_toSeparate[id], (tag, url) =>
+        exercise = _.find(obj.items, (item) ->
+          item.tags.indexOf(tag) > -1
+        )
+        exerciseObj =
+          items: [exercise]
+        @loaded(exerciseObj, url)
+      )
+
+      delete @_toSeparate[id]
+      return
+    else
+      @emit("loaded.#{id}")
+
+    obj
+
+
+  exports:
+    isQueued: (id) ->
+      _.chain(@_toSeparate)
+        .find((urlsAndTags) ->
+          urlsAndTags[id]?
+        )
+        .isObject()
+        .value()
+
+    getMultipleUrl: (multipleUrls) ->
+      baseUrl = _.first(multipleUrls).split(QUERY_START_STRING)[0]
+      url = getMultipleUrl(multipleUrls, baseUrl)
+      @loadMultiple(multipleUrls, baseUrl) unless @_toSeparate[url]?
+
+      url
 }
 
 extendConfig(ReferenceBookExerciseConfig, new CrudConfig())


### PR DESCRIPTION
Ref Book Pages renders much faster and is more reliable/less likely to crash/be blocked by stuffs

Improvements were made by:
* making one api request for exercises per page
  * as opposed to one for each exercise, which added up to 20 + requests sometimes
* ensuring each exercise only renders once per page load
  * there were at least 2 renders per exercise for whatever reason
* making exercise rendering strictly static
  * after they are loaded, the exercises don't need to be reactive
* link processing is deferred till after the rest of the page is mounted/updated/rendered
