### PR TITLE
media preview sizing

### DIFF
--- a/resources/styles/components/media-preview.less
+++ b/resources/styles/components/media-preview.less
@@ -1,6 +1,10 @@
 .media-preview {
   max-width: 50%;
 
+  &.popover {
+    z-index: 1;
+  }
+
   &.scrollable {
     .popover-content {
       overflow: auto;
@@ -20,7 +24,7 @@
     }
   }
 
-  figure span {
+  figure > figcaption + span {
     min-height: 1.75rem;
     min-width: 100%;
     position: relative;

--- a/src/components/media-preview.cjsx
+++ b/src/components/media-preview.cjsx
@@ -96,7 +96,13 @@ MediaPreview = React.createClass
 
   onMouseLeave: (mouseEvent) ->
     mouseEvent.preventDefault()
-    @hideMedia()
+    @hideMedia() if @isMouseLeft(mouseEvent)
+
+  isMouseLeft: (mouseEvent) ->
+    return true unless @refs.overlay.refs.popover?
+    linkDOM = @refs.overlay.refs.popper.getDOMNode()
+    popoverDOM = @refs.overlay.refs.popover.getDOMNode()
+    not (popoverDOM.contains(mouseEvent.relatedTarget) or linkDOM.isEqualNode(mouseEvent.relatedTarget))
 
   getOverlayProps: ->
     _.pick(@props, 'containerPadding')
@@ -147,6 +153,7 @@ MediaPreview = React.createClass
         'data-content-type': media.name
         className: 'media-preview'
         ref: 'popover'
+        onMouseLeave: @onMouseLeave
 
       content = <ArbitraryHtmlAndMath {...contentProps} html={contentHtml}/>
       allProps = {content, overlayProps, popoverProps, windowImpl}

--- a/src/components/media-preview.cjsx
+++ b/src/components/media-preview.cjsx
@@ -96,10 +96,11 @@ MediaPreview = React.createClass
 
   onMouseLeave: (mouseEvent) ->
     mouseEvent.preventDefault()
-    @hideMedia() if @isMouseLeft(mouseEvent)
+    @hideMedia() if @isMouseExited(mouseEvent)
 
-  isMouseLeft: (mouseEvent) ->
-    return true unless @refs.overlay.refs.popover?
+  # check that mouse has exited both the link and the overlay
+  isMouseExited: (mouseEvent) ->
+    return true unless mouseEvent.relatedTarget?.nodeType? and @refs.overlay.refs.popover?
     linkDOM = @refs.overlay.refs.popper.getDOMNode()
     popoverDOM = @refs.overlay.refs.popover.getDOMNode()
     not (popoverDOM.contains(mouseEvent.relatedTarget) or linkDOM.isEqualNode(mouseEvent.relatedTarget))

--- a/src/components/tutor-popover.cjsx
+++ b/src/components/tutor-popover.cjsx
@@ -58,6 +58,7 @@ TutorPopover = React.createClass
   setMaxImageWidth: (image, maxWidth) ->
     # unfortunately, css max-width does not work in firefox inside display: table elements
     # https://bugzilla.mozilla.org/show_bug.cgi?id=975632
+    # See https://github.com/openstax/tutor-js/issues/977 for full details.
     return unless image?
     {width} = image.getBoundingClientRect?()
     image.width = maxWidth if width > maxWidth

--- a/src/components/tutor-popover.cjsx
+++ b/src/components/tutor-popover.cjsx
@@ -32,8 +32,7 @@ TutorPopover = React.createClass
   componentDidUpdate: ->
     # Make sure the popover re-positions after the image loads
     if @refs.popcontent? and @state.firstShow
-      content = @refs.popcontent.getDOMNode()
-      images = content.querySelectorAll('img')
+      images = @getImages()
 
       imagesLoading = _.map images, (image, iter) =>
         unless image.onload? or image.complete
@@ -41,6 +40,10 @@ TutorPopover = React.createClass
         return not image.complete
 
       @setState(imagesLoading: imagesLoading, firstShow: false)
+
+  getImages: ->
+    content = @refs.popcontent.getDOMNode()
+    content.querySelectorAll('img')
 
   imageLoaded: (iter) ->
     return unless @isMounted()
@@ -51,6 +54,13 @@ TutorPopover = React.createClass
     currentImageStatus[iter] = false
 
     @setState(imagesLoading: currentImageStatus)
+
+  setMaxImageWidth: (image, maxWidth) ->
+    # unfortunately, css max-width does not work in firefox inside display: table elements
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=975632
+    return unless image?
+    {width} = image.getBoundingClientRect?()
+    image.width = maxWidth if width > maxWidth
 
   areImagesLoading: ->
     _.compact(@state.imagesLoading).length isnt 0
@@ -64,7 +74,9 @@ TutorPopover = React.createClass
     @refs.popper.updateOverlayPosition = =>
       updateOverlayPosition()
       viewer = @refs.popper.getOverlayDOMNode()
+      images = @getImages()
       {height, width} = viewer.getBoundingClientRect()
+      _.each images, _.partial(@setMaxImageWidth, _, width - 30)
 
       scrollable = false
 


### PR DESCRIPTION
Image `max-width` was not working in [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=975632).  See #977 for full details.

This was causing two problems:
* image was floating outside of the width of popover sometimes or made the popover overflow unnecessarily
* popover would flash in and out because the `mouseEnter` and `mouseLeave` would get called repeated as the popover would cover the link where the mouse was hovering
Additionally, Maths was looking weird.  See [this ticket](https://www.pivotaltracker.com/story/show/112930795) for additional details.

This PR addresses the above issues by:
* making `span` styling more specific within the popover
* manually detecting if image's `width` should be adjusted to fit
* checking if mouse has left both the link and the popover on `mouseLeave`

# Before

## image width messed up in Firefox
<img width="1440" alt="screen shot 2016-01-29 at 3 15 33 pm" src="https://cloud.githubusercontent.com/assets/2483873/12935990/bdf6c132-cf5f-11e5-94aa-afaebfabab7d.png">

## Maths is wrong
<img width="1440" alt="screen shot 2016-01-29 at 3 13 46 pm" src="https://cloud.githubusercontent.com/assets/2483873/12935991/bdf84ebc-cf5f-11e5-993a-432e5886d2a6.png">


# After

## Image width fixed in Firefox
![screen shot 2016-02-09 at 1 29 20 pm](https://cloud.githubusercontent.com/assets/2483873/12935935/57e524ce-cf5f-11e5-8463-577c5827302e.png)

## Maths fixed
![screen shot 2016-02-09 at 7 00 26 pm](https://cloud.githubusercontent.com/assets/2483873/12935949/6829e450-cf5f-11e5-83be-6cdfb6f48bc7.png)
