### PR TITLE
Course Roster - updated overlay to address positioning issue and close button

### DIFF
--- a/src/components/course-settings/change-period.cjsx
+++ b/src/components/course-settings/change-period.cjsx
@@ -34,12 +34,14 @@ module.exports = React.createClass
         <span>
           Move to <CourseGroupingLabel courseId={@props.courseId} lowercase/>:
         </span>
-    <BS.Popover className='change-period' title={title} {...@props}>
-      <BS.Nav stacked bsStyle='pills' onSelect={@updatePeriod}>
-        {for period in course.periods
-          @renderPeriod(period) unless period.id is @props.student.period_id }
-      </BS.Nav>
-    </BS.Popover>
+    <BS.Modal bsSize='small' className='change-period' title={title} {...@props}>
+      <div className='modal-body'>
+        <BS.Nav stacked bsStyle='pills' onSelect={@updatePeriod}>
+          {for period in course.periods
+            @renderPeriod(period) unless period.id is @props.student.period_id }
+        </BS.Nav>
+      </div>
+    </BS.Modal>
 
   render: ->
     # if we have only 1 period, it's imposible to move a student

--- a/src/components/course-settings/drop-student.cjsx
+++ b/src/components/course-settings/drop-student.cjsx
@@ -15,11 +15,13 @@ module.exports = React.createClass
 
   confirmPopOver: ->
     title = <span>Drop <Name {...@props.student} />?</span>
-    <BS.Popover title={title} {...@props}>
-      <BS.Button onClick={@performDeletion} bsStyle="danger">
-        <Icon type='ban' /> Drop
-      </BS.Button>
-    </BS.Popover>
+    <BS.Modal bsSize='small' title={title} {...@props}>
+      <div className='modal-body'>
+        <BS.Button onClick={@performDeletion} bsStyle="danger">
+          <Icon type='ban' /> Drop
+        </BS.Button>
+      </div>
+    </BS.Modal>
 
   render: ->
     <BS.OverlayTrigger rootClose={true} trigger='click' placement='left'

--- a/src/components/course-settings/remove-teacher.cjsx
+++ b/src/components/course-settings/remove-teacher.cjsx
@@ -45,12 +45,14 @@ module.exports = React.createClass
       </AsyncButton>
 
     title = <span>Remove <Name {...@props.teacher} />?</span>
-    <BS.Popover className='teacher-remove' title={title} {...@props}>
-      {removeButton}
-      <div className='warning'>
-        {WARN_REMOVE_CURRENT if @isRemovalCurrentTeacher()}
+    <BS.Modal bsSize='small' className='teacher-remove' title={title} {...@props}>
+      <div className='modal-body'>
+        {removeButton}
+        <div className='warning'>
+          {WARN_REMOVE_CURRENT if @isRemovalCurrentTeacher()}
+        </div>
       </div>
-    </BS.Popover>
+    </BS.Modal>
 
   render: ->
     <BS.OverlayTrigger rootClose={true} trigger='click' placement='left'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/109985726

https://www.pivotaltracker.com/story/show/105715954

![image](https://cloud.githubusercontent.com/assets/954569/12058234/000614d2-af18-11e5-9a12-3cf26e030916.png)

![image](https://cloud.githubusercontent.com/assets/954569/12058237/0c249158-af18-11e5-9558-c16006b50d1c.png)

![image](https://cloud.githubusercontent.com/assets/954569/12058243/166f134a-af18-11e5-8b04-423edb79d610.png)

Popovers were not positioning correctly in firefox or ie when page was scrolled.
Using modal instead also addresses ticket regarding having a confirm/close.
