### PR TITLE
Use appearance code from BE for styling courses

### DIFF
--- a/resources/styles/components/course-listings.less
+++ b/resources/styles/components/course-listings.less
@@ -51,7 +51,7 @@
       }
     }
 
-    &[data-category]{
+    &[data-appearance]{
       .flex-display();
       .tutor-course-item {
         .flex(1);
@@ -63,7 +63,7 @@
         font-weight: 800;
       }
     }
-    &[data-category=physics] {
+    &[data-appearance=physics] {
       .tutor-course-item {
         color: @tutor-book-hs-physics-secondary;
         background-color: @tutor-book-hs-physics-primary;
@@ -77,7 +77,7 @@
       }
     }
 
-    &[data-category=biology] {
+    &[data-appearance=biology] {
       .tutor-course-item {
         color: @tutor-book-ap-bio-secondary;
         background-color: @tutor-book-ap-bio-primary;
@@ -113,7 +113,7 @@
         }
       }
 
-      &[data-category=biology] {
+      &[data-appearance=biology] {
         .tutor-course-item {
           &::before {
             color: @tutor-book-ap-bio-primary;
@@ -122,7 +122,7 @@
         }
       }
 
-      &[data-category=physics] {
+      &[data-appearance=physics] {
         .tutor-course-item {
           &::before {
             color: @tutor-book-hs-physics-primary;

--- a/resources/styles/components/course-listings.less
+++ b/resources/styles/components/course-listings.less
@@ -63,6 +63,16 @@
         font-weight: 800;
       }
     }
+
+    // default styles for courses that do not
+    // have a recognized appearance_code
+    &[data-appearance=default] {
+      .tutor-course-item {
+        color: @tutor-primary;
+        background-color: @tutor-neutral-light;
+      }
+    }
+
     &[data-appearance=physics] {
       .tutor-course-item {
         color: @tutor-book-hs-physics-secondary;
@@ -90,6 +100,7 @@
         }
       }
     }
+
   }
 }
 

--- a/resources/styles/components/reference-book/page.less
+++ b/resources/styles/components/reference-book/page.less
@@ -51,7 +51,7 @@
     }
   }
 
-  &[data-category=physics]{
+  &[data-appearance=physics]{
     .content {
       .page {
         .tutor-book-content-theme-physics();
@@ -59,7 +59,7 @@
     }
   }
 
-  &[data-category=biology]{
+  &[data-appearance=biology]{
     .content {
       .page {
         .tutor-book-content-theme-biology();

--- a/resources/styles/components/student-dashboard/dashboard.less
+++ b/resources/styles/components/student-dashboard/dashboard.less
@@ -42,11 +42,11 @@
     &:hover { text-decoration: initial; }
   }
 
-  [data-category=physics] .view-reference-guide {
+  [data-appearance=physics] .view-reference-guide {
     .tutor-background-image("courses/physics-book-thumbnail.png");
     background-size: auto 80px;
   }
-  [data-category=biology] .view-reference-guide {
+  [data-appearance=biology] .view-reference-guide {
     .tutor-background-image("courses/biology-book-thumbnail.png");
     background-size: auto 80px;
   }

--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -15,11 +15,11 @@
     .tutor-book-note(reading);
     .tutor-book-titles(reading);
 
-    &[data-category=physics]{
+    &[data-appearance=physics]{
       .tutor-book-content-theme-physics();
     }
 
-    &[data-category=biology]{
+    &[data-appearance=biology]{
       .tutor-book-content-theme-biology();
     }
   }

--- a/resources/styles/global/tutor-booksplash-background.less
+++ b/resources/styles/global/tutor-booksplash-background.less
@@ -37,15 +37,15 @@
   }
 
   // custom backgrounds images for different courses
-  &[data-category=physics]:after{ .tutor-background-image("courses/physics-background.jpg"); }
-  &[data-category=biology]:after{ .tutor-background-image("courses/biology-background.jpg"); }
+  &[data-appearance=physics]:after{ .tutor-background-image("courses/physics-background.jpg"); }
+  &[data-appearance=biology]:after{ .tutor-background-image("courses/biology-background.jpg"); }
 
   // custom colors for specific courses
-  &[data-category=physics]:before{
+  &[data-appearance=physics]:before{
     .tutor-physics-cover-background();
   }
 
-  &[data-category=biology]:before{
+  &[data-appearance=biology]:before{
     .tutor-biology-cover-background();
   }
 

--- a/src/components/course-data-mixin.cjsx
+++ b/src/components/course-data-mixin.cjsx
@@ -7,4 +7,4 @@ module.exports =
 
     dataProps =
       'data-title': CourseStore.getShortName(courseId)
-      'data-category': CourseStore.getCategory(courseId)
+      'data-appearance': CourseStore.getAppearanceCode(courseId)

--- a/src/flux/course.coffee
+++ b/src/flux/course.coffee
@@ -92,12 +92,9 @@ CourseConfig =
         if not name? or name is ''
           return ['required']
 
-    # This is currently bassed on the course title.
-    # eventually the backend will provide it as part of the course's metadata.
-    getCategory: (courseId) ->
-      return @_get(courseId).catalog_offering_identifier or (
-        this.exports.getShortName.call(this, courseId).toLowerCase()
-      )
+    # Returns the configured appearance code for a course
+    getAppearanceCode: (courseId) ->
+      return @_get(courseId)?.appearance_code or 'default'
 
     getShortName: (courseId) ->
       title = @_get(courseId)?.name or ""


### PR DESCRIPTION
As part of https://github.com/openstax/tutor-server/pull/853 the BE will be sending a `appearance_code` attribute on courses.  The code will default to the offering but can be set on a per-course basis if needed.

Should be merged in connection with BE pr.