### PR TITLE
Export button single step test

### DIFF
--- a/test-integration/helpers/ui/scores.coffee
+++ b/test-integration/helpers/ui/scores.coffee
@@ -1,6 +1,5 @@
 fs = require 'fs'
 selenium = require 'selenium-webdriver'
-{expect} = require 'chai'
 {TestHelper} = require './test-element'
 {PeriodReviewTab} = require './items'
 Timeout = require '../timeout'
@@ -54,34 +53,25 @@ class Scores extends TestHelper
     @el.ccScoresLink().click()
     @waitUntilLoaded()
 
-  doneGenerating: =>
-    @test.utils.wait.until 'export url is set', =>
-      @test.driver.isElementPresent(COMMON_ELEMENTS.doneGenerating)
+  getExportDownloadPath: =>
+    # need to wait for the hidden iframe with the expected [src]
+    # before checking for file
+    @test.utils.wait.forHidden(@el.doneGenerating().getLocator()).getAttribute("src").then (src) =>
+      file = src.split('/').pop()
+      path = "#{@test.downloadDirectory}/#{file}"
 
-  downloadExport: =>
-    if @doneGenerating()
-      @el.exportUrl().findElement().getAttribute("src").then (src) =>
-        file = src.split('/').pop()
-        path = "#{@test.downloadDirectory}/#{file}"
-        if fs.existsSync(path)
-          fs.unlink(path)
-        else
-          throw new Error('BUG: Exported file not found!')
+      filePath = if fs.existsSync(path) then path else null
+      fs.unlink(filePath) if filePath
 
-  tooltipVisible: =>
-    @test.utils.wait.until 'hover over cc info tooltip', =>
-      @test.driver.isElementPresent(COMMON_ELEMENTS.ccTooltip)
+      filePath
 
   hoverCCTooltip: =>
     @el.hoverCCTooltip().findElement().then (e) =>
       @test.driver.actions().mouseMove(e).perform()
-      if @tooltipVisible()
-        @test.addTimeout(60)
-        @el.ccTooltip().findElement().getText().then (txt) ->
-          expect(txt).to.contain('Correct')
-          expect(txt).to.contain('Attempted')
-          expect(txt).to.contain('Total possible')
 
+  getCCTooltip: =>
+    @hoverCCTooltip()
+    @el.ccTooltip().get()
 
 
 

--- a/test-integration/helpers/ui/test-element.coffee
+++ b/test-integration/helpers/ui/test-element.coffee
@@ -92,6 +92,10 @@ class TestItemHelper
     locator = @getLocator(args...)
     @test.utils.dom.getParent(locator)
 
+  getParent: (args...) =>
+    locator = @getLocator(args...)
+    @test.utils.dom.getParent(locator)
+
 
 class TestHelper
   constructor: (test, testElementLocator, commonElements, options) ->

--- a/test-integration/helpers/ui/test-element.coffee
+++ b/test-integration/helpers/ui/test-element.coffee
@@ -92,10 +92,6 @@ class TestItemHelper
     locator = @getLocator(args...)
     @test.utils.dom.getParent(locator)
 
-  getParent: (args...) =>
-    locator = @getLocator(args...)
-    @test.utils.dom.getParent(locator)
-
 
 class TestHelper
   constructor: (test, testElementLocator, commonElements, options) ->

--- a/test-integration/helpers/utils/wait.coffee
+++ b/test-integration/helpers/utils/wait.coffee
@@ -3,34 +3,8 @@ selenium = require 'selenium-webdriver'
 class Wait
   constructor: (test) -> @test = test
 
-  _for: (single = true) =>
-    singleOptions =
-      find: @test.driver.findElement.bind(@test.driver)
-      untilLocated: selenium.until.elementLocated
-      buildWaitMessage: (locator) ->
-        "Looking for #{JSON.stringify(locator)}"
-      buildFoundMessage: (locator, result) ->
-        "Found #{JSON.stringify(locator)}"
-      buildDisplayMessage: (locator) ->
-        "Waiting for #{JSON.stringify(locator)} to show"
-      filter: (result) ->
-        result
-
-    multipleOptions =
-      find: @test.driver.findElements.bind(@test.driver)
-      untilLocated: selenium.until.elementsLocated
-      buildWaitMessage: (locator) ->
-        "Looking for multiple #{JSON.stringify(locator)}"
-      buildFoundMessage: (locator, result) ->
-        "Found #{result.count} matching #{JSON.stringify(locator)}"
-      buildDisplayMessage: (locator) ->
-        "Waiting for #{JSON.stringify(locator)} to show"
-      filter: (result) ->
-        result[0]
-
-    options = if single then singleOptions else multipleOptions
-
-    {find, untilLocated, buildWaitMessage, buildFoundMessage, buildDisplayMessage, filter} = options
+  _for: (settings) =>
+    {find, untilLocated, buildWaitMessage, buildFoundMessage, buildDisplayMessage, filter} = settings
 
     (locator, ms = 60 * 1000) =>
       locator = @test.utils.toLocator(locator)
