### PR TITLE
Use .tutor for the webpack config's entry configuration

### DIFF
--- a/webpack.config.coffee
+++ b/webpack.config.coffee
@@ -8,14 +8,15 @@ else
   { test: /\.less$/,   loaders: LOADERS.concat('style-loader', 'css-loader', 'less-loader') }
 
 module.exports =
-  entry: [
-    './resources/styles/tutor.less'
-    './index.coffee'
-  ]
-
   cache: true
 
   devtool: if isProduction then undefined else 'source-map'
+
+  entry:
+    tutor: [
+      './index.coffee',
+      './resources/styles/tutor.less'
+    ]
 
   output:
     path: if isProduction then 'dist' else '/'
@@ -46,8 +47,7 @@ module.exports =
     publicPath: 'http://localhost:8000/dist/'
     historyApiFallback: true
     inline: true
-    port: process.env['PORT'] or 8000
-
+    port: 8000
     # It suppress error shown in console, so it has to be set to false.
     quiet: false,
     # It suppress everything except error, so it has to be set to false as well


### PR DESCRIPTION
Looks like #730 and #728 had a subtle conflict where #730 expected the webpack's entry config to have a `.tutor` prefix, but #728 removed it.