### PR TITLE
Display reference view ecosystem spy mode info as a pseudo footer 

### DIFF
--- a/resources/styles/components/reference-book/page.less
+++ b/resources/styles/components/reference-book/page.less
@@ -40,7 +40,14 @@
     // only visible when "spy mode" is enabled
     .ecosystem-info {
       .tutor-spy-mode-content();
-      width: 90%;
+      position: fixed;
+      bottom: 0;
+      right: 0;
+      left: 0;
+      padding: 0;
+      margin: 0;
+      border: 0;
+      .tutor-shadow(2);
     }
   }
 
@@ -97,6 +104,9 @@
   &.menu-open {
     @media screen and (min-width: (@reference-book-page-width + @reference-book-menu-width + 50px) ) {
       .page-wrapper{ margin-left: @reference-book-menu-width; }
+    }
+    .content .ecosystem-info{
+      left: @reference-book-menu-width;
     }
   }
 


### PR DESCRIPTION
Kajal thought it'd be best displayed in this fashion so that it's not missed way at the bottom of the content.

![screen shot 2015-10-08 at 2 10 40 pm](https://cloud.githubusercontent.com/assets/79566/10377045/b4c0fa88-6dc6-11e5-9cf3-1c0430289281.png)