### PR TITLE
Selenium: Simplify helper namespace

### DIFF
--- a/test-integration/README.md
+++ b/test-integration/README.md
@@ -147,11 +147,11 @@ this.waitClick('.button').then(function() { console.log('debugging println'); })
 Example from [./task-plan/draft.coffee](./task-plan/draft.coffee)
 
 ```js
-var helpers = require('../helpers');
-var describe = helpers.describe;
-var CourseSelect = helpers.CourseSelect;
-var Calendar = helpers.Calendar;
-var ReadingBuilder = helpers.ReadingBuilder;
+var Helpers = require('../helpers');
+var describe = Helpers.describe;
+var CourseSelect = Helpers.CourseSelect;
+var Calendar = Helpers.Calendar;
+var ReadingBuilder = Helpers.ReadingBuilder;
 ```
 
 #### Coffee version

--- a/test-integration/calendar.coffee
+++ b/test-integration/calendar.coffee
@@ -3,7 +3,6 @@
 _ = require 'underscore'
 
 TEACHER_USERNAME = 'teacher01'
-{CalendarHelper} = Calendar
 {ScoresHelper} = Scores
 
 # Quick test that nothing "blows up". For a more exhaustive version that clicks on all the items, see "./exhaustive"
@@ -22,7 +21,7 @@ describe 'Calendar and Stats', ->
 
   beforeEach ->
     @user = new User(@)
-    @calendar = new CalendarHelper(@)
+    @calendar = new Calendar(@)
     @courseSelect = new CourseSelect(@)
     @scores = new ScoresHelper(@)
 

--- a/test-integration/calendar.coffee
+++ b/test-integration/calendar.coffee
@@ -1,4 +1,5 @@
-{describe, User, CourseSelect, Calendar, ReadingBuilder, Scores} = require './helpers'
+Helpers = require './helpers'
+{describe} = Helpers
 {expect} = require 'chai'
 _ = require 'underscore'
 
@@ -19,10 +20,10 @@ describe 'Calendar and Stats', ->
         done()
 
   beforeEach ->
-    @user = new User(@)
-    @calendar = new Calendar(@)
-    @courseSelect = new CourseSelect(@)
-    @scores = new Scores(@)
+    @user = new Helpers.User(@)
+    @calendar = new Helpers.Calendar(@)
+    @courseSelect = new Helpers.CourseSelect(@)
+    @scores = new Helpers.Scores(@)
 
     @user.login(TEACHER_USERNAME)
 

--- a/test-integration/calendar.coffee
+++ b/test-integration/calendar.coffee
@@ -3,7 +3,6 @@
 _ = require 'underscore'
 
 TEACHER_USERNAME = 'teacher01'
-{ScoresHelper} = Scores
 
 # Quick test that nothing "blows up". For a more exhaustive version that clicks on all the items, see "./exhaustive"
 
@@ -23,7 +22,7 @@ describe 'Calendar and Stats', ->
     @user = new User(@)
     @calendar = new Calendar(@)
     @courseSelect = new CourseSelect(@)
-    @scores = new ScoresHelper(@)
+    @scores = new Scores(@)
 
     @user.login(TEACHER_USERNAME)
 

--- a/test-integration/cc-dashboard.coffee
+++ b/test-integration/cc-dashboard.coffee
@@ -1,8 +1,6 @@
 {describe, CourseSelect, User, CCDashboard, Scores} = require './helpers'
 {expect} = require 'chai'
 
-{ScoresHelper} = Scores
-
 TEACHER_USERNAME = 'teacher01'
 CC_HELP_LINK = 'openstaxcc.zendesk.com/hc/en-us'
 
@@ -12,7 +10,7 @@ describe 'Concept Coach Dashboard', ->
     @user = new User(@)
     @courseSelect = new CourseSelect(@)
     @conceptCoach = new CCDashboard(@)
-    @scores = new ScoresHelper(@)
+    @scores = new Scores(@)
 
     @user.login(TEACHER_USERNAME)
     @courseSelect.goTo('CONCEPT_COACH')

