### PR TITLE
Anti-aliasing merriweather

### DIFF
--- a/resources/styles/global/typography.less
+++ b/resources/styles/global/typography.less
@@ -41,6 +41,8 @@
     font-style: normal;
     font-size: @size;
     line-height: @line-height;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
   .script (@size: 1.5rem, @line-height: 3rem, @style: normal) {
     font-family: 'Architects Daughter', cursive;

--- a/resources/styles/global/typography.less
+++ b/resources/styles/global/typography.less
@@ -41,6 +41,7 @@
     font-style: normal;
     font-size: @size;
     line-height: @line-height;
+    font-smooth: antialiased;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }


### PR DESCRIPTION
Add -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; to Merriweather
![2015-09-14_11-46-57](https://cloud.githubusercontent.com/assets/8514591/9855877/b3a6e840-5ad6-11e5-946c-79993b8a6ba7.png)
