### PR TITLE
Remove courseId and router references from reference view

### DIFF
--- a/src/components/reference-book/index.cjsx
+++ b/src/components/reference-book/index.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 Router = require 'react-router'
 BS = require 'react-bootstrap'
 _  = require 'underscore'
+classnames = require 'classnames'
 
 {ReferenceBookActions, ReferenceBookStore} = require '../../flux/reference-book'
 {CourseActions, CourseStore} = require '../../flux/course'
@@ -50,14 +51,12 @@ ReferenceBookShell = React.createClass
     <TeacherContentToggle onChange={@setTeacherContent} />
 
   renderBook: ->
-    classnames = []
-    classnames.push('is-teacher') if @state.isShowingTeacherContent
     {courseId, ecosystemId} = @state
 
     <ReferenceBook
         navbarControls={@renderNavbarControls()}
         section={@state.section}
-        className={classnames.join(' ')}
+        className={classnames('is-teacher': @state.isShowingTeacherContent)}
         dataProps={@getCourseDataProps(courseId) if courseId}
         ecosystemId={ecosystemId}
     />

--- a/src/components/reference-book/navbar.cjsx
+++ b/src/components/reference-book/navbar.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-Router = require 'react-router'
 BS = require 'react-bootstrap'
 _  = require 'underscore'
 
@@ -14,28 +13,19 @@ module.exports = React.createClass
   mixins: [BindStoreMixin]
   bindStore: ReferenceBookPageStore
   propTypes:
-    teacherLinkText: React.PropTypes.string
+    ecosystemId: React.PropTypes.string.isRequired
     toggleTocMenu: React.PropTypes.func.isRequired
-    showTeacherEdition: React.PropTypes.func
-    courseId: React.PropTypes.string.isRequired
     section: React.PropTypes.string.isRequired
     isMenuVisible: React.PropTypes.bool.isRequired
+    extraControls: React.PropTypes.element
 
   renderSectionTitle: ->
-    {section, courseId, ecosystemId} = @props
+    {section, ecosystemId} = @props
     title = ReferenceBookStore.getPageTitle({section, ecosystemId})
 
     <BS.Nav navbar className="section-title">
       <ChapterSection section={section} />
       {title}
-    </BS.Nav>
-
-
-  renderTeacher: ->
-    <BS.Nav navbar right>
-      <BS.Button className="btn-sm teacher-edition" onClick={@props.showTeacherEdition}>
-        {@props.teacherLinkText}
-      </BS.Button>
     </BS.Nav>
 
   render: ->
@@ -45,17 +35,18 @@ module.exports = React.createClass
           <SlideOutMenuToggle isVisible={@props.isMenuVisible} />
         </BS.NavItem>
       </BS.Nav>
-      <BS.Nav className="full-width-only" navbar>
+      <BS.Nav className='full-width-only' navbar>
         <li>
           <i className='ui-brand-logo' />
         </li>
       </BS.Nav>
       {@renderSectionTitle()}
-      <BS.Nav className="full-width-only" navbar right>
+      <BS.Nav className='full-width-only' navbar right>
         <li>
           <i className='ui-rice-logo' />
         </li>
       </BS.Nav>
-      {@renderTeacher() if @props.showTeacherEdition}
-
+      <BS.Nav navbar right>
+        {@props.extraControls}
+      </BS.Nav>
     </BS.Navbar>

--- a/src/components/reference-book/page-shell.cjsx
+++ b/src/components/reference-book/page-shell.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-BS = require 'react-bootstrap'
 _  = require 'underscore'
 
 LoadableItem = require '../loadable-item'

