### PR TITLE
Speedup Mathjax processing on a pages with many HTML components

### DIFF
--- a/src/helpers/mathjax.coffee
+++ b/src/helpers/mathjax.coffee
@@ -23,7 +23,7 @@ cleanMathArtifacts = ->
 
 
 # Typesets the entire document
-TypesetDocument = ->
+typesetDocument = ->
 
   nodes = document.querySelectorAll(MATH_SELECTOR)
   return if _.isEmpty(nodes)
@@ -45,7 +45,7 @@ TypesetDocument = ->
 
 # Install a debounce around typesetting function so that it will only run once
 # every 10ms even if called multiple calls times in that period
-TypesetDocument = _.debounce( TypesetDocument, 10)
+typesetDocument = _.debounce( typesetDocument, 10)
 
 
 typesetMath = (root) ->
@@ -59,7 +59,7 @@ typesetMath = (root) ->
   # render MathML with MathJax
   window.MathJax.Hub.Queue(['Typeset', MathJax.Hub, root]) if hasMath
 
-  TypesetDocument()
+  typesetDocument()
 
 
 


### PR DESCRIPTION
On the Teacher and QA views of exercises, mathjax was being invoked
several hundred times (twice per each answer on each question).  This modifies it so it will
only perform once pass on the entire document.  There was a concern about seeing flicker as it renders but I don't observe any.  

Before Mathjax was taking 4,627ms to switch from section 2.0 to 2.1 of physics in qa view.  Both timings were taken after a full page reload.
![screen shot 2015-10-02 at 5 12 16 pm](https://cloud.githubusercontent.com/assets/79566/10259016/4560edd4-6929-11e5-9ddd-6fb1602465e4.png)



With a single pass the time drops to 85ms


![screen shot 2015-10-02 at 5 14 15 pm](https://cloud.githubusercontent.com/assets/79566/10259015/454da1a2-6929-11e5-8ca7-da28f8f983db.png)