--- a/test-integration/cc-dashboard.coffee
+++ b/test-integration/cc-dashboard.coffee
@@ -1,4 +1,5 @@
-{describe, CourseSelect, User, CCDashboard, Scores} = require './helpers'
+Helpers = require './helpers'
+{describe} = Helpers
 {expect} = require 'chai'
 
 TEACHER_USERNAME = 'teacher01'
@@ -7,10 +8,10 @@ CC_HELP_LINK = 'openstaxcc.zendesk.com/hc/en-us'
 
 describe 'Concept Coach Dashboard', ->
   beforeEach ->
-    @user = new User(@)
-    @courseSelect = new CourseSelect(@)
-    @conceptCoach = new CCDashboard(@)
-    @scores = new Scores(@)
+    @user = new Helpers.User(@)
+    @courseSelect = new Helpers.CourseSelect(@)
+    @conceptCoach = new Helpers.CCDashboard(@)
+    @scores = new Helpers.Scores(@)
 
     @user.login(TEACHER_USERNAME)
     @courseSelect.goTo('CONCEPT_COACH')

--- a/test-integration/exhaustive/calendar.coffee
+++ b/test-integration/exhaustive/calendar.coffee
@@ -4,8 +4,6 @@ _ = require 'underscore'
 
 TEACHER_USERNAME = 'teacher01'
 
-{CalendarHelper} = Calendar
-
 describe 'Calendar and Stats', ->
 
   @eachCourse = (msg, fn) =>
@@ -18,7 +16,7 @@ describe 'Calendar and Stats', ->
 
   beforeEach ->
     @user = new User(@)
-    @calendar = new CalendarHelper(@)
+    @calendar = new Calendar(@)
     @courseSelect = new CourseSelect(@)
 
     @user.login(TEACHER_USERNAME)

--- a/test-integration/exhaustive/calendar.coffee
+++ b/test-integration/exhaustive/calendar.coffee
@@ -1,4 +1,5 @@
-{describe, User, CourseSelect, Calendar, ReadingBuilder} = require '../helpers'
+Helpers = require '../helpers'
+{describe} = Helpers
 {expect} = require 'chai'
 _ = require 'underscore'
 
@@ -15,9 +16,9 @@ describe 'Calendar and Stats', ->
       @user.goHome()
 
   beforeEach ->
-    @user = new User(@)
-    @calendar = new Calendar(@)
-    @courseSelect = new CourseSelect(@)
+    @user = new Helpers.User(@)
+    @calendar = new Helpers.Calendar(@)
+    @courseSelect = new Helpers.CourseSelect(@)
 
     @user.login(TEACHER_USERNAME)
 

--- a/test-integration/exhaustive/reference-book.coffee
+++ b/test-integration/exhaustive/reference-book.coffee
@@ -1,4 +1,5 @@
-{describe, User, ReferenceBook} = require '../helpers'
+Helpers = require '../helpers'
+{describe} = Helpers
 
 SERVER_URL = process.env['SERVER_URL'] or 'http://localhost:3001'
 TEACHER_USERNAME = 'teacher01'
@@ -8,8 +9,8 @@ SECTIONS_TO_TEST = 10
 describe 'Reference Book Exercises', ->
 
   beforeEach ->
-    new User(@).login(TEACHER_USERNAME)
-    @referenceBook = new ReferenceBook(@)
+    new Helpers.User(@).login(TEACHER_USERNAME)
+    @referenceBook = new Helpers.ReferenceBook(@)
 
   @it 'Loads Biology reference book with exercises (readonly)', ->
 

--- a/test-integration/exhaustive/reference-book.coffee
+++ b/test-integration/exhaustive/reference-book.coffee
@@ -1,5 +1,4 @@
 {describe, User, ReferenceBook} = require '../helpers'
-{ReferenceBookHelper} = ReferenceBook
 
 SERVER_URL = process.env['SERVER_URL'] or 'http://localhost:3001'
 TEACHER_USERNAME = 'teacher01'
@@ -10,7 +9,7 @@ describe 'Reference Book Exercises', ->
 
   beforeEach ->
     new User(@).login(TEACHER_USERNAME)
