### PR TITLE
Dashboard tab transparent fix, tab trouble flag adjustment for long names

### DIFF
--- a/resources/styles/mixins.less
+++ b/resources/styles/mixins.less
@@ -73,7 +73,7 @@
   background: none;
   display: flex;
   flex-wrap: wrap;
-  li.tab-item-period {
+  li {
     text-align: center;
     background: @tutor-neutral-lighter;
 
@@ -108,9 +108,12 @@
       a {
       display: inline-block;
       padding: 10px;
+      height: 20px;
+      min-width: 55px;
         &:before {
           .is-trouble();
-          margin-right: 5px;
+          margin: 2px 5px 0px 0px;
+          float: left;
         }
       }
     }

--- a/src/components/course-periods-nav.cjsx
+++ b/src/components/course-periods-nav.cjsx
@@ -60,7 +60,7 @@ CoursePeriodsNav = React.createClass
     @setState(active: key)
 
   renderPeriod: (period, key) ->
-    className = classnames('tab-item-period', {'is-trouble': period.is_trouble})
+    className = classnames({'is-trouble': period.is_trouble})
     tooltip =
       <BS.Tooltip>
         {period.name}

--- a/src/components/course-settings/roster.cjsx
+++ b/src/components/course-settings/roster.cjsx
@@ -48,7 +48,7 @@ module.exports = React.createClass
     {is_concept_coach} = course
     periods = course.periods.length > 0
     tabs = _.map course.periods, (period, index) =>
-      className = classnames('tab-item-period', {'is-trouble': period.is_trouble})
+      className = classnames({'is-trouble': period.is_trouble})
       tooltip =
         <BS.Tooltip>
           {period.name}


### PR DESCRIPTION
- fixed non-period tab styling conflict causing student dashboard tabs to appear transparent
- adjusted trouble flag placement for longer/truncated period names

fixes #1005