### PR TITLE
Use relative path for assets in stylesheets

### DIFF
--- a/webpack.config.coffee
+++ b/webpack.config.coffee
@@ -21,7 +21,7 @@ module.exports =
   output:
     path: if isProduction then 'dist' else '/'
     filename: '[name].js'
-    publicPath: if isProduction then '/dist/' else 'http://localhost:8000/dist/'
+    publicPath: if isProduction then '' else 'http://localhost:8000/dist/'
 
   plugins: [
     new ExtractTextPlugin("tutor.css")


### PR DESCRIPTION
I'm not sure why this broke now, it's always been set to "/dist/" since we went to webpack.  Suddenly the url in stylesheets was having it pre-pended though.