### PR TITLE
Set displayError: false option on notifications properly

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -287,7 +287,9 @@ start = (bootstrapData) ->
     url: "/api/courses/#{courseId}/dashboard"
 
   apiHelper NotificationActions, NotificationActions.loadUpdates, NotificationActions.loadedUpdates, 'GET', ->
-    displayError: false, url: "/api/notifications"
+    url: "/api/notifications"
+  , displayError: false
+
 
   CurrentUserActions.logout.addListener 'trigger', ->
     # Logging out programatically needs to be done via a form submission or follow redirects


### PR DESCRIPTION
Followup to #1015 which had it set incorrectly.

It needs to be set as the 4th argument to apiHelper, not as an option on the third 