### PR TITLE
Refactor how selenium TestElement elements are called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /coverage
 
 *.cjsx.js
+
+/phantomjsdriver.log

--- a/test-integration/helpers/calendar.coffee
+++ b/test-integration/helpers/calendar.coffee
@@ -107,16 +107,16 @@ class CalendarHelper extends TestHelper
     @waitUntilLoaded()
     # TODO: Make this a `data-title` attribute
     # HACK: Might need to scroll the item to click on into view
-    el = @el.planByTitle.get(title)
+    el = @el.planByTitle(title).get()
     @test.utils.windowPosition.scrollTo(el)
-    @el.planByTitle.click(title)
+    @el.planByTitle(title).click()
     @test.utils.windowPosition.scrollTop()
     @waitUntilLoaded() # Wait until either the popup opens or the Reading Builder opens (depending on the state of the thing clicked)
 
   waitUntilPublishingFinishedByTitle: (title) =>
     @test.utils.verbose("Waiting to see if plan is published #{title}")
     @test.utils.wait.giveTime PUBLISHING_TIMEOUT, =>
-      @test.driver.wait((=> @el.publishedPlanByTitle.isPresent(title)), PUBLISHING_TIMEOUT)
+      @test.driver.wait((=> @el.publishedPlanByTitle(title).isPresent()), PUBLISHING_TIMEOUT)
 
 verify = (test) ->
   new CalendarHelper(test).waitUntilLoaded()

--- a/test-integration/helpers/course-select.coffee
+++ b/test-integration/helpers/course-select.coffee
@@ -30,10 +30,10 @@ class CourseSelect extends TestHelper
     @waitUntilLoaded()
     # Go to the bio dashboard
     switch category
-      when 'BIOLOGY' then @el.courseLink.click('biology')
-      when 'PHYSICS' then @el.courseLink.click('physics')
-      when 'CONCEPT_COACH' then @el.courseLink.click(null, true)
-      else @el.courseLink.click()
+      when 'BIOLOGY' then @el.courseLink('biology').click()
+      when 'PHYSICS' then @el.courseLink('physics').click()
+      when 'CONCEPT_COACH' then @el.courseLink(null, true).click()
+      else @el.courseLink().click()
 
     @waitUntilLoaded() # TODO: This should probably use the `dashboard.waitUntilLoaded()`
 

--- a/test-integration/helpers/describe.coffee
+++ b/test-integration/helpers/describe.coffee
@@ -45,7 +45,10 @@ describe = (name, cb) ->
       @timeout(20 * 1000, true)
 
       @driver = new selenium.Builder()
-        # .withCapabilities(selenium.Capabilities.phantomjs())
+        # Choose which browser to run by setting the SELENIUM_BROWSER='firefox' envoronment variable
+        # see https://selenium.googlecode.com/git/docs/api/javascript/module_selenium-webdriver_class_Builder.html
+        .withCapabilities(selenium.Capabilities.phantomjs()) # TODO: get alerts working https://github.com/robotframework/Selenium2Library/issues/441
+        .withCapabilities(selenium.Capabilities.firefox())
         .withCapabilities(selenium.Capabilities.chrome())
         .build()
 
@@ -89,6 +92,12 @@ describe = (name, cb) ->
       @addTimeout(2 * 60) # Server might still be deleting/publishing
       {state, title} = @currentTest
 
+      # # Print out all the console messages
+      # console.log 'Printing log Messages'
+      # console.log '----------------------------------'
+      # @driver.manage().logs().get('browser').then (lines) ->
+      #   console.log line.level.name, line.message for line in lines
+
       if state is 'failed'
         @utils.screenshot("test-failed-#{title}")
         console.log "Action history (showing last #{COMMAND_HISTORY_MAX}):"
@@ -105,10 +114,6 @@ describe = (name, cb) ->
           console.log 'JS Error! ' + msg
           @utils.screenshot("test-failed-#{title}")
 
-
-      # Print out all the console messages
-      # logs = @driver.manage().logs().get('browser').then (lines) ->
-      #   console.log line.level.name, line.message for line in lines
 
       Verbose.reset()
       User.logout(@)

