### PR TITLE
Link to CC help if the current course isn't Tutor

### DIFF
--- a/src/flux/current-user.coffee
+++ b/src/flux/current-user.coffee
@@ -147,7 +147,12 @@ CurrentUserStore = flux.createStore
 
     getHelpLink: (courseId) ->
       course = CourseStore.get(courseId)
-      if course?.is_concept_coach then CONCEPT_COACH_HELP else TUTOR_HELP
+      if course
+        if course.is_concept_coach then CONCEPT_COACH_HELP else TUTOR_HELP
+      else
+        courses = CourseStore.allCourses()
+        # link to TUTOR_HELP if they have any tutor courses
+        if _.findWhere(courses, is_concept_coach: false) then TUTOR_HELP else CONCEPT_COACH_HELP
 
     # if menu routes are being retrieved, then getCourseRole should store
     # what courseId is being viewed.


### PR DESCRIPTION
Currently the help link points to the appropriate site help for either CC or Tutor *when there is a course displayed*.  It defaults to the Tutor help link.  This fails for situations such as the course chooser or if the user doesn't have any courses.

This PR adds additional checks to the "no current course" case.  It then checks all the courses and will link to Tutor help only if any of the courses are a non Concept Coach course.


