### PR TITLE
Fixing builder set date

### DIFF
--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -70,7 +70,6 @@ module.exports = React.createClass
     opensAt
 
   getQueriedDueAt: ->
-    window.moment = moment
     {due_at} = @context?.router?.getCurrentQuery() # attempt to read the due date from query params
     isNewPlan = TaskPlanStore.isNew(@props.id)
     dueAt = if due_at and isNewPlan then moment(due_at).toDate()

--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -124,14 +124,14 @@ module.exports = React.createClass
 
   setOpensAt: (value, period) ->
     {id} = @props
-    if not value._isAMomentObject
+    if Object.prototype.toString.call(value) is '[object Date]'
       value = moment(value).format(TutorDateFormat)
 
     TaskPlanActions.updateOpensAt(id, value, period?.id)
 
   setDueAt: (value, period) ->
     {id} = @props
-    if not value._isAMomentObject
+    if Object.prototype.toString.call(value) is '[object Date]'
       value = moment(value).format(TutorDateFormat)
 
     TaskPlanActions.updateDueAt(id, value, period?.id)

--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -70,6 +70,7 @@ module.exports = React.createClass
     opensAt
 
   getQueriedDueAt: ->
+    window.moment = moment
     {due_at} = @context?.router?.getCurrentQuery() # attempt to read the due date from query params
     isNewPlan = TaskPlanStore.isNew(@props.id)
     dueAt = if due_at and isNewPlan then moment(due_at).toDate()
@@ -116,8 +117,9 @@ module.exports = React.createClass
     @setPeriodDefaults()
 
   componentWillMount: ->
-    @setPeriodDefaults()
     TimeHelper.syncCourseTimezone()
+    #set the periods defaults only after the timezone has been synced
+    @setPeriodDefaults()
 
   componentWillUnmount: ->
     TimeHelper.unsyncCourseTimezone()

--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -8,6 +8,7 @@ PlanMixin = require './plan-mixin'
 BindStoreMixin = require '../bind-store-mixin'
 
 {TimeStore} = require '../../flux/time'
+TutorDateFormat = TimeStore.getFormat()
 TimeHelper = require '../../helpers/time'
 
 {TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
@@ -123,10 +124,16 @@ module.exports = React.createClass
 
   setOpensAt: (value, period) ->
     {id} = @props
+    if not value._isAMomentObject
+      value = moment(value).format(TutorDateFormat)
+
     TaskPlanActions.updateOpensAt(id, value, period?.id)
 
   setDueAt: (value, period) ->
     {id} = @props
+    if not value._isAMomentObject
+      value = moment(value).format(TutorDateFormat)
+
     TaskPlanActions.updateDueAt(id, value, period?.id)
 
   setAllPeriods: ->

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -5,10 +5,10 @@ _ = require 'underscore'
 
 {TimeStore} = require '../flux/time'
 TimeHelper = require '../helpers/time'
+TutorDateFormat = TimeStore.getFormat()
 
 DatePicker = require 'react-datepicker'
 TutorErrors = require './tutor-errors'
-TutorDateFormat = "MM/DD/YYYY"
 
 TutorInput = React.createClass
   propTypes:

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -26,8 +26,6 @@ sortTopics = (topics) ->
     TaskHelpers.chapterSectionToNumber(topic.chapter_section)
   )
 
-TutorDateFormat = 'MM/DD/YYYY'
-
 TaskPlanConfig =
 
   _stats: {}
@@ -177,10 +175,10 @@ TaskPlanConfig =
     # the BE to accept.
     if periodId
       tasking = @_findTasking(tasking_plans, periodId)
-      tasking[attr] = moment(date, [TutorDateFormat]).toDate()
+      tasking[attr] = moment(date, [TimeStore.getFormat()]).toDate()
     else
       for tasking in tasking_plans
-        tasking[attr] = moment(date, [TutorDateFormat]).toDate()
+        tasking[attr] = moment(date, [TimeStore.getFormat()]).toDate()
     @_change(id, {tasking_plans})
 
   updateOpensAt: (id, opens_at, periodId) ->

