### PR TITLE
Selenium: reduce for's repeated code

### DIFF
--- a/test-integration/helpers/ui/test-element.coffee
+++ b/test-integration/helpers/ui/test-element.coffee
@@ -87,6 +87,10 @@ class TestItemHelper
     locator = @getLocator(args...)
     @test.utils.dom.getParent(locator)
 
+  getParent: (args...) =>
+    locator = @getLocator(args...)
+    @test.utils.dom.getParent(locator)
+
 
 class TestHelper
   constructor: (test, testElementLocator, commonElements, options) ->

--- a/test-integration/helpers/ui/test-element.coffee
+++ b/test-integration/helpers/ui/test-element.coffee
@@ -87,10 +87,6 @@ class TestItemHelper
     locator = @getLocator(args...)
     @test.utils.dom.getParent(locator)
 
-  getParent: (args...) =>
-    locator = @getLocator(args...)
-    @test.utils.dom.getParent(locator)
-
 
 class TestHelper
   constructor: (test, testElementLocator, commonElements, options) ->

--- a/test-integration/helpers/utils/wait.coffee
+++ b/test-integration/helpers/utils/wait.coffee
@@ -3,34 +3,8 @@ selenium = require 'selenium-webdriver'
 class Wait
   constructor: (test) -> @test = test
 
-  _for: (single = true) =>
-    singleOptions =
-      find: @test.driver.findElement.bind(@test.driver)
-      untilLocated: selenium.until.elementLocated
-      buildWaitMessage: (locator) ->
-        "Looking for #{JSON.stringify(locator)}"
-      buildFoundMessage: (locator, result) ->
-        "Found #{JSON.stringify(locator)}"
-      buildDisplayMessage: (locator) ->
-        "Waiting for #{JSON.stringify(locator)} to show"
-      filter: (result) ->
-        result
-
-    multipleOptions =
-      find: @test.driver.findElements.bind(@test.driver)
-      untilLocated: selenium.until.elementsLocated
-      buildWaitMessage: (locator) ->
-        "Looking for multiple #{JSON.stringify(locator)}"
-      buildFoundMessage: (locator, result) ->
-        "Found #{result.count} matching #{JSON.stringify(locator)}"
-      buildDisplayMessage: (locator) ->
-        "Waiting for #{JSON.stringify(locator)} to show"
-      filter: (result) ->
-        result[0]
-
-    options = if single then singleOptions else multipleOptions
-
-    {find, untilLocated, buildWaitMessage, buildFoundMessage, buildDisplayMessage, filter} = options
+  _for: (settings) =>
+    {find, untilLocated, buildWaitMessage, buildFoundMessage, buildDisplayMessage, filter} = settings
 
     (locator, ms = 60 * 1000) =>
       locator = @test.utils.toLocator(locator)
@@ -50,11 +24,35 @@ class Wait
       el
 
   forMultiple: (locator, ms = 60 * 1000) ->
-    @_for(false)(locator, ms)
+    settings =
+      find: @test.driver.findElements.bind(@test.driver)
+      untilLocated: selenium.until.elementsLocated
+      buildWaitMessage: (locator) ->
+        "Looking for multiple #{JSON.stringify(locator)}"
+      buildFoundMessage: (locator, result) ->
+        "Found #{result.count} matching #{JSON.stringify(locator)}"
+      buildDisplayMessage: (locator) ->
+        "Waiting for #{JSON.stringify(locator)} to show"
+      filter: (result) ->
+        result[0]
+
+    @_for(settings)(locator, ms)
 
   # Waits for an element to be available and bumps up the timeout to be at least 60sec from now
   for: (locator, ms = 60 * 1000) ->
-    @_for(true)(locator, ms)
+    settings =
+      find: @test.driver.findElement.bind(@test.driver)
+      untilLocated: selenium.until.elementLocated
+      buildWaitMessage: (locator) ->
+        "Looking for #{JSON.stringify(locator)}"
+      buildFoundMessage: (locator, result) ->
+        "Found #{JSON.stringify(locator)}"
+      buildDisplayMessage: (locator) ->
+        "Waiting for #{JSON.stringify(locator)} to show"
+      filter: (result) ->
+        result
+
+    @_for(settings)(locator, ms)
 
   click: (locator, ms) =>
     @test.utils.verboseWrap "Wait and click #{JSON.stringify(locator)}", =>

--- a/test-integration/helpers/utils/wait.coffee
+++ b/test-integration/helpers/utils/wait.coffee
@@ -1,9 +1,24 @@
 selenium = require 'selenium-webdriver'
+_ = require 'underscore'
 
 class Wait
   constructor: (test) -> @test = test
 
   _for: (settings) =>
+
+    defaultSettings =
+      find: @test.driver.findElement.bind(@test.driver)
+      untilLocated: selenium.until.elementLocated
+      buildWaitMessage: (locator) ->
+        "Looking for #{JSON.stringify(locator)}"
+      buildFoundMessage: (locator, result) ->
+        "Found #{JSON.stringify(locator)}"
+      buildDisplayMessage: (locator) ->
+        "Waiting for #{JSON.stringify(locator)} to show"
+      filter: (result) ->
+        result
+
+    settings = _.extend({}, defaultSettings, settings)
     {find, untilLocated, buildWaitMessage, buildFoundMessage, buildDisplayMessage, filter} = settings
 
     (locator, ms = 60 * 1000) =>