@@ -50,11 +24,35 @@ class Wait
       el
 
   forMultiple: (locator, ms = 60 * 1000) ->
-    @_for(false)(locator, ms)
+    settings =
+      find: @test.driver.findElements.bind(@test.driver)
+      untilLocated: selenium.until.elementsLocated
+      buildWaitMessage: (locator) ->
+        "Looking for multiple #{JSON.stringify(locator)}"
+      buildFoundMessage: (locator, result) ->
+        "Found #{result.count} matching #{JSON.stringify(locator)}"
+      buildDisplayMessage: (locator) ->
+        "Waiting for #{JSON.stringify(locator)} to show"
+      filter: (result) ->
+        result[0]
+
+    @_for(settings)(locator, ms)
 
   # Waits for an element to be available and bumps up the timeout to be at least 60sec from now
   for: (locator, ms = 60 * 1000) ->
-    @_for(true)(locator, ms)
+    settings =
+      find: @test.driver.findElement.bind(@test.driver)
+      untilLocated: selenium.until.elementLocated
+      buildWaitMessage: (locator) ->
+        "Looking for #{JSON.stringify(locator)}"
+      buildFoundMessage: (locator, result) ->
+        "Found #{JSON.stringify(locator)}"
+      buildDisplayMessage: (locator) ->
+        "Waiting for #{JSON.stringify(locator)} to show"
+      filter: (result) ->
+        result
+
+    @_for(settings)(locator, ms)
 
   click: (locator, ms) =>
     @test.utils.verboseWrap "Wait and click #{JSON.stringify(locator)}", =>

--- a/test-integration/helpers/utils/wait.coffee
+++ b/test-integration/helpers/utils/wait.coffee
@@ -35,7 +35,7 @@ class Wait
       el = find(locator)
       el
 
-  forMultiple: (locator, ms = 60 * 1000) ->
+  forMultiple: (locator, ms = 60 * 1000) =>
     settings =
       find: @test.driver.findElements.bind(@test.driver)
       untilLocated: selenium.until.elementsLocated
@@ -49,11 +49,11 @@ class Wait
     @_for(settings)(locator, ms)
 
   # Waits for an element to be displayed and bumps up the timeout to be at least 60sec from now
-  for: (locator, ms = 60 * 1000) ->
+  for: (locator, ms = 60 * 1000) =>
     @_for()(locator, ms)
 
   # Waits for an element to be enabled and bumps up the timeout to be at least 60sec from now
-  forHidden: (locator, ms = 60 * 1000) ->
+  forHidden: (locator, ms = 60 * 1000) =>
     settings = 
       untilReady: selenium.until.elementIsEnabled
 

--- a/test-integration/helpers/utils/wait.coffee
+++ b/test-integration/helpers/utils/wait.coffee
@@ -1,9 +1,24 @@
 selenium = require 'selenium-webdriver'
+_ = require 'underscore'
 
 class Wait
   constructor: (test) -> @test = test
 
   _for: (settings) =>
+
+    defaultSettings =
+      find: @test.driver.findElement.bind(@test.driver)
+      untilLocated: selenium.until.elementLocated
+      buildWaitMessage: (locator) ->
+        "Looking for #{JSON.stringify(locator)}"
+      buildFoundMessage: (locator, result) ->
+        "Found #{JSON.stringify(locator)}"
+      buildDisplayMessage: (locator) ->
+        "Waiting for #{JSON.stringify(locator)} to show"
+      filter: (result) ->
+        result
+
+    settings = _.extend({}, defaultSettings, settings)
     {find, untilLocated, buildWaitMessage, buildFoundMessage, buildDisplayMessage, filter} = settings
 
     (locator, ms = 60 * 1000) =>
@@ -31,8 +46,6 @@ class Wait
         "Looking for multiple #{JSON.stringify(locator)}"
       buildFoundMessage: (locator, result) ->
         "Found #{result.count} matching #{JSON.stringify(locator)}"
-      buildDisplayMessage: (locator) ->
-        "Waiting for #{JSON.stringify(locator)} to show"
       filter: (result) ->
         result[0]
 
@@ -40,19 +53,7 @@ class Wait
 
   # Waits for an element to be available and bumps up the timeout to be at least 60sec from now
   for: (locator, ms = 60 * 1000) ->
