### PR TITLE
Selenium: replace .get().click() with just .click()

### DIFF
--- a/test-integration/helpers/calendar.coffee
+++ b/test-integration/helpers/calendar.coffee
@@ -47,17 +47,17 @@ class PlanPopupHelper extends  TestHelper
 
   close: =>
     @test.utils.windowPosition.scrollTop()
-    @el.closeButton.get().click()
+    @el.closeButton.click()
     # waits until the locator element is not present
     @test.driver.wait =>
       @isPresent().then (isPresent) ->
         not isPresent
 
   goEdit: =>
-    @el.editLink.get().click()
+    @el.editLink.click()
 
   goReview: =>
-    @el.reviewLink.get().click()
+    @el.reviewLink.click()
 
 
 class CalendarHelper extends TestHelper
@@ -76,21 +76,21 @@ class CalendarHelper extends TestHelper
   createNew: (type) =>
     @waitUntilLoaded()
 
-    @el.addToggle.get().click()
+    @el.addToggle.click()
 
     switch type
-      when 'READING' then @el.addReadingButton.get().click()
-      when 'HOMEWORK' then @el.addHomeworkButton.get().click()
-      when 'EXTERNAL' then @el.addExternalButton.get().click()
+      when 'READING' then @el.addReadingButton.click()
+      when 'HOMEWORK' then @el.addHomeworkButton.click()
+      when 'EXTERNAL' then @el.addExternalButton.click()
       else expect(false, 'Invalid assignment type').to.be.true
 
   goPerformanceForecast: =>
     @test.utils.windowPosition.scrollTop()
-    @el.forecastLink.get().click()
+    @el.forecastLink.click()
 
   goStudentScores: =>
     @test.utils.windowPosition.scrollTop()
-    @el.studentScoresLink.get().click()
+    @el.studentScoresLink.click()
 
   goOpen: (title) =>
     # wait until the calendar is open

--- a/test-integration/helpers/cc-dashboard.coffee
+++ b/test-integration/helpers/cc-dashboard.coffee
@@ -28,7 +28,7 @@ class CCDashboard extends TestHelper
     super(test, testElementLocator, COMMON_ELEMENTS)
 
   switchPeriods: () ->
-    @el.inactiveTab.get().click()
+    @el.inactiveTab.click()
 
   getTabPeriod: () ->
     @el.dashboard.get().getAttribute('data-period')
@@ -37,7 +37,7 @@ class CCDashboard extends TestHelper
     @el.activeTab.get().getAttribute('data-reactid')
 
   clickViewScores: () ->
-    @el.viewScoresButton.get().click()
+    @el.viewScoresButton.click()
 
   getHelpLink: () ->
     helpLink = @test.driver.findElement(COMMON_ELEMENTS.helpLink)

--- a/test-integration/helpers/course-select.coffee
+++ b/test-integration/helpers/course-select.coffee
@@ -30,10 +30,10 @@ class CourseSelect extends TestHelper
     @waitUntilLoaded()
     # Go to the bio dashboard
     switch category
-      when 'BIOLOGY' then @el.courseLink.get('biology').click()
-      when 'PHYSICS' then @el.courseLink.get('physics').click()
-      when 'CONCEPT_COACH' then @el.courseLink.get(null, true).click()
-      else @el.courseLink.get().click()
+      when 'BIOLOGY' then @el.courseLink.click('biology')
+      when 'PHYSICS' then @el.courseLink.click('physics')
+      when 'CONCEPT_COACH' then @el.courseLink.click(null, true)
+      else @el.courseLink.click()
 
   goToCourseByName: (name) ->
     @test.utils.wait.click(css: "[data-title='#{name}'] > a")

--- a/test-integration/helpers/reading-builder.coffee
+++ b/test-integration/helpers/reading-builder.coffee
@@ -109,15 +109,15 @@ class SelectReadingsList extends TestHelper
     # So handle chapters differently
     isChapter = not /\./.test(section)
     if isChapter
-      @el.chapterHeadingSelectAll.get(section).click()
+      @el.chapterHeadingSelectAll.click(section)
     else
       # BUG? Hidden dialogs remain in the DOM. When searching make sure it is in a dialog that is not hidden
       @el.sectionItem.findElement(section).isDisplayed().then (isDisplayed) =>
         # Expand the chapter accordion if necessary
         unless isDisplayed
-          @el.chapterHeading.get(section).click()
+          @el.chapterHeading.click(section)
 
