### PR TITLE
Concept Coach Teacher Dashboard

### DIFF
--- a/resources/styles/components/cc-dashboard/index.less
+++ b/resources/styles/components/cc-dashboard/index.less
@@ -1,0 +1,28 @@
+.dashboard-table-header {
+	font-size: 1.2rem;
+
+	> div {
+		text-align: center;
+	}
+	span.progress-legend {
+		font-size: 1rem;
+	}
+}
+
+.chapter-name-row {
+	font-size: 2rem;
+	padding: 1.5rem 0;
+}
+
+.section-info-row {
+	border-bottom: 1px solid @table-bg-accent;
+	margin: 0.5rem 0;
+	padding: 0.5rem 0;
+
+	.reading-progress-bar {
+		margin-bottom: 0
+	}
+	&:hover {
+		background: rgba(255, 255, 204, 0.5);
+	}
+}

--- a/resources/styles/tutor.less
+++ b/resources/styles/tutor.less
@@ -31,6 +31,7 @@
 @import './components/loadable';
 @import './components/course-calendar/index';
 @import './components/close';
+@import './components/cc-dashboard/index';
 @import './components/dialog';
 @import './components/smart-overflow';
 @import './components/tutor-input';

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -101,7 +101,6 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker) ->
           catch e
             msg = jqXhr.responseText
           Actions.FAILED(statusCode, msg, args...)
-
       $.ajax(url, opts)
       .then(resolved, rejected)
 
@@ -161,6 +160,9 @@ start = (bootstrapData) ->
 
   apiHelper CourseActions, CourseActions.loadGuide, CourseActions.loadedGuide, 'GET', (courseId) ->
     url: "/api/courses/#{courseId}/guide"
+
+  apiHelper CourseActions, CourseActions.loadCCDashboard, CourseActions.loadedCCDashboard, 'GET', (courseId) ->
+    url: "/api/courses/#{courseId}/cc/dashboard"
 
   createMethod = if IS_LOCAL then 'GET' else 'POST' # Hack to get back a full practice on create when on local
   apiHelper CourseActions, CourseActions.createPractice, CourseActions.createdPractice, createMethod, (courseId, params) ->

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -30,6 +30,7 @@ PerformanceForecast = require './flux/performance-forecast'
 {TeacherTaskPlanActions, TeacherTaskPlanStore} = require './flux/teacher-task-plan'
 {StudentDashboardActions} = require './flux/student-dashboard'
 {CourseListingActions, CourseListingStore} = require './flux/course-listing'
+{CCDashboardStore, CCDashboardActions} = require './flux/cc-dashboard'
 {ReferenceBookActions, ReferenceBookStore} = require './flux/reference-book'
 {ReferenceBookPageActions, ReferenceBookPageStore} = require './flux/reference-book-page'
 {ReferenceBookExerciseActions, ReferenceBookExerciseStore} = require './flux/reference-book-exercise'
@@ -161,7 +162,7 @@ start = (bootstrapData) ->
   apiHelper CourseActions, CourseActions.loadGuide, CourseActions.loadedGuide, 'GET', (courseId) ->
     url: "/api/courses/#{courseId}/guide"
 
-  apiHelper CourseActions, CourseActions.loadCCDashboard, CourseActions.loadedCCDashboard, 'GET', (courseId) ->
+  apiHelper CCDashboardActions, CCDashboardActions.load, CCDashboardActions.loaded, 'GET', (courseId) ->
     url: "/api/courses/#{courseId}/cc/dashboard"
 
   createMethod = if IS_LOCAL then 'GET' else 'POST' # Hack to get back a full practice on create when on local

--- a/src/components/cc-dashboard/index.cjsx
+++ b/src/components/cc-dashboard/index.cjsx
@@ -4,6 +4,7 @@ BS = require 'react-bootstrap'
 {CCDashboardStore, CCDashboardActions} = require '../../flux/cc-dashboard'
 ChapterSection = require '../task-plan/chapter-section'
 LoadableItem = require '../loadable-item'
