### PR TITLE
Disable right-click context menu on external assignments

### DIFF
--- a/src/components/task-step/all-steps.cjsx
+++ b/src/components/task-step/all-steps.cjsx
@@ -120,6 +120,12 @@ ExternalUrl = React.createClass
 
     external_url
 
+  # Disable right-click context menu on link.
+  # If someone selects "open in new tab" from the menu,
+  # we are unable to mark the step as completed
+  onContextMenu: (ev) ->
+    ev.preventDefault()
+
   renderBody: ->
     {taskId} = @props
     {description, title} = TaskStore.get(taskId)
@@ -129,7 +135,10 @@ ExternalUrl = React.createClass
 
     <div className='external-step'>
       <h1>
-        <a href={external_url} target='_blank' onClick={@onContinue}>{title}</a>
+        <a href={external_url}
+          target='_blank'
+          onContextMenu={@onContextMenu}
+          onClick={@onContinue}>{title}</a>
       </h1>
       {descriptionHTML}
     </div>


### PR DESCRIPTION
If someone selects "open in new tab" from the menu, the browser doesn't
receive any events and the code can't mark the step as completed.

No UI changes other than the menu doesn't appear.  Tested in Chrome/Firefox/Safari.  Will test IE later.

