### PR TITLE
ref book nav hide and show

### DIFF
--- a/src/components/reference-book/reference-book.cjsx
+++ b/src/components/reference-book/reference-book.cjsx
@@ -75,7 +75,9 @@ module.exports = React.createClass
     ev?.preventDefault() # stops react-router from scrolling to top
 
   onMenuClick: ->
-    @toggleMenuState() unless window.innerWidth > MENU_VISIBLE_BREAKPOINT
+    # menu state toggling needs to happen after new state
+    # is received and rendered from router for new section
+    _.defer(@toggleMenuState) unless window.innerWidth > MENU_VISIBLE_BREAKPOINT
 
   toggleMenuState: (ev) ->
     @setState(isMenuVisible: not @state.isMenuVisible)

--- a/src/components/reference-book/reference-book.cjsx
+++ b/src/components/reference-book/reference-book.cjsx
@@ -26,8 +26,11 @@ module.exports = React.createClass
 
   getPageState: ->
     {cnxId} = @context.router.getCurrentParams()
+    {isMenuVisible} = @state if @state?
+    isMenuVisible ?= not cnxId
+
     # Pop open the menu unless the page was explicitly navigated to
-    isMenuVisible: not cnxId
+    isMenuVisible: isMenuVisible
     pageProps: @getPageProps()
 
   setPageState: ->
@@ -36,7 +39,7 @@ module.exports = React.createClass
   getInitialState: ->
     @getPageState()
 
-  componentWillReceiveProps: (nextProps) ->
+  componentWillReceiveProps: ->
     @setPageState()
 
   componentWillMount: ->
@@ -84,15 +87,15 @@ module.exports = React.createClass
     courseDataProps = @getCourseDataProps(courseId)
 
     course = CourseStore.get(courseId)
-    classnames = ["reference-book"]
+    classnames = ['reference-book']
     classnames.push('menu-open') if @state.isMenuVisible
     if course and _.findWhere(course.roles, type: 'teacher')
       toggleTeacher = @toggleTeacherEdition
       teacherLinkText = if @state.showTeacherEdition
         classnames.push('is-teacher')
-        "Hide Teacher Edition"
+        'Hide Teacher Edition'
       else
-        "Show Teacher Edition"
+        'Show Teacher Edition'
 
     <div {...courseDataProps} className={classnames.join(' ')}>
       <NavBar

--- a/test/components/reference-book.spec.coffee
+++ b/test/components/reference-book.spec.coffee
@@ -22,6 +22,7 @@ FIRST_PAGE  = '1.1'
 SECOND_PAGE = '1.2'
 SECOND_PAGE_ID = '0e58aa87-2e09-40a7-8bf3-269b2fa16510'
 THIRD_PAGE  = '1.3'
+THIRD_PAGE_ID = '0e58aa87-2e09-40a7-8bf3-269b2fa16511'
 
 PAGE = require '../../api/pages/0e58aa87-2e09-40a7-8bf3-269b2fa16509.json'
 
@@ -111,12 +112,54 @@ describe 'Reference Book Component', ->
     expect(@state.div.querySelector('.page-wrapper > .prev').href)
       .to.contain(FIRST_PAGE)
 
+  it 'preserves menu toggle when navigating forward and back between pages', ->
+    toggle = @state.div.querySelector('.menu-toggle')
+    nextControl = @state.div.querySelector('.page-wrapper > .next')
+
+    page = ReactTestUtils.findRenderedComponentWithType(@state.book, Page)
+    ReferenceBookPageActions.loaded(PAGE, SECOND_PAGE_ID)
+
+    commonActions.click(toggle)
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.not.contain('menu-open')
+    # button:0 is a mystery argument needed by ReactRouter, taken from their specs
+    commonActions.click(nextControl, {button: 0})
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.not.contain('menu-open')
+
+    ReferenceBookPageActions.loaded(PAGE, THIRD_PAGE_ID)
+    commonActions.click(nextControl, {button: 0})
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.not.contain('menu-open')
+
+    commonActions.click(toggle)
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.contain('menu-open')
+
+    prevControl = @state.div.querySelector('.page-wrapper > .prev')
+    commonActions.click(prevControl, {button: 0})
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.contain('menu-open')
 
   it 'sets the menu item to be active based on the current page', ->
     selection = @state.div.querySelector(".toc [data-section='#{FIRST_PAGE}'] a")
     expect(selection).not.to.be.null
     expect(_.toArray(selection.classList)).to.include('active')
 
+  it 'closes TOC when using TOC to nav and window is small', (done) ->
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.contain('menu-open')
+
+    nextSelection = @state.div.querySelector(".toc [data-section='#{SECOND_PAGE}'] a")
+    ReferenceBookPageActions.loaded(PAGE, SECOND_PAGE_ID)
+
+    commonActions.click(nextSelection)
+    # menu toggle is deferred, test for it needs to be deferred as well.
+    _.defer( =>
+      expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+        .to.not.contain('menu-open')
+      done()
+    )
 
 describe 'Reference Book Component for a non-default ecosystem', ->
 


### PR DESCRIPTION
### candidate for closing in favor of #757
#757 addresses #754 as well and is better for components overall

## Fixes
- [x] on prev and next click, TOC preserves open or close state
- [x] on TOC section click, TOC closes in small view  -- @nathanstitt maybe a separate PR or this one?
  * setState toggling the menu close doesn't get to complete before the shell re-renders from the route change

## Tests
- [x] prev-next `menu-open` class preserved
- [x] TOC item `menu-open` absent after click

## Prev and Next click, preserves TOC open/close state
![fix](https://cloud.githubusercontent.com/assets/2483873/9973300/fd30355e-5e35-11e5-9fd6-a152bebdd2cb.gif)

## TOC item click, auto-closes TOC
![fix](https://cloud.githubusercontent.com/assets/2483873/10000022/4b9ad228-605f-11e5-9d75-1696a51eff7f.gif)
