### PR TITLE
Downgrade lodash to version compatible with calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "font-awesome": "4.4.0",
     "htmlparser2": "3.8.3",
     "jquery": "2.1.4",
-    "lodash": "4.5.1",
+    "lodash": "2.4.1",
     "markdown-it": "4.4.0",
     "mime-types": "2.1.7",
     "moment": "2.10.6",


### PR DESCRIPTION
We pulled in the full version of lodash In https://github.com/openstax/tutor-js/commit/dc8d3b43fc1442cfe578a45b1d74669a9bc7c465#diff-b9cfc7f2cdf78a7f4b91a753d10865a2 but required 4.5.1.  `react-calendar` is set to "^2.4.1", but somehow the calendar has required and using 4.5.1 on production.

The issue is that calendar uses `_.pick` with a function to choose the props for components  https://github.com/freiksenet/react-calendar/blob/0.4.0/src/propTypes.js#L170-L180.  Apparently lodash no longer supports using a function to pick the properties, it now has a `pickBy` method for that.

The end result is that the `onClick` property is discarded and not added to Days on the calendar, causing the popover menu to not display on a click.

This simply downgrades lodash but perhaps it'd be better to go back to the previous include of just `lodash.curry` ?  

Thoughts @pandafulmanda ?
