### PR TITLE
Show message when no periods

### DIFF
--- a/src/components/course-settings/roster.cjsx
+++ b/src/components/course-settings/roster.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 BS = require 'react-bootstrap'
 _  = require 'underscore'
 BindStoreMixin = require '../bind-store-mixin'
+NoPeriods = require '../no-periods'
 
 {CourseStore, CourseActions} = require '../../flux/course'
 {RosterStore, RosterActions} = require '../../flux/roster'
@@ -42,6 +43,7 @@ module.exports = React.createClass
 
   render: ->
     course = CourseStore.get(@props.courseId)
+    periods = course.periods.length > 0
     tabs = _.map course.periods, (period, index) =>
       <BS.TabPane key={period.id}, eventKey={index} tab={period.name}>
         <PeriodRoster 
@@ -49,22 +51,32 @@ module.exports = React.createClass
         courseId={@props.courseId}
         activeTab={@getActivePeriod(@state.key, course.periods)} />
       </BS.TabPane>
-    <BS.TabbedArea activeKey={@state.key} onSelect={@handleSelect}>
-      <div className='period-edit-ui'>
-        <AddPeriodLink courseId={@props.courseId} periods={course.periods} />
-        <RenamePeriodLink
-        courseId={@props.courseId}
-        periods={course.periods}
-        activeTab={@getActivePeriod(@state.key, course.periods)} />
-        <DeletePeriodLink
-        courseId={@props.courseId}
-        periods={course.periods}
-        activeTab={@getActivePeriod(@state.key, course.periods)}
-        selectPreviousTab={@selectPreviousTab} />
-      </div>
+    enrollmentButton =
       <PeriodEnrollmentCode
       activeTab={@getActivePeriod(@state.key, course.periods)}
       periods={course.periods} />
+    renameButton =
+      <RenamePeriodLink
+      courseId={@props.courseId}
+      periods={course.periods}
+      activeTab={@getActivePeriod(@state.key, course.periods)} />
+    deleteButton =
+      <DeletePeriodLink
+      courseId={@props.courseId}
+      periods={course.periods}
+      activeTab={@getActivePeriod(@state.key, course.periods)}
+      selectPreviousTab={@selectPreviousTab} />
+    noPeriodMessage =
+      <NoPeriods noPanel={true} />
+
+    <BS.TabbedArea activeKey={@state.key} onSelect={@handleSelect}>
+      <div className='period-edit-ui'>
+        <AddPeriodLink courseId={@props.courseId} periods={course.periods} />
+        {renameButton if periods}
+        {deleteButton if periods}
+      </div>
+      {enrollmentButton if periods}
       <div><span className='course-settings-subtitle tabbed'>Roster</span></div>
+      {noPeriodMessage unless periods}
       {tabs}
     </BS.TabbedArea>

--- a/src/components/no-periods.cjsx
+++ b/src/components/no-periods.cjsx
@@ -1,11 +1,14 @@
 _ = require 'underscore'
 React = require 'react'
+BS = require 'react-bootstrap'
 
 NO_PERIODS_TEXT = 'Please add at least one period to the course.'
 
 NoPeriods = React.createClass
 
   render: ->
-    <span className='-no-periods-text'>{NO_PERIODS_TEXT}</span>
+    <BS.Panel>
+      <span className='-no-periods-text'>{NO_PERIODS_TEXT}</span>
+    </BS.Panel>
 
 module.exports = NoPeriods

--- a/src/components/no-periods.cjsx
+++ b/src/components/no-periods.cjsx
@@ -1,0 +1,11 @@
+_ = require 'underscore'
+React = require 'react'
+
+NO_PERIODS_TEXT = 'Please add at least one period to the course.'
+
+NoPeriods = React.createClass
+
+  render: ->
+    <span className='-no-periods-text'>{NO_PERIODS_TEXT}</span>
+
+module.exports = NoPeriods

--- a/src/components/no-periods.cjsx
+++ b/src/components/no-periods.cjsx
@@ -6,9 +6,16 @@ NO_PERIODS_TEXT = 'Please add at least one period to the course.'
 
 NoPeriods = React.createClass
 
+  propTypes:
+    noPanel:   React.PropTypes.bool
+
   render: ->
-    <BS.Panel>
-      <span className='-no-periods-text'>{NO_PERIODS_TEXT}</span>
-    </BS.Panel>
+    text = <span className='-no-periods-text'>{NO_PERIODS_TEXT}</span>
+    if @props.noPanel
+      text
+    else
+      <BS.Panel>
+        {text}
+      </BS.Panel>
 
 module.exports = NoPeriods

