### PR TITLE
Student Scores - fixed spacing on student id column and label

### DIFF
--- a/resources/styles/components/scores/index.less
+++ b/resources/styles/components/scores/index.less
@@ -99,7 +99,7 @@
       height: 100%;
     }
     .student-id {
-      margin-left: 160px; 
+      margin-left: 85px; 
     }
   }
 

--- a/src/components/scores/index.cjsx
+++ b/src/components/scores/index.cjsx
@@ -172,7 +172,7 @@ Scores = React.createClass
     <ColumnGroup fixed={true} groupHeaderRenderer={-> emptyCell}>
       <Column
         width={@state.colSetWidth * nameColumns}
-        flexGrow={1}
+        flexGrow={0}
         allowCellsRecycling={true}
         isResizable=false
         dataKey='0'


### PR DESCRIPTION
Student id label was shifting / column flexing unnecessarily.