### PR TITLE
Fix test runner starting up multiple copies

### DIFF
--- a/test/config/test-runner.coffee
+++ b/test/config/test-runner.coffee
@@ -15,8 +15,8 @@ class TestRunner
   pendingSpecs: []
 
   runKarma: ->
-    return if isKarmaRunning or _.isEmpty(@pendingSpecs)
-    isKarmaRunning = true
+    return if @isKarmaRunning or _.isEmpty(@pendingSpecs)
+    @isKarmaRunning = true
     specs = _.unique @pendingSpecs
     gutil.log("[specs]", gutil.colors.green("testing #{specs.join(' ')}"))
     @pendingSpecs = []
@@ -28,7 +28,7 @@ class TestRunner
     ], {stdio: 'inherit'} )
 
     child.on('exit', (exitCode) =>
-      isKarmaRunning = false
+      @isKarmaRunning = false
       duration = moment.duration(moment().diff(startAt))
       elapsed = duration.minutes() + ':' + duration.seconds()
       gutil.log("[test]", gutil.colors.green("done. #{specs.length} specs in #{elapsed}"))


### PR DESCRIPTION
Made an error when the code was translated into a runner class and didn't convert the sentinel variable checks into an instance var