--- a/src/flux/time.coffee
+++ b/src/flux/time.coffee
@@ -5,6 +5,8 @@ flux = require 'flux-react'
 
 {makeSimpleStore} = require './helpers'
 
+TutorDateFormat = "MM/DD/YYYY"
+
 TimeConfig =
 
   setNow: (now, localNow = new Date()) ->
@@ -23,6 +25,8 @@ TimeConfig =
     getNow: (localNow = new Date()) ->
       shift = @_shiftMs or 0
       new Date(localNow.getTime() + shift)
+
+    getFormat: -> TutorDateFormat
 
 {actions, store} = makeSimpleStore(TimeConfig)
 module.exports = {TimeActions:actions, TimeStore:store}

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -43,7 +43,7 @@ describe 'Task Plan Builder', ->
     helper(NEW_READING).then ({dom}) ->
       expect(dom.querySelector('#show-periods-radio')).to.not.be.null
       expect(dom.querySelector('#hide-periods-radio')).to.not.be.null
- 
+
   it 'should not allow editable periods radio if plan is visible', ->
     helper(PUBLISHED_MODEL).then ({dom, element}) ->
       expect(dom.querySelector('#show-periods-radio')).to.be.null
@@ -117,5 +117,4 @@ describe 'Task Plan Builder', ->
   it 'sets the correct moment timezone on mount', ->
     expect((new moment()).tz()).to.be.falsy
     helper(NEW_READING).then ({dom, element}) ->
-      console.log((new moment()).tz())
       expect((new moment()).tz()).to.be.truthy

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -72,22 +72,34 @@ describe 'Task Plan Builder', ->
       dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
       expect(dueAt).to.be.falsy
 
-  it 'can update open date', ->
+  it 'can update open date with date obj', ->
     helper(NEW_READING).then ({dom, element}) ->
-      element.setOpensAt(dayAfter)
+      element.setOpensAt(new Date(dayAfter))
       opensAt = TaskPlanStore.getOpensAt(NEW_READING.id)
       expect(getDateString(opensAt)).to.be.equal(getDateString(dayAfter))
 
-  it 'can update due date', ->
+  it 'can update open date with string', ->
     helper(NEW_READING).then ({dom, element}) ->
-      element.setDueAt(dayAfter)
-      opensAt = TaskPlanStore.getDueAt(NEW_READING.id)
-      expect(getDateString(opensAt)).to.be.equal(getDateString(dayAfter))
+      element.setDueAt(getDateString(tomorrow))
+      opensAt = TaskPlanStore.getOpensAt(NEW_READING.id)
+      expect(getDateString(opensAt)).to.be.equal(getDateString(tomorrow))
+
+  it 'can update due date with date obj', ->
+    helper(NEW_READING).then ({dom, element}) ->
+      element.setDueAt(new Date(dayAfter))
+      dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
+      expect(getDateString(dueAt)).to.be.equal(getDateString(dayAfter))
+
+  it 'can update due date with string', ->
+    helper(NEW_READING).then ({dom, element}) ->
+      element.setDueAt(getDateString(tomorrow))
+      dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
+      expect(getDateString(dueAt)).to.be.equal(getDateString(tomorrow))
 
   it 'can update open date for individual period', ->
     periodId = COURSES[0].periods[0].id
     helper(NEW_READING).then ({dom, element}) ->
-      element.setOpensAt(dayAfter)
+      element.setOpensAt(new Date(dayAfter))
       opensAt = TaskPlanStore.getOpensAt(NEW_READING.id)
       expect(getDateString(opensAt)).to.be.falsy
       opensAt = TaskPlanStore.getOpensAt(NEW_READING.id, periodId)
@@ -96,7 +108,7 @@ describe 'Task Plan Builder', ->
   it 'can update due date for individual period', ->
     periodId = COURSES[0].periods[0].id
     helper(NEW_READING).then ({dom, element}) ->