--- a/src/components/reference-book/page-shell.cjsx
+++ b/src/components/reference-book/page-shell.cjsx
@@ -1,0 +1,53 @@
+React = require 'react'
+BS = require 'react-bootstrap'
+_  = require 'underscore'
+
+LoadableItem = require '../loadable-item'
+ReferenceBookPage = require './page'
+
+{Invalid} = require '../index'
+{ReferenceBookPageActions, ReferenceBookPageStore} = require '../../flux/reference-book-page'
+
+ReferenceBookPageShell = React.createClass
+
+  propTypes:
+    cnxId: React.PropTypes.string.isRequired
+
+  getDefaultState: ->
+    previousPageProps: null
+
+  componentWillReceiveProps: (nextProps) ->
+    @setState(previousPageProps: @props)
+
+  isAnotherPage: (previousPageProps, currentProps) ->
+    previousPageProps? and previousPageProps.cnxId? and not _.isEqual(previousPageProps, currentProps)
+
+  renderLoading: (previousPageProps, currentProps, refreshButton) ->
+    if @isAnotherPage(previousPageProps, currentProps)
+      loading = <ReferenceBookPage
+        {...previousPageProps}
+        className='page-loading loadable is-loading'>
+        {refreshButton}
+      </ReferenceBookPage>
+    else
+      loading = <div className='loadable is-loading'>Loading... {refreshButton}</div>
+
+    loading
+
+  renderLoaded: ->
+    <ReferenceBookPage {...@props}/>
+
+  render: ->
+    if @props.cnxId?
+      <LoadableItem
+        id={@props.cnxId}
+        store={ReferenceBookPageStore}
+        actions={ReferenceBookPageActions}
+        renderLoading={_.partial(@renderLoading, @state?.previousPageProps, @props)}
+        renderItem={@renderLoaded}
+      />
+    else
+      <Invalid />
+
+
+module.exports = ReferenceBookPageShell

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -28,22 +28,20 @@ module.exports = React.createClass
     ReferenceBookStore.getPageTitle(@props)
 
   prevLink: (info) ->
-    {query} = @props
     params = _.extend({}, @context.router.getCurrentParams(),
       section: @sectionFormat(info.prev.chapter_section))
     <Router.Link className='nav prev' to='viewReferenceBookSection'
-      query={query}
+      query={@context.router.getCurrentQuery()}
       params={params}>
       <div className='triangle' />
     </Router.Link>
 
   nextLink: (info) ->
-    {query} = @props
     params = _.extend({}, @context.router.getCurrentParams(),
       section: @sectionFormat(info.next.chapter_section))
 
     <Router.Link className='nav next' to='viewReferenceBookSection'
-      query={query}
+      query={@context.router.getCurrentQuery()}
       params={params}>
       <div className='triangle' />
     </Router.Link>

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 Router = require 'react-router'
 _  = require 'underscore'
+classnames = require 'classnames'
 
 HTML = require '../html'
 ArbitraryHtmlAndMath = require '../html'
@@ -98,7 +99,7 @@ module.exports = React.createClass
     React.render(<ReferenceBookExerciseShell exerciseAPIUrl={exerciseAPIUrl}/>, exerciseNode) if exerciseNode?
 
   render: ->
-    {courseId, cnxId, className, ecosystemId} = @props
+    {courseId, cnxId, ecosystemId} = @props
     # read the id from props, or failing that the url
     page = ReferenceBookPageStore.get(cnxId)
     info = ReferenceBookStore.getPageInfo({ecosystemId, cnxId})
@@ -110,12 +111,7 @@ module.exports = React.createClass
       .replace(/^[\s\S]*<body[\s\S]*?>/, '')
       .replace(/<\/body>[\s\S]*$/, '')
 
-    if className?
-      className += ' page-wrapper'
-    else
-      className = 'page-wrapper'
-
-    <div className={className}>
+    <div className={classnames('page-wrapper', @props.className)}>
       {@props.children}
       {@prevLink(info) if info.prev}
       <ArbitraryHtmlAndMath className='page' block html={html} />

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -1,6 +1,5 @@
 React = require 'react'
 Router = require 'react-router'
-BS = require 'react-bootstrap'
 _  = require 'underscore'
 
 HTML = require '../html'

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -18,7 +18,6 @@ ChapterSectionMixin = require '../chapter-section-mixin'
 module.exports = React.createClass
   displayName: 'ReferenceBookPage'
   propTypes:
-    courseId: React.PropTypes.string.isRequired
     cnxId: React.PropTypes.string.isRequired
   mixins: [BookContentMixin, GetPositionMixin, ChapterSectionMixin]
   contextTypes:
@@ -30,19 +29,22 @@ module.exports = React.createClass
 
   prevLink: (info) ->
     {query} = @props
-
+    params = _.extend({}, @context.router.getCurrentParams(),
+      section: @sectionFormat(info.prev.chapter_section))
     <Router.Link className='nav prev' to='viewReferenceBookSection'
       query={query}
-      params={courseId: @props.courseId, section: @sectionFormat(info.prev.chapter_section)}>
+      params={params}>
       <div className='triangle' />
     </Router.Link>
 
   nextLink: (info) ->
     {query} = @props
+    params = _.extend({}, @context.router.getCurrentParams(),
+      section: @sectionFormat(info.next.chapter_section))
 
     <Router.Link className='nav next' to='viewReferenceBookSection'
       query={query}
-      params={courseId: @props.courseId, section: @sectionFormat(info.next.chapter_section)}>
+      params={params}>
       <div className='triangle' />
     </Router.Link>
 

