### PR TITLE
Use a link with target=_blank for account profile

### DIFF
--- a/src/components/navbar/account-link.cjsx
+++ b/src/components/navbar/account-link.cjsx
@@ -1,20 +1,13 @@
 React = require 'react'
 BS = require 'react-bootstrap'
-Router = require 'react-router'
+
 {CurrentUserStore} = require '../../flux/current-user'
-{TransitionAssistant} = require '../unsaved-state'
 
 module.exports = React.createClass
   displayName: 'Navigation'
 
-  contextTypes:
-    router: React.PropTypes.func
-
-  redirectToAccount: ->
-    window.open(CurrentUserStore.getProfileUrl(), 'account-profile')
-
   render: ->
     return null unless CurrentUserStore.getProfileUrl()
-    <BS.MenuItem onSelect={@redirectToAccount} >
-      My Account
-    </BS.MenuItem>
+    <li>
+      <a href={CurrentUserStore.getProfileUrl()} target='_blank'>My Account</a>
+    </li>


### PR DESCRIPTION
Because it's more reliable than window.open.  Accounts was also testing for the existence of `window.opener`, (which has been corrected).

No UI changes, but:

![image](https://cloud.githubusercontent.com/assets/79566/11700727/1b90a34e-9e91-11e5-872f-83337343eff0.png)
