### PR TITLE
validate the versions of packages in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Client for OpenStax Tutor",
   "main": "index.js",
   "scripts": {
-    "ci": "gulp coverage",
-    "test": "gulp coverage",
+    "ci": "npm run test",
+    "test": "npm run coverage",
+    "precoverage": "npm run validate",
     "coverage": "gulp coverage",
     "build": "gulp build",
     "build-archive": "gulp build-archive",
@@ -15,6 +16,8 @@
     "test-integration": "./scripts/run-test-integration.sh",
     "posttest-integration": "istanbul report --include ./coverage-selenium.json json --dir ./coverage/ lcov",
     "lint-cjsx": "./scripts/lint-cjsx-files.sh",
+    "validate": "node ./scripts/validate-package-json.js",
+    "prestart": "npm run validate",
     "start": "gulp dev"
   },
   "repository": {

--- a/scripts/validate-package-json.js
+++ b/scripts/validate-package-json.js
@@ -1,0 +1,20 @@
+// Validates the package.json file to make sure semantic versioning is not used (ie `npm install --save-dev`)
+
+var data = require('../package.json');
+
+function validate(group) {
+  var packageNames = Object.keys(data[group]);
+  for (var index in packageNames) {
+    var packageName = packageNames[index];
+    var ver = data[group][packageName];
+    // Either the format is `0.0.0` or `xxx/xxx#sha`
+    if (/^[0-9]+\.[0-9]+\.[0-9]+/.test(ver) || /.*\/.*#[0-9a-f]/.test(ver)) {
+    } else {
+      console.log('Invalid entry in package.json ' + group + '. package must be an exact version or point to a GitHub repo: ' + packageName + ' ' + ver);
+      process.exit(1);
+    }
+  }
+}
+
+validate('dependencies');
+validate('devDependencies');


### PR DESCRIPTION
Validates that we are using exact versions when including 3rd-party npm packages in the `package.json` file.

I was thinking of adding it to `gulp` but I'm hoping we can finally get rid of gulp. Maybe this should be ported to the other repos? (if merged)

Thoughts @openstax/tutor-fe ?