### PR TITLE
Set image max-width to 100% on book-content styles

### DIFF
--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -47,6 +47,10 @@ div[data-type="document-title"] ~ p:first-of-type {
   .tutor-reading-first-letter();
 }
 
+// prevent larger images from pushing out past their container.
+// Most images are inside a <figure> and will be handled by the rules below
+img { max-width: 100%; }
+
 .tutor-figure();
 figure {
   margin-right: 30px;


### PR DESCRIPTION
Occasionally there's a large image that isn't inside a figure.  In that
case we need a default rule that stops it from extending past the container.

Before:

![screen shot 2015-10-26 at 2 23 46 pm](https://cloud.githubusercontent.com/assets/79566/10739895/355edb22-7bed-11e5-9090-24289c840f09.png)


After:

![screen shot 2015-10-26 at 2 24 13 pm](https://cloud.githubusercontent.com/assets/79566/10739903/4184964e-7bed-11e5-9ef6-9a84dd9f3e19.png)
