### PR TITLE
reset specific plan on edit cancel

### DIFF
--- a/src/components/task-plan/plan-mixin.coffee
+++ b/src/components/task-plan/plan-mixin.coffee
@@ -89,7 +89,7 @@ PlanMixin =
 
   reset: ->
     {id, courseId} = @props
-    TaskPlanActions.reset(id)
+    TaskPlanActions.resetPlan(id)
     @goBackToCalendar()
 
   # TODO move to helper type thing.


### PR DESCRIPTION
## Bug
after hitting cancel while editing any existing plan and then going back to look at it
![screen shot 2015-10-09 at 5 06 52 pm](https://cloud.githubusercontent.com/assets/2483873/10406758/6285eb38-6ea8-11e5-8d90-fc336544820a.png)


## Fix
after hitting cancel while editing any existing plan and then going back to look at it
![screen shot 2015-10-09 at 5 10 21 pm](https://cloud.githubusercontent.com/assets/2483873/10406765/7b70e332-6ea8-11e5-8a3e-e90a9f910117.png)
