### PR TITLE
Update react bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "pluralize": "^1.1.2",
     "promise-loader": "^1.0.0",
     "react": "0.13.1",
-    "react-bootstrap": "0.24.0",
+    "react-bootstrap": "0.23.0",
     "react-calendar": "^0.4.0",
     "react-datepicker": "^0.8.0",
     "react-router": "~0.13.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "pluralize": "^1.1.2",
     "promise-loader": "^1.0.0",
     "react": "0.13.1",
-    "react-bootstrap": "~0.22.0",
+    "react-bootstrap": "0.24.0",
     "react-calendar": "^0.4.0",
     "react-datepicker": "^0.8.0",
     "react-router": "~0.13.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mime-types": "^2.1.3",
     "moment": "^2.9.0",
     "moment-timezone": "^0.4.0",
-    "openstax-react-components": "openstax/react-components#a8a29638c07cdad0d693ac41da4a9957b922878a",
+    "openstax-react-components": "openstax/react-components#7385391a312779a5c2e80fb94ad158b821785fef",
     "pluralize": "^1.1.2",
     "promise-loader": "^1.0.0",
     "react": "0.13.1",


### PR DESCRIPTION
This update fixes the popover positioning bug present in ie and firefox, pertaining to:
https://www.pivotaltracker.com/story/show/109985726

Requires that openstax-react-components peerDependencies be updated to 0.23.0

Have been testing and I found no issues due to changes in framework so far.

react-bootstrap changelog of issue:

- [66e41a4](../../commit/66e41a4) [fixed] Fix scroll top calculation for overlays

Refs #922