### PR TITLE
silent 404 for media preview links

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -51,7 +51,7 @@ setNow = (jqXhr) ->
   date ?= jqXhr.getResponseHeader('Date')
   TimeActions.setFromString(date)
 
-apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker) ->
+apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker, options) ->
   listenAction.addListener 'trigger', (args...) ->
     # Make sure API calls occur **after** all local Action listeners complete
     delay 20, ->
@@ -63,11 +63,15 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker) ->
         headers:
           'X-CSRF-Token': CurrentUserStore.getCSRFToken(),
           token: CurrentUserStore.getToken()
+        displayError: true
+
       if payload?
         opts.data = JSON.stringify(payload)
         opts.processData = false
         # For now, the backend is expecting JSON and cannot accept url-encoded forms
         opts.contentType = 'application/json'
+
+      opts = _.extend({}, opts, options)
 
       if IS_LOCAL
         [uri, params] = url.split("?")
@@ -265,6 +269,10 @@ start = (bootstrapData) ->
 
   apiHelper ReferenceBookPageActions, ReferenceBookPageActions.load, ReferenceBookPageActions.loaded, 'GET', (cnxId) ->
     url: "/api/pages/#{cnxId}"
+
+  apiHelper ReferenceBookPageActions, ReferenceBookPageActions.loadSilent, ReferenceBookPageActions.loaded, 'GET', (cnxId) ->
+    url: "/api/pages/#{cnxId}"
+  , displayError: false
 
   apiHelper ReferenceBookExerciseActions,
     ReferenceBookExerciseActions.load,

--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -21,9 +21,18 @@ MEDIA_LINK_EXCLUDES = [
   '[data-targeted=media]'
 ]
 
-MEDIA_LINK_SELECTOR = _.reduce(MEDIA_LINK_EXCLUDES, (current, exclude) ->
+NOT_MEDIAS = _.reduce(MEDIA_LINK_EXCLUDES, (current, exclude) ->
   "#{current}:not(#{exclude})"
-, 'a')
+, '')
+
+IS_LOCAL = 'a[href^="#"]'
+IS_CNX = 'a[href~=".cnx.org/contents/"]'
+
+ALLOWED_MEDIAS = [IS_LOCAL, IS_CNX]
+
+MEDIA_LINK_SELECTOR = _.map(ALLOWED_MEDIAS, (allowed) ->
+  "#{allowed}#{NOT_MEDIAS}"
+).join(', ')
 
 LinkContentMixin =
   componentDidMount:  ->
@@ -96,6 +105,7 @@ LinkContentMixin =
       bookHref: @buildReferenceBookLink(mediaCNXId)
       mediaDOMOnParent: mediaDOM
       shouldLinkOut: @shouldOpenNewTab?()
+      originalHref: link.getAttribute('href')
 
     mediaPreview = <MediaPreview {...mediaProps}>
         {link.innerText}

--- a/src/components/book-content-mixin.cjsx
+++ b/src/components/book-content-mixin.cjsx
@@ -13,26 +13,6 @@ ScrollTo = require './scroll-to'
 # According to the tagging legend exercises with a link should have `a.os-embed`
 # but in the content they are just a vanilla link.
 EXERCISE_LINK_SELECTOR = '.os-exercise > [data-type="problem"] > p > a[href]'
-MEDIA_LINK_EXCLUDES = [
-  '.nav'
-  '.view-reference-guide'
-  '[data-type=footnote-number]'
-  '[data-type=footnote-ref]'
-  '[data-targeted=media]'
-]
-
-NOT_MEDIAS = _.reduce(MEDIA_LINK_EXCLUDES, (current, exclude) ->
-  "#{current}:not(#{exclude})"
-, '')
-
-IS_LOCAL = 'a[href^="#"]'
-IS_CNX = 'a[href~=".cnx.org/contents/"]'
-
-ALLOWED_MEDIAS = [IS_LOCAL, IS_CNX]
-
-MEDIA_LINK_SELECTOR = _.map(ALLOWED_MEDIAS, (allowed) ->
-  "#{allowed}#{NOT_MEDIAS}"
-).join(', ')
 
 LinkContentMixin =
   componentDidMount:  ->
@@ -126,7 +106,7 @@ LinkContentMixin =
   _processLinks: ->
     return unless @isMounted()
     root = @getDOMNode()
-    mediaLinks = root.querySelectorAll(MEDIA_LINK_SELECTOR)
+    mediaLinks = root.querySelectorAll(MediaStore.getSelector())
     exerciseLinks = root.querySelectorAll(EXERCISE_LINK_SELECTOR)
 
     otherLinks = _.chain(mediaLinks)

--- a/src/components/media-preview.cjsx
+++ b/src/components/media-preview.cjsx
@@ -25,6 +25,7 @@ MediaPreview = React.createClass
     windowImpl: React.PropTypes.object
     buffer: React.PropTypes.number
     shouldLinkOut: React.PropTypes.bool
+    originalHref: React.PropTypes.string
 
   getDefaultProps: ->
     buffer: 160
@@ -37,7 +38,7 @@ MediaPreview = React.createClass
     @updateMedia(media) if media?
 
     unless media? or ReferenceBookPageStore.isLoading(cnxId) or ReferenceBookPageStore.isLoaded(cnxId)