--- a/test-integration/helpers/reading-builder.coffee
+++ b/test-integration/helpers/reading-builder.coffee
@@ -109,15 +109,15 @@ class SelectReadingsList extends TestHelper
     # So handle chapters differently
     isChapter = not /\./.test(section)
     if isChapter
-      @el.chapterHeadingSelectAll.click(section)
+      @el.chapterHeadingSelectAll(section).click()
     else
       # BUG? Hidden dialogs remain in the DOM. When searching make sure it is in a dialog that is not hidden
-      @el.sectionItem.findElement(section).isDisplayed().then (isDisplayed) =>
+      @el.sectionItem(section).findElement().isDisplayed().then (isDisplayed) =>
         # Expand the chapter accordion if necessary
         unless isDisplayed
-          @el.chapterHeading.click(section)
+          @el.chapterHeading(section).click()
 
-        @el.sectionItem.click(section)
+        @el.sectionItem(section).click()
 
 
 # TODO could probably make this a general dialog/modal helper to extend from.
@@ -173,10 +173,10 @@ class ReadingBuilder extends TestHelper
       @_setDate('due', dueAt)
 
   openDatePicker: (type) =>
-    @el.dateInput.click(type)
+    @el.dateInput(type).click()
 
   chooseDate: (date) =>
-    @el.datepickerDay.click(date)
+    @el.datepickerDay(date).click()
 
   waitUntilDatepickerClosed: =>
     @test.driver.wait =>
@@ -193,13 +193,13 @@ class ReadingBuilder extends TestHelper
     @el.selectReadingsList.waitUntilLoaded()
 
   hasError: (type) =>
-    @el.hasErrorWarning.get(type).isDisplayed()
+    @el.hasErrorWarning(type).get().isDisplayed()
 
   hasRequiredHint: (type) =>
-    @el.requiredHint.get(type).isDisplayed()
+    @el.requiredHint(type).get().isDisplayed()
 
   hasRequiredMessage: (type) =>
-    @el.requiredItemNotice.get(type).isDisplayed()
+    @el.requiredItemNotice(type).get().isDisplayed()
 
   publish: (name) =>
     @el.publishButton.waitClick()

--- a/test-integration/helpers/reading-builder.coffee
+++ b/test-integration/helpers/reading-builder.coffee
@@ -91,7 +91,7 @@ COMMON_SELECT_READING_ELEMENTS =
   chapterHeadingSelectAll: (section) ->
     css: "#{OPENED_PANEL_SELECTOR} [data-chapter-section='#{section.split('.')[0]}'] .chapter-checkbox input"
   chapterHeading: (section) ->
-    css: "#{OPENED_PANEL_SELECTOR} [data-chapter-section='#{section.split('.')[0]}']"
+    css: "#{OPENED_PANEL_SELECTOR} [data-chapter-section='#{section.split('.')[0]}'] > a"
 
 
 COMMON_UNSAVED_DIALOG_ELEMENTS =

--- a/test-integration/helpers/test-element.coffee
+++ b/test-integration/helpers/test-element.coffee
@@ -54,9 +54,13 @@ class TestItemHelper
     @test.driver.isElementPresent(locator)
 
   isDisplayed: (args...) =>
-    locator = @getLocator(args...)
-    el = @findElement(args...)
-    el.isDisplayed()
+    @isPresent(args...).then (isPresent) =>
+      if isPresent
+        locator = @getLocator(args...)
+        el = @findElement(args...)
+        el.isDisplayed()
+      else
+        false
 
   # Helper for the common case of `get(...).click()`.
   # Plus, it allows a place to add logging since this is one of the most

--- a/test-integration/helpers/test-element.coffee
+++ b/test-integration/helpers/test-element.coffee
@@ -6,24 +6,27 @@ S = require '../../src/helpers/string'
 
 class TestItemHelper
   constructor: (test, testElementLocator) ->
-    @_test = test
-    @_locator = testElementLocator
+    throw new Error('BUG: Missing the current test!') unless test
+    throw new Error('BUG: Missing locator') unless testElementLocator
+
+    @test = test
+    @locator = testElementLocator
 
     # Instrument all the methods of helpers to print using verboseWrap
     # so we can see where Selenium stopped
     _.each _.omit(@, Object.keys(TestItemHelper::), Object.keys(TestHelper::)), (value, key) =>
       # Wrap all functions!
