### PR TITLE
Limit completed percentage to 100

### DIFF
--- a/src/components/cc-dashboard/section-progress.cjsx
+++ b/src/components/cc-dashboard/section-progress.cjsx
@@ -7,6 +7,7 @@ SectionProgress = React.createClass
 
   render: ->
     percent = Math.round(@props.section.completed_percentage * 100)
+    if (percent > 100) then percent = 100
     completedLabel = "#{percent}%"
     completedLabel = if percent is 100 then "#{completedLabel} completed" else completedLabel
 


### PR DESCRIPTION
Relates to: https://www.pivotaltracker.com/n/projects/1156756/stories/109459654

Limits completed percentage to be no greater than 100.  I think the source of the error is on the backend though.  I'm just adding this front end piece to protect from the broken UI.