--- a/src/components/scores/index.cjsx
+++ b/src/components/scores/index.cjsx
@@ -11,7 +11,6 @@ ExternalCell = require './external-cell'
 SortingHeader = require './sorting-header'
 FixedDataTable = require 'fixed-data-table'
 ConceptCoachCell = require './concept-coach-cell'
-NoPeriods = require '../no-periods'
 
 Table = FixedDataTable.Table
 Column = FixedDataTable.Column
@@ -278,16 +277,12 @@ ScoresShell = React.createClass
   render: ->
     {courseId} = @context.router.getCurrentParams()
     course = CourseStore.get(courseId)
-    if course.periods.length > 0
-      renderItem = <Scores courseId={courseId} isConceptCoach={course.is_concept_coach} />
-    else
-      renderItem = <NoPeriods/>
     <BS.Panel className='scores-report'>
       <LoadableItem
         id={courseId}
         store={ScoresStore}
         actions={ScoresActions}
-        renderItem={-> renderItem}
+        renderItem={-> <Scores courseId={courseId} isConceptCoach={course.is_concept_coach} />}
       />
     </BS.Panel>
 

--- a/src/components/scores/index.cjsx
+++ b/src/components/scores/index.cjsx
@@ -11,6 +11,7 @@ ExternalCell = require './external-cell'
 SortingHeader = require './sorting-header'
 FixedDataTable = require 'fixed-data-table'
 ConceptCoachCell = require './concept-coach-cell'
+NoPeriods = require '../no-periods'
 
 Table = FixedDataTable.Table
 Column = FixedDataTable.Column
@@ -277,12 +278,16 @@ ScoresShell = React.createClass
   render: ->
     {courseId} = @context.router.getCurrentParams()
     course = CourseStore.get(courseId)
+    if course.periods.length > 0
+      renderItem = <Scores courseId={courseId} isConceptCoach={course.is_concept_coach} />
+    else
+      renderItem = <NoPeriods/>
     <BS.Panel className='scores-report'>
       <LoadableItem
         id={courseId}
         store={ScoresStore}
         actions={ScoresActions}
-        renderItem={-> <Scores courseId={courseId} isConceptCoach={course.is_concept_coach} />}
+        renderItem={-> renderItem}
       />
     </BS.Panel>
 

--- a/src/helpers/conditional-rendering.coffee
+++ b/src/helpers/conditional-rendering.coffee
@@ -3,6 +3,8 @@
 React = require 'react'
 {CurrentUserStore}   = require '../flux/current-user'
 {Invalid} = require '../components'
+NoPeriods = require '../components/no-periods'
+{CourseStore} = require '../flux/course'
 
 module.exports = (component, options = {}) ->
 
@@ -10,9 +12,12 @@ module.exports = (component, options = {}) ->
   RouteHandler.contextTypes = { router: React.PropTypes.func }
   RouteHandler::render = ->
     {courseId} = @context.router.getCurrentParams()
+    course = CourseStore.get(courseId)
     React.createElement(
       if options.requireRole and courseId and options.requireRole isnt CurrentUserStore.getCourseRole(courseId)
         Invalid
+      else if options.requirePeriods and course.periods.length is 0
+        NoPeriods
       else
         component
     )

--- a/src/router.cjsx
+++ b/src/router.cjsx
@@ -48,11 +48,11 @@ routes = (
         <Route path='t/' name='viewTeacherDashBoard'>
           <Router.DefaultRoute handler={TeacherTaskPlans} />
           <Route path='scores/?' name='viewScores'
-            handler={Handler(ScoresShell, requireRole: 'teacher')} />
+            handler={Handler(ScoresShell, requireRole: 'teacher', requirePeriods: true)} />
           <Route path='guide' name='viewTeacherPerformanceForecast'
-            handler={Handler(PerformanceForecastShell.Teacher, requireRole: 'teacher')} />
+            handler={Handler(PerformanceForecastShell.Teacher, requireRole: 'teacher', requirePeriods: true)} />
           <Route path='guide/student/:roleId?' name='viewStudentTeacherPerformanceForecast'
-            handler={Handler(PerformanceForecastShell.TeacherStudent, requireRole: 'teacher')}/>
+            handler={Handler(PerformanceForecastShell.TeacherStudent, requireRole: 'teacher', requirePeriods: true)}/>
 
           <Route path='calendar/?' name='taskplans'>
             <Router.DefaultRoute handler={TeacherTaskPlans} />


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/954569/11603753/90b6eddc-9ab2-11e5-9f50-75aea0c5bda1.png)

![image](https://cloud.githubusercontent.com/assets/954569/11604882/b0178138-9ac0-11e5-97f2-b88067bc1b55.png)

- [x] no periods boilerplate message on scores
- [x] finalized message text
- [x] no periods message on performance forecast
- [x] roster updated to handle no periods