--- a/src/components/reference-book/reference-book.cjsx
+++ b/src/components/reference-book/reference-book.cjsx
@@ -75,7 +75,6 @@ module.exports = React.createClass
         <Menu
           ecosystemId={@props.ecosystemId}
           activeSection={@state.section}
-          opened={@state.isMenuVisible}
           onMenuSelection={@onMenuClick}
         />
 

--- a/src/components/reference-book/reference-book.cjsx
+++ b/src/components/reference-book/reference-book.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 _  = require 'underscore'
+classnames = require 'classnames'
 
 {ReferenceBookActions, ReferenceBookStore} = require '../../flux/reference-book'
 
@@ -56,11 +57,10 @@ module.exports = React.createClass
     ev?.preventDefault() # needed to prevent scrolling to top
 
   render: ->
-    classnames = ["reference-book"]
-    classnames.push(@props.className) if @props.className
-    classnames.push('menu-open') if @state.isMenuVisible
+    className = classnames 'reference-book', @props.className,
+      'menu-open': @state.isMenuVisible
 
-    <div {...@props.dataProps} className={classnames.join(' ')}>
+    <div {...@props.dataProps} className={className}>
 
       <NavBar
         ecosystemId={@props.ecosystemId}

--- a/src/components/reference-book/reference-book.cjsx
+++ b/src/components/reference-book/reference-book.cjsx
@@ -1,14 +1,12 @@
 React = require 'react'
-BS = require 'react-bootstrap'
 _  = require 'underscore'
+
+{ReferenceBookActions, ReferenceBookStore} = require '../../flux/reference-book'
 
 NavBar = require './navbar'
 Menu = require './slide-out-menu'
 ChapterSectionMixin = require '../chapter-section-mixin'
 PageShell = require './page-shell'
-
-{ReferenceBookActions, ReferenceBookStore} = require '../../flux/reference-book'
-
 WindowResizeListenerMixin = require '../resize-listener-mixin'
 
 # menu width (300) + page width (1000) + 50 px padding

--- a/src/components/reference-book/slide-out-menu.cjsx
+++ b/src/components/reference-book/slide-out-menu.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-BS = require 'react-bootstrap'
 ReferenceBookTOC = require './toc'
 
 module.exports = React.createClass

--- a/src/components/reference-book/slide-out-menu.cjsx
+++ b/src/components/reference-book/slide-out-menu.cjsx
@@ -6,7 +6,7 @@ module.exports = React.createClass
   displayName: 'SlideOutMenu'
   propTypes:
     onMenuSelection: React.PropTypes.func.isRequired
-
+    routeLinkTarget: React.PropTypes.string
 
   render: ->
     <div className='menu'>

--- a/src/components/reference-book/teacher-content-toggle.cjsx
+++ b/src/components/reference-book/teacher-content-toggle.cjsx
@@ -1,0 +1,27 @@
+React = require 'react'
+BS = require 'react-bootstrap'
+
+TeacherContentToggle = React.createClass
+
+  getInitialState: ->
+    isShowing: false
+
+  propTypes:
+    onChange: React.PropTypes.func.isRequired
+
+  onClick: ->
+    isShowing = not @state.isShowing
+    @setState({isShowing})
+    @props.onChange(isShowing)
+
+  render: ->
+    teacherLinkText = if @state.isShowing
+      'Hide Teacher Edition'
+    else
+      'Show Teacher Edition'
+
+    <BS.Button className='btn-sm teacher-edition' onClick={@onClick}>
+      {teacherLinkText}
+    </BS.Button>
+
+module.exports = TeacherContentToggle

--- a/src/components/reference-book/toc.cjsx
+++ b/src/components/reference-book/toc.cjsx
@@ -25,7 +25,7 @@ Section = React.createClass
     @setState(skipZeros: false)
 
   render: ->
-    {activeSection, query} = @props
+    {activeSection} = @props
     section = @sectionFormat(@props.section.chapter_section)
 
     className = if section is activeSection then 'active' else ''
@@ -38,7 +38,7 @@ Section = React.createClass
           className={className}
           onClick={@props.onMenuSelection}
           to={@props.routeLinkTarget}
-          query={query}
+          query={@context.router.getCurrentQuery()}
         >
           <span className="section-number">{section}</span>
           {@props.section.title}
@@ -48,7 +48,6 @@ Section = React.createClass
         <li key={child.id} data-section={@sectionFormat(child.chapter_section)}>
           <Section
             activeSection={activeSection}
-            query={query}
             onMenuSelection={@props.onMenuSelection}
             section={child} />
         </li> }

