### PR TITLE
Fix open date when opening with due_at equals to tomorrow or today

### DIFF
--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -16,6 +16,8 @@ TimeHelper = require '../../helpers/time'
 {CourseStore}   = require '../../flux/course'
 {UnsavedStateMixin} = require '../unsaved-state'
 
+ISO_DATE_FORMAT = 'YYYY-MM-DD'
+
 module.exports = React.createClass
   displayName: 'TaskPlanBuilder'
   mixins: [PlanMixin, BindStoreMixin, UnsavedStateMixin]
@@ -57,21 +59,21 @@ module.exports = React.createClass
       tasking
 
   getOpensAtDefault: ->
-    moment(TimeStore.getNow()).add(1, 'day').toDate()
+    moment(TimeStore.getNow()).add(1, 'day').format(ISO_DATE_FORMAT)
 
   getQueriedOpensAt: ->
     {opens_at} = @context?.router?.getCurrentQuery() # attempt to read the open date from query params
     isNewPlan = TaskPlanStore.isNew(@props.id)
-    opensAt = if opens_at and isNewPlan then moment(opens_at).toDate()
+    opensAt = if opens_at and isNewPlan then TimeHelper.getMomentPreserveDate(opens_at).toDate()
     if not opensAt
       # default open date is tomorrow
       opensAt = @getOpensAtDefault()
 
     # if there is a queried due date, make sure it's not the same as the open date
     dueAt = @getQueriedDueAt()
-    if dueAt? and moment(dueAt).isSame(opensAt, 'day')
+    if dueAt? and not TimeHelper.getMomentPreserveDate(dueAt).isAfter(opensAt, 'day')
       # make open date today if default due date is tomorrow
-      opensAt = moment(TimeStore.getNow()).toDate()
+      opensAt = moment(TimeStore.getNow()).format(ISO_DATE_FORMAT)
 
     opensAt
 

--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -71,9 +71,14 @@ module.exports = React.createClass
 
     # if there is a queried due date, make sure it's not the same as the open date
     dueAt = @getQueriedDueAt()
-    if dueAt? and not TimeHelper.getMomentPreserveDate(dueAt).isAfter(opensAt, 'day')
-      # make open date today if default due date is tomorrow
-      opensAt = moment(TimeStore.getNow()).format(ISO_DATE_FORMAT)
+
+    if dueAt?
+      dueAtMoment = TimeHelper.getMomentPreserveDate(dueAt)
+      # there's a corner case is certain timezones where isAfter doesn't quite cut it
+      # and we need to check that the ISO strings don't match
+      unless (dueAtMoment.isAfter(opensAt, 'day') and dueAtMoment.format(ISO_DATE_FORMAT) isnt opensAt)
+        # make open date today if default due date is tomorrow
+        opensAt = moment(TimeStore.getNow()).format(ISO_DATE_FORMAT)
 
     opensAt
 

--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -162,7 +162,7 @@ module.exports = React.createClass
     TaskPlanActions.setPeriods(@props.id, periods)
 
     #set dates for all periods
-    taskingDueAt = TaskPlanStore.getDueAt(@props.id)
+    taskingDueAt = TaskPlanStore.getDueAt(@props.id) or @getQueriedDueAt()
 
     if taskingDueAt
       @setDueAt(taskingDueAt)

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -130,8 +130,8 @@ TaskPlanConfig =
     {tasking_plans} = @_getPlan(id)
     # do all the tasking_plans have the same date?
     dates = _.compact _.uniq _.map(tasking_plans, (plan) ->
-      date = TimeHelper.getMomentPreserveDate(plan[attr]).toDate()
-      if isNaN(date.getTime()) then 0 else date.getTime()
+      date = TimeHelper.getMomentPreserveDate(plan[attr]).toDate() if plan[attr]?
+      if isNaN(date?.getTime()) then 0 else date.getTime()
     )
     if dates.length is 1 then new Date(_.first(dates)) else null
 

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -439,7 +439,7 @@ TaskPlanConfig =
     getOpensAt: (id, periodId) ->
       if periodId?
         tasking = @_getPeriodDates(id, periodId)
