### PR TITLE
Selenium: add code coverage for selenium tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /dist
 /test-failed-*.png
 /coverage
+/coverage-selenium.json
 
 *.cjsx.js
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "build": "gulp build",
     "build-archive": "gulp build-archive",
     "test-integration:only": "mocha --bail -R spec ./test-integration/index",
-    "pretest-integration": "if [ -z ${SERVER_URL} ]; then npm run build; fi",
+    "pretest-integration": "if [ -z ${SERVER_URL} ]; then NODE_COVERAGE=true npm run build; fi",
     "test-integration": "./scripts/run-test-integration.sh",
+    "posttest-integration": "istanbul report --include ./coverage-selenium.json json --dir ./coverage/ lcov",
     "lint-cjsx": "./scripts/lint-cjsx-files.sh",
     "start": "gulp dev"
   },
@@ -89,6 +90,7 @@
     "gulp-util": "3.0.6",
     "gulp-watch": "4.3.5",
     "http-server": "0.8.5",
+    "istanbul": "0.4.1",
     "istanbul-instrumenter-loader": "0.1.3",
     "json-loader": "0.5.3",
     "karma": "0.13.19",

--- a/test-integration/helpers/describe.coffee
+++ b/test-integration/helpers/describe.coffee
@@ -1,6 +1,8 @@
+fs = require 'fs'
 selenium = require 'selenium-webdriver'
 seleniumMocha = require('selenium-webdriver/testing')
 _ = require 'underscore'
+
 chai = require 'chai'
 chai.use require 'chai-as-promised'
 expect = {chai}
@@ -26,6 +28,8 @@ logger.addHandler (record) ->
 
 
 
+
+
 describe = (name, cb) ->
   seleniumMocha.describe name, ->
 
@@ -40,6 +44,7 @@ describe = (name, cb) ->
     @__afterEach = afterEach
 
     @before ->
+      Verbose.reset()
 
       # Wait 20sec for the browser to start up
       @timeout(20 * 1000, true)
@@ -116,7 +121,11 @@ describe = (name, cb) ->
 
 
       Verbose.reset()
-      User.logout(@)
+      User.logout(@).then ->
+        # Save the coverage data to a file
+        # Keep replacing the file as tests finish (the object will continue to be appended to in memory)
+        coverageData = User.getCoverageData()
+        fs.writeFileSync('./coverage-selenium.json', JSON.stringify(coverageData), 'utf8')
 
 
     @after ->

--- a/webpack.config.coffee
+++ b/webpack.config.coffee
@@ -2,11 +2,20 @@ ExtractTextPlugin = require 'extract-text-webpack-plugin'
 webpack = require 'webpack'
 
 isStandaloneBuild = process.env.NODE_BUILD_TYPE is 'standalone'
+isCoverage = process.env.NODE_COVERAGE
 LOADERS = if isStandaloneBuild then [] else ["react-hot", "webpack-module-hot-accept"]
 lessLoader = if isStandaloneBuild
   { test: /\.less$/,   loader: ExtractTextPlugin.extract('css!less') }
 else
   { test: /\.less$/,   loaders: LOADERS.concat('style-loader', 'css-loader', 'less-loader') }
+
+if isCoverage
+  POST_LOADERS = [
+    { test: /\.coffee$/, loaders: ["istanbul-instrumenter"] }
+    { test: /\.cjsx$/, loaders: ["istanbul-instrumenter"] }
+  ]
+else
+  POST_LOADERS = []
 
 module.exports =
   cache: true
@@ -41,7 +50,8 @@ module.exports =
       { test: /\.cjsx$/,   loaders: LOADERS.concat("coffee-jsx-loader") }
       { test: /\.(png|jpg|svg)/, loader: 'file-loader?name=[name].[ext]'}
       { test: /\.(woff|woff2|eot|ttf)/, loader: "url-loader?limit=30000&name=[name]-[hash].[ext]" }
-   ]
+    ]
+    postLoaders: POST_LOADERS
   resolve:
     extensions: ['', '.js', '.json', '.coffee', '.cjsx']
 


### PR DESCRIPTION
This injects the JS built by webpack with coverage recording and then the selenium mocha tests extract the coverage data out at the end of each test using the `__coverage__` global that `istanbul` fills. refs #931

**[Example coverage Report](https://openstax.github.io/tutor-js/coverage/lcov-report/)**

# To run

Run `npm run test-integration`. This command:

1. builds the JS files with coverage recording sprinkled in
2. serves the files at `http://localhost:8000`
3. runs selenium tests while recording coverage information to `/coverage-selenium.json`
4. generates an HTML and `.lcov` report in `/coverage/`


# TODO

- [x] save the `__coverage__` data to a file and then generate a report

Thoughts @openstax/tutor-fe ?