### PR TITLE
Display feedback for exercise question choices

### DIFF
--- a/resources/styles/components/task-plan/homework/exercises.less
+++ b/resources/styles/components/task-plan/homework/exercises.less
@@ -168,7 +168,12 @@ label.exercises-section-label {
         }
         .answer {
           display: table;
+        }
+        .feedback {
+          display: table;
           margin-bottom: 5px;
+          color: @tutor-neutral;
+          margin-left: 1.5rem;
         }
       }
     }
@@ -232,5 +237,3 @@ label.exercises-section-label {
     .panel-body { padding: 20px 100px; }
   }
 }
-
-

--- a/src/components/task-plan/homework/exercises.cjsx
+++ b/src/components/task-plan/homework/exercises.cjsx
@@ -17,7 +17,10 @@ ExerciseCardMixin =
 
     <div className={classes.join(' ')}>
       <div className="answer-letter" />
-      <ArbitraryHtmlAndMath className="answer" block={false} html={answer.content_html} />
+      <div className="answer">
+        <ArbitraryHtmlAndMath className="choice" block={false} html={answer.content_html} />
+        <ArbitraryHtmlAndMath className="feedback" block={false} html={answer.feedback_html} />
+      </div>
     </div>
 
   renderTags: (tag) ->
@@ -52,7 +55,6 @@ ExerciseCardMixin =
       <ArbitraryHtmlAndMath className='-stimulus' block={true} html={content.stimulus_html} />
       <ArbitraryHtmlAndMath className='stem' block={true} html={question.stem_html} />
       <div className='answers-table'>{renderedAnswers}</div>
-
       <div className='exercise-tags'>{renderedTags}</div>
     </BS.Panel>
 


### PR DESCRIPTION
Displays the question feedback to the teacher when they select exercises.  Will also be displayed on QA view since it shares the mixin as part of #782 

I'm undecided if the indent should match the question or be increased (as shown in screenshot)..  I felt like it might be confused as part of the question if it matched, even though it is displayed as grey.

<img width="1577" alt="screen shot 2015-10-01 at 6 22 19 pm" src="https://cloud.githubusercontent.com/assets/79566/10236292/91e6ba82-6869-11e5-98d4-3c2d67eeabd2.png">