### PR TITLE
looking for ways to improve calendar code

### DIFF
--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -70,6 +70,12 @@ CourseDuration = React.createClass
       .each(@setDuration(viewingDuration))
       .filter(@isInDuration(viewingDuration))
       .sortBy((plan) ->
+        moment(plan.published_at).valueOf()
+      )
+      .sortBy((plan) ->
+        plan.duration.end.valueOf()
+      )
+      .sortBy((plan) ->
         plan.duration.start.valueOf()
       )
       .value()
@@ -160,8 +166,12 @@ CourseDuration = React.createClass
     dueDates = _.pluck(plan.tasking_plans, 'due_at')
 
     plan.duration = @_getDurationFromMoments(dueDates)
-    plan.openRange = @_getDurationRange(plan)
-    plan.isOpen = plan.openRange.start.isBefore(referenceDate)
+
+  setPlanStatus: (plan) ->
+    {referenceDate} = @props
+    openRange = @_getDurationRange(plan)
+
+    plan.isOpen = openRange.start.isBefore(referenceDate)
     plan.isPublished = (plan.published_at? and plan.published_at)
     plan.isPublishing = @isPlanPublishing(plan)
     plan.isTrouble = plan.is_trouble
@@ -175,6 +185,8 @@ CourseDuration = React.createClass
       plan.mode = 'day'
       durationMethod = camelCase("set-duration-#{plan.mode}")
       @[durationMethod](plan)
+
+      @setPlanStatus(plan)
 
   isInDuration: (duration) ->
     (plan) ->
@@ -196,7 +208,7 @@ CourseDuration = React.createClass
     # Make a simple plan that omits duration/time related information
     # and adds back in only the relevant time information needed by the
     # CoursePlan component.
-    simplePlan = _.omit(plan, 'duration', 'tasking_plans', 'openRange')
+    simplePlan = _.omit(plan, 'duration', 'tasking_plans')
     earliestOpensAt = @_getEarliestOpensAt(plan)
     simplePlan.opensAt = moment(earliestOpensAt).format('M/D')
     simplePlan.durationLength = plan.duration.length('days')

--- a/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -92,7 +92,7 @@ TeacherTaskPlanListing = React.createClass
 
     date = @getDateFromParams()
 
-    loadPlansList = TeacherTaskPlanStore.getActiveCoursePlans.bind(TeacherTaskPlanStore, courseId)
+    loadPlansList = _.partial(TeacherTaskPlanStore.getActiveCoursePlans, courseId)
 
     loadedCalendarProps = {loadPlansList, courseId, date}
 
@@ -108,7 +108,6 @@ TeacherTaskPlanListing = React.createClass
           id={courseId}
           renderItem={-> <CourseCalendar {...loadedCalendarProps}/>}
           renderLoading={-> <CourseCalendar className='calendar-loading'/>}
-          update={@update}
         />
 
       </BS.Panel>


### PR DESCRIPTION
## plans seem to be sorted randomly
why is the draft in the middle of the two multi-day/multi-row plans?
![screen shot 2015-10-06 at 4 58 21 pm](https://cloud.githubusercontent.com/assets/2483873/10323857/6f0fb94c-6c4b-11e5-90ae-4b88418806fc.png)


## plans sorted
1. last published at
1. end time
1. start time
such that the two multi-day/multi-row plans stack adjacently
![screen shot 2015-10-06 at 5 00 41 pm](https://cloud.githubusercontent.com/assets/2483873/10323887/ad72e9fc-6c4b-11e5-821d-59b4133e2606.png)
