### PR TITLE
Show uid everywhere an exercise is displayed

### DIFF
--- a/resources/styles/components/question.less
+++ b/resources/styles/components/question.less
@@ -240,12 +240,7 @@
     }
   }
 
-  .exercise-uid {
-    position: absolute;
-    right: @tutor-card-body-padding-horizontal;
-    bottom: 10px;
-    .tutor-exercise-question-uid();
-  }
+  .exercise-uid { .tutor-task-step-question-uid(); }
 
 } // end of .question
 

--- a/resources/styles/components/task-step/exercise/index.less
+++ b/resources/styles/components/task-step/exercise/index.less
@@ -16,4 +16,7 @@
     font-size: 0.8em;
     line-height: 150%;
   }
+
+  .exercise-uid { .tutor-task-step-question-uid(); }
+
 }

--- a/resources/styles/mixins.less
+++ b/resources/styles/mixins.less
@@ -97,6 +97,13 @@
   #fonts > .sans(1.2rem, 1.2rem);
 }
 
+.tutor-task-step-question-uid() {
+  position: absolute;
+  right: @tutor-card-body-padding-horizontal;
+  bottom: 10px;
+  .tutor-exercise-question-uid();
+}
+
 .tutor-icon-active(@scale: 1.4; @shadow: 0.12) {
   .scale(@scale);
   .box-shadow(0 1px 6px rgba(0, 0, 0, @shadow));

--- a/src/components/task-step/exercise/modes.cjsx
+++ b/src/components/task-step/exercise/modes.cjsx
@@ -227,6 +227,7 @@ ExerciseTeacherReadOnly = React.createClass
     <Question
       model={question}
       answer_id={answer_id}
+      exercise_uid={content.uid}
       correct_answer_id={correct_answer_id}
       feedback_html={feedback_html}
       onChangeAttempt={@onChangeAnswerAttempt}>

--- a/src/components/task-step/exercise/modes.cjsx
+++ b/src/components/task-step/exercise/modes.cjsx
@@ -41,7 +41,7 @@ ExerciseFreeResponse = React.createClass
 
   isContinueEnabled: ->
     {id} = @props
-    {free_response} = TaskStepStore.get(id)
+    {free_response, content} = TaskStepStore.get(id)
     response = free_response or @state.freeResponse
     response?.trim().length > 0
 
@@ -60,6 +60,7 @@ ExerciseFreeResponse = React.createClass
         value={@state.freeResponse or ''}
         onChange={@onFreeResponseChange}
         />
+      <div className="exercise-uid">{content.uid}</div>
     </div>
 
   componentDidMount: ->

--- a/src/components/task-teacher-review/exercise.cjsx
+++ b/src/components/task-teacher-review/exercise.cjsx
@@ -78,6 +78,7 @@ TaskTeacherReviewExercise = React.createClass
         model={question}
         answered_count={answered_count}
         type='teacher-review'
+        exercise_uid={@props.content.uid}
         onChangeAttempt={@onChangeAnswerAttempt}>
         {studentResponses}
       </Question>


### PR DESCRIPTION
The teacher review screens and the student free-response steps were lacking the exercise uid.

![screen shot 2015-09-14 at 2 48 53 pm](https://cloud.githubusercontent.com/assets/79566/9860906/844b9262-5af4-11e5-98ab-6ec88fab3022.png)
![screen shot 2015-09-14 at 3 09 24 pm](https://cloud.githubusercontent.com/assets/79566/9860907/845c1b1e-5af4-11e5-8511-14bd64242b63.png)