### PR TITLE
stash answer change when waiting for server, save when next ready

### DIFF
--- a/src/components/task-step/exercise/modes.cjsx
+++ b/src/components/task-step/exercise/modes.cjsx
@@ -87,6 +87,17 @@ ExerciseMultiChoice = React.createClass
     onStepCompleted: React.PropTypes.func.isRequired
     onNextStep: React.PropTypes.func
 
+  queueAnswer: (answer) ->
+    @setState(queuedAnswer: answer)
+
+  unqueueAnswer: ->
+    @queueAnswer(null)
+
+  componentDidUpdate: (prevProps, prevState) ->
+    {id} = @props
+    isReady = not TaskStepStore.isLoading(id) and not TaskStepStore.isSaving(id)
+    @onAnswerChanged(@state.queuedAnswer) if @state.queuedAnswer? and isReady
+
   renderBody: ->
     {id} = @props
     {content, free_response, answer_id, correct_answer_id, feedback_html} = TaskStepStore.get(id)
@@ -106,7 +117,13 @@ ExerciseMultiChoice = React.createClass
 
   onAnswerChanged: (answer) ->
     {id} = @props
-    TaskStepActions.setAnswerId(id, answer.id)
+    isReady = not TaskStepStore.isLoading(id) and not TaskStepStore.isSaving(id)
+
+    if isReady
+      TaskStepActions.setAnswerId(id, answer.id)
+      @unqueueAnswer() if @state.queuedAnswer?.id is answer.id
+    else
+      @queueAnswer(answer)
 
   isContinueEnabled: ->
     {id} = @props


### PR DESCRIPTION
Alternate solution to #749, fix for #751

![750](https://cloud.githubusercontent.com/assets/2483873/9968920/1e69c188-5e11-11e5-9bd0-cb0f3b380671.gif)
Clicking on answers while save is still pending shows a change to the student as choice has been selected.  The answer/server save doesn't happen until the the free response is saved

## Fix
1. Answer a free response
1. Choose a multiple choice answer
  * You are able to click and select answer
  * Answer does not actually send a `PATCH` to server until previous response is returned
