### PR TITLE
Scores Table Width in IE

### DIFF
--- a/src/components/scores/index.cjsx
+++ b/src/components/scores/index.cjsx
@@ -66,9 +66,7 @@ Scores = React.createClass
     @sizeTable()
 
   sizeTable: ->
-    _.delay( =>
-      @setState({tableWidth: @tableWidth(), tableHeight: @tableHeight(), resizeSpacerNeeded: false}) if @isMounted()
-    , 100)
+    @setState({tableWidth: @tableWidth(), tableHeight: @tableHeight(), resizeSpacerNeeded: false}) if @isMounted()
 
 
   tableWidth: (debug) ->

--- a/src/components/scores/index.cjsx
+++ b/src/components/scores/index.cjsx
@@ -57,6 +57,7 @@ Scores = React.createClass
     colResizeWidth: 180
     colResizeKey: 0
     sort: INITIAL_SORT
+    resizeSpacerNeeded: true
 
   componentDidMount: ->
     @sizeTable()
@@ -66,10 +67,11 @@ Scores = React.createClass
 
   sizeTable: ->
     _.delay( =>
-      @setState({tableWidth: @tableWidth(), tableHeight: @tableHeight()}) if @isMounted()
+      @setState({tableWidth: @tableWidth(), tableHeight: @tableHeight(), resizeSpacerNeeded: false}) if @isMounted()
     , 100)
 
-  tableWidth: ->
+
+  tableWidth: (debug) ->
     table = React.findDOMNode(@refs.tableContainer)
     Math.max(400, table.clientWidth)
 
@@ -274,12 +276,15 @@ Scores = React.createClass
 
     if data.rows.length > 0 then students = true
 
+    if @state.resizeSpacerNeeded then resizeSpacer = <span>&nbsp;</span>
+
     <div className='course-scores-wrap'>
         <span className='course-scores-title'>Student Scores</span>
         {scoresExport if students}
         {if isConceptCoach then scoresNote}
         {periodNav}
         <div className='course-scores-container' ref='tableContainer'>
+          {resizeSpacer}
           {if students then scoresTable else noAssignments}
         </div>
     </div>


### PR DESCRIPTION
For ticket: https://www.pivotaltracker.com/story/show/110357606

![screen shot 2015-12-17 at 3 53 54 pm](https://cloud.githubusercontent.com/assets/6434717/11881754/b1f5861a-a4d6-11e5-8e90-2c2e0d8f492e.png)


When the table first loads, because the container div is empty, the div has no width.  This PR adds a temporary spacer in there that gets removed once we resize the table.  Pretty hacky, but I couldn't think of a great css only solution.