### PR TITLE
Roster endpoint rename

### DIFF
--- a/api/courses/1/students.json
+++ b/api/courses/1/students.json
@@ -1,38 +1,41 @@
 {
-  "0": {
-    "id": "7",
-    "period_id": "2",
-    "role_id": "9",
-    "first_name": "Clyde",
-    "last_name": "Griffiths",
-    "full_name": "Clyde Griffiths",
-    "is_active": true
-  },
-  "1": {
-    "id": "11",
-    "period_id": "1",
-    "role_id": "13",
-    "first_name": "Harry",
-    "last_name": "Potter",
-    "full_name": "Harry Potter",
-    "is_active": true
-  },
-  "2": {
-    "id": "9",
-    "period_id": "2",
-    "role_id": "11",
-    "first_name": "Florentino",
-    "last_name": "Ariza",
-    "full_name": "Florentino Ariza",
-    "is_active": true
-  },
-  "3": {
-    "id": "10",
-    "period_id": "2",
-    "role_id": "15",
-    "first_name": "Jimmy",
-    "last_name": "Bud",
-    "full_name": "Jimmy Bud",
-    "is_active": false
-  }
+  "teacher_join_url": "http://localhost:3001/courses/join/af3bda369c95d4f10c24327609c77bc0",
+  "students": [
+    {
+      "id": "7",
+      "period_id": "2",
+      "role_id": "9",
+      "first_name": "Clyde",
+      "last_name": "Griffiths",
+      "full_name": "Clyde Griffiths",
+      "is_active": true
+    },
+    {
+      "id": "11",
+      "period_id": "1",
+      "role_id": "13",
+      "first_name": "Harry",
+      "last_name": "Potter",
+      "full_name": "Harry Potter",
+      "is_active": true
+    },
+    {
+      "id": "9",
+      "period_id": "2",
+      "role_id": "11",
+      "first_name": "Florentino",
+      "last_name": "Ariza",
+      "full_name": "Florentino Ariza",
+      "is_active": true
+    },
+    {
+      "id": "10",
+      "period_id": "2",
+      "role_id": "15",
+      "first_name": "Jimmy",
+      "last_name": "Bud",
+      "full_name": "Jimmy Bud",
+      "is_active": false
+    }
+  ]
 }

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -203,9 +203,9 @@ start = (bootstrapData) ->
   apiHelper RosterActions, RosterActions.save, RosterActions.saved, 'PATCH', (id, params) ->
     url: "/api/students/#{id}", payload: params
   apiHelper RosterActions, RosterActions.create, RosterActions.created, createMethod, (courseId, params) ->
-    url: "/api/courses/#{courseId}/students", payload: params
+    url: "/api/courses/#{courseId}/roster", payload: params
   apiHelper RosterActions, RosterActions.load, RosterActions.loaded, 'GET', (id) ->
-    url: "/api/courses/#{id}/students"
+    url: "/api/courses/#{id}/roster"
 
   apiHelper PeriodActions, PeriodActions.create, PeriodActions.created, createMethod, (courseId, params) ->
     url: "/api/courses/#{courseId}/periods", payload: params

--- a/src/flux/roster.coffee
+++ b/src/flux/roster.coffee
@@ -15,21 +15,23 @@ RosterConfig = {
   saved: (newProps, studentId) ->
     # update the student from all the courses rosters
     for courseId, roster of @_local
-      student = _.findWhere(roster, id: studentId)
+      students = roster.students
+      student = _.findWhere(students, id: studentId)
       _.extend(student, newProps) if student
     @emitChange()
 
   deleted: (unused, studentId) ->
     # remove the student from all the courses rosters
     for courseId, roster of @_local
-      index = _.findIndex(roster, id: studentId)
-      roster.splice(index, 1) unless -1 is index
+      students = roster.students
+      index = _.findIndex(students, id: studentId)
+      students.splice(index, 1) unless -1 is index
     @emitChange()
 
   exports:
 
     getActiveStudentsForPeriod: (courseId, periodId) ->
-      _.where(@_get(courseId), period_id: periodId, is_active: true)
+      _.where(@_get(courseId).students, period_id: periodId, is_active: true)
 
 }
 


### PR DESCRIPTION
This PR corresponds with https://github.com/openstax/tutor-server/pull/783

GET /api/courses/:course_id/students is changed to 
GET /api/courses/:course_id/roster 

and format updated to contain students and teacher join url.

