### PR TITLE
Show new tab indicator on external tasks

### DIFF
--- a/resources/styles/book-content/target.less
+++ b/resources/styles/book-content/target.less
@@ -8,13 +8,7 @@
   padding-top: @tutor-navbar-height;
 }
 
-a[target=_blank] {
-  &::after {
-    .fa-icon();
-    content: @fa-var-external-link;
-    margin: 0 4px 0 6px;
-  }
-}
+a[target=_blank] { .tutor-external-link-indicator(); }
 
 figure {
   &:target, .target {

--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -25,6 +25,7 @@
   }
 }
 
+@import './external';
 @import './reading';
 @import './video';
 @import './ends';

--- a/resources/styles/components/task-step/external.less
+++ b/resources/styles/components/task-step/external.less
@@ -1,0 +1,3 @@
+.external-step {
+  a[target=_blank] { .tutor-external-link-indicator(); }
+}

--- a/resources/styles/mixins.less
+++ b/resources/styles/mixins.less
@@ -253,6 +253,7 @@
   &::after {
     .fa-icon();
     display: inline;
+    font-size: 85%;
     content: " @{fa-var-external-link}";
   }
 }

--- a/resources/styles/mixins.less
+++ b/resources/styles/mixins.less
@@ -249,6 +249,15 @@
   }
 }
 
+.tutor-external-link-indicator() {
+  &::after {
+    .fa-icon();
+    display: inline;
+    content: " @{fa-var-external-link}";
+  }
+}
+
+
 // If you want to use these please uncomment.
 //
 // .tutor-shadow(3) {

--- a/resources/styles/mixins.less
+++ b/resources/styles/mixins.less
@@ -253,7 +253,7 @@
   &::after {
     .fa-icon();
     display: inline;
-    font-size: 85%;
+    font-size: 80%;
     content: " @{fa-var-external-link}";
   }
 }


### PR DESCRIPTION
Converts the less styles to a mixin and shares it between book-content
and the external tasks.


This also shrinks the indicator a bit to make it only 80% of the text size.
Before:
![screen shot 2015-09-15 at 3 20 20 pm](https://cloud.githubusercontent.com/assets/79566/9888920/6656168c-5bbd-11e5-99f4-979b843f58e8.png)

![screen shot 2015-09-15 at 3 19 56 pm](https://cloud.githubusercontent.com/assets/79566/9888923/6a05142c-5bbd-11e5-8e94-08b62af24fe2.png)


After:
![screen shot 2015-09-15 at 4 21 09 pm](https://cloud.githubusercontent.com/assets/79566/9890487/cc84d044-5bc5-11e5-9aa3-a4ae0b9e8647.png)



![screen shot 2015-09-15 at 4 19 14 pm](https://cloud.githubusercontent.com/assets/79566/9890466/aa784788-5bc5-11e5-8a9e-2c98459c2df8.png)