-    @referenceBook = new ReferenceBookHelper(@)
+    @referenceBook = new ReferenceBook(@)
 
   @it 'Loads Biology reference book with exercises (readonly)', ->
 

--- a/test-integration/helpers/calendar.coffee
+++ b/test-integration/helpers/calendar.coffee
@@ -72,8 +72,11 @@ class PlanPopupHelper extends TestHelper
 
 
 class Calendar extends TestHelper
-  constructor: (test, testElementLocator) ->
+  @PlanPopupHelper: PlanPopupHelper
+  @verify: (test) ->
+    (new Calendar(test)).waitUntilLoaded()
 
+  constructor: (test, testElementLocator) ->
     testElementLocator ?=
       css: '.calendar-container'
     calendarOptions =
@@ -117,9 +120,5 @@ class Calendar extends TestHelper
     @test.utils.verbose("Waiting to see if plan is published #{title}")
     @test.utils.wait.giveTime PUBLISHING_TIMEOUT, =>
       @test.driver.wait((=> @el.publishedPlanByTitle(title).isPresent()), PUBLISHING_TIMEOUT)
-
-Calendar.PlanPopupHelper = PlanPopupHelper
-Calendar.verify = (test) ->
-  new Calendar(test).waitUntilLoaded()
 
 module.exports = Calendar

--- a/test-integration/helpers/calendar.coffee
+++ b/test-integration/helpers/calendar.coffee
@@ -45,7 +45,7 @@ COMMON_POPUP_ELEMENTS =
   modal:
     css: '.plan-modal.active'
 
-class PlanPopupHelper extends  TestHelper
+class PlanPopupHelper extends TestHelper
   constructor: (test, testElementLocator) ->
 
     testElementLocator ?=
@@ -71,7 +71,7 @@ class PlanPopupHelper extends  TestHelper
     @el.reviewLink.waitClick()
 
 
-class CalendarHelper extends TestHelper
+class Calendar extends TestHelper
   constructor: (test, testElementLocator) ->
 
     testElementLocator ?=
@@ -118,7 +118,8 @@ class CalendarHelper extends TestHelper
     @test.utils.wait.giveTime PUBLISHING_TIMEOUT, =>
       @test.driver.wait((=> @el.publishedPlanByTitle(title).isPresent()), PUBLISHING_TIMEOUT)
 
-verify = (test) ->
-  new CalendarHelper(test).waitUntilLoaded()
+Calendar.PlanPopupHelper = PlanPopupHelper
+Calendar.verify = (test) ->
+  new Calendar(test).waitUntilLoaded()
 
-module.exports = {CalendarHelper, verify}
+module.exports = Calendar

--- a/test-integration/helpers/reading-builder.coffee
+++ b/test-integration/helpers/reading-builder.coffee
@@ -214,7 +214,7 @@ class ReadingBuilder extends TestHelper
     @test.utils.wait.giveTime (2 * 60 * 1000), =>
       # Publishing can be async so wait until the assignment shows up as 'published' in the calendar
       # Added here because folks won't remember to wait for this
-      (new Calendar.CalendarHelper(@test)).waitUntilPublishingFinishedByTitle(name)
+      (new Calendar(@test)).waitUntilPublishingFinishedByTitle(name)
 
   save: =>
     @test.utils.wait.giveTime (2 * 60 * 1000), =>

--- a/test-integration/helpers/reference-book.coffee
+++ b/test-integration/helpers/reference-book.coffee
@@ -14,7 +14,7 @@ COMMON_ELEMENTS =
     css: '.loading-exercise'
 
 
-class ReferenceBookHelper extends TestHelper
+class ReferenceBook extends TestHelper
   constructor: (test, testElementLocator) ->
     referenceBookOptions =
       loadingLocator:
@@ -38,7 +38,7 @@ class ReferenceBookHelper extends TestHelper
     @el.tocToggle.click()
 
   goNext: =>
-    # go next until old href isnt 
+    # go next until old href isnt
     @test.driver.wait =>
       oldNextHref = ''
       @el.nextPageButton.get().getAttribute('href').then (href) =>
@@ -73,4 +73,4 @@ class ReferenceBookHelper extends TestHelper
       {exercises, missingUrls}
 
 
