### PR TITLE
Teacher Calendar: Fix publishing status

### DIFF
--- a/api/courses/1/plans/POST.json
+++ b/api/courses/1/plans/POST.json
@@ -5,7 +5,9 @@
   "description":"yo yo yo",
   "is_publish_requested":true,
   "publish_last_requested_at":"2015-07-28T20:31:59.893Z",
-  "publish_job_uuid":"0a55b79f-56cb-40b7-83ef-9afa7875e1e9",
+  "publish_job": {
+    "id": "0a55b79f-56cb-40b7-83ef-9afa7875e1e9"
+  },
   "publish_job_url":"/api/jobs/0a55b79f-56cb-40b7-83ef-9afa7875e1e9",
   "settings":{
     "page_ids":["2","3"]

--- a/resources/styles/components/course-calendar/plan.less
+++ b/resources/styles/components/course-calendar/plan.less
@@ -48,7 +48,7 @@
         margin-right: @calendar-plan-left-label-offset;
       }
 
-      &.is-failed, &.is-killed{
+      &.is-failed, &.is-killed, &.is-404 {
         .tutor-plan-display(@tutor-danger);
       }
     }

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -202,6 +202,7 @@ start = (bootstrapData) ->
 
   apiHelper JobActions, JobActions.load, JobActions.loaded, 'GET', (id) ->
     url: "/api/jobs/#{id}"
+  , displayError: false
 
   apiHelper EcosystemsActions, EcosystemsActions.load, EcosystemsActions.loaded, 'GET', ->
     url: "/api/ecosystems"

--- a/src/flux/helpers.coffee
+++ b/src/flux/helpers.coffee
@@ -39,6 +39,7 @@ CrudConfig = ->
     FAILED: (status, msg, id) ->
       @_asyncStatus[id] = FAILED
       @_errors[id] = msg
+      @_failed?({status, msg}, id)
       unless status is 0 # indicates network failure
         delete @_local[id]
         @emitChange()

