### PR TITLE
Setting open date maximum on builder

### DIFF
--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -287,6 +287,7 @@ module.exports = React.createClass
     {taskingOpensAt, taskingDueAt} = @getDefaultPlanDates()
     commonOpensAt = taskingOpensAt
     commonDueAt = taskingDueAt
+    maxOpensAt = new moment(TaskPlanStore.getDueAt(@props.id)).subtract(1, 'day').toDate()
 
     opensAt = <BS.Col sm=4 md=3>
       <TutorDateInput
@@ -297,7 +298,7 @@ module.exports = React.createClass
         onChange={@setOpensAt}
         disabled={@state.showingPeriods or @state.isVisibleToStudents or not @state.isEditable}
         min={TimeStore.getNow()}
-        max={TaskPlanStore.getDueAt(@props.id)}
+        max={maxOpensAt}
         value={commonOpensAt}
         currentLocale={@state.currentLocale} />
     </BS.Col>
@@ -365,6 +366,7 @@ module.exports = React.createClass
 
   renderEnabledTasking: (plan) ->
     {taskingOpensAt, taskingDueAt} = @getDefaultPlanDates(plan.id)
+    maxOpensAt = new moment(TaskPlanStore.getDueAt(@props.id, plan.id)).subtract(1, 'day').toDate()
 
     <BS.Row key={plan.id} className="tasking-plan tutor-date-input">
       <BS.Col sm=4 md=3>
@@ -381,7 +383,7 @@ module.exports = React.createClass
           label="Open Date"
           required={@state.showingPeriods}
           min={TimeStore.getNow()}
-          max={TaskPlanStore.getDueAt(@props.id, plan.id)}
+          max={maxOpensAt}
           onChange={_.partial(@setOpensAt, _, plan)}
           value={ taskingOpensAt }
           currentLocale={@state.currentLocale} />

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -130,8 +130,8 @@ TaskPlanConfig =
     {tasking_plans} = @_getPlan(id)
     # do all the tasking_plans have the same date?
     dates = _.compact _.uniq _.map(tasking_plans, (plan) ->
-      date = TimeHelper.getMomentPreserveDate(plan[attr]).toDate()
-      if isNaN(date.getTime()) then 0 else date.getTime()
+      date = TimeHelper.getMomentPreserveDate(plan[attr]).toDate() if plan[attr]
+      if not date or isNaN(date.getTime()) then 0 else date.getTime()
     )
     if dates.length is 1 then new Date(_.first(dates)) else null
 


### PR DESCRIPTION
Fix for: https://www.pivotaltracker.com/story/show/105018176

~~And also found a bug recently introduced where adding a new homework from the button on the calendar was setting a due at.~~  Nevermind, looks like someone put in the same fix that I did already.

Before fix:
![screen shot 2015-10-12 at 11 53 45 pm](https://cloud.githubusercontent.com/assets/6434717/10432309/c50ba7b6-713c-11e5-9437-5a3b20556dfc.png)

After fix:
![screen shot 2015-10-12 at 11 52 07 pm](https://cloud.githubusercontent.com/assets/6434717/10432311/c8e7ed22-713c-11e5-827f-dce65f47777b.png)