--- a/src/components/reference-book/toc.cjsx
+++ b/src/components/reference-book/toc.cjsx
@@ -11,32 +11,42 @@ Section = React.createClass
   mixins: [ChapterSectionMixin]
   propTypes:
     section: React.PropTypes.object.isRequired
+    activeSection: React.PropTypes.string.isRequired
     onMenuSelection: React.PropTypes.func.isRequired
+    routeLinkTarget: React.PropTypes.string
+
+  getDefaultProps: ->
+    routeLinkTarget: 'viewReferenceBookSection'
+
+  contextTypes:
+    router: React.PropTypes.func
+
   componentWillMount: ->
     @setState(skipZeros: false)
+
   render: ->
-    {courseId, activeSection, query} = @props
-    sections = @sectionFormat(@props.section.chapter_section)
-    activeSection = @sectionFormat(activeSection)
-    className = 'active' if sections is activeSection
+    {activeSection, query} = @props
+    section = @sectionFormat(@props.section.chapter_section)
+
+    className = if section is activeSection then 'active' else ''
+    params = _.extend({}, @context.router.getCurrentParams(), {section: section})
 
     <ul className="section" data-depth={@props.section.chapter_section.length}>
-      <li data-section={sections}>
+      <li data-section={section}>
         <Router.Link
+          params={params}
           className={className}
           onClick={@props.onMenuSelection}
-          to='viewReferenceBookSection'
-          params={{courseId: courseId, section: sections}}
+          to={@props.routeLinkTarget}
           query={query}
         >
