### PR TITLE
Fix infinite continue button on an intro-only assignment

### DIFF
--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -222,12 +222,11 @@ module.exports = React.createClass
     taskClasses += " task-#{panelType}" if panelType?
     taskClasses += ' task-completed' if TaskStore.isTaskCompleted(id)
 
-    unless TaskStore.isSingleStepped(id)
-      breadcrumbs = <Breadcrumbs
-        id={id}
-        goToStep={@goToStep}
-        currentStep={@state.currentStep}
-        key="task-#{id}-breadcrumbs"/>
+    breadcrumbs = <Breadcrumbs
+      id={id}
+      goToStep={@goToStep}
+      currentStep={@state.currentStep}
+      key="task-#{id}-breadcrumbs"/>
 
     <PinnedHeaderFooterCard
       forceShy={true}

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -118,13 +118,7 @@ TaskConfig =
 
     getDefaultStepIndex: (taskId) ->
       steps = getSteps(@_steps[taskId])
-
-      if steps.length is 1
-        return 0
-      stepIndex = getCurrentStepIndex(steps)
-
-      completeStep = _.find steps, {is_completed: true}
-      if stepIndex is 0 and not completeStep? then -1 else stepIndex
+      getCurrentStepIndex(steps)
 
     getStepsIds: (id) ->
       _.map(@_steps[id], (step) ->

--- a/test/components/task.spec.coffee
+++ b/test/components/task.spec.coffee
@@ -184,6 +184,22 @@ describe 'Task Widget, through routes', ->
   #     # .then(taskChecks.checkRecoveryContent)
   #     .then(_.delay(done, 1800)).catch(done)
 
+  it 'should continue even if task has only a single step', (done) ->
+    TaskActions.reset()
+    model = _.clone(VALID_MODEL)
+    model.steps = _.clone(VALID_MODEL.steps)
+    model.steps.splice(1, model.steps.length)
+    TaskActions.loaded(model, TASK_ID)
+    expect(model.steps.length).to.equal(1)
+
+    taskActions
+      .clickContinue(@result)
+      .then(taskActions.completeSteps)
+      .then(taskChecks.checkIsCompletePage)
+      .then( ->
+        done()
+      , done)
+
   it 'should show appropriate done page on completion', (done) ->
     # run a full step through and check each step
     taskActions


### PR DESCRIPTION
The actual bug is that if `steps.length is 1` then 0 is always returned, which causes `setStepKey` in [task/index](https://github.com/openstax/tutor-js/blob/master/src/components/task/index.cjsx#L37) to always display the first step.

After looking at the method closer it appears to me that most of it wasn't needed though.

`getCurrentStepIndex` method (at top of file) returns the index of the first non-completed step, or -1 if not found. It seems to me that that's exactly what we want to return here.  I've tested this and it seems to be correct.

Note that breadcrumbs are not displayed on a "intro only assignment" since it has only a single step. That's disabled by the check to `TaskStore.isSingleStepped(id)` in [task/index.cjsx](https://github.com/openstax/tutor-js/blob/master/src/components/task/index.cjsx#L225-L230)  not sure if that should be re-enabled?

@pandafulmanda thoughts?