### PR TITLE
continue button fix no more disappearing

### DIFF
--- a/src/components/buttons/async-button.cjsx
+++ b/src/components/buttons/async-button.cjsx
@@ -51,10 +51,11 @@ module.exports = React.createClass
     {isTimedout} = @state
 
     buttonTypeClass = 'async-button'
+    FailedState = @props.failedState
 
     if isFailed or isTimedout
       stateClass = 'is-failed'
-      return <failedState {...failedProps}/>
+      return <FailedState {...failedProps}/>
     else if isWaiting
       stateClass = 'is-waiting'
       text = waitingText

--- a/src/components/buttons/async-button.cjsx
+++ b/src/components/buttons/async-button.cjsx
@@ -29,7 +29,7 @@ module.exports = React.createClass
     isDone: React.PropTypes.bool
     isFailed: React.PropTypes.bool
     waitingText: React.PropTypes.node # TODO: This should be a Component or array
-    failedState: React.PropTypes.func
+    FailedState: React.PropTypes.func
     failedProps: React.PropTypes.object
     doneText: React.PropTypes.node
     isJob: React.PropTypes.bool
@@ -38,7 +38,7 @@ module.exports = React.createClass
     isDone: false
     isFailed: false
     waitingText: 'Loading…'
-    failedState: RefreshButton
+    FailedState: RefreshButton
     failedProps:
       beforeText: 'There was a problem.  '
     doneText: ''
@@ -47,11 +47,10 @@ module.exports = React.createClass
   render: ->
     {className, disabled} = @props
     {isWaiting, isDone, isFailed} = @props
-    {children, waitingText, failedState, failedProps, doneText} = @props
+    {children, waitingText, FailedState, failedProps, doneText} = @props
     {isTimedout} = @state
 
     buttonTypeClass = 'async-button'
-    FailedState = @props.failedState
 
     if isFailed or isTimedout
       stateClass = 'is-failed'


### PR DESCRIPTION
This fix is ported over from openstax/react-components#31, and will basically be deprecated after #925 as that will move to using the shared `async-button` that will have the same fix.

There was intermittent cases in which the continue button would disappear during exercises.  This was due to a request taking too long to return (> 30 secs allotted by the `asyncButton`) and the button trying to render it's failed state, which it could not do without this fix.