### PR TITLE
Review Metrics Back Button - fixed route

### DIFF
--- a/src/helpers/routes-and-destinations.coffee
+++ b/src/helpers/routes-and-destinations.coffee
@@ -14,7 +14,7 @@ STEP = 'Step'
 TASK = 'Task'
 
 REMEMBERED_ROUTES =
-  dashboard: COURSES
+  dashboard: DASHBOARD
   viewStudentDashboard: DASHBOARD
   viewPerformanceForecast: PERFORMANCE_FORECAST
   viewTeacherDashboard: DASHBOARD
@@ -23,6 +23,7 @@ REMEMBERED_ROUTES =
   viewStudentTeacherPerformanceForecast: PERFORMANCE_FORECAST
   taskplans: DASHBOARD
   calendarByDate: DASHBOARD
+  calendarViewPlanStats: DASHBOARD
   courseSettings: COURSE_SETTINGS
   viewStats: PLAN_STATS
   reviewTask: PLAN_REVIEW


### PR DESCRIPTION
regarding: 
https://www.pivotaltracker.com/story/show/109830470
https://www.pivotaltracker.com/story/show/103940100

- [x] Route recognized as dashboard was going to courselist / showing course label
- [x] calendarViewPlanStats added.  Button now returns correctly back to dash planstats

Back button from review metrics in plan stats:
![image](https://cloud.githubusercontent.com/assets/954569/11698657/c2ab3878-9e8d-11e5-8eb2-3873c5e88b25.png)

Back button from scores review:
![image](https://cloud.githubusercontent.com/assets/954569/11698672/e00b8eea-9e8d-11e5-8e1b-910882606146.png)