-        opensAt = new Date(tasking?.opens_at) if tasking?.opens_at?
+        opensAt = TimeHelper.getMomentPreserveDate(tasking?.opens_at).toDate() if tasking?.opens_at?
       else
         # default opens_at to 1 day from now
         opensAt = @_getTaskingsCommonDate(id, 'opens_at')
@@ -449,7 +449,7 @@ TaskPlanConfig =
     getDueAt: (id, periodId) ->
       if periodId?
         tasking = @_getPeriodDates(id, periodId)
-        dueAt = new Date(tasking?.due_at) if tasking?.due_at?
+        dueAt = TimeHelper.getMomentPreserveDate(tasking?.due_at).toDate() if tasking?.due_at?
       else
         dueAt = @_getTaskingsCommonDate(id, 'due_at')
 

--- a/src/helpers/time.coffee
+++ b/src/helpers/time.coffee
@@ -58,7 +58,10 @@ TimeHelper =
     tzdetect.matches()
 
   getMomentPreserveDate: (value, args...) ->
-    moment.utc(value, args...).hour(12)
+    if @_local
+      return moment(value, args...).tz(@_local).hour(12)
+
+    moment(value, args...).hour(12)
 
   getLocal: ->
     @_local

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -18,8 +18,8 @@ yesterday = (new Date(Date.now() - 1000 * 3600 * 24)).toString()
 tomorrow = (new Date(Date.now() + 1000 * 3600 * 24)).toString()
 dayAfter = (new Date(Date.now() + 1000 * 3600 * 48)).toString()
 
-getDateString = (value) -> TimeHelper.getMomentPreserveDate(moment(value)).format(TutorDateFormat)
-getISODateString = (value) -> TimeHelper.getMomentPreserveDate(moment(value)).format(ISO_DATE_FORMAT)
+getDateString = (value) -> moment(value).format(TutorDateFormat)
+getISODateString = (value) -> moment(value).format(ISO_DATE_FORMAT)
 
 COURSES = require '../../../api/user/courses.json'
 NEW_READING = ExtendBasePlan({id: "_CREATING_1", settings: {page_ids: []}}, false, false)

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -71,10 +71,12 @@ describe 'Task Plan Builder', ->
 
   it 'does not load a default due at for all periods', ->
     helper(NEW_READING).then ({dom, element}) ->
+      dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
+      expect(dueAt).to.not.be.ok
       element.setIndividualPeriods()
       element.setAllPeriods()
       dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
-      expect(dueAt).to.be.falsy
+      expect(dueAt).to.not.be.ok
 
   it 'can clear due at when there is no common due at', ->
     firstPeriod = COURSES[0].periods[0].id
@@ -93,7 +95,7 @@ describe 'Task Plan Builder', ->
 
       #due at should be cleared
       dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
-      expect(dueAt).to.be.falsy
+      expect(dueAt).to.not.be.ok
 
   it 'can update open date with date obj', ->
     helper(NEW_READING).then ({dom, element}) ->
@@ -124,7 +126,7 @@ describe 'Task Plan Builder', ->
     helper(NEW_READING).then ({dom, element}) ->
       element.setOpensAt(new Date(dayAfter))
       opensAt = TaskPlanStore.getOpensAt(NEW_READING.id)
-      expect(getDateString(opensAt)).to.be.falsy
+      expect(getDateString(opensAt)).to.not.be.ok
       opensAt = TaskPlanStore.getOpensAt(NEW_READING.id, periodId)
       expect(getDateString(opensAt)).to.be.equal(getDateString(dayAfter))
 
@@ -133,7 +135,7 @@ describe 'Task Plan Builder', ->
     helper(NEW_READING).then ({dom, element}) ->
       element.setDueAt(new Date(tomorrow))
       dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
