### PR TITLE
Student Scores - Faster horizontal scrolling

### DIFF
--- a/src/components/scores/index.cjsx
+++ b/src/components/scores/index.cjsx
@@ -127,6 +127,7 @@ Scores = React.createClass
         cellRenderer={-> @cellData}
         width={@state.colSetWidth}
         flexGrow={1}
+        allowCellsRecycling={true}
         isResizable=false
         dataKey={i} />
     </ColumnGroup>
@@ -169,6 +170,8 @@ Scores = React.createClass
       <Column
         width={@state.colSetWidth * nameColumns}
         flexGrow={1}
+        allowCellsRecycling={true}
+        isResizable=false
         dataKey='0'
         fixed={true}
         cellRenderer={-> @cellData}


### PR DESCRIPTION
This setting could increase horizontal scrolling performance when a large number of columns are present, by only rendering visible.