### PR TITLE
Concept coach tweaks

### DIFF
--- a/resources/styles/components/cc-dashboard/index.less
+++ b/resources/styles/components/cc-dashboard/index.less
@@ -1,28 +1,34 @@
 .dashboard-table-header {
-	font-size: 1.2rem;
+  font-size: 1.2rem;
 
-	> div {
-		text-align: center;
-	}
-	span.progress-legend {
-		font-size: 1rem;
-	}
+  > div {
+    text-align: left;
+  }
+  span.progress-legend {
+    font-size: 1rem;
+  }
 }
 
 .chapter-name-row {
-	font-size: 2rem;
-	padding: 1.5rem 0;
+  font-size: 2rem;
+  padding: 1.5rem 0;
 }
 
 .section-info-row {
-	border-bottom: 1px solid @table-bg-accent;
-	margin: 0.5rem 0;
-	padding: 0.5rem 0;
+  border-bottom: 1px solid @table-bg-accent;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
 
-	.reading-progress-bar {
-		margin-bottom: 0
-	}
-	&:hover {
-		background: rgba(255, 255, 204, 0.5);
-	}
+  .reading-progress-group {
+    width: 80%;
+    display: inline-block;
+    float: left;
+    margin-right: 2%;
+  }
+  .reading-progress-bar {
+    margin-bottom: 0;
+  }
+  &:hover {
+    background: rgba(255, 255, 204, 0.5);
+  }
 }

--- a/src/components/cc-dashboard/index.cjsx
+++ b/src/components/cc-dashboard/index.cjsx
@@ -15,45 +15,45 @@ DashboardSectionProgress = React.createClass
     
     percents =
       completed: @_getPercentage(@props.section.completed, total)
-      inProgress: @_getPercentage(@props.section.in_progress, total)
 
     if percents.completed > 0
       completed = <BS.ProgressBar 
         className="reading-progress-bar" 
-        bsStyle="success" 
+        bsStyle="info" 
         now={percents.completed} 
         key={1} />
 
-    if percents.inProgress > 0
-      inProgress = <BS.ProgressBar 
-        className="reading-progress-bar" 
-        bsStyle="info" 
-        now={percents.inProgress} 
-        key={2} />
-
-    <BS.ProgressBar className="reading-progress-group">
-      {completed}
-      {inProgress}
-    </BS.ProgressBar>
+    <div>
+      <BS.ProgressBar className="reading-progress-group">
+        {completed}
+      </BS.ProgressBar>
+      {percents.completed}%
+    </div>
 
 DashboardSectionPerformance = React.createClass
   render: ->
     percents =
-      correct: Math.round(@props.section.original_performance * 100)
+      correct: if @props.performance then Math.round(@props.performance * 100) else 0
 
     percents.incorrect = 100 - percents.correct
-    
-    <BS.ProgressBar className="reading-progress-group">
-      <BS.ProgressBar 
-        className="reading-progress-bar progress-bar-correct" 
-        now={percents.correct}
-        label="#{percents.correct}%"
-        key={1} />
-      <BS.ProgressBar 
-        className="reading-progress-bar progress-bar-incorrect" 
-        now={percents.incorrect} 
-        key={2} />
-    </BS.ProgressBar>
+
+    correctBar = if percents.correct then <BS.ProgressBar 
+      className="reading-progress-bar progress-bar-correct" 
+      now={percents.correct}
+      key={1} />
+
+    incorrectBar = if percents.incorrect then <BS.ProgressBar 
+      className="reading-progress-bar progress-bar-incorrect" 
+      now={percents.incorrect} 
+      key={2} />
+
+    <div>
+      <BS.ProgressBar className="reading-progress-group">
+        {correctBar}
+        {incorrectBar}
+      </BS.ProgressBar>
+      {percents.correct}%
+    </div>
 
 DashboardSection = React.createClass
   render: ->
@@ -66,9 +66,10 @@ DashboardSection = React.createClass
         <DashboardSectionProgress section={@props.section} />
       </BS.Col>
       <BS.Col xs={2}>
-        <DashboardSectionPerformance section={@props.section} />
+        <DashboardSectionPerformance performance={@props.section.original_performance} />
       </BS.Col>
       <BS.Col xs={2}>
+        <DashboardSectionPerformance performance={@props.section.spaced_practice_performance} />
       </BS.Col>
     </BS.Row>
 
@@ -123,10 +124,7 @@ CCDashboard = React.createClass
       
       <BS.Row className="dashboard-table-header">
         <BS.Col xs={2} xsOffset={6}>
-          <div>Students</div>
-          <span className="progress-legend">
-            Completed / In progress / Not started
-          </span>
+          Complete
         </BS.Col>
         <BS.Col xs={2}>
           Original Performance

--- a/src/components/course-listing.cjsx
+++ b/src/components/course-listing.cjsx
@@ -72,7 +72,7 @@ CourseListing = React.createClass
             to='taskplans'
             params={{courseId}}>View as Teacher</Router.Link>
         else
-          to = if isConceptCoach then 'cc-taskplans' else 'taskplans'
+          to = if isConceptCoach then 'cc-dashboard' else 'taskplans'
           courseLink = <Router.Link
             className='tutor-course-item'
             to={to}

--- a/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -68,7 +68,12 @@ TeacherTaskPlanListing = React.createClass
 
   statics:
     willTransitionTo: (transition, params, query, callback) ->
-      {date, planId} = params
+      {date, planId, courseId} = params
+      course = CourseStore.get(courseId)
+      if course.is_concept_coach
+        transition.redirect('cc-dashboard', {courseId})
+        return callback()
+
       unless date? and moment(date, DATE_FORMAT).isValid()
         date = moment(TimeStore.getNow())
         params.date = date.format(DATE_FORMAT)


### PR DESCRIPTION
![screen shot 2015-11-21 at 12 38 19 am](https://cloud.githubusercontent.com/assets/6434717/11305703/e2860ba4-8fe8-11e5-86ce-242cc4d2c6ba.png)

- [x] Updating how the completed tasks progress bar is displayed
- [x] Add in spaced practice performance progress bar
- [x] Fix transitions when typing in URL for the course only: /courses/2
- [x] Fix link to visit concept coach dashboard, as it was cc-taskplans before