+Router = require 'react-router'
 
 DashboardSectionProgress = React.createClass
   _getPercentage: (num, total) ->
@@ -108,7 +109,10 @@ CCDashboard = React.createClass
     periods = CCDashboardStore.getPeriods(courseId)
     periodChapters = CCDashboardStore.getPeriodChapters(courseId, @state.activePeriodId)
 
-    chapters = _.map periodChapters, @renderChapters
+    if periodChapters.length
+      chapters = _.map periodChapters, @renderChapters
+    else
+      chapters = <div>There are no completed concept coach tasks for this period.</div>
 
     <BS.Panel className='reading-stats'>
       <CoursePeriodsNav
@@ -141,12 +145,20 @@ DashboardShell = React.createClass
   render: ->
     {courseId} = @context.router.getCurrentParams()
 
-    <LoadableItem
-      store={CCDashboardStore}
-      actions={CCDashboardActions}
-      id={courseId}
-      renderItem={-> <CCDashboard key={courseId} id={courseId} />}
-    />
+    <div>
+      <h1>
+        Class Performance
+        <Router.Link className='btn btn-default pull-right' to='viewScores' params={{courseId}}>
+          View Detailed Scores
+        </Router.Link>
+      </h1>
+      <LoadableItem
+        store={CCDashboardStore}
+        actions={CCDashboardActions}
+        id={courseId}
+        renderItem={-> <CCDashboard key={courseId} id={courseId} />}
+      />
+    </div>
 
 module.exports = DashboardShell
 

--- a/src/components/cc-dashboard/index.cjsx
+++ b/src/components/cc-dashboard/index.cjsx
@@ -65,7 +65,7 @@ DashboardSection = React.createClass
         <DashboardSectionProgress section={@props.section} />
       </BS.Col>
       <BS.Col xs={2}>
-        <DashboardSectionPerformance section={@props.section} /> 
+        <DashboardSectionPerformance section={@props.section} />
       </BS.Col>
       <BS.Col xs={2}>
       </BS.Col>

--- a/src/components/cc-dashboard/index.cjsx
+++ b/src/components/cc-dashboard/index.cjsx
@@ -1,0 +1,47 @@
+React = require 'react'
+BS = require 'react-bootstrap'
+{CoursePeriodsNav} = require '../course-periods-nav'
+{CourseStore, CourseActions} = require '../../flux/course'
+LoadableItem = require '../loadable-item'
+
+CCDashboard = React.createClass
+  getDefaultProps: ->
+    initialActivePeriod: 0
+
+  getInitialState: -> {}
+
+  handlePeriodSelect: (period) ->
+    @setState({period})
+
+  render: ->
+    courseId = @props.id
+    periods = CourseStore.getCCPeriods(courseId)
+
+    <BS.Panel className='reading-stats'>
+      <CoursePeriodsNav
+        handleSelect={@handlePeriodSelect}
+        initialActive={@props.initialActivePeriod}
+        periods={periods}
+        courseId={courseId} />
+        {@state.period?.id}
+    </BS.Panel>
+
+DashboardShell = React.createClass
+  contextTypes:
+    router: React.PropTypes.func
+
+  render: ->
+    {courseId} = @context.router.getCurrentParams()
+
+    <LoadableItem
+      store={CourseStore}
+      actions={CourseActions}
+      load={CourseActions.loadCCDashboard}
+      isLoaded={CourseStore.isCCDashboardLoaded}
+      isLoading={CourseStore.isCCDashboardLoading}
+      id={courseId}
+      renderItem={-> <CCDashboard key={courseId} id={courseId} />}
+    />
+
+module.exports = DashboardShell
+

