### PR TITLE
make crumbs not show for external tasks with only one step

### DIFF
--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -226,11 +226,12 @@ module.exports = React.createClass
     taskClasses += " task-#{panelType}" if panelType?
     taskClasses += ' task-completed' if TaskStore.isTaskCompleted(id)
 
-    breadcrumbs = <Breadcrumbs
-      id={id}
-      goToStep={@goToStep}
-      currentStep={@state.currentStep}
-      key="task-#{id}-breadcrumbs"/>
+    if TaskStore.hasCrumbs(id)
+      breadcrumbs = <Breadcrumbs
+        id={id}
+        goToStep={@goToStep}
+        currentStep={@state.currentStep}
+        key="task-#{id}-breadcrumbs"/>
 
     <PinnedHeaderFooterCard
       forceShy={true}

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -183,8 +183,8 @@ TaskConfig =
       incompleteStep = getCurrentStep(getSteps(@_steps[taskId]))
       not incompleteStep
 
-    isSingleStepped: (taskId) ->
-      @_steps[taskId].length is 1
+    hasCrumbs: (taskId) ->
+      not (@_steps[taskId].length is 1 and @_get(taskId).type is 'external')
 
     doesAllowSeeAhead: (taskId) ->
       allowed = [


### PR DESCRIPTION
### Fixed for external
![screen shot 2016-02-15 at 10 49 16 am](https://cloud.githubusercontent.com/assets/2483873/13054938/f2edcd06-d3d1-11e5-94c8-c98e09f84847.png)

### Crumbs still correct for readings with only one step
![screen shot 2016-02-15 at 10 49 03 am](https://cloud.githubusercontent.com/assets/2483873/13054939/f59f9930-d3d1-11e5-9170-a892d320324c.png)


Regression for external crumbs came from #963, this addresses [this ticket](https://www.pivotaltracker.com/story/show/113636529)