-        @el.sectionItem.get(section).click()
+        @el.sectionItem.click(section)
 
 
 # TODO could probably make this a general dialog/modal helper to extend from.
@@ -135,7 +135,7 @@ class UnsavedDialog extends TestHelper
       return unless modalIsOpened
 
       @waitUntilLoaded()
-      @el.dismissButton.get().click()
+      @el.dismissButton.click()
       @waitUntilClose()
 
 
@@ -173,10 +173,10 @@ class ReadingBuilder extends TestHelper
       @_setDate('due', dueAt)
 
   openDatePicker: (type) =>
-    @el.dateInput.get(type).click()
+    @el.dateInput.click(type)
 
   chooseDate: (date) =>
-    @el.datepickerDay.get(date).click()
+    @el.datepickerDay.click(date)
 
   waitUntilDatepickerClosed: =>
     @test.driver.wait =>
@@ -189,7 +189,7 @@ class ReadingBuilder extends TestHelper
     @el.name.get().getAttribute('value')
 
   openSelectReadingList: =>
-    @el.selectReadingsButton.get().click()
+    @el.selectReadingsButton.click()
     @el.selectReadingsList.waitUntilLoaded()
 
   hasError: (type) =>
@@ -203,18 +203,18 @@ class ReadingBuilder extends TestHelper
 
   publish: =>
     # Wait up to 3min for publish to complete
-    @el.publishButton.get().click()
+    @el.publishButton.click()
     # wait for
     @test.driver.wait =>
       @el.pendingPublishButton.isPresent().then (isPresent) -> not isPresent
     , (3 * 60 * 1000)
 
   save: =>
-    @el.saveButton.get().click()
+    @el.saveButton.click()
 
   cancel: =>
     # BUG: "X" close button behaves differently than the footer close button
-    @el.cancelButton.get().click()
+    @el.cancelButton.click()
     # BUG: Should not prompt when canceling
     # Confirm the "Unsaved Changes" dialog
     @el.unsavedDialog.close()
@@ -222,7 +222,7 @@ class ReadingBuilder extends TestHelper
 
   delete: =>
     # Wait up to 60sec for delete to complete
-    @el.deleteButton.get().click()
+    @el.deleteButton.click()
     # Accept the browser confirm dialog
     @test.driver.wait(selenium.until.alertIsPresent()).then (alert) ->
       alert.accept()
@@ -267,7 +267,7 @@ class ReadingBuilder extends TestHelper
           @cancel() if isDisplayed
       else
         # Click "Add Readings"
-        @el.addReadingsButton.get().click()
+        @el.addReadingsButton.click()
 
     switch action
       when 'PUBLISH' then @publish()

--- a/test-integration/helpers/reference-book.coffee
+++ b/test-integration/helpers/reference-book.coffee
@@ -35,7 +35,7 @@ class ReferenceBookHelper extends TestHelper
   open: =>
     @waitUntilLoaded()
     @test.utils.windowPosition.setLarge()
-    @el.tocToggle.get().click()
+    @el.tocToggle.click()
 
   goNext: =>
     # go next until old href isnt 
@@ -43,7 +43,7 @@ class ReferenceBookHelper extends TestHelper
       oldNextHref = ''
       @el.nextPageButton.get().getAttribute('href').then (href) =>
         oldNextHref = href
-        @el.nextPageButton.get().click()
+        @el.nextPageButton.click()
         @waitUntilLoaded()
         @el.nextPageButton.get().getAttribute('href')
       .then (href) ->

--- a/test-integration/helpers/scores.coffee
+++ b/test-integration/helpers/scores.coffee
@@ -47,7 +47,7 @@ class ScoresHelper extends TestHelper
   # this could be moved to cc-dashboard helper at some point
   goCCScores: =>
     @test.utils.windowPosition.scrollTop()
-    @el.ccScoresLink.get().click()
+    @el.ccScoresLink.click()
 
   doneGenerating: =>
     #@test.driver.wait =>

--- a/test-integration/helpers/test-element.coffee
+++ b/test-integration/helpers/test-element.coffee
@@ -42,6 +42,12 @@ class TestItemHelper
     @test.driver.isElementPresent(locator).then (isPresent) ->
       isPresent
 
+  # Helper for the common case of `get(...).click()`.
+  # Plus, it allows a place to add logging since this is one of the most
+  # common places for Selenium to time out (trying to click on an element)
+  click: (args...) =>
+    @get(args...).click()
+
 # Using defined properties for access eliminates the possibility
 # of accidental assignment
 Object.defineProperties TestItemHelper.prototype,

