### PR TITLE
dont show view student responses button

### DIFF
--- a/src/components/task-teacher-review/exercise.cjsx
+++ b/src/components/task-teacher-review/exercise.cjsx
@@ -45,6 +45,7 @@ TaskTeacherReviewExercise = React.createClass
       className={freeResponsesClasses}/>
 
   renderFreeResponse: ->
+    return null unless @expectsFreeResponse()
     {answers} = @props
     {showAnswers} = @state
     question = @getQuestion()

--- a/src/components/task-teacher-review/exercise.cjsx
+++ b/src/components/task-teacher-review/exercise.cjsx
@@ -36,7 +36,6 @@ TaskTeacherReviewExercise = React.createClass
     formats.indexOf('free-response') > -1
 
   renderNoFreeResponse: ->
-    return null unless @expectsFreeResponse()
     freeResponsesClasses = 'teacher-review-answers has-no-answers'
     header = <i>No student text responses</i>
 
@@ -45,7 +44,6 @@ TaskTeacherReviewExercise = React.createClass
       className={freeResponsesClasses}/>
 
   renderFreeResponse: ->
-    return null unless @expectsFreeResponse()
     {answers} = @props
     {showAnswers} = @state
     question = @getQuestion()
@@ -72,7 +70,8 @@ TaskTeacherReviewExercise = React.createClass
     {answers, answered_count} = @props
     question = @getQuestion()
 
-    studentResponses = if answers.length then @renderFreeResponse() else @renderNoFreeResponse()
+    if @expectsFreeResponse()
+      studentResponses = if answers.length then @renderFreeResponse() else @renderNoFreeResponse()
 
     <CardBody className='task-step' pinned={false}>
       <Question


### PR DESCRIPTION
...  when the question does not have free response portion

## Bug
![problem](https://cloud.githubusercontent.com/assets/2483873/10081127/064a19a2-62b9-11e5-9cde-148f17f6b557.gif)

## Fixed
![screen shot 2015-09-24 at 12 35 01 pm](https://cloud.githubusercontent.com/assets/2483873/10081141/12c7bf18-62b9-11e5-92d5-1f3201243e64.png)

## If problem has not been worked
"No Student Text Responses" still only shows on questions that have a free response portion
![screen shot 2015-09-24 at 12 40 09 pm](https://cloud.githubusercontent.com/assets/2483873/10081208/6ab37c1c-62b9-11e5-9c5f-542cc08d9c9e.png)

