### PR TITLE
Move control for displaying feedback below the card

### DIFF
--- a/resources/styles/components/task-plan/homework/exercises.less
+++ b/resources/styles/components/task-plan/homework/exercises.less
@@ -109,14 +109,10 @@ label.exercises-section-label {
 
   .feedback-toggle {
     float: right;
-    .checkbox {margin: 0;}
-    input[type=checkbox] { position: relative; margin-right: 0.5rem; }
-    label {
-      color: @tutor-neutral;
-      margin-left: 0;
-      #fonts >.sans(1.1rem, 1.1rem);
-      font-style: italic;
-    }
+    margin-top: -@tutor-card-body-padding-vertical;
+    color: @tutor-neutral;
+    background-color: @tutor-white;
+    border: 0;
   }
 
 }

--- a/src/components/task-plan/homework/exercises.cjsx
+++ b/src/components/task-plan/homework/exercises.cjsx
@@ -5,29 +5,31 @@ BS = require 'react-bootstrap'
 ArbitraryHtmlAndMath = require '../../html'
 ExerciseCard = require '../../exercise-card'
 ChapterSection = require '../chapter-section'
+Icon = require '../../icon'
 {ExerciseStore, ExerciseActions} = require '../../../flux/exercise'
 {TaskPlanStore, TaskPlanActions} = require '../../../flux/task-plan'
 {TocStore} = require '../../../flux/toc'
 
 ExerciseCardMixin =
 
-  toggleFeedbackDisplay: ->
+  toggleFeedbackDisplay: (ev) ->
     @setState(displayFeedback: not @state?.displayFeedback)
 
   renderExercise: ->
-    <ExerciseCard
-      {...@props}
-      toggleExercise={@toggleExercise}
-      header={@renderHeader()}
-      displayFeedback={@state?.displayFeedback}
-      panelStyle={@getPanelStyle()}>
-
-      <BS.Input type="checkbox" label="Display Feedback" standalone
-        wrapperClassName={"feedback-toggle"}
-        checked={@state?.displayFeedback}
-        onChange={@toggleFeedbackDisplay} />
-
-    </ExerciseCard>
+    <div>
+      <ExerciseCard
+        {...@props}
+        toggleExercise={@toggleExercise}
+        header={@renderHeader()}
+        displayFeedback={@state?.displayFeedback}
+        panelStyle={@getPanelStyle()}>
+      </ExerciseCard>
+      <button className="feedback-toggle" onClick={@toggleFeedbackDisplay}>
+        <Icon
+          type={(if @state?.displayFeedback then 'check-' else '' ) + 'square-o'}
+        /> Display Feedback
+      </button>
+    </div>
 
 ReviewExerciseCard = React.createClass
   displayName: 'ReviewExerciseCard'

--- a/src/components/task-plan/homework/exercises.cjsx
+++ b/src/components/task-plan/homework/exercises.cjsx
@@ -16,7 +16,7 @@ ExerciseCardMixin =
     @setState(displayFeedback: not @state?.displayFeedback)
 
   renderExercise: ->
-    <div>
+    <div className="-exercise-wrapper">
       <ExerciseCard
         {...@props}
         toggleExercise={@toggleExercise}


### PR DESCRIPTION
Moves the control below the card so it doesn't select the exercise when its clicked.

I experimented with `stopPropagation` but it would only work if the checkbox itself was clicked, not the label. Clicks on the label would still trigger exercise selection callback event though they were above it on the dom tree.  Puzzlingly, clicks on the label would have the panel title as it's target, which makes no sense since that's not an ancestor of the label.  After awhile I gave up and figured we should just implement the mockup ;)

![screen shot 2015-11-03 at 1 28 39 pm](https://cloud.githubusercontent.com/assets/79566/10919252/64500652-822f-11e5-8a5b-051460ffb441.png)