--- a/test-integration/helpers/user.coffee
+++ b/test-integration/helpers/user.coffee
@@ -44,16 +44,16 @@ class User extends TestHelper
     # Login as local
     @el.searchQuery.get().sendKeys(username)
     @el.searchQuery.get().submit()
-    @el.usernameLink.get(username).click()
+    @el.usernameLink.click(username)
 
   logInDeployed: (username, password = 'password') =>
     # Login as dev (using accounts)
     @el.usernameInput.get().sendKeys(username)
     @el.passworkInput.get().sendKeys(password)
-    @el.loginSubmit.get().click()
+    @el.loginSubmit.click()
 
   login: (username, password = 'password') =>
-    @el.loginLink.get().click()
+    @el.loginLink.click()
 
     @isLocal().then (isLocal) =>
       if isLocal
@@ -65,7 +65,7 @@ class User extends TestHelper
     @el.modalClose.isPresent()
 
   _closeModal: =>
-    @el.modalClose.get().click()
+    @el.modalClose.click()
 
   closeModal: =>
     @isModalOpen().then (isOpen) =>
@@ -78,7 +78,7 @@ class User extends TestHelper
     @el.userMenu.isPresent()
 
   _logout: =>
-    @el.userMenu.get().click()
+    @el.userMenu.click()
     @el.logoutForm.get().submit()
 
   logout: =>
@@ -89,7 +89,7 @@ class User extends TestHelper
 
   goHome: =>
     @test.utils.windowPosition.scrollTop()
-    @el.homeLink.get().click()
+    @el.homeLink.click()
 
 
 User.logout = (test) ->

--- a/test-integration/scores.coffee
+++ b/test-integration/scores.coffee
@@ -24,11 +24,11 @@ describe 'HS Student Scores', ->
 
 
   @it 'sorts by name or data', ->
-    @scores.el.nameHeaderSort.get().click()
-    @scores.el.dataHeaderSort.get().click()
+    @scores.el.nameHeaderSort.click()
+    @scores.el.dataHeaderSort.click()
 
   @it 'changes periods', ->
-    @scores.el.periodTab.get().click()
+    @scores.el.periodTab.click()
 
 
 
@@ -50,23 +50,23 @@ describe 'CC Student Scores', ->
 
 
   @it 'sorts by name or data', ->
-    @scores.el.nameHeaderSort.get().click()
-    @scores.el.dataHeaderSort.get().click()
+    @scores.el.nameHeaderSort.click()
+    @scores.el.dataHeaderSort.click()
 
   @it 'changes periods', ->
-    @scores.el.periodTab.get().click()
+    @scores.el.periodTab.click()
 
   @it 'toggles display as', ->
     @scores.el.scoreCell.get().getText().then (txt) ->
       expect(txt).to.contain('%')
-    @scores.el.displayAs.get().click()
+    @scores.el.displayAs.click()
     @scores.el.scoreCell.get().getText().then (txt) ->
       expect(txt).to.contain('of')
 
   @it 'toggles based on', ->
     @scores.el.averageLabel.get().getText().then (txt) ->
       expect(txt).to.contain('possible')
-    @scores.el.basedOn.get().click()
+    @scores.el.basedOn.click()
     @scores.el.averageLabel.get().getText().then (txt) ->
       expect(txt).to.contain('attempted')
 

--- a/test-integration/task.coffee
+++ b/test-integration/task.coffee
@@ -27,8 +27,8 @@ describe 'Student performing tasks', ->
       @task.waitUntilLoaded(2000)
 
       # demonstrating get in spec.
-      @task.el.enabledContinueButton.get().click()
-      @task.el.enabledContinueButton.get().click()
+      @task.el.enabledContinueButton.click()
+      @task.el.enabledContinueButton.click()
       # get multiple seems to not be working right now.
       # @task.getStepCrumbs(4).then (crumb) ->
       #   crumb.click()


### PR DESCRIPTION
When paired with #970 this provides a bunch of extra logging.

The issue I was initially diagnosing was why publishing an assignment sometimes worked and sometimes did not.

The problem was that when you click an item in the calendar a popup may or may not appear depending on the state of the `task-plan`. The test was waiting for a button to appear but it never appeared.

Thoughts on this approach @openstax/tutor-fe ?

Atom search/replace string used: `\.get\((.*)\)\.click\(\)` and `.click($1)`

refs #931 