-module.exports = {ReferenceBookHelper}
+module.exports = ReferenceBook

--- a/test-integration/helpers/scores.coffee
+++ b/test-integration/helpers/scores.coffee
@@ -33,7 +33,7 @@ COMMON_ELEMENTS =
     css: "a.scores-cell[data-assignment-type='#{type}']"
 
 
-class ScoresHelper extends TestHelper
+class Scores extends TestHelper
   constructor: (testContext, testElementLocator) ->
 
     testElementLocator ?=
@@ -55,4 +55,4 @@ class ScoresHelper extends TestHelper
     @utils.isPresent(@el.downloadExport)
 
 
-module.exports = {ScoresHelper}
+module.exports = Scores

--- a/test-integration/helpers/student-dashboard.coffee
+++ b/test-integration/helpers/student-dashboard.coffee
@@ -29,7 +29,9 @@ class Event extends TestHelper
       selenium.promise.fulfilled(null)
 
 
-class Dashboard extends TestHelper
+class StudentDashboard extends TestHelper
+
+  @Event: Event
 
   elementRefs:
     progressGuide:
@@ -58,5 +60,4 @@ class Dashboard extends TestHelper
           )
       )
 
-
-module.exports = {Dashboard, Event}
+module.exports = StudentDashboard

--- a/test-integration/helpers/task.coffee
+++ b/test-integration/helpers/task.coffee
@@ -25,7 +25,7 @@ COMMON_ELEMENTS =
   #   css: '.pinned-container.task.task-event'
 
 # all convenience functions for helping with task tests will be seen here.
-class TaskHelper extends TestHelper
+class Task extends TestHelper
   constructor: (test, testElementLocator) ->
 
     testElementLocator ?= '.task-reading, .task-homework'
@@ -51,4 +51,4 @@ class TaskHelper extends TestHelper
       @test.utils.verboseWrap 'Waiting for continue button to be enabled again', =>
         @test.driver.wait => selenium.until.elementIsEnabled(@el.continueButton.get())
 
-module.exports = {TaskHelper}
+module.exports = Task

--- a/test-integration/scores.coffee
+++ b/test-integration/scores.coffee
@@ -1,4 +1,5 @@
-{describe, User, CourseSelect, Calendar, Scores} = require './helpers'
+Helpers = require './helpers'
+{describe} = Helpers
 {expect} = require 'chai'
 _ = require 'underscore'
 
@@ -8,10 +9,10 @@ TEACHER_USERNAME = 'teacher01'
 describe 'HS Student Scores', ->
 
   @beforeEach ->
-    @user = new User(@)
-    @calendar = new Calendar(@)
-    @scores = new Scores(@)
-    @courseSelect = new CourseSelect(@)
+    @user = new Helpers.User(@)
+    @calendar = new Helpers.Calendar(@)
+    @scores = new Helpers.Scores(@)
+    @courseSelect = new Helpers.CourseSelect(@)
     @user.login(TEACHER_USERNAME)
     @courseSelect.goTo('PHYSICS')
     @calendar.goStudentScores()
@@ -33,10 +34,10 @@ describe 'HS Student Scores', ->
 describe 'CC Student Scores', ->
 
   beforeEach ->
-    @user = new User(@)
-    @calendar = new Calendar(@)
-    @scores = new Scores(@)
-    @courseSelect = new CourseSelect(@)
+    @user = new Helpers.User(@)
+    @calendar = new Helpers.Calendar(@)
+    @scores = new Helpers.Scores(@)
+    @courseSelect = new Helpers.CourseSelect(@)
     @user.login(TEACHER_USERNAME)
     @courseSelect.goTo('CONCEPT_COACH')
     @scores.goCCScores()

--- a/test-integration/scores.coffee
+++ b/test-integration/scores.coffee
@@ -4,7 +4,6 @@ _ = require 'underscore'
 
 TEACHER_USERNAME = 'teacher01'
 
-{CalendarHelper} = Calendar
 {ScoresHelper} = Scores
 
 
@@ -12,7 +11,7 @@ describe 'HS Student Scores', ->
 
   @beforeEach ->
     @user = new User(@)
