### PR TITLE
use date preserving helper function to handle calendar tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "camelcase": "^1.0.2",
     "classnames": "^2.1.3",
     "es6-promise": "^2.3",
-    "flux-react": "~2.6.4",
+    "flux-react": "2.6.6",
     "font-awesome": "~4.3.0",
     "htmlparser2": "^3.8.3",
     "jquery": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "jquery": "^2.1.4",
     "markdown-it": "^4.1.1",
     "mime-types": "^2.1.3",
-    "moment": "^2.9.0",
+    "moment": "~2.10.0",
     "moment-timezone": "^0.4.0",
     "openstax-react-components": "openstax/react-components#a8a29638c07cdad0d693ac41da4a9957b922878a",
     "pluralize": "^1.1.2",

--- a/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -97,7 +97,7 @@ TeacherTaskPlanListing = React.createClass
   getDateFromParams: ->
     {date} = @context.router.getCurrentParams()
     if date?
-      date = moment(date, @props.dateFormat)
+      date = TimeHelper.getMomentPreserveDate(date, @props.dateFormat)
     date
 
   render: ->

--- a/test/components/helpers/calendar/checks.coffee
+++ b/test/components/helpers/calendar/checks.coffee
@@ -69,22 +69,22 @@ checks =
     {div, component, state, router, history, courseId}
 
   _checkIsDateToday: (args...) ->
-    checks.doesDateMatchMonthOf(moment(TimeStore.getNow()), args...)
+    checks.doesDateMatchMonthOf(TimeHelper.getMomentPreserveDate(TimeStore.getNow()), args...)
 
   _checkIsLabelThisMonth: (args...) ->
-    checks.doesLabelMatchMonthOf(moment(TimeStore.getNow()), args...)
+    checks.doesLabelMatchMonthOf(TimeHelper.getMomentPreserveDate(TimeStore.getNow()), args...)
 
   _checkIsDateNextMonth: (args...) ->
-    checks.doesDateMatchMonthOf(moment(TimeStore.getNow()).add(1, 'month'), args...)
+    checks.doesDateMatchMonthOf(TimeHelper.getMomentPreserveDate(TimeStore.getNow()).add(1, 'month'), args...)
 
   _checkIsLabelNextMonth: (args...) ->
-    checks.doesLabelMatchMonthOf(moment(TimeStore.getNow()).add(1, 'month'), args...)
+    checks.doesLabelMatchMonthOf(TimeHelper.getMomentPreserveDate(TimeStore.getNow()).add(1, 'month'), args...)
 
   _checkIsDatePreviousMonth: (args...) ->
-    checks.doesDateMatchMonthOf(moment(TimeStore.getNow()).subtract(1, 'month'), args...)
+    checks.doesDateMatchMonthOf(TimeHelper.getMomentPreserveDate(TimeStore.getNow()).subtract(1, 'month'), args...)
 
   _checkIsLabelPreviousMonth: (args...) ->
-    checks.doesLabelMatchMonthOf(moment(TimeStore.getNow()).subtract(1, 'month'), args...)
+    checks.doesLabelMatchMonthOf(TimeHelper.getMomentPreserveDate(TimeStore.getNow()).subtract(1, 'month'), args...)
 
   _checkDoesViewHavePlans: ({div, component, state, router, history, courseId}) ->
     {durations, viewingDuration} = component.refs.calendarHandler.refs.courseDurations.props

--- a/test/components/task-plan/builder.spec.coffee
+++ b/test/components/task-plan/builder.spec.coffee
@@ -18,8 +18,8 @@ yesterday = (new Date(Date.now() - 1000 * 3600 * 24)).toString()
 tomorrow = (new Date(Date.now() + 1000 * 3600 * 24)).toString()
 dayAfter = (new Date(Date.now() + 1000 * 3600 * 48)).toString()
 
-getDateString = (value) -> moment(value).format(TutorDateFormat)
-getISODateString = (value) -> moment(value).format(ISO_DATE_FORMAT)
+getDateString = (value) -> TimeHelper.getMomentPreserveDate(value).format(TutorDateFormat)
+getISODateString = (value) -> TimeHelper.getMomentPreserveDate(value).format(ISO_DATE_FORMAT)
 
 COURSES = require '../../../api/user/courses.json'
 NEW_READING = ExtendBasePlan({id: "_CREATING_1", settings: {page_ids: []}}, false, false)
@@ -143,7 +143,7 @@ describe 'Task Plan Builder', ->
 
   it 'can update open date with string', ->
     helper(NEW_READING).then ({dom, element}) ->
-      element.setDueAt(getDateString(tomorrow))
+      element.setOpensAt(getDateString(tomorrow))
       opensAt = TaskPlanStore.getOpensAt(NEW_READING.id)
       expect(getDateString(opensAt)).to.be.equal(getDateString(tomorrow))
 


### PR DESCRIPTION
especially important around the first of the month since travis runs on a different timezone, that used to confused what month the tests should be rendering the calendar in when converting string dates back to moment date objects

Also includes commit for pinning `flux-react` to 2.6.6 so that travis can install to completion.

The tests will now pass on travis for this PR today, but still not all pass for travis on another branch around this time.

* `moment` upgrade from `2.10.6` to `2.11` is causing lots of problems.  This PR pins to `moment@~2.10` for now.
* `flux-react@2.6.7` requires `react@0.14.0` which we are not ready for either.  Pinning to `flux-react@2.6.6`
* various other test updates in this pr addresses the normal weird time dependent test failures we were getting

Looked into upgrading to `moment@2.11` locally...doesn't look fun if we want the course time stuff to work still, so leaving this PR like this and looking to make upgrading `moment` a separate issue