@@ -31,8 +46,6 @@ class Wait
         "Looking for multiple #{JSON.stringify(locator)}"
       buildFoundMessage: (locator, result) ->
         "Found #{result.count} matching #{JSON.stringify(locator)}"
-      buildDisplayMessage: (locator) ->
-        "Waiting for #{JSON.stringify(locator)} to show"
       filter: (result) ->
         result[0]
 
@@ -40,19 +53,7 @@ class Wait
 
   # Waits for an element to be available and bumps up the timeout to be at least 60sec from now
   for: (locator, ms = 60 * 1000) ->
-    settings =
-      find: @test.driver.findElement.bind(@test.driver)
-      untilLocated: selenium.until.elementLocated
-      buildWaitMessage: (locator) ->
-        "Looking for #{JSON.stringify(locator)}"
-      buildFoundMessage: (locator, result) ->
-        "Found #{JSON.stringify(locator)}"
-      buildDisplayMessage: (locator) ->
-        "Waiting for #{JSON.stringify(locator)} to show"
-      filter: (result) ->
-        result
-
-    @_for(settings)(locator, ms)
+    @_for()(locator, ms)
 
   click: (locator, ms) =>
     @test.utils.verboseWrap "Wait and click #{JSON.stringify(locator)}", =>

--- a/test-integration/helpers/utils/wait.coffee
+++ b/test-integration/helpers/utils/wait.coffee
@@ -40,14 +40,11 @@ class Wait
       untilReady = if shouldBeVisible then selenium.until.elementIsVisible else selenium.until.elementIsEnabled
 
       @giveTime ms, =>
-        @test.utils.verboseWrap buildWaitMessage(locator), =>
-          @test.driver.wait(untilLocated(locator))
-
-          # Because of animations an element might be in the DOM but not visible
-          find(locator).then (result) =>
-            @test.utils.verbose(buildFoundMessage(locator, result))
-            @test.utils.verboseWrap buildDisplayMessage(locator), =>
-              @test.driver.wait(untilReady(filter(result)))
+        @until buildWaitMessage(locator), untilLocated(locator)
+        # Because of animations an element might be in the DOM but not visible
+        find(locator).then (result) =>
+          @test.utils.verbose(buildFoundMessage(locator, result))
+          @until buildDisplayMessage(locator), untilReady(filter(result))
 
       el = find(locator)
       el

--- a/test-integration/helpers/utils/wait.coffee
+++ b/test-integration/helpers/utils/wait.coffee
@@ -9,6 +9,7 @@ class Wait
     defaultSettings =
       find: @test.driver.findElement.bind(@test.driver)
       untilLocated: selenium.until.elementLocated
+      untilReady: selenium.until.elementIsVisible
       buildWaitMessage: (locator) ->
         "Looking for #{JSON.stringify(locator)}"
       buildFoundMessage: (locator, result) ->
@@ -19,14 +20,10 @@ class Wait
         result
 
     settings = _.extend({}, defaultSettings, settings)
-    {find, untilLocated, buildWaitMessage, buildFoundMessage, buildDisplayMessage, filter} = settings
+    {find, untilLocated, untilReady, buildWaitMessage, buildFoundMessage, buildDisplayMessage, filter} = settings
 
     (locator, ms = 60 * 1000) =>
       locator = @test.utils.toLocator(locator)
-
-      {shouldBeVisible} = locator
-      shouldBeVisible ?= true
-      untilReady = if shouldBeVisible then selenium.until.elementIsVisible else selenium.until.elementIsEnabled
 
       @giveTime ms, =>
         @until buildWaitMessage(locator), untilLocated(locator)
@@ -51,9 +48,16 @@ class Wait
 
     @_for(settings)(locator, ms)
 
-  # Waits for an element to be available and bumps up the timeout to be at least 60sec from now
+  # Waits for an element to be displayed and bumps up the timeout to be at least 60sec from now
   for: (locator, ms = 60 * 1000) ->
     @_for()(locator, ms)
+
+  # Waits for an element to be enabled and bumps up the timeout to be at least 60sec from now
+  forHidden: (locator, ms = 60 * 1000) ->
+    settings = 
+      untilReady: selenium.until.elementIsEnabled
+
+    @_for(settings)(locator, ms)
 
   click: (locator, ms) =>
     @test.utils.verboseWrap "Wait and click #{JSON.stringify(locator)}", =>


### PR DESCRIPTION
# This is not a PullRequest to Master

@philschatz, @openstax/tutor-fe  heheh is this too much?  I kinda like that it means the structure of the `for`'s will remain in sync but it make's it less readable.  Although, with `_for`, pulling out the `shouldBeVisible` from the `locator` and making a `forHidden` would be easier and less copy and paste

base branch is #1000