### PR TITLE
show distractors and style free response tables

### DIFF
--- a/resources/styles/components/html.less
+++ b/resources/styles/components/html.less
@@ -1,0 +1,4 @@
+.has-html {
+  .tutor-tables();
+  .tutor-tables(@tutor-white, @tutor-white);
+}

--- a/resources/styles/components/question.less
+++ b/resources/styles/components/question.less
@@ -192,10 +192,11 @@
       }
 
       // For questions showing feedback,
-      // if the answers are not correct and are not chosen, hide the distracting answer.
-      // answers-answer still needs to render so that answer-letter increments as expected.
+      // if the answers are not correct and are not chosen, tone down the distracting answer.
       .answers-answer:not(.answer-correct):not(.answer-checked) .answer-label{
-        display: none;
+        &:hover {
+          background: @answer-background;
+        }
       }
 
       .answer-correct:not(.answer-checked)::before {

--- a/resources/styles/components/question.less
+++ b/resources/styles/components/question.less
@@ -69,7 +69,6 @@
 
   .size-exercise-card();
   .clearfix();
-  .tutor-tables(@tutor-white, @tutor-white);
 
   counter-reset: answer 0;
   #fonts > .sans (2rem, 3rem);

--- a/resources/styles/components/task-step/exercise/index.less
+++ b/resources/styles/components/task-step/exercise/index.less
@@ -18,5 +18,5 @@
   }
 
   .exercise-uid { .tutor-task-step-question-uid(); }
-
+  .tutor-tables(@tutor-white, @tutor-white);
 }

--- a/resources/styles/components/task-step/exercise/index.less
+++ b/resources/styles/components/task-step/exercise/index.less
@@ -18,5 +18,4 @@
   }
 
   .exercise-uid { .tutor-task-step-question-uid(); }
-  .tutor-tables(@tutor-white, @tutor-white);
 }

--- a/resources/styles/mixins.less
+++ b/resources/styles/mixins.less
@@ -199,7 +199,7 @@
   }
 }
 
-.tutor-tables(@table-header, @table-bottom-color) {
+.tutor-tables() {
   table {
     width: 100%;
     margin-bottom: 32px;
@@ -209,7 +209,6 @@
     thead {
       th {
         padding: 8px 10px;
-        background: @table-header;
         border-bottom: solid 2px @tutor-neutral-light;
       }
       tr:first-of-type:not(:last-child) th {
@@ -227,7 +226,6 @@
     }
     tbody {
       border-top: solid 4px @tutor-neutral-light;
-      border-bottom: solid 4px @table-bottom-color;
     }
     caption,
     thead tr:first-of-type:not(:last-child) th{
@@ -235,6 +233,19 @@
      #fonts > .sans(2rem, 3rem);
      font-weight: 900;
      color: @tutor-neutral-darker;
+    }
+  }
+}
+
+.tutor-tables(@table-header, @table-bottom-color) {
+  table {
+    thead {
+      th {
+        background: @table-header;
+      }
+    }
+    tbody {
+      border-bottom: solid 4px @table-bottom-color;
     }
   }
 }

--- a/resources/styles/tutor.less
+++ b/resources/styles/tutor.less
@@ -23,6 +23,7 @@
 @import './global/icons';
 
 // Component Styling
+@import './components/html';
 @import './components/loadable';
 @import './components/course-calendar/index';
 @import './components/close';


### PR DESCRIPTION
## Before
![screen shot 2015-09-15 at 10 49 33 am](https://cloud.githubusercontent.com/assets/2483873/9883862/4148602c-5ba2-11e5-8895-5271a90e2d76.png)
![screen shot 2015-09-15 at 11 56 29 am](https://cloud.githubusercontent.com/assets/2483873/9883867/46785c28-5ba2-11e5-9311-79eeaedbee03.png)
Table styles are missing for free response, they are in multiple choice portion


## After
![screen shot 2015-09-15 at 12 03 19 pm](https://cloud.githubusercontent.com/assets/2483873/9883863/414f8e2e-5ba2-11e5-84f0-30a9f51ec8a4.png)
![screen shot 2015-09-15 at 11 55 06 am](https://cloud.githubusercontent.com/assets/2483873/9883866/467750a8-5ba2-11e5-94ad-804af5f73c34.png)



## Tables cascading as expected
after changing the mixin to be a base one with variations in a separate mixin
## only under `.has-html`
![screen shot 2015-09-17 at 12 32 51 pm](https://cloud.githubusercontent.com/assets/2483873/9941125/e371680c-5d38-11e5-80a4-e4bcf825c01d.png)
## in `.book-content-mixin`, custom colors on top of `.has-html`
![screen shot 2015-09-17 at 12 33 10 pm](https://cloud.githubusercontent.com/assets/2483873/9941128/e3792b64-5d38-11e5-905e-9276540f55d2.png)
## in a question, in reference view, and in `has-html`
![screen shot 2015-09-17 at 12 32 49 pm](https://cloud.githubusercontent.com/assets/2483873/9941126/e372472c-5d38-11e5-9815-fb31790e46f1.png)