--- a/src/components/cc-dashboard/index.cjsx
+++ b/src/components/cc-dashboard/index.cjsx
@@ -1,21 +1,114 @@
 React = require 'react'
 BS = require 'react-bootstrap'
 {CoursePeriodsNav} = require '../course-periods-nav'
-{CourseStore, CourseActions} = require '../../flux/course'
+{CCDashboardStore, CCDashboardActions} = require '../../flux/cc-dashboard'
+ChapterSection = require '../task-plan/chapter-section'
 LoadableItem = require '../loadable-item'
 
+DashboardSectionProgress = React.createClass
+  _getPercentage: (num, total) ->
+    Math.round((num / total) * 100)
+
+  render: ->
+    total = @props.section.completed + @props.section.in_progress + @props.section.not_started
+    
+    percents =
+      completed: @_getPercentage(@props.section.completed, total)
+      inProgress: @_getPercentage(@props.section.in_progress, total)
+
+    if percents.completed > 0
+      completed = <BS.ProgressBar 
+        className="reading-progress-bar" 
+        bsStyle="success" 
+        now={percents.completed} 
+        key={1} />
+
+    if percents.inProgress > 0
+      inProgress = <BS.ProgressBar 
+        className="reading-progress-bar" 
+        bsStyle="info" 
+        now={percents.inProgress} 
+        key={2} />
+
+    <BS.ProgressBar className="reading-progress-group">
+      {completed}
+      {inProgress}
+    </BS.ProgressBar>
+
+DashboardSectionPerformance = React.createClass
+  render: ->
+    percents =
+      correct: Math.round(@props.section.original_performance * 100)
+
+    percents.incorrect = 100 - percents.correct
+    
+    <BS.ProgressBar className="reading-progress-group">
+      <BS.ProgressBar 
+        className="reading-progress-bar progress-bar-correct" 
+        now={percents.correct}
+        label="#{percents.correct}%"
+        key={1} />
+      <BS.ProgressBar 
+        className="reading-progress-bar progress-bar-incorrect" 
+        now={percents.incorrect} 
+        key={2} />
+    </BS.ProgressBar>
+
+DashboardSection = React.createClass
+  render: ->
+    <BS.Row className="section-info-row" key={@props.section.id}>
+      <BS.Col xs={6}>
+        <ChapterSection section={@props.section.chapter_section} />
+        . {@props.section.title}
+      </BS.Col>
+      <BS.Col xs={2}>
+        <DashboardSectionProgress section={@props.section} />
+      </BS.Col>
+      <BS.Col xs={2}>
+        <DashboardSectionPerformance section={@props.section} /> 
+      </BS.Col>
+      <BS.Col xs={2}>
+      </BS.Col>
+    </BS.Row>
+
+DashboardChapter = React.createClass
+  renderSection: (section, index) ->
+    <DashboardSection section={section} key={index} />
+
+  render: ->
+    chapter = <BS.Row className="chapter-name-row" key={@props.chapter.id}>
+      <BS.Col xs={12}>
+        <ChapterSection section={@props.chapter.chapter_section} />
+        . {@props.chapter.title}
+      </BS.Col>
+    </BS.Row>
+
+    sections = _.map @props.chapter.pages, @renderSection
+    <div>
+      {chapter}
+      {sections}
+    </div>
+    
 CCDashboard = React.createClass
   getDefaultProps: ->
     initialActivePeriod: 0
 
-  getInitialState: -> {}
+  getInitialState: ->
+    activePeriod = CCDashboardStore.getPeriods(@props.id)?[@props.initialActivePeriod]
+    activePeriodId: activePeriod?.id
 
   handlePeriodSelect: (period) ->
-    @setState({period})
+    @setState({activePeriodId: period.id})
+
+  renderChapters: (chapter, index) ->
+    <DashboardChapter chapter={chapter} key={index} />
 
   render: ->
     courseId = @props.id
