### PR TITLE
:art: find unused vars in cjsx files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-unused-vars": 1
+  }
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "rules": {
-    "no-unused-vars": 1
+    "no-unused-vars": 1,
+    "no-unreachable": 1
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /.tmp
 /dist
 /test-failed-*.png
+
+*.cjsx.js

--- a/lint-cjsx-files.sh
+++ b/lint-cjsx-files.sh
@@ -1,0 +1,7 @@
+
+for FILE in $(find ./src/ -name '*.cjsx')
+do
+  ./node_modules/.bin/cjsx-transform ${FILE} | ./node_modules/.bin/coffee --compile --stdio > ${FILE}.js
+  ./node_modules/.bin/eslint --no-ignore ${FILE}.js
+  rm ${FILE}.js
+done

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "coverage": "gulp coverage",
     "deployment": "gulp prod",
     "test-integration": "mocha -R spec ./test-integration/",
+    "lint-cjsx": "./lint-cjsx-files.sh",
     "start": "gulp dev"
   },
   "repository": {
@@ -61,6 +62,7 @@
     "coffeelint-loader": "^0.1.1",
     "css-loader": "^0.16.0",
     "del": "~1.1.1",
+    "eslint": "^1.10.1",
     "extract-text-webpack-plugin": "^0.8.2",
     "file-exists": "^0.1.1",
     "file-loader": "^0.8.4",


### PR DESCRIPTION
`coffeelint` does not lint `cjsx` files and even for `coffee` files it does not find unused vars.

This adds a `npm run lint-cjsx` which compiles the `cjsx` files individually and then runs `eslint` on each.