### PR TITLE
removed 'practice weakest' button from student dash

### DIFF
--- a/src/components/student-dashboard/progress-guide.cjsx
+++ b/src/components/student-dashboard/progress-guide.cjsx
@@ -9,7 +9,6 @@ ChapterSection = require '../task-plan/chapter-section'
 ChapterSectionMixin = require '../chapter-section-mixin'
 LearningGuideSection = require '../learning-guide/section'
 LearningGuideColorKey = require '../learning-guide/color-key'
-PracticeButton = require '../learning-guide/practice-button'
 Section = require '../learning-guide/section'
 
 # Number of sections to display
@@ -84,10 +83,6 @@ ProgressGuidePanels = React.createClass
     sections = LearningGuide.Student.store.getAllSections(@props.courseId)
     recent = LearningGuide.Helpers.recentSections(sections)
     return @renderEmpty(sections) if _.isEmpty(recent)
-
-    practiceSections = LearningGuide.Helpers.weakestSections(sections)
-    if _.isEmpty(practiceSections)
-      practiceSections = recent
 
     <div className='progress-guide'>
       <div className='actions-box'>

--- a/src/components/student-dashboard/progress-guide.cjsx
+++ b/src/components/student-dashboard/progress-guide.cjsx
@@ -94,9 +94,6 @@ ProgressGuidePanels = React.createClass
 
         <ProgressGuide sections={recent} courseId={@props.courseId} />
 
-        <PracticeButton ref='practiceBtn' title='Practice my weakest topics'
-            courseId={@props.courseId} sections={practiceSections} />
-
         <BS.Button
           onClick={@viewGuide}
           className='view-learning-guide'

--- a/test/components/student-dashboard/progress-guide.spec.coffee
+++ b/test/components/student-dashboard/progress-guide.spec.coffee
@@ -9,14 +9,6 @@ GUIDE_DATA = require '../../../api/courses/1/guide.json'
 
 describe 'Student Dashboard Progress Panel', ->
 
-  it 'renders practice button', ->
-    LearningGuide.Student.actions.loaded(GUIDE_DATA, COURSE_ID)
-    Testing.renderComponent( Guide,
-      props: { courseId: COURSE_ID, sampleSizeThreshold: 3 }
-    ).then ({dom, element}) ->
-      expect(dom).not.to.be.null
-      expect(dom.querySelector('button.practice')).not.to.be.null
-
   it 'is disabled if Student Scores sections are empty', ->
     LearningGuide.Student.actions.loaded({"title": "Physics"}, COURSE_ID)
     Testing.renderComponent( Guide,
@@ -32,36 +24,4 @@ describe 'Student Dashboard Progress Panel', ->
       Testing.actions.click(dom.querySelector('.view-learning-guide'))
       expect(Testing.router.transitionTo).to.have.been.calledWith(
         'viewGuide', { courseId: COURSE_ID }
-      )
-
-  it 'practices weak sections when they are available', ->
-    LearningGuide.Student.actions.loaded(GUIDE_DATA, COURSE_ID)
-    Testing.renderComponent( Guide,
-      props: { courseId: COURSE_ID, sampleSizeThreshold: 3 }
-    ).then ({element}) ->
-      btn = ReactTestUtils.findRenderedComponentWithType(element, PracticeButton)
-      expect(btn).not.to.be.null
-      expect( btn.props.sections ).to.deep.equal(
-        LearningGuide.Helpers.weakestSections(
-          LearningGuide.Student.store.getAllSections(COURSE_ID)
-        )
-      )
-
-  it 'practices recent sections when weaker sectsions are not available', ->
-    data = _.clone(GUIDE_DATA)
-    data.children = [ data.children[0] ]
-    # mark all sections as un-forecastable
-    for section in data.children[0].children
-      section.clue.sample_size = 1
-      section.clue.sample_size_interpretation = "below"
-    LearningGuide.Student.actions.loaded(data, COURSE_ID)
-
-    Testing.renderComponent( Guide,
-      props: { courseId: COURSE_ID, sampleSizeThreshold: 3 }
-    ).then ({dom, element}) ->
-      btn = ReactTestUtils.findRenderedComponentWithType(element, PracticeButton)
-      expect( btn.props.sections ).to.deep.equal(
-        LearningGuide.Helpers.recentSections(
-          LearningGuide.Student.store.getAllSections(COURSE_ID)
-        )
       )


### PR DESCRIPTION
This is regarding task:  https://www.pivotaltracker.com/story/show/102283464

'Practice Weakest in dashboard is misleading '

This removes the button.

![image](https://cloud.githubusercontent.com/assets/954569/9857650/b2c50688-5ae9-11e5-952b-df4e32394110.png)