-      ReferenceBookPageActions.load(cnxId)
+      ReferenceBookPageActions.loadSilent(cnxId)
       MediaStore.once("loaded.#{mediaId}", @updateMedia)
 
   componentWillUnmount: ->
@@ -101,7 +102,7 @@ MediaPreview = React.createClass
     _.pick(@props, 'containerPadding')
 
   getLinkProps: (otherProps) ->
-    {mediaId, mediaDOMOnParent, bookHref, shouldLinkOut} = @props
+    {mediaId, mediaDOMOnParent, bookHref, shouldLinkOut, originalHref} = @props
     {media} = @state
 
     otherPropTypes = _.chain(otherProps)
@@ -115,9 +116,12 @@ MediaPreview = React.createClass
 
     if mediaDOMOnParent?
       linkProps.href = "##{mediaId}"
-    else if (media and shouldLinkOut) or not media
+    else if (media and shouldLinkOut) # or not media
       linkProps.href = bookHref
       linkProps.href += "##{mediaId}" if mediaId
+      linkProps.target = '_blank'
+    else if not media
+      linkProps.href = originalHref
       linkProps.target = '_blank'
 
     linkProps.onMouseEnter = @onMouseEnter

--- a/src/flux/app.coffee
+++ b/src/flux/app.coffee
@@ -10,6 +10,8 @@ AppConfig =
 
   setServerError: (statusCode, message, requestDetails) ->
     {url, opts} = requestDetails
+    return unless opts.displayError
+
     sparseOpts = _.pick(opts, 'method', 'data')
     request = {url, opts: sparseOpts}
     @_currentServerError = {statusCode, message, request}

--- a/src/flux/media.coffee
+++ b/src/flux/media.coffee
@@ -3,7 +3,7 @@ htmlparser = require 'htmlparser2'
 {makeSimpleStore} = require './helpers'
 
 LINKS_BEGIN = ['#']
-LINKS_CONTAIN = ['/contents/', '.cnx.org']
+LINKS_CONTAIN = ['cnx.org/contents/']
 
 MEDIA_LINK_EXCLUDES = [
   '.nav'

--- a/src/flux/reference-book-page.coffee
+++ b/src/flux/reference-book-page.coffee
@@ -9,6 +9,9 @@ ReferenceBookPageConfig = {
     MediaActions.parse(obj.content_html)
     obj
 
+  loadSilent: (id) ->
+    @load(id)
+
 }
 
 extendConfig(ReferenceBookPageConfig, new CrudConfig())

--- a/test/components/media-preview.spec.coffee
+++ b/test/components/media-preview.spec.coffee
@@ -43,6 +43,9 @@ fakeMediaNotInViewport = (mediaDOM, window) ->
   window.innerHeight = 400
 
 
+linkString = MediaStore.getLinksContained()[0]
+BOOK_HREF = "link-to-book#{linkString}"
+
 describe 'Media Preview', ->
 
   afterEach ->
@@ -121,7 +124,7 @@ describe 'Media Preview', ->
     mediaIds = MediaStore.getMediaIds()
     mediaId = mediaIds[0]
     media = MediaStore.get(mediaId)
-    bookHref = 'link-to-book'
+    bookHref = BOOK_HREF
 
     props = {mediaId: mediaId, bookHref: bookHref, children: 'this figure', shouldLinkOut: true}
 
@@ -137,7 +140,7 @@ describe 'Media Preview', ->
     mediaIds = MediaStore.getMediaIds()
     mediaId = mediaIds[0]
     media = MediaStore.get(mediaId)
-    bookHref = 'link-to-book'
+    bookHref = BOOK_HREF
 
     props = {mediaId: mediaId, bookHref: bookHref, children: 'this figure', shouldLinkOut: false}
 
@@ -276,12 +279,13 @@ describe 'Media Preview', ->
       mediaId: MEDIA_ID_FROM_ANOTHER_MODULE
       children: 'no figure'
       cnxId: PAGE_ID
-      bookHref: "link-to-book/#{PAGE_ID}"
+      bookHref: "#{BOOK_HREF}#{PAGE_ID}"
+      originalHref: 'originalHrefToExternal'
 
     Testing
       .renderComponent( MediaPreview, props: props )
       .then ({dom, element}) ->
-        expect(dom.href).to.contain(props.bookHref).and.to.contain(props.mediaId)
+        expect(dom.getAttribute('href')).to.equal(props.originalHref)
         expect(dom.target).to.equal('_blank')
 
         Testing.actions.mouseEnter(dom)
@@ -297,7 +301,7 @@ describe 'Media Preview', ->
       mediaId: MEDIA_ID_FROM_ANOTHER_MODULE
       children: 'this figure'
       cnxId: PAGE_ID
-      bookHref: "link-to-book/#{PAGE_ID}"
+      bookHref: "#{BOOK_HREF}#{PAGE_ID}"
 
     Testing
       .renderComponent( MediaPreview, props: props )


### PR DESCRIPTION
* silent 404 for media preview links
* make media selectors more picky
* pass through original href if needed

[ticket](https://www.pivotaltracker.com/story/show/113027561), worked with @inconceivablevizzini

![screen shot 2016-02-03 at 5 45 44 pm](https://cloud.githubusercontent.com/assets/2483873/12800902/fe4e7840-ca9d-11e5-9a3f-2748fdfc0bda.png)

look, no 404s!