--- a/src/flux/job.coffee
+++ b/src/flux/job.coffee
@@ -28,7 +28,11 @@ JobConfig = {
 
     jobData
 
-  checkUntil: (id, checkJob, interval = 1000, maxRepeats = 50, finalStatus = ['succeeded', 'failed', 'killed']) ->
+  # load in to store on fail.
+  _failed: (obj, id) ->
+    @loaded(obj, id)
+
+  checkUntil: (id, checkJob, interval = 1000, maxRepeats = 50, finalStatus = ['succeeded', 'failed', 'killed', 404]) ->
     unless @_checkUntil[id]?
       @_checkUntil[id] = {checkJob, finalStatus, interval, maxRepeats, count: 0}
       checkJob()

--- a/src/flux/plan-publish.coffee
+++ b/src/flux/plan-publish.coffee
@@ -3,11 +3,17 @@
 _ = require 'underscore'
 moment = require 'moment'
 
+getIds = (obj) ->
+  {publish_job, id} = obj
+  jobId = publish_job?.id or null
+  {id, jobId}
+
 PlanPublishConfig =
   _getIds: (obj) ->
-    {publish_job_uuid, id} = obj
-    jobId = publish_job_uuid
-    {id, jobId}
+    @exports._getIds(obj)
+
+  exports:
+    _getIds: getIds
 
 extendConfig(PlanPublishConfig, new JobListenerConfig(2000, 100))
 

--- a/src/helpers/job.coffee
+++ b/src/helpers/job.coffee
@@ -67,11 +67,15 @@ JobListenerConfig = (checkIntervals, checkRepeats) ->
       # whenever this job status is updated, emit the status for this wrapper
       updateJobStatus = @_updateJobStatusFor(id)
       JobStore.on("job.#{jobId}.*", updateJobStatus)
-      JobStore.off("job.#{jobId}.final", updateJobStatus)
+      JobStore.once("job.#{jobId}.final", @stopListening(updateJobStatus))
 
     stopChecking: (id) ->
       jobId = @_getLatestJob(id)
       JobActions.stopChecking(jobId) if jobId?
+
+    stopListening: (updateJobStatus) ->
+      (jobData) ->
+        JobStore.off("job.#{jobData.id}.*", updateJobStatus)
 
     _getJobs: (id) ->
       _.clone(@_job[id])

--- a/src/helpers/job.coffee
+++ b/src/helpers/job.coffee
@@ -11,6 +11,7 @@ JOBBED = 'succeeded'
 JOB_FAILED = 'failed'
 JOB_KILLED = 'killed'
 JOB_UNKNOWN = 'unknown'
+JOB_NOT_FOUND = 404
 
 JobListenerConfig = (checkIntervals, checkRepeats) ->
   {
@@ -95,6 +96,7 @@ JobListenerConfig = (checkIntervals, checkRepeats) ->
         failedStates = [
           JOB_FAILED
           JOB_KILLED
+          JOB_NOT_FOUND
         ]
 
         failedStates.indexOf(@_asyncStatus[id]) > -1
@@ -104,6 +106,7 @@ JobListenerConfig = (checkIntervals, checkRepeats) ->
           JOBBED
           JOB_FAILED
           JOB_KILLED
+          JOB_NOT_FOUND
         ]
 
         doneStates.indexOf(@_asyncStatus[id]) > -1

--- a/src/helpers/plan.coffee
+++ b/src/helpers/plan.coffee
@@ -19,19 +19,19 @@ PlanHelper =
     isPublishing
 
   subscribeToPublishing: (plan, callback) ->
-    {id, publish_job_uuid} = plan
+    {jobId, id} = PlanPublishStore._getIds(plan)
     isPublishing = PlanHelper.isPublishing(plan)
 
     publishStatus = PlanPublishStore.getAsyncStatus(id)
     isPublishingInStore = PlanPublishStore.isPublishing(id)
 
     if isPublishing and not isPublishingInStore and not PlanPublishStore.isPublished(id)
-      PlanPublishActions.queued({id, publish_job_uuid}) if publish_job_uuid?
+      PlanPublishActions.queued(plan, id) if jobId
 
     isPublishing = isPublishing or isPublishingInStore
 
     if isPublishing
-      PlanPublishActions.startChecking(id, publish_job_uuid)
+      PlanPublishActions.startChecking(id, jobId)
       PlanPublishStore.on("progress.#{id}.*", callback) if callback? and _.isFunction(callback)
 
     {isPublishing, publishStatus}

--- a/test/components/course-calendar/plan.spec.coffee
+++ b/test/components/course-calendar/plan.spec.coffee
@@ -49,7 +49,7 @@ _.each(TEST_ITEMS, (item) ->
 fakePublishing = (plan) ->
   publishingPlan = _.clone(plan)
   publishingPlan.publish_last_requested_at = moment(TimeStore.getNow())
-  publishingPlan.publish_job_uuid = JOB_UUID
+  publishingPlan.publish_job = {id: JOB_UUID, status: 'queued'}
 
   if publishingPlan.published_at and moment(publishingPlan.published_at).isAfter(publishingPlan.publish_last_requested_at)
     publishingPlan.published_at = moment(publishingPlan.publish_last_requested_at).subtract(2, 'days')

--- a/test/flux/plan-publish.spec.coffee
+++ b/test/flux/plan-publish.spec.coffee
@@ -1,7 +1,7 @@
-{expect} = require 'chai'
-sinon = require 'sinon'
+expect = chai.expect
 _ = require 'underscore'
 
+{JobActions, JobStore} = require '../../src/flux/job'
 {PlanPublishActions, PlanPublishStore} = require '../../src/flux/plan-publish'
 
 expectedActions = [
@@ -37,6 +37,16 @@ JOB_QUEUED_RESPONSE =
   id: JOB_FOR_ID
   jobId: JOB_DATA_ID
 
+JOB_NOT_FOUND_RESPONSE =
+  status: 404
+  msg: 'JOB_NOT_FOUND'
+  id: JOB_DATA_ID
+
+PLAN =
+  id: JOB_FOR_ID
+  publish_job:
+    id: JOB_DATA_ID
+
 JOB_STATUSES = [
   'job_requesting'
   'job_queued'
@@ -62,3 +72,12 @@ describe 'Plan Publish flux', ->
       expect(PlanPublishStore)
         .to.have.property(storeAsker).that.is.a('function')
     )
+
+  it 'should update status when failed', ->
+    JobStore.emit = sinon.spy()
+    JobActions.loaded = sinon.spy(JobActions.loaded)
+
+    PlanPublishActions.queued(PLAN, PLAN.id)
+    PlanPublishActions.startChecking(PLAN.id)
+    JobActions.FAILED(JOB_NOT_FOUND_RESPONSE.status, JOB_NOT_FOUND_RESPONSE.msg, JOB_DATA_ID)
+    expect(JobStore.emit).to.have.been.called

--- a/test/helpers/job.spec.coffee
+++ b/test/helpers/job.spec.coffee
@@ -101,7 +101,7 @@ describe 'Job Helper', ->
   it 'should be able update job status', ->
     jobWorking = _.clone(JOB_DATA)
     jobWorking.status = JOB_STATUSES[3]
-    jobListenerConfig._updateJobStatusFor(JOB_FOR_ID)(jobWorking)
+    jobListenerConfig._updateJobStatusFor(JOB_FOR_ID, jobWorking)
     jobWorking.for = JOB_FOR_ID
 
     expect(jobListenerConfig.exports.getAsyncStatus(JOB_FOR_ID)).to.equal(JOB_STATUSES[3])


### PR DESCRIPTION
* match updated data structure where `publish_job` is an object, and the `publish_job_uuid` is `publish_job.id`
* add a way to customize API fails
  * 404 of jobs should not trigger modal
  * should load as the latest state and show on calendar as failed

matches BE openstax/tutor-server#997