### PR TITLE
Fix overflow on exercises table

### DIFF
--- a/resources/styles/components/task-plan/homework/exercises.less
+++ b/resources/styles/components/task-plan/homework/exercises.less
@@ -54,6 +54,16 @@ table.exercise-table {
     * + * {
       display: none;
     }
+
+    img {
+      display: block;
+      width: 100%;
+      padding: 20px;
+    }
+
+    span p:first-child {
+      display: inline;
+    }
   }
 
   td {


### PR DESCRIPTION
For: https://www.pivotaltracker.com/n/projects/1156756/stories/109743900

I've made the image fit the width of the box, I think it's better than hiding the image.  Also, the overflow for text is fixed as well.

Before:
https://www.pivotaltracker.com/file_attachments/57298699/download
After: 
![screen shot 2016-03-08 at 7 56 20 am](https://cloud.githubusercontent.com/assets/6434717/13587704/ee8f6514-e504-11e5-88ca-44082d0e6d33.png)