-          <span className="section-number">{sections}</span>
+          <span className="section-number">{section}</span>
           {@props.section.title}
         </Router.Link>
       </li>
       { _.map @props.section.children, (child) =>
         <li key={child.id} data-section={@sectionFormat(child.chapter_section)}>
           <Section
-            courseId={courseId}
             activeSection={activeSection}
             query={query}
             onMenuSelection={@props.onMenuSelection}
@@ -49,7 +59,9 @@ module.exports = React.createClass
   displayName: 'ReferenceBookTOC'
   mixins: [ChapterSectionMixin]
   propTypes:
-    onMenuSelection: React.PropTypes.func
+    onMenuSelection: React.PropTypes.func.isRequired
+    activeSection:   React.PropTypes.string.isRequired
+
   componentWillMount: ->
     @setState(skipZeros: false)
   componentDidMount:  -> @scrollSelectionIntoView()
@@ -70,14 +82,13 @@ module.exports = React.createClass
 
 
   render: ->
-    {courseId, section, ecosystemId, query} = @props
+    {activeSection, ecosystemId, query} = @props
     toc = ReferenceBookStore.getToc(ecosystemId)
     <div className="toc">
       { _.map toc.children, (child) =>
         <Section
-          courseId={courseId}
           query={query}
-          activeSection={section}
+          activeSection={activeSection}
           onMenuSelection={@props.onMenuSelection}
           key={child.id}
           section={child} /> }

--- a/src/components/reference-book/toc.cjsx
+++ b/src/components/reference-book/toc.cjsx
@@ -1,7 +1,6 @@
 React = require 'react'
 Router = require 'react-router'
 _  = require 'underscore'
-BS = require 'react-bootstrap'
 
 {ReferenceBookActions, ReferenceBookStore} = require '../../flux/reference-book'
 ChapterSectionMixin = require '../chapter-section-mixin'

--- a/src/flux/course.coffee
+++ b/src/flux/course.coffee
@@ -97,6 +97,9 @@ CourseConfig =
       periods = @_get(courseId).periods or []
       sortedPeriods = PeriodHelper.sort(periods)
 
+    isTeacher: (courseId) ->
+      !!_.findWhere(@_get(courseId)?.roles, type: 'teacher')
+
 extendConfig(CourseConfig, new CrudConfig())
 {actions, store} = makeSimpleStore(CourseConfig)
 module.exports = {CourseActions:actions, CourseStore:store}

--- a/src/flux/reference-book.coffee
+++ b/src/flux/reference-book.coffee
@@ -40,7 +40,8 @@ ReferenceBookConfig = {
     # Takes a ecosystemId and a chapter_section specifier
     # which is a string joined with dots i.e. "1.2.3"
     getChapterSectionPage: ({ecosystemId, section}) ->
-      parts = _.map(section.split('.'), (part) -> parseInt(part, 10) )
+      parts = if _.isArray(section) then section else
+        _.map(section.split('.'), (part) -> parseInt(part, 10) )
       toc = @_get(ecosystemId)?['0']
       section = findChapterSection(toc, parts)
       if section

--- a/src/router.cjsx
+++ b/src/router.cjsx
@@ -87,7 +87,7 @@ routes = (
       <Router.DefaultRoute name="viewReferenceBookFirstPage" handler={ReferenceBookPageShell}/>
 
       <Route path='section/:section'
-        name='viewReferenceBookSection' handler={ReferenceBookPageShell} />
+        name='viewReferenceBookSection' handler={ReferenceBookShell} />
 
       <Route path='page/:cnxId' name='viewReferenceBookPage' handler={ReferenceBookPageShell}/>
 

--- a/test/components/reference-book.spec.coffee
+++ b/test/components/reference-book.spec.coffee
@@ -154,12 +154,10 @@ describe 'Reference Book Component', ->
     ReferenceBookPageActions.loaded(PAGE, SECOND_PAGE_ID)
 
     commonActions.click(nextSelection)
-    # menu toggle is deferred, test for it needs to be deferred as well.
-    _.defer( =>
-      expect(_.toArray(@state.div.querySelector('.reference-book').classList))
-        .to.not.contain('menu-open')
-      done()
-    )
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.not.contain('menu-open')
+    done()
+
 
 describe 'Reference Book Component for a non-default ecosystem', ->
 
@@ -214,4 +212,3 @@ describe 'Reference Book Component for a non-default ecosystem', ->
     _.each(linkAddresses, (linkAddress) ->
       expect(linkAddress).to.contain("?ecosystemId=#{ECO_ID}")
     )
-

--- a/test/components/reference-book.spec.coffee
+++ b/test/components/reference-book.spec.coffee
@@ -22,6 +22,7 @@ FIRST_PAGE  = '1.1'
 SECOND_PAGE = '1.2'
 SECOND_PAGE_ID = '0e58aa87-2e09-40a7-8bf3-269b2fa16510'
 THIRD_PAGE  = '1.3'
+THIRD_PAGE_ID = '0e58aa87-2e09-40a7-8bf3-269b2fa16511'
 
 PAGE = require '../../api/pages/0e58aa87-2e09-40a7-8bf3-269b2fa16509.json'
 
@@ -111,12 +112,54 @@ describe 'Reference Book Component', ->
     expect(@state.div.querySelector('.page-wrapper > .prev').href)
       .to.contain(FIRST_PAGE)
 
+  it 'preserves menu toggle when navigating forward and back between pages', ->
+    toggle = @state.div.querySelector('.menu-toggle')
+    nextControl = @state.div.querySelector('.page-wrapper > .next')
+
+    page = ReactTestUtils.findRenderedComponentWithType(@state.book, Page)
+    ReferenceBookPageActions.loaded(PAGE, SECOND_PAGE_ID)
+
+    commonActions.click(toggle)
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.not.contain('menu-open')
+    # button:0 is a mystery argument needed by ReactRouter, taken from their specs
+    commonActions.click(nextControl, {button: 0})
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.not.contain('menu-open')
+
+    ReferenceBookPageActions.loaded(PAGE, THIRD_PAGE_ID)
+    commonActions.click(nextControl, {button: 0})
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.not.contain('menu-open')
+
+    commonActions.click(toggle)
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.contain('menu-open')
+
+    prevControl = @state.div.querySelector('.page-wrapper > .prev')
+    commonActions.click(prevControl, {button: 0})
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.contain('menu-open')
 
   it 'sets the menu item to be active based on the current page', ->
     selection = @state.div.querySelector(".toc [data-section='#{FIRST_PAGE}'] a")
     expect(selection).not.to.be.null
     expect(_.toArray(selection.classList)).to.include('active')
 
+  it 'closes TOC when using TOC to nav and window is small', (done) ->
+    expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+      .to.contain('menu-open')
+
+    nextSelection = @state.div.querySelector(".toc [data-section='#{SECOND_PAGE}'] a")
+    ReferenceBookPageActions.loaded(PAGE, SECOND_PAGE_ID)
+
+    commonActions.click(nextSelection)
+    # menu toggle is deferred, test for it needs to be deferred as well.
+    _.defer( =>
+      expect(_.toArray(@state.div.querySelector('.reference-book').classList))
+        .to.not.contain('menu-open')
+      done()
+    )
 
 describe 'Reference Book Component for a non-default ecosystem', ->
 


### PR DESCRIPTION
This is a step towards repurposing the reference view components for QA in #747 

It removes all the logic for getting the ecosystem from a courseId into the shell so the main component can be wrapped by different components.

As a side effect of the extraction, I think it also fixes the same bugs that #753, fixes #754