### PR TITLE
Use SPDX identifier for license

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/openstax/tutor-js.git"
   },
   "author": "Philip Schatz <http://philschatz.com>",
-  "license": "AGPL3",
+  "license": "AGPL-3.0",
   "bugs": {
     "url": "https://github.com/openstax/tutor-js/issues"
   },


### PR DESCRIPTION
No UI changes other than `npm` commands will no longer complain about "license should be a valid SPDX license expression"