-      expect(getDateString(dueAt)).to.be.falsy
+      expect(getDateString(dueAt)).to.not.be.ok
       dueAt = TaskPlanStore.getDueAt(NEW_READING.id, periodId)
       expect(getDateString(dueAt)).to.be.equal(getDateString(tomorrow))
 

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -18,8 +18,8 @@ yesterday = (new Date(Date.now() - 1000 * 3600 * 24)).toString()
 tomorrow = (new Date(Date.now() + 1000 * 3600 * 24)).toString()
 dayAfter = (new Date(Date.now() + 1000 * 3600 * 48)).toString()
 
-getDateString = (value) -> moment.utc(moment(value)).format(TutorDateFormat)
-getISODateString = (value) -> moment.utc(moment(value)).format(ISO_DATE_FORMAT)
+getDateString = (value) -> moment(value).format(TutorDateFormat)
+getISODateString = (value) -> moment(value).format(ISO_DATE_FORMAT)
 
 COURSES = require '../../../api/user/courses.json'
 NEW_READING = ExtendBasePlan({id: "_CREATING_1", settings: {page_ids: []}}, false, false)

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -110,6 +110,25 @@ describe 'Task Plan Builder', ->
       dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
       expect(dueAt).to.not.be.ok
 
+  it 'will default to queried due date if no common due at with a due date query string', ->
+    firstPeriod = COURSES[0].periods[0]
+    secondPeriod = COURSES[0].periods[1]
+
+    helper(NEW_READING, {due_at: getISODateString(dayAfter)} ).then ({dom, element}) ->
+      #set individual periods
+      element.setIndividualPeriods()
+
+      #set due dates to be different
+      element.setDueAt(getDateString(tomorrow), firstPeriod)
+      element.setDueAt(getDateString(dayAfter), secondPeriod)
+
+      #set all periods
+      element.setAllPeriods()
+
+      #due at should reset to query string due at
+      dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
+      expect(getDateString(dueAt)).to.be.equal(getDateString(dayAfter))
+
   it 'can update open date with date obj', ->
     helper(NEW_READING).then ({dom, element}) ->
       element.setOpensAt(new Date(dayAfter))

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -18,8 +18,8 @@ yesterday = (new Date(Date.now() - 1000 * 3600 * 24)).toString()
 tomorrow = (new Date(Date.now() + 1000 * 3600 * 24)).toString()
 dayAfter = (new Date(Date.now() + 1000 * 3600 * 48)).toString()
 
-getDateString = (value) -> moment(value).format(TutorDateFormat)
-getISODateString = (value) -> moment(value).format(ISO_DATE_FORMAT)
+getDateString = (value) -> TimeHelper.getMomentPreserveDate(moment(value)).format(TutorDateFormat)
+getISODateString = (value) -> TimeHelper.getMomentPreserveDate(moment(value)).format(ISO_DATE_FORMAT)
 
 COURSES = require '../../../api/user/courses.json'
 NEW_READING = ExtendBasePlan({id: "_CREATING_1", settings: {page_ids: []}}, false, false)