-    @calendar = new CalendarHelper(@)
+    @calendar = new Calendar(@)
     @scores = new ScoresHelper(@)
     @courseSelect = new CourseSelect(@)
     @user.login(TEACHER_USERNAME)
@@ -37,7 +36,7 @@ describe 'CC Student Scores', ->
 
   beforeEach ->
     @user = new User(@)
-    @calendar = new CalendarHelper(@)
+    @calendar = new Calendar(@)
     @scores = new ScoresHelper(@)
     @courseSelect = new CourseSelect(@)
     @user.login(TEACHER_USERNAME)

--- a/test-integration/scores.coffee
+++ b/test-integration/scores.coffee
@@ -4,15 +4,13 @@ _ = require 'underscore'
 
 TEACHER_USERNAME = 'teacher01'
 
-{ScoresHelper} = Scores
-
 
 describe 'HS Student Scores', ->
 
   @beforeEach ->
     @user = new User(@)
     @calendar = new Calendar(@)
-    @scores = new ScoresHelper(@)
+    @scores = new Scores(@)
     @courseSelect = new CourseSelect(@)
     @user.login(TEACHER_USERNAME)
     @courseSelect.goTo('PHYSICS')
@@ -37,7 +35,7 @@ describe 'CC Student Scores', ->
   beforeEach ->
     @user = new User(@)
     @calendar = new Calendar(@)
-    @scores = new ScoresHelper(@)
+    @scores = new Scores(@)
     @courseSelect = new CourseSelect(@)
     @user.login(TEACHER_USERNAME)
     @courseSelect.goTo('CONCEPT_COACH')

--- a/test-integration/simple.js
+++ b/test-integration/simple.js
@@ -1,4 +1,5 @@
-import {describe, CourseSelect, User} from './helpers'
+import Helpers from './helpers'
+var {describe} = Helpers
 
 var TEACHER_USERNAME = 'teacher01'
 