-    settings =
-      find: @test.driver.findElement.bind(@test.driver)
-      untilLocated: selenium.until.elementLocated
-      buildWaitMessage: (locator) ->
-        "Looking for #{JSON.stringify(locator)}"
-      buildFoundMessage: (locator, result) ->
-        "Found #{JSON.stringify(locator)}"
-      buildDisplayMessage: (locator) ->
-        "Waiting for #{JSON.stringify(locator)} to show"
-      filter: (result) ->
-        result
-
-    @_for(settings)(locator, ms)
+    @_for()(locator, ms)
 
   click: (locator, ms) =>
     @test.utils.verboseWrap "Wait and click #{JSON.stringify(locator)}", =>

--- a/test-integration/helpers/utils/wait.coffee
+++ b/test-integration/helpers/utils/wait.coffee
@@ -40,14 +40,11 @@ class Wait
       untilReady = if shouldBeVisible then selenium.until.elementIsVisible else selenium.until.elementIsEnabled
 
       @giveTime ms, =>
-        @test.utils.verboseWrap buildWaitMessage(locator), =>
-          @test.driver.wait(untilLocated(locator))
-
-          # Because of animations an element might be in the DOM but not visible
-          find(locator).then (result) =>
-            @test.utils.verbose(buildFoundMessage(locator, result))
-            @test.utils.verboseWrap buildDisplayMessage(locator), =>
-              @test.driver.wait(untilReady(filter(result)))
+        @until buildWaitMessage(locator), untilLocated(locator)
+        # Because of animations an element might be in the DOM but not visible
+        find(locator).then (result) =>
+          @test.utils.verbose(buildFoundMessage(locator, result))
+          @until buildDisplayMessage(locator), untilReady(filter(result))
 
       el = find(locator)
       el

--- a/test-integration/helpers/utils/wait.coffee
+++ b/test-integration/helpers/utils/wait.coffee
@@ -9,6 +9,7 @@ class Wait
     defaultSettings =
       find: @test.driver.findElement.bind(@test.driver)
       untilLocated: selenium.until.elementLocated
+      untilReady: selenium.until.elementIsVisible
       buildWaitMessage: (locator) ->
         "Looking for #{JSON.stringify(locator)}"
       buildFoundMessage: (locator, result) ->
@@ -19,14 +20,10 @@ class Wait
         result
 
     settings = _.extend({}, defaultSettings, settings)
-    {find, untilLocated, buildWaitMessage, buildFoundMessage, buildDisplayMessage, filter} = settings
+    {find, untilLocated, untilReady, buildWaitMessage, buildFoundMessage, buildDisplayMessage, filter} = settings
 
     (locator, ms = 60 * 1000) =>
       locator = @test.utils.toLocator(locator)
-
-      {shouldBeVisible} = locator
-      shouldBeVisible ?= true
-      untilReady = if shouldBeVisible then selenium.until.elementIsVisible else selenium.until.elementIsEnabled
 
       @giveTime ms, =>
         @until buildWaitMessage(locator), untilLocated(locator)
@@ -51,9 +48,16 @@ class Wait
 
     @_for(settings)(locator, ms)
 
-  # Waits for an element to be available and bumps up the timeout to be at least 60sec from now
+  # Waits for an element to be displayed and bumps up the timeout to be at least 60sec from now
   for: (locator, ms = 60 * 1000) ->
     @_for()(locator, ms)
+
+  # Waits for an element to be enabled and bumps up the timeout to be at least 60sec from now
+  forHidden: (locator, ms = 60 * 1000) ->
+    settings = 
+      untilReady: selenium.until.elementIsEnabled
+
+    @_for(settings)(locator, ms)
 
   click: (locator, ms) =>
     @test.utils.verboseWrap "Wait and click #{JSON.stringify(locator)}", =>

--- a/test-integration/scores.coffee
+++ b/test-integration/scores.coffee
@@ -32,8 +32,8 @@ describe 'HS Student Scores', ->
 
   @it 'generates export', ->
     @scores.el.generateExport().click()
-    @addTimeout(60)
-    @scores.downloadExport()
+    @scores.getExportDownloadPath().then (downloadedFilePath) =>
+      expect(downloadedFilePath).to.contain(@downloadDirectory)
 
 
 
@@ -72,6 +72,8 @@ describe 'CC Student Scores', ->
       @user.goToHome()
 
   @it 'hovers tooltip info popover', ->
-    @addTimeout(60)
-    @scores.hoverCCTooltip()
+    @scores.getCCTooltip().getText().then (txt) ->
+      expect(txt).to.contain('Correct')
+      expect(txt).to.contain('Attempted')
+      expect(txt).to.contain('Total possible')
 


### PR DESCRIPTION
# This is not a PullRequest to Master

Amendment to #996
Move `expects` out to `scores` spec, uses `for` waits as opposed hard timeouts