### PR TITLE
Selenium: rename ReadingBuilder to TaskBuilder

### DIFF
--- a/test-integration/README.md
+++ b/test-integration/README.md
@@ -77,7 +77,7 @@ So, the test would look something like:
 App.login(TEACHER_USERNAME)
 CourseSelect.goToByType('ANY')            # Choose any course
 Calendar.createNew('HOMEWORK')
-ReadingBuilder.edit(action: 'SAVE') # Try to save
+TaskBuilder.edit(action: 'SAVE') # Try to save
 
 (validation tests would go here)
 ```
@@ -151,13 +151,13 @@ var Helpers = require('../helpers');
 var describe = Helpers.describe;
 var CourseSelect = Helpers.CourseSelect;
 var Calendar = Helpers.Calendar;
-var ReadingBuilder = Helpers.ReadingBuilder;
+var TaskBuilder = Helpers.TaskBuilder;
 ```
 
 #### Coffee version
 
 ```coffee
-{describe, CourseSelect, Calendar, ReadingBuilder} = require '../helpers'
+{describe, CourseSelect, Calendar, TaskBuilder} = require '../helpers'
 ```
 
 
@@ -182,7 +182,7 @@ describe('Draft Tests', function() {
     // Click to add a reading
     Calendar.createNew(this, 'READING');
 
-    ReadingBuilder.edit(this, {
+    TaskBuilder.edit(this, {
       name: title,
       // opensAt: 'NOT_TODAY'
       dueAt: 'EARLIEST',
@@ -195,7 +195,7 @@ describe('Draft Tests', function() {
     // BUG: .course-list shouldn't be in the DOM
     Calendar.goToOpenByTitle(this, title);
 
-    ReadingBuilder.edit(this, {
+    TaskBuilder.edit(this, {
       action: 'DELETE'
     });
 
@@ -223,7 +223,7 @@ describe 'Draft Tests', ->
     # Click to add a reading
     Calendar.createNew(@, 'READING')
 
-    ReadingBuilder.edit @,
+    TaskBuilder.edit @,
       name: title
       # opensAt: 'NOT_TODAY'
       dueAt: 'EARLIEST'
@@ -235,7 +235,7 @@ describe 'Draft Tests', ->
     # BUG: .course-list shouldn't be in the DOM
     Calendar.goToOpenByTitle(@, title)
 
-    ReadingBuilder.edit(@, action: 'DELETE')
+    TaskBuilder.edit(@, action: 'DELETE')
 
     # Just verify we get back to the calendar
     Calendar.verify(@)

--- a/test-integration/helpers/index.coffee
+++ b/test-integration/helpers/index.coffee
@@ -2,7 +2,7 @@
 
 module.exports =
   Calendar         : require './ui/calendar'
-  ReadingBuilder   : require './ui/reading-builder'
+  TaskBuilder      : require './ui/task-builder'
   CourseSelect     : require './ui/course-select'
   CCDashboard      : require './ui/cc-dashboard'
   StudentDashboard : require './ui/student-dashboard'

--- a/test-integration/helpers/ui/task-builder.coffee
+++ b/test-integration/helpers/ui/task-builder.coffee
@@ -155,8 +155,8 @@ class UnsavedDialog extends TestHelper
 
 # Helper methods for dealing with the Reading Assignment Builder
 # TODO this could probably be made into a BuilderHelper that extends the TestHelper
-# and then the ReadingBuilder and HomeworkBuilder can extend the BuilderHelper
-class ReadingBuilder extends TestHelper
+# and then the TaskBuilder and HomeworkBuilder can extend the BuilderHelper
+class TaskBuilder extends TestHelper
 
   constructor: (test, testElementLocator) ->
     testElementLocator ?= COMMON_ELEMENTS.anyPlan
@@ -299,4 +299,4 @@ class ReadingBuilder extends TestHelper
       when 'DELETE' then @delete()
 
 
-module.exports = ReadingBuilder
+module.exports = TaskBuilder

--- a/test-integration/student/dashboard.js
+++ b/test-integration/student/dashboard.js
@@ -28,7 +28,7 @@ describe('Student Dashboard', function(){
     this.courseSelect.goToByTitle('Biology I');
     const calendar = new Helpers.Calendar(this);
     calendar.createNew('READING');
-    const reading = new Helpers.ReadingBuilder(this);
+    const reading = new Helpers.TaskBuilder(this);
 
     reading.edit({
       name: title,

--- a/test-integration/task-plan/cleanup.coffee
+++ b/test-integration/task-plan/cleanup.coffee
@@ -14,7 +14,7 @@ describe 'Assignment Cleanup', ->
     new Helpers.CourseSelect(@).goToByType('ANY')
 
     @calendar = new Helpers.Calendar(@)
-    @reading = new Helpers.ReadingBuilder(@)
+    @reading = new Helpers.TaskBuilder(@)
     @calendarPopup = new Helpers.Calendar.Popup(@)
 
     @calendar.waitUntilLoaded()

--- a/test-integration/task-plan/draft.coffee
+++ b/test-integration/task-plan/draft.coffee
@@ -18,7 +18,7 @@ describe 'Draft Tests', ->
     new Helpers.CourseSelect(@).goToByType('ANY')
     @calendar.waitUntilLoaded()
     @calendar.createNew('READING')
-    @reading = new Helpers.ReadingBuilder(@)
+    @reading = new Helpers.TaskBuilder(@)
 
 
   @it 'Shows Validation Error when saving a blank Reading, Homework, and External (idempotent)', ->

--- a/test-integration/task-plan/publish.coffee
+++ b/test-integration/task-plan/publish.coffee
@@ -10,7 +10,7 @@ describe 'Assignment Publishing Tests', ->
   beforeEach ->
     @calendar = new Helpers.Calendar(@)
     @calendarPopup = new Helpers.Calendar.Popup(@)
-    @reading = new Helpers.ReadingBuilder(@)
+    @reading = new Helpers.TaskBuilder(@)
 
     @title = @utils.getFreshId()
     new Helpers.User(@).login(TEACHER_USERNAME)


### PR DESCRIPTION
Since the helper creates both Reading and Homeworks it's better named as Task

Note, there's currently one spec failure:
```
  1) CC Student Scores hovers tooltip info popover:
     AssertionError: expected '' to include 'Correct Attempted Total possible'
```

I'm not sure if that's a side effect of my courses loaded or what, but don't see how it could be related to the rename.