@@ -7,8 +8,8 @@ describe('Simple ES7 Calendar Test', function() {
   // This test should click on a teacher dashboard and, if it is `Biology I`,
   // should goHome twice, and logging output as things are happening.
   this.it('Simply logs in and selects a course', async function() {
-    this.user = new User(this)
-    this.courseSelect = new CourseSelect(this)
+    this.user = new Helpers.User(this)
+    this.courseSelect = new Helpers.CourseSelect(this)
 
     debugger // This line tells the debugger (using `npm run debug-integration`) to pause here
 

--- a/test-integration/student/dashboard.js
+++ b/test-integration/student/dashboard.js
@@ -24,7 +24,7 @@ describe('Student Dashboard', function(){
     const teacher = new User(this);
     teacher.login('teacher01');
     this.courseSelect.goToCourseByName('Biology I');
-    const calendar = new Calendar.CalendarHelper(this);
+    const calendar = new Calendar(this);
     calendar.createNew('READING');
     const reading = new ReadingBuilder(this);
 

--- a/test-integration/student/dashboard.js
+++ b/test-integration/student/dashboard.js
@@ -1,13 +1,15 @@
-import {describe, CourseSelect, Calendar, ReadingBuilder, StudentDashboard, User, freshId} from '../helpers';
+import Helpers from '../helpers';
+const {describe} = Helpers;
+const {freshId} = Helpers;
 import {expect} from 'chai';
 import _ from 'underscore'
 
 describe('Student Dashboard', function(){
 
   beforeEach( function(){
-    this.student = new User(this);
-    this.courseSelect = new CourseSelect(this);
-    this.dash = new StudentDashboard.Dashboard(this);
+    this.student = new Helpers.User(this);
+    this.courseSelect = new Helpers.CourseSelect(this);
+    this.dash = new Helpers.StudentDashboard.Dashboard(this);
     this.student.login('student01');
     this.courseSelect.goToCourseByName('Biology I');
   });
@@ -21,12 +23,12 @@ describe('Student Dashboard', function(){
 
     const title = this.utils.getFreshId();
     this.student.logout();
-    const teacher = new User(this);
+    const teacher = new Helpers.User(this);
     teacher.login('teacher01');
     this.courseSelect.goToCourseByName('Biology I');
-    const calendar = new Calendar(this);
+    const calendar = new Helpers.Calendar(this);
     calendar.createNew('READING');
-    const reading = new ReadingBuilder(this);
+    const reading = new Helpers.ReadingBuilder(this);
 
     reading.edit({
       name: title,

--- a/test-integration/task-plan/cleanup.coffee
+++ b/test-integration/task-plan/cleanup.coffee
@@ -3,8 +3,6 @@ _ = require 'underscore'
 
 TEACHER_USERNAME = 'teacher01'
 
-{CalendarHelper} =  Calendar
-
 describe 'Assignment Cleanup', ->
 
   beforeEach ->
@@ -12,7 +10,7 @@ describe 'Assignment Cleanup', ->
     @addTimeout(2)
     new CourseSelect(@).goTo('ANY')
 
-    @calendar = new CalendarHelper(@)
+    @calendar = new Calendar(@)
     @reading = new ReadingBuilder(@)
 
     @calendar.waitUntilLoaded()

--- a/test-integration/task-plan/cleanup.coffee
+++ b/test-integration/task-plan/cleanup.coffee
@@ -1,4 +1,7 @@
-{describe, CourseSelect, forEach, Calendar, User, ReadingBuilder} = require '../helpers'
+Helpers = require '../helpers'
+{describe} = Helpers
+{forEach} = Helpers
+
 _ = require 'underscore'
 
 TEACHER_USERNAME = 'teacher01'
@@ -6,12 +9,12 @@ TEACHER_USERNAME = 'teacher01'
 describe 'Assignment Cleanup', ->
 
   beforeEach ->
-    new User(@).login(TEACHER_USERNAME)
+    new Helpers.User(@).login(TEACHER_USERNAME)
     @addTimeout(2)
-    new CourseSelect(@).goTo('ANY')
+    new Helpers.CourseSelect(@).goTo('ANY')
 
-    @calendar = new Calendar(@)
-    @reading = new ReadingBuilder(@)
+    @calendar = new Helpers.Calendar(@)
+    @reading = new Helpers.ReadingBuilder(@)
 
     @calendar.waitUntilLoaded()
 

--- a/test-integration/task-plan/draft.coffee
+++ b/test-integration/task-plan/draft.coffee
@@ -1,4 +1,5 @@
-{describe, CourseSelect, User, Calendar, ReadingBuilder} = require '../helpers'
+Helpers = require '../helpers'
+{describe} = Helpers
 
 {expect} = require 'chai'
 
@@ -11,13 +12,13 @@ describe 'Draft Tests', ->
       expect(hasError).to.be.true
 
   beforeEach ->
-    @calendar = new Calendar(@)
+    @calendar = new Helpers.Calendar(@)
     @title = @utils.getFreshId()
-    new User(@).login(TEACHER_USERNAME)
+    new Helpers.User(@).login(TEACHER_USERNAME)
     # Go to the 1st courses dashboard
-    new CourseSelect(@).goTo('ANY')
+    new Helpers.CourseSelect(@).goTo('ANY')
     @calendar.createNew('READING')
-    @reading = new ReadingBuilder(@)
+    @reading = new Helpers.ReadingBuilder(@)
 
 
   @it 'Shows Validation Error when saving a blank Reading, Homework, and External (idempotent)', ->

--- a/test-integration/task-plan/draft.coffee
+++ b/test-integration/task-plan/draft.coffee
@@ -4,8 +4,6 @@
 
 TEACHER_USERNAME = 'teacher01'
 
-{CalendarHelper} =  Calendar
-
 describe 'Draft Tests', ->
 
   beforeEach ->
@@ -13,11 +11,11 @@ describe 'Draft Tests', ->
       expect(hasError).to.be.true
 
   beforeEach ->
+    @calendar = new Calendar(@)
     @title = @utils.getFreshId()
     new User(@).login(TEACHER_USERNAME)
     # Go to the 1st courses dashboard
     new CourseSelect(@).goTo('ANY')
-    @calendar = new CalendarHelper(@)
     @calendar.createNew('READING')
     @reading = new ReadingBuilder(@)
 

--- a/test-integration/task-plan/publish.coffee
+++ b/test-integration/task-plan/publish.coffee
@@ -1,4 +1,6 @@
-{describe, CourseSelect, User, Calendar, ReadingBuilder} = require '../helpers'
+Helpers = require '../helpers'
+{describe} = Helpers
+
 {expect} = require 'chai'
 
 TEACHER_USERNAME = 'teacher01'
@@ -6,14 +8,14 @@ TEACHER_USERNAME = 'teacher01'
 describe 'Assignment Publishing Tests', ->
 
   beforeEach ->
-    @calendar = new Calendar(@)
-    @reading = new ReadingBuilder(@)
+    @calendar = new Helpers.Calendar(@)
+    @reading = new Helpers.ReadingBuilder(@)
 
     @title = @utils.getFreshId()
-    new User(@).login(TEACHER_USERNAME)
+    new Helpers.User(@).login(TEACHER_USERNAME)
 
     # Go to the 1st courses dashboard
-    new CourseSelect(@).goTo('ANY')
+    new Helpers.CourseSelect(@).goTo('ANY')
 
     @calendar.createNew('READING')
 

--- a/test-integration/task-plan/publish.coffee
+++ b/test-integration/task-plan/publish.coffee
@@ -3,21 +3,19 @@
 
 TEACHER_USERNAME = 'teacher01'
 
-{CalendarHelper} =  Calendar
-
 describe 'Assignment Publishing Tests', ->
 
   beforeEach ->
+    @calendar = new Calendar(@)
+    @reading = new ReadingBuilder(@)
+
     @title = @utils.getFreshId()
     new User(@).login(TEACHER_USERNAME)
 
     # Go to the 1st courses dashboard
     new CourseSelect(@).goTo('ANY')
 
-    @calendar = new CalendarHelper(@)
     @calendar.createNew('READING')
-
-    @reading = new ReadingBuilder(@)
 
   @it 'Sets the name of an reading', ->
     @reading.setName(@title)

--- a/test-integration/task.coffee
+++ b/test-integration/task.coffee
@@ -1,4 +1,5 @@
-{describe, CourseSelect, Task, User, StudentDashboard} = require './helpers'
+Helpers = require './helpers'
+{describe} = Helpers
 {expect} = require 'chai'
 _ = require 'underscore'
 selenium = require 'selenium-webdriver'
@@ -9,10 +10,10 @@ STUDENT_USERNAME = 'student01'
 describe 'Student performing tasks', ->
 
   beforeEach ->
-    @user = new User(@)
-    @task = new Task(@)
-    @courseSelect = new CourseSelect(@)
-    @dashboard = new StudentDashboard(@)
+    @user = new Helpers.User(@)
+    @task = new Helpers.Task(@)
+    @courseSelect = new Helpers.CourseSelect(@)
+    @dashboard = new Helpers.StudentDashboard(@)
 
     @user.login(STUDENT_USERNAME)
 

--- a/test-integration/task.coffee
+++ b/test-integration/task.coffee
@@ -3,9 +3,6 @@
 _ = require 'underscore'
 selenium = require 'selenium-webdriver'
 
-{TaskHelper} = Task
-{Dashboard} = StudentDashboard
-
 STUDENT_USERNAME = 'student01'
 
 
@@ -13,9 +10,9 @@ describe 'Student performing tasks', ->
 
   beforeEach ->
     @user = new User(@)
-    @task = new TaskHelper(@)
+    @task = new Task(@)
     @courseSelect = new CourseSelect(@)
-    @dashboard = new Dashboard(@)
+    @dashboard = new StudentDashboard(@)
 
     @user.login(STUDENT_USERNAME)
 


### PR DESCRIPTION
Sometimes a helper would export:

- just the helper (ie `Calendar`)
- `{Calendar}`
- `{CalendarHelper}`
- `{CalendarHelper, CalendarPopupHelper, verify}`.

This makes it export just the helper and the subhelper (if you need it it can be referred to by `new Calendar.Popup(test)`) and removes the `Helper` part in the class name