-      element.setDueAt(tomorrow)
+      element.setDueAt(new Date(tomorrow))
       dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
       expect(getDateString(dueAt)).to.be.falsy
       dueAt = TaskPlanStore.getDueAt(NEW_READING.id, periodId)

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -1,4 +1,5 @@
 _ = require 'underscore'
+moment = require 'moment'
 
 Builder = require '../../../src/components/task-plan/builder'
 {TaskPlanActions, TaskPlanStore} = require '../../../src/flux/task-plan'
@@ -7,9 +8,14 @@ Builder = require '../../../src/components/task-plan/builder'
 
 {CourseListingActions, CourseListingStore} = require '../../../src/flux/course-listing'
 {CourseStore} = require '../../../src/flux/course'
+{TimeStore} = require '../../../src/flux/time'
+TutorDateFormat = TimeStore.getFormat()
 
 yesterday = (new Date(Date.now() - 1000 * 3600 * 24)).toString()
 tomorrow = (new Date(Date.now() + 1000 * 3600 * 24)).toString()
+dayAfter = (new Date(Date.now() + 1000 * 3600 * 48)).toString()
+
+getDateString = (value) -> moment(value).format(TutorDateFormat)
 
 COURSES = require '../../../api/user/courses.json'
 NEW_READING = ExtendBasePlan({id: "_CREATING_1", settings: {page_ids: []}})
@@ -65,3 +71,34 @@ describe 'Task Plan Builder', ->
       element.setAllPeriods()
       dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
       expect(dueAt).to.be.falsy
+
+  it 'can update open date', ->
+    helper(NEW_READING).then ({dom, element}) ->
+      element.setOpensAt(dayAfter)
+      opensAt = TaskPlanStore.getOpensAt(NEW_READING.id)
+      expect(getDateString(opensAt)).to.be.equal(getDateString(dayAfter))
+
+  it 'can update due date', ->
+    helper(NEW_READING).then ({dom, element}) ->
+      element.setDueAt(dayAfter)
+      opensAt = TaskPlanStore.getDueAt(NEW_READING.id)
+      expect(getDateString(opensAt)).to.be.equal(getDateString(dayAfter))
+
+  it 'can update open date for individual period', ->
+    periodId = COURSES[0].periods[0].id
+    helper(NEW_READING).then ({dom, element}) ->
+      element.setOpensAt(dayAfter)
+      opensAt = TaskPlanStore.getOpensAt(NEW_READING.id)
+      expect(getDateString(opensAt)).to.be.falsy
+      opensAt = TaskPlanStore.getOpensAt(NEW_READING.id, periodId)
+      expect(getDateString(opensAt)).to.be.equal(getDateString(dayAfter))
+
+  it 'can update due date for individual period', ->
+    periodId = COURSES[0].periods[0].id
+    helper(NEW_READING).then ({dom, element}) ->
+      element.setDueAt(tomorrow)
+      dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
+      expect(getDateString(dueAt)).to.be.falsy
+      dueAt = TaskPlanStore.getDueAt(NEW_READING.id, periodId)
+      expect(getDateString(dueAt)).to.be.equal(getDateString(tomorrow))
+

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -114,3 +114,8 @@ describe 'Task Plan Builder', ->
       dueAt = TaskPlanStore.getDueAt(NEW_READING.id, periodId)
       expect(getDateString(dueAt)).to.be.equal(getDateString(tomorrow))
 
+  it 'sets the correct moment timezone on mount', ->
+    expect((new moment()).tz()).to.be.falsy
+    helper(NEW_READING).then ({dom, element}) ->
+      console.log((new moment()).tz())
+      expect((new moment()).tz()).to.be.truthy


### PR DESCRIPTION
Fixing the bug described here: https://www.pivotaltracker.com/n/projects/1156756/stories/103133164

The bug was due to calling setDueAt and setOpensAt with a date object instead of a moment.  It should be able to handle both now.

Also adding in some specs.