### PR TITLE
Fix QA view loading when book_id differs from ecosystem_id

### DIFF
--- a/resources/styles/qa.less
+++ b/resources/styles/qa.less
@@ -55,6 +55,12 @@
         }
       }
     }
+    .available-books .book {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      .version { margin-left: 5px; }
+    }
     // hide logos when screen is narrow.
     // QA has more navbar controls so needs to be more agressive than reference book media query
     @media screen and ( max-width: (@reference-book-page-width+300px) ){

--- a/src/components/qa/book-link.cjsx
+++ b/src/components/qa/book-link.cjsx
@@ -13,9 +13,10 @@ BookLink = React.createClass
     ).isRequired
 
   render: ->
-    <Router.Link to='QAViewBook'
+    <Router.Link to='QAViewBook' className="book"
       params={ecosystemId: @props.book.ecosystemId}>
-        {@props.book.title}
+        <span className="title">{@props.book.title}</span>
+        <span className="version">{@props.book.version}</span>
     </Router.Link>
 
 

--- a/src/components/qa/index.cjsx
+++ b/src/components/qa/index.cjsx
@@ -23,7 +23,6 @@ QADashboard = React.createClass
     if EcosystemsStore.isLoaded()
       params = _.clone @context.router.getCurrentParams()
       params.ecosystemId ?= "#{EcosystemsStore.first().id}"
-      params.bookId ?= "#{EcosystemsStore.getBook(params.ecosystemId).id}"
       <RouteHandler {...params} />
     else
       <h3>Loading ...</h3>

--- a/src/components/qa/view-book.cjsx
+++ b/src/components/qa/view-book.cjsx
@@ -18,7 +18,6 @@ UserActionsMenu      = require '../navbar/user-actions-menu'
 QAViewBook = React.createClass
 
   propTypes:
-    bookId: React.PropTypes.string.isRequired
     section: React.PropTypes.string
     ecosystemId: React.PropTypes.string.isRequired
 
@@ -34,7 +33,7 @@ QAViewBook = React.createClass
         {teacherContent}
         <QAContentToggle isShowingBook={@state.isShowingBook} onChange={@setContentShowing}/>
       </BS.NavItem>
-      <BS.DropdownButton title="Available Books" className="dropdown-toggle">
+      <BS.DropdownButton title="Available Books" className="available-books">
         {for book in EcosystemsStore.allBooks()
           <li key={book.id} className={'active' if @props.ecosystemId is book.ecosystemId}>
             <BookLink book={book} />
@@ -50,7 +49,7 @@ QAViewBook = React.createClass
     @setState(isShowingTeacherContent: isShowing)
 
   renderBook: ->
-    section = @props.section or ReferenceBookStore.getFirstSection(@props.bookId).join('.')
+    section = @props.section or ReferenceBookStore.getFirstSection(@props.ecosystemId).join('.')
     contentComponent = if @state.isShowingBook then QAContent else QAExercises
     <SpyMode.Wrapper>
       <div className="qa">
@@ -61,7 +60,7 @@ QAViewBook = React.createClass
             section={section}
             className={classnames('is-teacher')}
             className={classnames('is-teacher': @state.isShowingTeacherContent)}
-            ecosystemId={@props.bookId}
+            ecosystemId={@props.ecosystemId}
             contentComponent={contentComponent}
         />
       </div>
@@ -69,7 +68,7 @@ QAViewBook = React.createClass
 
   render: ->
     <LoadableItem
-      id={@props.bookId}
+      id={@props.ecosystemId}
       store={ReferenceBookStore}
       actions={ReferenceBookActions}
       renderItem={@renderBook}


### PR DESCRIPTION
The two id's are usually identical, so this wasn't noticed until now.  In places the QA view was using the book id, when it should have been using the ecosystem_id.

I also noted that the "Available Books" menu was confusing when there were multiple ecosystems using books with the same title.  I added the version to the list in order to distinguish them.
![screen shot 2015-11-30 at 1 11 14 pm](https://cloud.githubusercontent.com/assets/79566/11481692/8cf79346-9764-11e5-9d53-fbc10a184ad8.png)
