### PR TITLE
Display exercise feedback when is_feedback_available is set

### DIFF
--- a/src/helpers/policies/utils.coffee
+++ b/src/helpers/policies/utils.coffee
@@ -9,7 +9,7 @@ DEFAULT = 'default'
 utils =
   _dueState: (task) ->
     state = 'before'
-    state = 'after' if task.due_at? and TaskStore.isTaskPastDue(task.id)
+    state = 'after' if task.is_feedback_available or (task.due_at? and TaskStore.isTaskPastDue(task.id))
 
     state
 


### PR DESCRIPTION
To accompany openstax/tutor-server#1023 and #1021 

Will display feedback as expected for homework where feedback is immediately available, and will continue to on to next question without doing so if feed back is only available after feedback.