-      if typeof value is 'function' and not /^_locator/.test(key) # Exclude the _locator() function because that is used in waitUntil loops
+      if _.isFunction(value) and not /^_locator/.test(key) # Exclude the _locator() function because that is used in waitUntil loops
         @[key] = (args...) =>
           @test.utils.verboseWrap("HELPER: #{key}", => value.apply(@, args))
 
   getLocator: (args...) =>
-    locator = if _.isFunction(@_locator)
-      @_locator(args...)
-    else if _.isString(@_locator)
-      @test.utils.toLocator(@_locator)
+    locator = if _.isFunction(@locator)
+      @locator(args...)
+    else if _.isString(@locator)
+      @test.utils.toLocator(@locator)
     else
-      @_locator
+      @locator
 
   get: (args...) =>
     locator = @getLocator(args...)
@@ -75,16 +78,6 @@ class TestItemHelper
     @test.utils.wait.for(locator)
     @click(args...)
 
-# Using defined properties for access eliminates the possibility
-# of accidental assignment
-Object.defineProperties TestItemHelper.prototype,
-  test:
-    get: -> @_test
-  locator:
-    get: -> @_locator
-  element:
-    get: -> @get()
-
 
 class TestHelper extends TestItemHelper
   constructor: (test, testElementLocator, commonElements, options) ->
@@ -115,7 +108,19 @@ class TestHelper extends TestItemHelper
     @el[name] = helper
 
   setCommonElement: (locator, name) =>
-    @setCommonHelper(name, new TestItemHelper(@test, locator))
+    if _.isFunction(locator)
+      fn = (args...) => new TestItemHelper(@test, locator(args...))
+      # START: BACKWARDS_COMPATIBILITY Area
+      # For backwards compatibility, stick all the testItemHelper Methods onto the fn  (so it "looks like" a TestItemHelper)
+      oldItemHelper = new TestItemHelper(@test, locator)
+      _.each ['getLocator', 'get', 'getAll', 'findElement', 'findElements', 'forEach', 'isPresent', 'isDisplayed', 'click', 'waitClick'], (fnName) ->
+        fn[fnName] = (args...) ->
+          console.log "Deprecated call to el.#{name}.#{fnName}(...). Use el.#{name}(...).#{fnName}() instead"
+          oldItemHelper[fnName].apply(oldItemHelper, args)
+      # END: BACKWARDS_COMPATIBILITY Area
+      @setCommonHelper(name, fn)
+    else
+      @setCommonHelper(name, new TestItemHelper(@test, locator))
 
 
 # Using defined properties for access eliminates the possibility

--- a/test-integration/helpers/user.coffee
+++ b/test-integration/helpers/user.coffee
@@ -31,6 +31,9 @@ COMMON_ELEMENTS =
   homeLink:
     css: '.navbar-brand'
 
+  pageTitle:
+    css: '.navbar-brand.active'
+
 COMMON_ELEMENTS.eitherSignInElement =
   css: "#{COMMON_ELEMENTS.searchQuery.css}, #{COMMON_ELEMENTS.usernameInput.css}"
 
@@ -47,7 +50,7 @@ class User extends TestHelper
     # Login as local
     @el.searchQuery.get().sendKeys(username)
     @el.searchQuery.get().submit()
-    @el.usernameLink.click(username)
+    @el.usernameLink(username).click()
 
   logInDeployed: (username, password = 'password') =>
     # Login as dev (using accounts)

--- a/test-integration/helpers/user.coffee
+++ b/test-integration/helpers/user.coffee
@@ -1,9 +1,15 @@
 _ = require 'underscore'
 {TestHelper} = require './test-element'
+selenium = require 'selenium-webdriver'
 
 COMMON_ELEMENTS =
   loginLink:
     linkText: 'Login'
+
+  # When the screen is narrow the login button is not immediately visible. It is hidden under a dropdown
+  smallScreenNavbarToggle:
+    css: '.navbar-header .navbar-toggle'
+
   searchQuery:
     css: '#search_query'
   usernameLink: (username) ->
