### PR TITLE
add coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /.tmp
 /dist
 /test-failed-*.png
+/coverage
 
 *.cjsx.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,9 @@ sudo: false
 language: node_js
 node_js:
   - "0.10"
+script:
+  - npm run ci
 after_failure:
   - npm list
+after_success:
+  - cat ./coverage/all.lcov.txt | node ./node_modules/.bin/coveralls

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Client for OpenStax Tutor",
   "main": "index.js",
   "scripts": {
-    "test": "gulp test && gulp prod",
+    "ci": "gulp coverage",
+    "test": "gulp coverage",
     "coverage": "gulp coverage",
     "deployment": "gulp prod",
     "test-integration": "mocha -R spec ./test-integration/",
@@ -61,6 +62,7 @@
     "coffee-script": "1.9.3",
     "coffeelint": "1.13.0",
     "coffeelint-loader": "0.1.1",
+    "coveralls": "2.11.6",
     "css-loader": "0.22.0",
     "del": "1.1.1",
     "eslint": "1.10.3",

--- a/test/config/karma-coverage.config.coffee
+++ b/test/config/karma-coverage.config.coffee
@@ -2,6 +2,8 @@
 _ = require 'underscore'
 commonConfig = require './karma.common'
 
+LCOV_FILENAME = 'all.lcov.txt'
+
 module.exports = (karmaConfig) ->
 
   config = _.extend({
@@ -10,7 +12,12 @@ module.exports = (karmaConfig) ->
     # logLevel: karmaConfig.LOG_DEBUG
 
     coverageReporter:
-      type: 'text'
+      dir: 'coverage'
+      reporters: [
+        {type: 'html', subdir: '.'}
+        {type: 'lcovonly', subdir: '.', file: LCOV_FILENAME}
+        # {type: 'text'}
+      ]
 
   }, commonConfig)
 


### PR DESCRIPTION
Adds coveralls.io reporting.

Also, changes Travis to use `npm run ci` instead of `npm test` so folks can locally run just the tests (not `gulp prod`)

refs #931