### PR TITLE
Legend for hidden chapters/sections

### DIFF
--- a/resources/styles/components/cc-dashboard/index.less
+++ b/resources/styles/components/cc-dashboard/index.less
@@ -22,7 +22,11 @@
     float: right;
     margin: -10px 0 0 0;
   }
-
+  .hide-section-legend {
+    font-size: 0.9rem;
+    font-style: italic;
+    text-align: right;
+  }
   .chapter {
 
     &.empty {

--- a/src/components/cc-dashboard/dashboard.cjsx
+++ b/src/components/cc-dashboard/dashboard.cjsx
@@ -94,6 +94,11 @@ CCDashboard = React.createClass
         </BS.Row>
         {for chapter, index in chapters
           <DashboardChapter chapter={chapter} key={index} />}
+        <BS.Row>
+          <BS.Col className="hide-section-legend" xs={12}>
+            Chapters and sections that are less than 10% complete are hidden
+          </BS.Col>
+        </BS.Row>
       </BS.Panel>
     </div>
 module.exports = CCDashboard

--- a/src/flux/cc-dashboard.coffee
+++ b/src/flux/cc-dashboard.coffee
@@ -31,7 +31,9 @@ DashboardConfig =
           page.chapter_section[1] or 0
         ).reverse()
         chapter
-      chapters.reverse()
+
+      _.select chapters.reverse(), (chapter) ->
+        chapter.valid_sections?.length
 
 
 extendConfig(DashboardConfig, new CrudConfig())


### PR DESCRIPTION
![screen shot 2015-12-08 at 4 09 46 am](https://cloud.githubusercontent.com/assets/6434717/11638362/9718f510-9d61-11e5-8ddf-abcd5a4d7e6b.png)

Putting this at the bottom of the dashboard progress table, it shouldn't show up on the blank dashboard.