### PR TITLE
Tweak line-height to move text up vertically

### DIFF
--- a/resources/styles/components/cc-dashboard/index.less
+++ b/resources/styles/components/cc-dashboard/index.less
@@ -111,7 +111,7 @@
       text-align: left;
       padding-left: 50px;
       padding-right: 50px;
-      line-height: @banner-height;
+      line-height: @banner-height - 20px; // manually tweak vertical position to center text
     }
   }
 


### PR DESCRIPTION
Per @Fredasaurus, this should align the text so the space at the bottom of the `g` equals the top of the `A`

![image](https://cloud.githubusercontent.com/assets/79566/11692173/e076fec0-9e63-11e5-9c79-762f55b26d15.png)