@@ -31,6 +31,19 @@ PUBLISHED_MODEL = ExtendBasePlan({
 
 helper = (model, routerQuery) -> PlanRenderHelper(model, Builder, {}, {}, routerQuery)
 
+fakePeriodDisable = (element, disabledPeriod) ->
+  fakeEvent =
+    target:
+      checked: false
+
+  element.togglePeriodEnabled(disabledPeriod, fakeEvent)
+
+fakePeriodEnable = (element, enabledPeriod) ->
+  fakeEvent =
+    target:
+      checked: true
+
+  element.togglePeriodEnabled(enabledPeriod, fakeEvent)
 
 describe 'Task Plan Builder', ->
   beforeEach ->
@@ -79,8 +92,8 @@ describe 'Task Plan Builder', ->
       expect(dueAt).to.not.be.ok
 
   it 'can clear due at when there is no common due at', ->
-    firstPeriod = COURSES[0].periods[0].id
-    secondPeriod = COURSES[0].periods[1].id
+    firstPeriod = COURSES[0].periods[0]
+    secondPeriod = COURSES[0].periods[1]
 
     helper(NEW_READING).then ({dom, element}) ->
       #set individual periods
@@ -121,22 +134,55 @@ describe 'Task Plan Builder', ->
       dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
       expect(getDateString(dueAt)).to.be.equal(getDateString(tomorrow))
 
-  it 'can update open date for individual period', ->
-    periodId = COURSES[0].periods[0].id
+  it 'can disable individual periods', ->
+    disabledPeriod = COURSES[0].periods[1]
+    anotherDisabledPeriod = COURSES[0].periods[7]
+
     helper(NEW_READING).then ({dom, element}) ->
-      element.setOpensAt(new Date(dayAfter))
+      element.setIndividualPeriods()
+
+      fakePeriodDisable(element, disabledPeriod)
+      fakePeriodDisable(element, anotherDisabledPeriod)
+
+      taskings = TaskPlanStore.getEnabledTaskings(NEW_READING.id)
+      expect(taskings).to.have.length(COURSES[0].periods.length - 2)
+      expect(taskings).to.not.have.members([disabledPeriod, anotherDisabledPeriod])
+
+  it 'can update open date for individual period', ->
+    period = COURSES[0].periods[0]
+    anotherPeriod = COURSES[0].periods[2]
+    disabledPeriod = COURSES[0].periods[1]
+    anotherDisabledPeriod = COURSES[0].periods[7]
+
+    helper(NEW_READING).then ({dom, element}) ->
+      element.setIndividualPeriods()
+
+      fakePeriodDisable(element, disabledPeriod)
+      fakePeriodDisable(element, anotherDisabledPeriod)
+      element.setOpensAt(new Date(dayAfter), period)
+
       opensAt = TaskPlanStore.getOpensAt(NEW_READING.id)
-      expect(getDateString(opensAt)).to.not.be.ok
-      opensAt = TaskPlanStore.getOpensAt(NEW_READING.id, periodId)
+      expect(opensAt).to.not.be.ok
+
+      opensAt = TaskPlanStore.getOpensAt(NEW_READING.id, period.id)
       expect(getDateString(opensAt)).to.be.equal(getDateString(dayAfter))
 
   it 'can update due date for individual period', ->
-    periodId = COURSES[0].periods[0].id
+    period = COURSES[0].periods[0]
+    disabledPeriod = COURSES[0].periods[1]
+    anotherPeriod = COURSES[0].periods[2]
+
     helper(NEW_READING).then ({dom, element}) ->
-      element.setDueAt(new Date(tomorrow))
+      element.setIndividualPeriods()
+
+      fakePeriodDisable(element, disabledPeriod)
+      element.setDueAt(new Date(dayAfter), anotherPeriod)
+      element.setDueAt(new Date(tomorrow), period)
+
       dueAt = TaskPlanStore.getDueAt(NEW_READING.id)
-      expect(getDateString(dueAt)).to.not.be.ok
-      dueAt = TaskPlanStore.getDueAt(NEW_READING.id, periodId)
+      expect(dueAt).to.not.be.ok
+
+      dueAt = TaskPlanStore.getDueAt(NEW_READING.id, period.id)
       expect(getDateString(dueAt)).to.be.equal(getDateString(tomorrow))
 
   it 'sets the correct moment timezone on mount', ->


### PR DESCRIPTION
## Fixes
 - [x] open date bug with due_at query string
  - [ ] need to test again throughout a date
 - [x] due at not clearing bug
 - [x] tests for falsy times when expected
 - [x] tests for individual periods date changing

## Adds
  - [x] test for period disabling
  - [x] test for default due at after disable and enable all periods