### PR TITLE
Selenium use recordo for failed test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /bower_components
 /.tmp
 /dist
-/test-failed-*.png
+/test-failed-*
 /coverage
 
 *.cjsx.js

--- a/test-integration/helpers/describe.coffee
+++ b/test-integration/helpers/describe.coffee
@@ -1,3 +1,4 @@
+fs = require 'fs'
 selenium = require 'selenium-webdriver'
 seleniumMocha = require('selenium-webdriver/testing')
 _ = require 'underscore'
@@ -67,6 +68,7 @@ describe = (name, cb) ->
 
     @__beforeEach ->
       Verbose.reset()
+      User.resetRecordoLog()
       Timeout.installCustomImplementation(@)
 
       @utils = utils(@)
@@ -116,7 +118,13 @@ describe = (name, cb) ->
 
 
       Verbose.reset()
-      User.logout(@)
+      User.logout(@).then ->
+        if state is 'failed'
+          recordoLog = User.getRecordoLog()
+          if recordoLog
+            fs.writeFileSync("test-failed-#{title}.json", JSON.stringify(recordoLog))
+        User.resetRecordoLog()
+
 
 
     @after ->


### PR DESCRIPTION
In addition to taking a screenshot for failed tests, this saves the `recordo` log (mostly to quickly get the server JSON) when `VERBOSE=true` environment var is set.

It uses the `window.__Recordo` global (if available) and has commented code to inject `recordo` instead. It works, but might need some refactoring to not include the UI.

Thoughts @openstax/tutor-fe?

# This PR is not to master . refs #983