### PR TITLE
Stop using course title for styling

### DIFF
--- a/resources/styles/components/course-listings.less
+++ b/resources/styles/components/course-listings.less
@@ -49,18 +49,14 @@
     }
 
     &[data-category=physics] {
-      .tutor-course-item {
-        .tutor-physics-cover-background();
-      }
+      &[data-title=Physics]{ .tutor-course-item { .tutor-physics-cover-background(); } }
       .tutor-course-alt-link {
         color: @tutor-book-hs-physics-primary;
         background-color: @tutor-book-hs-physics-secondary;
       }
     }
     &[data-category=biology] {
-      .tutor-course-item {
-        .tutor-biology-cover-background();
-      }
+      &[data-title=Biology]{ .tutor-course-item { .tutor-biology-cover-background(); }
       .tutor-course-alt-link {
         color: @tutor-book-ap-bio-primary;
         background-color: @tutor-book-ap-bio-secondary;

--- a/resources/styles/components/course-listings.less
+++ b/resources/styles/components/course-listings.less
@@ -5,9 +5,15 @@
 .course-listing {
   margin-top: @course-listing-buffer;
 
+  .row {
+    margin-top: @course-listing-buffer;
+    &:first-child{
+      margin-top: 0;
+    }
+  }
+
   .tutor-booksplash-course-item {
     position: relative;
-
     .tutor-course-item {
       height: @course-listing-item-height;
       width: 100%;

--- a/resources/styles/components/course-listings.less
+++ b/resources/styles/components/course-listings.less
@@ -11,7 +11,7 @@
     .tutor-course-item {
       height: @course-listing-item-height;
       width: 100%;
-      display: block;
+      display: inline;
       overflow: hidden;
       background-repeat: no-repeat;
       background-size: contain;
@@ -20,20 +20,17 @@
 
       &::before {
         content: 'Go to ';
-        display: block;
-        margin-top: -40px;
+        height: 100%;
         font-style: italic;
+        display: block;
+        width: @course-listing-item-offset;
+        float: left;
+        overflow: hidden;
         .transition(margin .1s ease-in);
       }
-
       &:hover {
         background-position-y: 30px;
-
-        &::before {
-          margin-top: 0;
-        }
       }
-
     }
 
     .tutor-course-alt-link {
@@ -48,18 +45,43 @@
       }
     }
 
-    &[data-category=physics] {
-      &[data-title=Physics]{ .tutor-course-item { .tutor-physics-cover-background(); } }
-      .tutor-course-alt-link {
-        color: @tutor-book-hs-physics-primary;
-        background-color: @tutor-book-hs-physics-secondary;
+    &[data-category]{
+      .flex-display();
+      .tutor-course-item {
+        .flex(1);
+        font-family: 'Helvetica', 'Lato', sans-serif;
+        font-size: 18rem;
+        line-height: 18rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-weight: 800;
       }
     }
+    &[data-category=physics] {
+      .tutor-course-item {
+        color: @tutor-book-hs-physics-secondary;
+        background-color: @tutor-book-hs-physics-primary;
+      }
+      // use SVG background if the title matches
+      &[data-title=Physics]{
+        .tutor-course-item {
+          .tutor-physics-cover-background();
+          font-size: 0px; // hide text title
+        }
+      }
+    }
+
     &[data-category=biology] {
-      &[data-title=Biology]{ .tutor-course-item { .tutor-biology-cover-background(); }
-      .tutor-course-alt-link {
-        color: @tutor-book-ap-bio-primary;
-        background-color: @tutor-book-ap-bio-secondary;
+      .tutor-course-item {
+        color: @tutor-book-ap-bio-secondary;
+        background-color: @tutor-book-ap-bio-primary;
+      }
+      // use SVG background if the title matches
+      &[data-title=Biology]{
+        .tutor-course-item {
+          .tutor-biology-cover-background();
+          font-size: 0px; // hide text title
+        }
       }
     }
   }
@@ -71,10 +93,7 @@
       .tutor-course-item {
         &::before {
           font-size: 4rem;
-          content: 'Go to ';
-          height: 100%;
           width: @course-listing-item-offset;
-          display: block;
           padding: @course-listing-buffer/2 0 0 @course-listing-buffer/2;
           margin-left: -@course-listing-item-offset;
           margin-top: 0;
@@ -82,7 +101,6 @@
 
         &:hover {
           background-position: 200px 0;
-
           &::before {
             margin-left: 0;
           }

--- a/src/components/course-listing.cjsx
+++ b/src/components/course-listing.cjsx
@@ -57,7 +57,7 @@ CourseListing = React.createClass
         courseLink = <Router.Link
           className='tutor-course-item'
           to='viewStudentDashboard'
-          params={{courseId}}></Router.Link>
+          params={{courseId}}>{course.name}</Router.Link>
 
       if isTeacher
         if courseLink?
@@ -69,7 +69,7 @@ CourseListing = React.createClass
           courseLink = <Router.Link
             className='tutor-course-item'
             to='taskplans'
-            params={{courseId}}></Router.Link>
+            params={{courseId}}>{course.name}</Router.Link>
 
       courseDataProps = @getCourseDataProps(courseId)
       <BS.Row>

--- a/src/flux/course.coffee
+++ b/src/flux/course.coffee
@@ -87,9 +87,9 @@ CourseConfig =
     # This is currently bassed on the course title.
     # eventually the backend will provide it as part of the course's metadata.
     getCategory: (courseId) ->
-      this.exports
-        .getShortName.call(this, courseId)
-        .toLowerCase()
+      return @_get(courseId).catalog_offering_identifier or (
+        this.exports.getShortName.call(this, courseId).toLowerCase()
+      )
 
     getShortName: (courseId) ->
       title = @_get(courseId)?.name or ""


### PR DESCRIPTION
This uses the new `catalog_offering_identifier` from https://github.com/openstax/tutor-server/pull/721 to style course.

This also adds some margin between the courses, To me it looked strange when there were two courses with the same colors right beside one another.


TODO:
* [x] display course name in chooser for courses that aren't titled "Physics" or "Biology"

 
![screen shot 2015-10-22 at 3 35 28 pm](https://cloud.githubusercontent.com/assets/79566/10677525/97ac4c1a-78d2-11e5-9846-2aa72098c9ef.png)

Displays ellipsis when text is to long to fit

![screen shot 2015-10-22 at 3 35 37 pm](https://cloud.githubusercontent.com/assets/79566/10677524/979ac0e4-78d2-11e5-940f-186fca0a3e37.png)
