### PR TITLE
updated maths to try katex first and then use mathjax when needed

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF8">
     <link rel="stylesheet" href="/dist/tutor.css" />
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/katex.min.css">
     <script src="//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
     <script src="/dist/tutor.js" async></script>
   </head>

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "font-awesome": "~4.3.0",
     "htmlparser2": "^3.8.3",
     "jquery": "^2.1.4",
+    "katex": "^0.5.1",
     "markdown-it": "^4.1.1",
     "mime-types": "^2.1.3",
     "moment": "^2.9.0",

--- a/resources/styles/global/maths.less
+++ b/resources/styles/global/maths.less
@@ -1,18 +1,12 @@
 // Math Rendering
 // Hides all data-math elements, but still reserves their space in the DOM.
 // when .MathJax renders them, it'll be inside a .MathJax element which is displayed
-[data-math]{
+[data-math]:not(.math-rendered) {
   visibility: hidden;
   .MathJax {
     visibility: visible;
   }
 }
-
-// KaTeX 1.0.2 generates both HTML and MathML
-//
-// Hide the HTML and use MathJax for rendering
-// TODO: Decide whether to remove KaTeX (involves additional code for MathJax)
-.has-html .katex > .katex-html { display: none; }
 
 // Override the inline style on mathjax text elements to match the tutor default of lato
 .MathJax .mtext { font-family: lato !important; }


### PR DESCRIPTION
it's like so fast, as in i don't even see the flash of unrendered maths. and it works in Windows (IE included) with lots of maths on the same page.  soooooo it's kinda like...cool.

and also, also, because you can run katex without the DOM using `renderToString`, if we are really trying to pinch for speed, we can send katex processing easily to a web worker

If this is to be accepted, this change should be ported to the components repo as well

openstax/tutor-server#904