@@ -20,7 +26,7 @@ COMMON_ELEMENTS =
     css: '.modal-dialog .modal-header .close'
 
   userMenu:
-    css: '.-hamburger-menu'
+    css: '.-hamburger-menu .dropdown-toggle'
 
   openHamburgerMenu:
     css: '.-hamburger-menu.open'
@@ -33,6 +39,9 @@ COMMON_ELEMENTS =
 
   pageTitle:
     css: '.navbar-brand.active'
+
+  courseListing:
+    css: '.course-listing'
 
 COMMON_ELEMENTS.eitherSignInElement =
   css: "#{COMMON_ELEMENTS.searchQuery.css}, #{COMMON_ELEMENTS.usernameInput.css}"
@@ -59,7 +68,12 @@ class User extends TestHelper
     @el.loginSubmit.click()
 
   login: (username, password = 'password') =>
-    @el.loginLink.click()
+    @el.loginLink.isDisplayed().then (isDisplayed) =>
+      unless isDisplayed
+        @el.smallScreenNavbarToggle.click()
+      @el.loginLink.click()
+
+    @test.utils.windowPosition.setLarge()
 
     @isLocal().then (isLocal) =>
       if isLocal
@@ -67,24 +81,30 @@ class User extends TestHelper
       else
         @logInDeployed(username, password)
     # Inject a little CSS to unfix the pesky fixed navbar
-    .then =>
-      @test.driver.executeScript ->
-        hider = document.createElement('style')
-        hider.textContent = '''
-          .navbar-fixed-bottom, .navbar-fixed-top,
-          .pinned-on .pinned-header,
-          .pinned-footer {
-            z-index: initial !important;
-            position: initial !important;
-          }
+    @test.driver.executeScript ->
+      hider = document.createElement('style')
+      hider.textContent = '''
+        .navbar-fixed-bottom, .navbar-fixed-top,
+        .pinned-on .pinned-header,
+        .pinned-footer {
+          z-index: initial !important;
+          position: initial !important;
+        }
 
-          body.pinned-shy .navbar-fixed-top, body.pinned-shy .pinned-header {
-            transform: initial !important;
-          }
+        body.pinned-shy .navbar-fixed-top, body.pinned-shy .pinned-header {
+          transform: initial !important;
+        }
 
-          body { padding: 0; }
-        '''
-        document.head.appendChild(hider)
+        body { padding: 0; }
+      '''
+      document.head.appendChild(hider)
+
+
+    # Wait until the page has loaded.
+    # Going to the root URL while logged in will redirect to dashboard
+    # which may redirect to the course page.
+    @test.utils.verbose('Waiting until tutor-js page loads up')
+    @test.driver.wait(selenium.until.elementLocated(css: '#react-root-container .-hamburger-menu'))
 
 
   isModalOpen: =>
@@ -116,6 +136,7 @@ class User extends TestHelper
   goHome: =>
     @test.utils.windowPosition.scrollTop()
     @el.homeLink.click()
+    @test.utils.wait.for(@el.courseListing.getLocator())
 
   isHamburgerMenuOpen: =>
     @el.openHamburgerMenu.isPresent()

--- a/test-integration/scores.coffee
+++ b/test-integration/scores.coffee
@@ -20,16 +20,14 @@ describe 'HS Student Scores', ->
     @calendar.goStudentScores()
     @scores.waitUntilLoaded()
 
-  @afterEach ->
-    @user.goHome()
-
-
   @it 'sorts by name or data', ->
     @scores.el.nameHeaderSort.get().click() # If you use just `.click()` that will scroll to try to make the element visible but cause the next element to not be clickable
     @scores.el.dataHeaderSort.click()
+    @user.goHome()
 
   @it 'changes periods', ->
     @scores.el.periodTab.click()
+    @user.goHome()
 
 
 


### PR DESCRIPTION
Changes the syntax to `courseSelect.el.courseByType('physics').click()` instead of `courseSelect.el.courseByType.click('physics')`

Keeps a deprecation warning in _just in case_.

Thoughts @openstax/tutor-fe @openstax/test ? refs #931

# This PR is not to master. refs #981 