### PR TITLE
Fix for long summaries in exercises table

### DIFF
--- a/resources/styles/components/task-plan/homework/exercises.less
+++ b/resources/styles/components/task-plan/homework/exercises.less
@@ -48,7 +48,10 @@ table.exercise-table {
     text-overflow: ellipsis;
     max-width: 250px;
 
-    img {
+    *:first-child {
+      margin: 0;
+    }
+    * + * {
       display: none;
     }
   }

--- a/src/components/task-plan/homework/exercises.cjsx
+++ b/src/components/task-plan/homework/exercises.cjsx
@@ -183,11 +183,6 @@ ExerciseTable = React.createClass
   renderExerciseRow: (exerciseId, index, hasTeks) ->
     {section, lo, tagString} = ExerciseStore.getTagStrings(exerciseId)
     content = ExerciseStore.getContent(exerciseId)
-    contentDiv = document.createElement('div')
-    contentDiv.innerHTML = content
-    
-    if contentDiv.children.length > 1
-      content = contentDiv.children[0].innerHTML
 
     if (hasTeks)
       teksString = ExerciseStore.getTeksString(exerciseId)

--- a/src/components/task-plan/homework/exercises.cjsx
+++ b/src/components/task-plan/homework/exercises.cjsx
@@ -1,7 +1,6 @@
 React = require 'react'
 _ = require 'underscore'
 BS = require 'react-bootstrap'
-$ = require 'jquery'
 
 ArbitraryHtmlAndMath = require '../../html'
 ExerciseCard = require '../../exercise-card'
@@ -184,9 +183,11 @@ ExerciseTable = React.createClass
   renderExerciseRow: (exerciseId, index, hasTeks) ->
     {section, lo, tagString} = ExerciseStore.getTagStrings(exerciseId)
     content = ExerciseStore.getContent(exerciseId)
-
-    if $("<div>#{content}</div>").children().length > 1
-      content = $(content).first().html()
+    contentDiv = document.createElement('div')
+    contentDiv.innerHTML = content
+    
+    if contentDiv.children.length > 1
+      content = contentDiv.children[0].innerHTML
 
     if (hasTeks)
       teksString = ExerciseStore.getTeksString(exerciseId)

--- a/src/components/task-plan/homework/exercises.cjsx
+++ b/src/components/task-plan/homework/exercises.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 _ = require 'underscore'
 BS = require 'react-bootstrap'
+$ = require 'jquery'
 
 ArbitraryHtmlAndMath = require '../../html'
 ExerciseCard = require '../../exercise-card'
@@ -183,6 +184,9 @@ ExerciseTable = React.createClass
   renderExerciseRow: (exerciseId, index, hasTeks) ->
     {section, lo, tagString} = ExerciseStore.getTagStrings(exerciseId)
     content = ExerciseStore.getContent(exerciseId)
+
+    if $("<div>#{content}</div>").children().length > 1
+      content = $(content).first().html()
 
     if (hasTeks)
       teksString = ExerciseStore.getTeksString(exerciseId)


### PR DESCRIPTION
For pivotal ticket: https://www.pivotaltracker.com/story/show/109743900

Before: 
![screen shot 2016-01-05 at 7 54 29 pm](https://cloud.githubusercontent.com/assets/6434717/12120988/f56de50e-b40d-11e5-80b2-c156313431ae.png)


After:
![screen shot 2016-01-05 at 7 53 48 pm](https://cloud.githubusercontent.com/assets/6434717/12120989/f9636c06-b40d-11e5-9440-74d55c490995.png)