-    periods = CourseStore.getCCPeriods(courseId)
+    periods = CCDashboardStore.getPeriods(courseId)
+    periodChapters = CCDashboardStore.getPeriodChapters(courseId, @state.activePeriodId)
+
+    chapters = _.map periodChapters, @renderChapters
 
     <BS.Panel className='reading-stats'>
       <CoursePeriodsNav
@@ -23,7 +116,22 @@ CCDashboard = React.createClass
         initialActive={@props.initialActivePeriod}
         periods={periods}
         courseId={courseId} />
-        {@state.period?.id}
+      
+      <BS.Row className="dashboard-table-header">
+        <BS.Col xs={2} xsOffset={6}>
+          <div>Students</div>
+          <span className="progress-legend">
+            Completed / In progress / Not started
+          </span>
+        </BS.Col>
+        <BS.Col xs={2}>
+          Original Performance
+        </BS.Col>
+        <BS.Col xs={2}>
+          Spaced Practice Performance
+        </BS.Col>
+      </BS.Row>
+      {chapters}
     </BS.Panel>
 
 DashboardShell = React.createClass
@@ -34,11 +142,8 @@ DashboardShell = React.createClass
     {courseId} = @context.router.getCurrentParams()
 
     <LoadableItem
-      store={CourseStore}
-      actions={CourseActions}
-      load={CourseActions.loadCCDashboard}
-      isLoaded={CourseStore.isCCDashboardLoaded}
-      isLoading={CourseStore.isCCDashboardLoading}
+      store={CCDashboardStore}
+      actions={CCDashboardActions}
       id={courseId}
       renderItem={-> <CCDashboard key={courseId} id={courseId} />}
     />

--- a/src/components/course-listing.cjsx
+++ b/src/components/course-listing.cjsx
@@ -15,11 +15,17 @@ DisplayOrRedirect = (transition, callback) ->
   [course] = courses
   if courses.length is 1 and course.roles?.length is 1
     roleType = courses[0].roles[0].type
-    type = switch roleType
-      when 'student' then 'viewStudentDashboard'
-      when 'teacher' then 'taskplans'
-      else
-        throw new Error("BUG: Unrecognized role type #{roleType}")
+    conceptCoach = courses[0].is_concept_coach
+
+    if roleType is 'student'
+      type = 'viewStudentDashboard'
+    else if roleType is 'teacher' and not conceptCoach
+      type = 'taskplans'
+    else if roleType is 'teacher' and conceptCoach
+      type = 'cc-dashboard'
+    else
+      throw new Error("BUG: Unrecognized role type #{roleType}")
+
     transition.redirect(type, {courseId: _.first(courses).id})
   callback()
 

--- a/src/components/course-listing.cjsx
+++ b/src/components/course-listing.cjsx
@@ -49,7 +49,7 @@ CourseListing = React.createClass
 
   renderCourses: (courses) ->
     _.map courses, (course) =>
-      {id:courseId, name, roles} = course
+      {id:courseId, name, roles, is_concept_coach:isConceptCoach} = course
       isStudent = _.find roles, (role) -> role.type is 'student'
       isTeacher = _.find roles, (role) -> role.type is 'teacher'
 
@@ -66,9 +66,10 @@ CourseListing = React.createClass
             to='taskplans'
             params={{courseId}}>View as Teacher</Router.Link>
         else
+          to = if isConceptCoach then 'cc-taskplans' else 'taskplans'
           courseLink = <Router.Link
             className='tutor-course-item'
-            to='taskplans'
+            to={to}
             params={{courseId}}>{course.name}</Router.Link>
 
       courseDataProps = @getCourseDataProps(courseId)

--- a/src/flux/cc-dashboard.coffee
+++ b/src/flux/cc-dashboard.coffee
@@ -12,8 +12,11 @@ DashboardConfig =
     getPeriods: (courseId) -> @_get(courseId)?.course?.periods
 
     getPeriodChapters: (courseId, periodId) ->
