### PR TITLE
HW Builder: Remove images in summary table

### DIFF
--- a/resources/styles/components/task-plan/homework/exercises.less
+++ b/resources/styles/components/task-plan/homework/exercises.less
@@ -56,9 +56,7 @@ table.exercise-table {
     }
 
     img {
-      display: block;
-      width: 100%;
-      padding: 20px;
+      display: none;
     }
 
     span p:first-child {

--- a/src/components/task-plan/homework/exercises.cjsx
+++ b/src/components/task-plan/homework/exercises.cjsx
@@ -183,10 +183,13 @@ ExerciseTable = React.createClass
 
   renderExerciseRow: (exerciseId, index, hasTeks) ->
     {section, lo, tagString} = ExerciseStore.getTagStrings(exerciseId)
-    content = $("<span>#{ExerciseStore.getContent(exerciseId)}</span>")
+    content = document.createElement("span")
+    content.innerHTML = ExerciseStore.getContent(exerciseId)
+    _.each(content.getElementsByTagName('img'), (img) ->
+      if img.nextSibling then img.remove() else img.parentElement?.remove()
+    )
 
-    _.each(content.find('img'), (img) -> $(img).before("<span>[image] #{img.alt}</span>"))
-    content = content.html()
+    content = content.innerHTML
 
     if (hasTeks)
       teksString = ExerciseStore.getTeksString(exerciseId)

--- a/src/components/task-plan/homework/exercises.cjsx
+++ b/src/components/task-plan/homework/exercises.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 _ = require 'underscore'
 BS = require 'react-bootstrap'
+$ = require 'jquery'
 
 {ArbitraryHtmlAndMath} = require 'openstax-react-components'
 ExerciseCard = require '../../exercise-card'
@@ -182,7 +183,10 @@ ExerciseTable = React.createClass
 
   renderExerciseRow: (exerciseId, index, hasTeks) ->
     {section, lo, tagString} = ExerciseStore.getTagStrings(exerciseId)
-    content = ExerciseStore.getContent(exerciseId)
+    content = $("<span>#{ExerciseStore.getContent(exerciseId)}</span>")
+
+    _.each(content.find('img'), (img) -> $(img).before("<span>[image] #{img.alt}</span>"))
+    content = content.html()
 
     if (hasTeks)
       teksString = ExerciseStore.getTeksString(exerciseId)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/109743900

This PR removes images from the summary table.

![screen shot 2016-03-18 at 1 48 28 am](https://cloud.githubusercontent.com/assets/6434717/13869470/94d1a498-ecab-11e5-8056-5fb926207677.png)
