### PR TITLE
Remove mix-blend-mode style

### DIFF
--- a/resources/styles/book-content/target.less
+++ b/resources/styles/book-content/target.less
@@ -16,13 +16,6 @@ a[target=_blank] { .tutor-external-link-indicator(); }
 figure {
   .highlight-target(will-transition);
 
-  &:target, &.link-target, &.target-scroll {
-    img {
-      mix-blend-mode: multiply;
-    }
-  }
-
-
   &:target, &.link-target {
     .highlight-animation();
 
@@ -50,17 +43,12 @@ section, div, span, table {
   &:target, &.link-target, &.target-scroll {
     position: relative;
 
-    img {
-      mix-blend-mode: multiply;
-    }
-
     &::after {
       content: ' ';
       width: 100%;
       height: 100%;
       position: absolute;
       top: 0;
-      mix-blend-mode: multiply;
     }
   }
 

--- a/resources/styles/components/scores/index.less
+++ b/resources/styles/components/scores/index.less
@@ -117,10 +117,6 @@
 
     &[data-assignment-type] {
       font-weight: 400;
-
-      > div:nth-child(even) {
-        mix-blend-mode: overlay;
-      }
     }
 
     .review-plan {

--- a/resources/styles/mixins/tutor-plans.less
+++ b/resources/styles/mixins/tutor-plans.less
@@ -77,7 +77,6 @@
 .tutor-plan-cell(@plan-color) {
   color: @tutor-neutral-darker;
   background-color: fade(@plan-color, 2.5%);
-  mix-blend-mode: multiply;
   .transition(background-color 0.1s ease-in);
 }
 


### PR DESCRIPTION
This causes the the Chrome web browser on some windows machines to make
the element disappear.   

It seems to affect higher-end machines where Chrome might be using the
graphics card to compose the images.