### PR TITLE
Fix teacher coach hw summary breadcrumb styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mime-types": "2.1.7",
     "moment": "2.10.6",
     "moment-timezone": "0.4.1",
-    "openstax-react-components": "openstax/react-components#d-20160406.a.coach-crumbs",
+    "openstax-react-components": "openstax/react-components#d-20160406.coach-crumbs-candidate.b",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mime-types": "2.1.7",
     "moment": "2.10.6",
     "moment-timezone": "0.4.1",
-    "openstax-react-components": "openstax/react-components#d-20160406.coach-crumbs-candidate.b",
+    "openstax-react-components": "openstax/react-components#d-20160411.a",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mime-types": "2.1.7",
     "moment": "2.10.6",
     "moment-timezone": "0.4.1",
-    "openstax-react-components": "openstax/react-components#d-20160405.candidate.a",
+    "openstax-react-components": "openstax/react-components#d-20160406.a.coach-crumbs",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -1,3 +1,5 @@
+@import '~openstax-react-components/resources/styles/components/breadcrumbs/coach';
+
 .task {
   iframe {
     width: 960px;
@@ -37,7 +39,11 @@
     }
   }
   // only visible when "spy mode" is enabled
-  .task-ecosystem-info { .tutor-spy-mode-content() }
+  .task-ecosystem-info { .tutor-spy-mode-content() };
+
+  &.task-concept_coach {
+    .concept-coach-breadcrumbs();
+  }
 }
 
 @import './external';

--- a/resources/styles/global/menus.less
+++ b/resources/styles/global/menus.less
@@ -4,7 +4,7 @@
 
   // The QuestionLibrary is hidden until it's ready for release
   // it's re-enabled below when spy mode is engaged
-  [data-name=viewQuestionsLibrary] {
+  .viewQuestionsLibrary {
     display: none;
   }
 
@@ -14,5 +14,5 @@
 // This and the above 'display: none' should be removed when the
 // Question Library is released
 .openstax-debug-content.is-enabled {
-  .dropdown-menu [data-name=viewQuestionsLibrary] { display: block; }
+  .dropdown-menu .viewQuestionsLibrary { display: block; }
 }

--- a/src/components/navbar/user-actions-menu.cjsx
+++ b/src/components/navbar/user-actions-menu.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 BS = require 'react-bootstrap'
 Router = require 'react-router'
 _ = require 'underscore'
+classnames = require 'classnames'
 
 UserName = require './username'
 AccountLink = require './account-link'
@@ -40,11 +41,12 @@ UserActionsMenu = React.createClass
 
     key = if route.key then "dropdown-item-#{route.key}" else "dropdown-item-#{index}"
 
+    # MenuItem doesn't pass on props to the li currently, so using className instead for route.name visual control.
     <BS.MenuItem
       {...menuGoProps}
+      className={classnames(route.name, 'active': isActive)}
       key={key}
       data-name={route.name}
-      className={'active' if isActive}
       eventKey={index + 2}>
         {route.label}
     </BS.MenuItem>

--- a/src/components/task-step/concept-coach-end.cjsx
+++ b/src/components/task-step/concept-coach-end.cjsx
@@ -35,7 +35,6 @@ ConceptCoachEnd = React.createClass
     completedReview = @renderReviewSteps(taskId, completedSteps)
 
     <div className='task-review -concept-coach-completed'>
-      <h1>Summary</h1>
       {completedReview}
       <PinnableFooter>
         {footer}

--- a/src/components/task/breadcrumbs.cjsx
+++ b/src/components/task/breadcrumbs.cjsx
@@ -108,6 +108,7 @@ module.exports = React.createClass
         onMount={@crumbMounted}
         style={crumbStyle}
         crumb={crumb}
+        data-label={crumb.label}
         currentStep={currentStep}
         goToStep={goToStep}
         key="breadcrumb-#{crumb.type}-#{crumb.key}"

--- a/src/components/task/crumb-mixin.cjsx
+++ b/src/components/task/crumb-mixin.cjsx
@@ -71,6 +71,7 @@ module.exports =
       crumb: @_shouldStepCrumb(steps.length)
       type: crumbType
       listeners: @_getStepListeners(crumbType)
+      label: 'Summary'
 
     crumbs
 


### PR DESCRIPTION
- [x] update when openstax/react-components#55 is merged

**Review for review  otherwise**

Related to [CC: Marketing request: When teacher views student HW summary, it should look the same as when the student views their HW summary.](https://www.pivotaltracker.com/story/show/110131688)

![screen shot 2016-04-06 at 3 00 15 am](https://cloud.githubusercontent.com/assets/2483873/14309728/db1b2a08-fba3-11e5-99af-33bcc67ebe0b.png)
