### PR TITLE
QA view: show all tags, two step filter, and question id

### DIFF
--- a/api/ecosystems.json
+++ b/api/ecosystems.json
@@ -1,0 +1,1 @@
+[{"id":3,"books":[{"id":3,"uuid":"334f8b61-30eb-4475-8e05-5260a4866b4b","title":"Physics","version":"7.21"}]},{"id":2,"books":[{"id":2,"uuid":"f10533ca-f803-490d-b935-88899941197f","title":"Mini CC Biology Tes Coll","version":"3.1"}]},{"id":1,"books":[{"id":1,"uuid":"d52e93f4-8653-4273-86da-3850001c0786","title":"Biology For AP® Courses","version":"9.1"}]}]

--- a/api/exercises.json
+++ b/api/exercises.json
@@ -2,6 +2,7 @@
     "total_count": 5,
     "items": [{
         "id": "1616",
+        "pool_types": ["reading_dynamic", "practice_widget", "all_exercises"],
         "url": "https://exercises-dev.openstax.org/exercises/1663@1",
         "content": {
             "uid": "1663@1",
@@ -99,6 +100,7 @@
     }, {
         "id": "1617",
         "url": "https://exercises-dev.openstax.org/exercises/1664@1",
+        "pool_types": ["reading_dynamic", "practice_widget", "all_exercises"],
         "content": {
             "uid": "1664@1",
             "number": 1664,
@@ -195,6 +197,7 @@
     }, {
         "id": "1618",
         "url": "https://exercises-dev.openstax.org/exercises/1665@1",
+        "pool_types": ["practice_widget", "all_exercises"],
         "content": {
             "uid": "1665@1",
             "number": 1665,
@@ -291,6 +294,7 @@
     }, {
         "id": "1619",
         "url": "https://exercises-dev.openstax.org/exercises/1666@1",
+        "pool_types": ["practice_widget", "all_exercises"],
         "content": {
             "uid": "1666@1",
             "number": 1666,
@@ -385,6 +389,7 @@
     }, {
         "id": "1620",
         "url": "https://exercises-dev.openstax.org/exercises/1667@1",
+        "pool_types": ["practice_widget", "all_exercises"],
         "content": {
             "uid": "1667@1",
             "number": 1667,

--- a/resources/styles/qa.less
+++ b/resources/styles/qa.less
@@ -3,12 +3,39 @@
   .reference-book .content { margin-top: 0; }
   .exercises {
     width: @reference-book-page-width;
+    > .heading {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      > * { margin-left: 1rem; }
+      label span { margin-right: 0.5rem; }
+    }
+
     .exercise {
       margin-bottom: @tutor-card-body-padding-vertical;
+
+      &.answers-hidden {
+        .answers-table {
+          height: 80px;
+          border: 1px solid @tutor-neutral-dark;
+          &:after{
+            content: "Enter your response";
+            #fonts > .sans(1.8rem, 3rem);
+            margin-left: 1rem;
+            font-style: italic;
+            color: lightgrey;
+          };
+        }
+      }
+
       .panel-heading {
         position: inherit;
         display: block;
         padding: 0;
+      }
+      .exercise-identifier-link {
+        float: left;
+        position: initial;
       }
       .edit-link {
         .tutor-external-link-indicator();

--- a/resources/styles/qa.less
+++ b/resources/styles/qa.less
@@ -8,7 +8,7 @@
       align-items: center;
       justify-content: flex-end;
       > * { margin-left: 1rem; }
-      label span { margin-right: 0.5rem; }
+      .preview2step { margin-left: 0.5rem; }
     }
 
     .exercise {

--- a/src/components/exercise-card.cjsx
+++ b/src/components/exercise-card.cjsx
@@ -13,6 +13,7 @@ ExerciseCard = React.createClass
     panelStyle: React.PropTypes.string
     header:     React.PropTypes.element
     displayAllTags: React.PropTypes.bool
+    hideAnswers: React.PropTypes.bool
     exercise:   React.PropTypes.shape(
       content: React.PropTypes.object
       tags:    React.PropTypes.array
@@ -49,16 +50,19 @@ ExerciseCard = React.createClass
   render: ->
     content = @props.exercise.content
     question = content.questions[0]
-    renderedAnswers = _(question.answers).chain()
-      .sortBy('id')
-      .map(@renderAnswer)
-      .value()
+
+    renderedAnswers = if @props.hideAnswers
+      []
+    else
+      _(question.answers).chain().sortBy('id').map(@renderAnswer).value()
+
     tags = _.clone @props.exercise.tags
     unless @props.displayAllTags
       tags = _.where tags, is_visible: true
     renderedTags = _.map(_.sortBy(tags, 'name'), @renderTag)
     renderedTags.push(
-      <ExerciseIdentifierLink exerciseId={@props.exercise.content.uid} />
+      <ExerciseIdentifierLink key='identifier'
+        exerciseId={@props.exercise.content.uid} />
     )
     classes = classnames 'card', 'exercise',
       'is-displaying-feedback': @props.displayFeedback

--- a/src/components/exercise-card.cjsx
+++ b/src/components/exercise-card.cjsx
@@ -52,10 +52,9 @@ ExerciseCard = React.createClass
     content = @props.exercise.content
     question = content.questions[0]
 
-    renderedAnswers = if @props.hideAnswers
-      []
-    else
-      _(question.answers).chain().sortBy('id').map(@renderAnswer).value()
+    unless @props.hideAnswers
+      renderedAnswers = _(question.answers)
+        .chain().sortBy('id').map(@renderAnswer).value()
 
     tags = _.clone @props.exercise.tags
     unless @props.displayAllTags

--- a/src/components/exercise-card.cjsx
+++ b/src/components/exercise-card.cjsx
@@ -12,6 +12,7 @@ ExerciseCard = React.createClass
     displayFeedback: React.PropTypes.bool
     panelStyle: React.PropTypes.string
     header:     React.PropTypes.element
+    displayAllTags: React.PropTypes.bool
     exercise:   React.PropTypes.shape(
       content: React.PropTypes.object
       tags:    React.PropTypes.array
@@ -53,6 +54,8 @@ ExerciseCard = React.createClass
       .map(@renderAnswer)
       .value()
     tags = _.clone @props.exercise.tags
+    unless @props.displayAllTags
+      tags = _.where tags, is_visible: true
     renderedTags = _.map(_.sortBy(tags, 'name'), @renderTag)
     renderedTags.push(
       <ExerciseIdentifierLink exerciseId={@props.exercise.content.uid} />

--- a/src/components/exercise-card.cjsx
+++ b/src/components/exercise-card.cjsx
@@ -14,6 +14,7 @@ ExerciseCard = React.createClass
     header:     React.PropTypes.element
     displayAllTags: React.PropTypes.bool
     hideAnswers: React.PropTypes.bool
+    className: React.PropTypes.className
     exercise:   React.PropTypes.shape(
       content: React.PropTypes.object
       tags:    React.PropTypes.array
@@ -64,9 +65,10 @@ ExerciseCard = React.createClass
       <ExerciseIdentifierLink key='identifier'
         exerciseId={@props.exercise.content.uid} />
     )
-    classes = classnames 'card', 'exercise',
+    classes = classnames( 'card', 'exercise', @props.className, {
+      'answers-hidden': @props.hideAnswers,
       'is-displaying-feedback': @props.displayFeedback
-
+    })
     <BS.Panel
       className={classes}
       bsStyle={@props.panelStyle}

--- a/src/components/exercise-card.cjsx
+++ b/src/components/exercise-card.cjsx
@@ -8,12 +8,13 @@ BS = require 'react-bootstrap'
 
 ExerciseCard = React.createClass
 
-  PropTypes:
+  propTypes:
     displayFeedback: React.PropTypes.bool
     panelStyle: React.PropTypes.string
     header:     React.PropTypes.element
     displayAllTags: React.PropTypes.bool
     hideAnswers: React.PropTypes.bool
+    toggleExercise: React.PropTypes.func
     className: React.PropTypes.className
     exercise:   React.PropTypes.shape(
       content: React.PropTypes.object
@@ -46,7 +47,7 @@ ExerciseCard = React.createClass
 
   onClick: (ev) ->
     # don't toggle exercise selection click target is a link (such as "Report an error")
-    @props.toggleExercise() unless ev.target.tagName is 'A'
+    @props.toggleExercise?() unless ev.target.tagName is 'A'
 
   render: ->
     content = @props.exercise.content

--- a/src/components/exercise-card.cjsx
+++ b/src/components/exercise-card.cjsx
@@ -15,7 +15,7 @@ ExerciseCard = React.createClass
     displayAllTags: React.PropTypes.bool
     hideAnswers: React.PropTypes.bool
     toggleExercise: React.PropTypes.func
-    className: React.PropTypes.className
+    className: React.PropTypes.string
     exercise:   React.PropTypes.shape(
       content: React.PropTypes.object
       tags:    React.PropTypes.array

--- a/src/components/qa/exercise-card.cjsx
+++ b/src/components/qa/exercise-card.cjsx
@@ -21,7 +21,11 @@ Exercise = React.createClass
   render: ->
     return null if _.every( ExerciseStore.poolTypes(@props.exercise), (pt) => @props.ignoredPoolTypes[pt] )
     editUrl = @props.exercise.url.replace(/@\d+/, '@draft')
-    <ExerciseCard {...@props} header={@renderHeader()} displayFeedback>
+    <ExerciseCard {...@props}
+      header={@renderHeader()}
+      displayAllTags
+      displayFeedback
+    >
       <a target="_blank" className="edit-link" href={editUrl}>edit</a>
     </ExerciseCard>
 

--- a/src/components/qa/exercises.cjsx
+++ b/src/components/qa/exercises.cjsx
@@ -53,11 +53,11 @@ QAExercises = React.createClass
     @setState(isShowing2StepPreview: ev.target.checked)
 
   renderExerciseContent: (exercises) ->
-    exercises = _.map exercises, (ex) =>
+    exercises = _.map exercises, (exercise) =>
       hideAnswers = @state.isShowing2StepPreview and
-        ExerciseStore.hasQuestionWithFormat(ex, 'free-response')
-      <ExerciseCard key={ex.id}
-        exercise={ex}
+        ExerciseStore.hasQuestionWithFormat('free-response', {exercise})
+      <ExerciseCard key={exercise.id}
+        exercise={exercise}
         hideAnswers={hideAnswers}
         ignoredPoolTypes={@state.ignored} />
     selections = _.map ExerciseStore.getPagePoolTypes(@state.pageId), (pt) =>

--- a/src/components/qa/exercises.cjsx
+++ b/src/components/qa/exercises.cjsx
@@ -69,7 +69,9 @@ QAExercises = React.createClass
       <div className="heading">
         <label>
           Show 2-Step Preview
-          <input type="checkbox" checked={@state.isShowing2StepPreview}
+          <input type='checkbox'
+            className='preview2step'
+            checked={@state.isShowing2StepPreview}
             onChange={@on2StepPreviewChange} />
         </label>
         <MultiSelect

--- a/src/components/qa/exercises.cjsx
+++ b/src/components/qa/exercises.cjsx
@@ -1,6 +1,7 @@
 _ = require 'underscore'
 BS = require 'react-bootstrap'
 React = require 'react'
+classnames = require 'classnames'
 {SpyMode} = require 'openstax-react-components'
 
 {ReferenceBookStore} = require '../../flux/reference-book'
@@ -48,17 +49,35 @@ QAExercises = React.createClass
     ignored[selection.id] = not ignored[selection.id]
     @setState({ignored})
 
+  on2StepPreviewChange: (ev) ->
+    @setState(isShowing2StepPreview: ev.target.checked)
+
   renderExerciseContent: (exercises) ->
     exercises = _.map exercises, (ex) =>
-      <ExerciseCard key={ex.id} exercise={ex} ignoredPoolTypes={@state.ignored} />
+      hideAnswers = @state.isShowing2StepPreview and
+        ExerciseStore.hasTag(ex, 'display-free-response')
+      <ExerciseCard key={ex.id}
+        exercise={ex}
+        hideAnswers={hideAnswers}
+        ignoredPoolTypes={@state.ignored} />
     selections = _.map ExerciseStore.getPagePoolTypes(@state.pageId), (pt) =>
       id: pt, title: String.titleize(pt), selected: not @state.ignored[pt]
+    classNames = classnames("exercises", {
+      'show-2step': @state.isShowing2StepPreview
+    })
+    <div className={classNames} >
+      <div className="heading">
+        <label>
+          Show 2-Step Preview
+          <input type="checkbox" checked={@state.isShowing2StepPreview}
+            onChange={@on2StepPreviewChange} />
+        </label>
+        <MultiSelect
+          title='Exercise Types'
+          selections={selections}
+          onSelect={@onSelectPoolType} />
 
-    <div className="-exercises">
-      <MultiSelect className="pull-right"
-        title='Exercise Types'
-        selections={selections}
-        onSelect={@onSelectPoolType} />
+      </div>
       {exercises}
     </div>
 

--- a/src/components/qa/exercises.cjsx
+++ b/src/components/qa/exercises.cjsx
@@ -55,7 +55,7 @@ QAExercises = React.createClass
   renderExerciseContent: (exercises) ->
     exercises = _.map exercises, (ex) =>
       hideAnswers = @state.isShowing2StepPreview and
-        ExerciseStore.hasTag(ex, 'display-free-response')
+        ExerciseStore.hasQuestionWithFormat(ex, 'free-response')
       <ExerciseCard key={ex.id}
         exercise={ex}
         hideAnswers={hideAnswers}

--- a/src/components/task-teacher-review/exercise.cjsx
+++ b/src/components/task-teacher-review/exercise.cjsx
@@ -3,6 +3,7 @@ _ = require 'underscore'
 BS = require 'react-bootstrap'
 
 {ArbitraryHtmlAndMath, Question, CardBody, FreeResponse} = require 'openstax-react-components'
+{ExerciseStore} = require '../../flux/exercise'
 
 TaskTeacherReviewExercise = React.createClass
   displayName: 'TaskTeacherReviewExercise'
@@ -26,11 +27,6 @@ TaskTeacherReviewExercise = React.createClass
     {content} = @props
     # TODO: Assumes 1 question.
     content.questions[0]
-
-  expectsFreeResponse: ->
-    question = @getQuestion()
-    {formats} = question
-    formats.indexOf('free-response') > -1
 
   renderNoFreeResponse: ->
     freeResponsesClasses = 'teacher-review-answers has-no-answers'
@@ -67,7 +63,7 @@ TaskTeacherReviewExercise = React.createClass
     {answers, answered_count} = @props
     question = @getQuestion()
 
-    if @expectsFreeResponse()
+    if ExerciseStore.hasQuestionWithFormat('free-response', {content: @props.content})
       studentResponses = if answers.length then @renderFreeResponse() else @renderNoFreeResponse()
 
     <CardBody className='task-step openstax-exercise' pinned={false}>

--- a/src/flux/exercise.coffee
+++ b/src/flux/exercise.coffee
@@ -101,8 +101,10 @@ ExerciseConfig =
         section.toString() is topic_chapter_section.toString()
       )
 
-    hasQuestionWithFormat: (exercise, format) ->
-      !!_.detect exercise?.content.questions, (q) -> _.include(q.formats, format)
+    # Searches for the given format in either an exercise or it's content
+    hasQuestionWithFormat: (format, {exercise, content}) ->
+      content = exercise.content unless content?
+      !!_.detect content.questions, (q) -> _.include(q.formats, format)
 
     getPagePoolTypes: (pageId) ->
       types = _.unique _.flatten _.pluck @_exercises[pageId], 'pool_types'

--- a/src/flux/exercise.coffee
+++ b/src/flux/exercise.coffee
@@ -10,7 +10,9 @@ EXERCISE_TAGS =
   GENERIC: ['blooms', 'dok', 'length']
 
 getTagName = (tag) ->
-  [tag.name, tag.description].join(' ')
+  name = _.compact([tag.name, tag.description]).join(' ')
+  name = tag.id unless name
+  name
 
 getImportantTags = (tags) ->
   obj =

--- a/src/flux/exercise.coffee
+++ b/src/flux/exercise.coffee
@@ -101,6 +101,9 @@ ExerciseConfig =
         section.toString() is topic_chapter_section.toString()
       )
 
+    hasQuestionWithFormat: (exercise, format) ->
+      _.detect exercise?.content.questions, (q) -> _.include(q.formats, format)
+
     getPagePoolTypes: (pageId) ->
       types = _.unique _.flatten _.pluck @_exercises[pageId], 'pool_types'
       _.without( types, 'all_exercises' ).sort()

--- a/src/flux/exercise.coffee
+++ b/src/flux/exercise.coffee
@@ -102,7 +102,7 @@ ExerciseConfig =
       )
 
     hasQuestionWithFormat: (exercise, format) ->
-      _.detect exercise?.content.questions, (q) -> _.include(q.formats, format)
+      !!_.detect exercise?.content.questions, (q) -> _.include(q.formats, format)
 
     getPagePoolTypes: (pageId) ->
       types = _.unique _.flatten _.pluck @_exercises[pageId], 'pool_types'

--- a/test/components/exercise-card.spec.coffee
+++ b/test/components/exercise-card.spec.coffee
@@ -26,3 +26,9 @@ describe 'Exercise Card Component', ->
     _.extend(@props, displayFeedback: true)
     Testing.renderComponent( ExerciseCard, props: @props ).then ({dom}) ->
       expect(dom.classList.contains('is-displaying-feedback')).to.be.true
+
+  it 'can hide the answers', ->
+    _.extend(@props, hideAnswers: true)
+    Testing.renderComponent( ExerciseCard, props: @props ).then ({dom}) ->
+      expect(dom.querySelector('.answers-table').textContent).to.be.empty
+      expect(dom.classList.contains('answers-hidden')).to.be.true

--- a/test/components/qa/exercises.spec.coffee
+++ b/test/components/qa/exercises.spec.coffee
@@ -1,0 +1,47 @@
+{Testing, expect, sinon, _, ReactTestUtils} = require '../helpers/component-testing'
+
+Exercises = require '../../../src/components/qa/exercises'
+{ExerciseActions, ExerciseStore} = require '../../../src/flux/exercise'
+{EcosystemsActions, EcosystemsStore} = require '../../../src/flux/ecosystems'
+{ReferenceBookActions, ReferenceBookStore} = require '../../../src/flux/reference-book'
+
+EXERCISES  = require '../../../api/exercises.json'
+ECOSYSTEMS = require '../../../api/ecosystems.json'
+PAGE = require '../../../api/ecosystems/3/readings.json'
+COURSE_ID = '1'
+ECOSYSTEM_ID = '3'
+CNX_ID = '17f6ff53-2d92-4669-acdd-9a958ea7fd0a@12'
+
+
+describe 'QA Exercises Component', ->
+
+  beforeEach (done) ->
+    @props = {
+      cnxId: CNX_ID
+      ecosystemId: ECOSYSTEM_ID
+      section: 'test-section'
+    }
+    EcosystemsActions.loaded(ECOSYSTEMS)
+    ReferenceBookActions.loaded(PAGE, ECOSYSTEM_ID)
+    ExerciseActions.loaded(EXERCISES, COURSE_ID, ['146'])
+    _.defer(done) # defer done signal so it fires after exercise load emits
+
+  it 'displays the exercise questions', ->
+    Testing.renderComponent( Exercises, props: @props ).then ({dom}) ->
+      questions = _.map EXERCISES.items, (e) ->
+        e.content.questions[0].stem_html
+      renderedQs = _.pluck dom.querySelectorAll('.panel-body .stem'), 'innerHTML'
+      expect(renderedQs).to.deep.equal(questions)
+
+  it 'hides answers when previewing 2-step', ->
+    Testing.renderComponent( Exercises, props: @props ).then ({dom, element}) ->
+      cb = dom.querySelector('.preview2step')
+      ReactTestUtils.Simulate.change(cb, {target: checked: true})
+      all  = element.getDOMNode().querySelectorAll('.exercise')
+      hidden = element.getDOMNode().querySelectorAll('.answers-hidden')
+      freeResponseCount = _.reduce(EXERCISES.items, (count, ex) ->
+        count + (if ExerciseStore.hasQuestionWithFormat(ex, 'free-response') then 1 else 0)
+      , 0)
+      expect(all.length).to.equal(EXERCISES.items.length)
+      expect(hidden.length).to.equal(freeResponseCount)
+      expect(hidden[0].querySelector('.answers-table').textContent).to.be.empty


### PR DESCRIPTION
Needs to be merged & deployed along with BE PR: https://github.com/openstax/tutor-server/pull/986 

Notice that I'm displaying a pseudo text entry box (which is really just a styled div).  When I just hid the questions it wasn't easy to tell the 2-step exercises apart from one with a very short question.

![image](https://cloud.githubusercontent.com/assets/79566/13150211/6c3f5c60-d62a-11e5-90b5-8f1bd0d69a4a.png)