### PR TITLE
Remove performance forecast from CC courses

### DIFF
--- a/src/flux/current-user.coffee
+++ b/src/flux/current-user.coffee
@@ -34,7 +34,8 @@ ROUTES =
       student: 'viewStudentDashboard'
       default: 'app'
   guide:
-    label: 'Performance Forecast'
+    label: 'Performance Forecast' # a bit hard to read, but we only want to reject the === true case
+    allowedForCourse: (course) -> not course?.is_concept_coach is true
     roles:
       student: 'viewPerformanceForecast'
       teacher: 'viewTeacherPerformanceForecast'
@@ -148,8 +149,12 @@ CurrentUserStore = flux.createStore
     # if menu routes are being retrieved, then getCourseRole should store
     # what courseId is being viewed.
     getCourseMenuRoutes: (courseId, silent = false) ->
+      course = CourseStore.get(courseId)
       menuRole = @_getCourseRole(courseId, silent)
-      routes = _.keys(ROUTES)
+      validRoutes = _.pick ROUTES, (route) ->
+        false isnt route.allowedForCourse?(course)
+
+      routes = _.keys(validRoutes)
 
       _.chain(routes)
         .map((routeType) =>

--- a/test/components/navbar/user-actions-menu.spec.coffee
+++ b/test/components/navbar/user-actions-menu.spec.coffee
@@ -1,7 +1,7 @@
 {Testing, expect, sinon, _} = require '../helpers/component-testing'
 
 UserActionsMenu = require '../../../src/components/navbar/user-actions-menu'
-
+{CourseActions, CourseStore} = require '../../../src/flux/course'
 {testParams, setupStores, resetStores, userModel, courseModel} = require './spec-test-params'
 
 testWithRole = (roleType) ->
@@ -18,6 +18,7 @@ testWithRole = (roleType) ->
       Testing.renderComponent( UserActionsMenu, props: {courseId: courseModel.id} ).then ({dom}) =>
         dropdownItems = dom.querySelectorAll('li')
         roleItems = Array.prototype.slice.call(dropdownItems, 0, -4)
+
         labels = _.pluck(@roleTestParams.menu, 'label')
         labels.push 'Browse the Book'
         expect(_.pluck(roleItems, 'innerText')).to.deep.equal(labels)
@@ -29,6 +30,27 @@ testWithRole = (roleType) ->
         expect(bookLink).not.to.be.null
         expect(bookLink.getAttribute('target')).to.equal('_blank')
         done()
+
+    it 'should have performance forecast menu', (done) ->
+      Testing.renderComponent( UserActionsMenu, props: {courseId: courseModel.id} ).then ({dom}) ->
+        dropdownItems = dom.querySelectorAll('li')
+        expect(_.pluck(dropdownItems, 'innerText')).to.include('Performance Forecast')
+        done()
+
+    describe 'A concept coach course', ->
+      beforeEach ->
+        courseModel.is_concept_coach = true
+        CourseActions.loaded(courseModel, courseModel.id)
+      afterEach ->
+        courseModel.is_concept_coach = false
+        CourseActions.loaded(courseModel, courseModel.id)
+
+      it 'should not have performance forecast menu', (done) ->
+        Testing.renderComponent( UserActionsMenu, props: {courseId: courseModel.id} ).then ({dom}) ->
+          dropdownItems = dom.querySelectorAll('li')
+          expect(_.pluck(dropdownItems, 'innerText')).to.not.include('Performance Forecast')
+          done()
+
 
 describe 'Student Navbar Component', testWithRole('student')
 


### PR DESCRIPTION
Hopefully we can use the same method to allow/disallow other options as well if we need to.

![screen shot 2015-11-24 at 2 44 19 pm](https://cloud.githubusercontent.com/assets/79566/11380146/f5f807ea-92b9-11e5-85c4-3bfe024fef93.png)