+
       periods = @_get(courseId)?.course?.periods
-      _.findWhere(periods, {id: periodId})?.chapters
+
+      _.sortBy(_.findWhere(periods, {id: periodId})?.chapters, (chapter) ->
+        chapter.chapter_section?[0])?.reverse()
 
     
 

--- a/src/flux/cc-dashboard.coffee
+++ b/src/flux/cc-dashboard.coffee
@@ -1,0 +1,22 @@
+# coffeelint: disable=no_empty_functions
+_ = require 'underscore'
+
+{TaskActions, TaskStore} = require './task'
+{CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
+PeriodHelper = require '../helpers/period'
+
+DEFAULT_COURSE_TIMEZONE = 'US/Central'
+
+DashboardConfig =
+  exports:
+    getPeriods: (courseId) -> @_get(courseId)?.course?.periods
+
+    getPeriodChapters: (courseId, periodId) ->
+      periods = @_get(courseId)?.course?.periods
+      _.findWhere(periods, {id: periodId})?.chapters
+
+    
+
+extendConfig(DashboardConfig, new CrudConfig())
+{actions, store} = makeSimpleStore(DashboardConfig)
+module.exports = {CCDashboardActions:actions, CCDashboardStore:store}

--- a/src/flux/course.coffee
+++ b/src/flux/course.coffee
@@ -50,6 +50,19 @@ CourseConfig =
     TaskActions.loaded(obj, obj.id)
     @emit('practice.loaded', obj.id)
 
+  _cc_dashboard: {}
+  _asyncStatusCCDashboard: {}
+
+  loadCCDashboard: (courseId) ->
+    delete @_cc_dashboard[courseId]
+    @_asyncStatusCCDashboard[courseId] = 'loading'
+    @emitChange()
+
+  loadedCCDashboard: (obj, courseId) ->
+    @_cc_dashboard[courseId] = obj
+    @_asyncStatusCCDashboard[courseId] = 'loaded'
+    @emitChange()
+
   _loaded: (obj, id) ->
     @emit('course.loaded', obj.id)
 
@@ -69,6 +82,9 @@ CourseConfig =
     isPracticeLoading: (courseId) -> @_asyncStatusPractices[courseId] is 'loading'
     isPracticeLoaded: (courseId) -> !! @_practices[courseId]
 
+    isCCDashboardLoading: (courseId) -> @_asyncStatusCCDashboard is 'loading'
+    isCCDashboardLoaded : (courseId) -> !! @_cc_dashboard[courseId]
+
     getPracticeId: (courseId) ->
       @_practices[courseId]?.id
 
@@ -84,6 +100,9 @@ CourseConfig =
         task = TaskStore.get(id)
       task
 
+    getCCDashboard: (courseId) ->
+      @_cc_dashboard[courseId]
+
     # This is currently bassed on the course title.
     # eventually the backend will provide it as part of the course's metadata.
     getCategory: (courseId) ->
@@ -98,6 +117,9 @@ CourseConfig =
     getPeriods: (courseId) ->
       periods = @_get(courseId).periods or []
       sortedPeriods = PeriodHelper.sort(periods)
+
+    getCCPeriods: (courseId) ->
+      @_cc_dashboard[courseId]?.periods
 
     getTimezone: (courseId) ->
       @_get(courseId)?.timezone or DEFAULT_COURSE_TIMEZONE

--- a/src/flux/course.coffee
+++ b/src/flux/course.coffee
@@ -50,19 +50,6 @@ CourseConfig =
     TaskActions.loaded(obj, obj.id)
     @emit('practice.loaded', obj.id)
 
-  _cc_dashboard: {}
-  _asyncStatusCCDashboard: {}
-
-  loadCCDashboard: (courseId) ->
-    delete @_cc_dashboard[courseId]
-    @_asyncStatusCCDashboard[courseId] = 'loading'
-    @emitChange()
-
-  loadedCCDashboard: (obj, courseId) ->
-    @_cc_dashboard[courseId] = obj
-    @_asyncStatusCCDashboard[courseId] = 'loaded'
-    @emitChange()
-
   _loaded: (obj, id) ->
     @emit('course.loaded', obj.id)
 
@@ -82,9 +69,6 @@ CourseConfig =
     isPracticeLoading: (courseId) -> @_asyncStatusPractices[courseId] is 'loading'
     isPracticeLoaded: (courseId) -> !! @_practices[courseId]
 
-    isCCDashboardLoading: (courseId) -> @_asyncStatusCCDashboard is 'loading'
-    isCCDashboardLoaded : (courseId) -> !! @_cc_dashboard[courseId]
-
     getPracticeId: (courseId) ->
       @_practices[courseId]?.id
 
@@ -100,9 +84,6 @@ CourseConfig =
         task = TaskStore.get(id)
       task
 
-    getCCDashboard: (courseId) ->
-      @_cc_dashboard[courseId]
-
     # This is currently bassed on the course title.
     # eventually the backend will provide it as part of the course's metadata.
     getCategory: (courseId) ->
@@ -117,9 +98,6 @@ CourseConfig =
     getPeriods: (courseId) ->
       periods = @_get(courseId).periods or []
       sortedPeriods = PeriodHelper.sort(periods)
-
-    getCCPeriods: (courseId) ->
-      @_cc_dashboard[courseId]?.periods
 
     getTimezone: (courseId) ->
       @_get(courseId)?.timezone or DEFAULT_COURSE_TIMEZONE

--- a/src/router.cjsx
+++ b/src/router.cjsx
@@ -67,7 +67,7 @@ routes = (
                 ignoreScrollBehavior/>
             </Route>
           </Route>
-          <Route path='cc-taskplans/?' name='cc-taskplans' handler={CCDashboard} />
+          <Route path='cc-dashboard/?' name='cc-dashboard' handler={CCDashboard} />
 
           <Route path='homeworks/new/?' name='createHomework' handler={HomeworkShell} />
           <Route path='homeworks/:id/?' name='editHomework' handler={HomeworkShell} />

--- a/src/router.cjsx
+++ b/src/router.cjsx
@@ -16,6 +16,8 @@ TeacherTaskPlans = require './components/task-plan/teacher-task-plans-listing'
   require './components/reference-book'
 
 {StatsShell} = require './components/plan-stats'
+CCDashboard = require './components/cc-dashboard'
+
 CourseSettings = require './components/course-settings'
 Sandbox = require './sandbox'
 Handler = require './helpers/conditional-rendering'
@@ -65,6 +67,8 @@ routes = (
                 ignoreScrollBehavior/>
             </Route>
           </Route>
+          <Route path='cc-taskplans/?' name='cc-taskplans' handler={CCDashboard} />
+
           <Route path='homeworks/new/?' name='createHomework' handler={HomeworkShell} />
           <Route path='homeworks/:id/?' name='editHomework' handler={HomeworkShell} />
           <Route path='readings/new/?' name='createReading' handler={ReadingShell} />


### PR DESCRIPTION
![screen shot 2015-11-18 at 6 17 55 pm](https://cloud.githubusercontent.com/assets/6434717/11244947/4a914b72-8e4b-11e5-94f6-06775cc9194e.png)

- [x] Make route and component for initial dashboard display
- [x] Make request to backend for dashboard json
- [x] Show allow changing of periods
- [x] Show tasks
- [x] Show task completion and CC data
- [x] Chapter/section sorting - might need more chapters/sections in data to test
- [x] Link to detailed scores
- [x] Empty period messages
- [x] Linking to correct dashboard when there's only one concept coach course

Still need to do in a separate PR:
- [ ] Spaced practice progress bar (not in api)
- [ ] Update completed progress bar to be like latest in mockup
- [ ] Book pdf/webview links
