### PR TITLE
Remove appearance codes that were duplicated

### DIFF
--- a/resources/styles/variables/colors.less
+++ b/resources/styles/variables/colors.less
@@ -34,7 +34,7 @@
 
 // TODO: Move book styles to react-components
 
-@openstax-book-appearance-codes: default physics biology principles_economics macro_economics college_physics micro_economics college_physics micro_economics concepts_biology intro_sociology anatomy_physiology;
+@openstax-book-appearance-codes: default physics biology principles_economics macro_economics college_physics micro_economics concepts_biology intro_sociology anatomy_physiology;
 
 @openstax-book-default-fg: rgb(119, 175, 66);
 @openstax-book-default-bg: rgb(94,96,98);


### PR DESCRIPTION
Somehow `college_physics` & `micro_economics` were listed twice.