### PR TITLE
Redirect to webview if a single course CC student

### DIFF
--- a/src/components/course-listing.cjsx
+++ b/src/components/course-listing.cjsx
@@ -18,7 +18,10 @@ DisplayOrRedirect = (transition, callback) ->
     conceptCoach = courses[0].is_concept_coach
 
     if roleType is 'student'
-      if conceptCoach then callback() else view = 'viewStudentDashboard'
+      if conceptCoach
+        window.location.replace(course.webview_url)
+      else
+        view = 'viewStudentDashboard'
     else if roleType is 'teacher'
       view = if conceptCoach then 'cc-dashboard' else 'taskplans'
     else


### PR DESCRIPTION
Note, this uses `.replace()` vs `window.location.href=` since `.replace()` doesn't leave an entry in the history.  I think that'd be the best behavior here.