### PR TITLE
Concept Coach Dashboard Period Ordering

### DIFF
--- a/src/flux/cc-dashboard.coffee
+++ b/src/flux/cc-dashboard.coffee
@@ -14,10 +14,7 @@ DashboardConfig =
     isBlank: (courseId) ->
       not _.any @_get(courseId)?.course?.periods
 
-    getPeriods: (courseId) ->
-      _.chain(@_get(courseId)?.course?.periods)
-        .tap(PeriodHelper.sort)
-        .value()
+    getPeriods: (courseId) -> PeriodHelper.sort(@_get(courseId)?.course?.periods)
 
     chaptersForDisplay: (courseId, periodId) ->
       period = _.findWhere( @_get(courseId)?.course?.periods, {id: periodId})


### PR DESCRIPTION
Before: 
![screen shot 2016-01-30 at 12 58 14 am](https://cloud.githubusercontent.com/assets/6434717/12682143/f15aebf0-c6ec-11e5-8c6f-df534ca01b0b.png)


After:
![screen shot 2016-01-28 at 12 34 12 am](https://cloud.githubusercontent.com/assets/6434717/12682097/c258ec12-c6ec-11e5-8801-5f5be19624c3.png)


I think this PR is pretty urgent, sometimes, the dashboard will be showing the wrong data based on which period is selected initially.  See the hansolo prod user for the bug.