### PR TITLE
format multiple exercise query properly when it comes to double quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mime-types": "2.1.7",
     "moment": "2.10.6",
     "moment-timezone": "0.4.1",
-    "openstax-react-components": "openstax/react-components#d-20160411.a",
+    "openstax-react-components": "openstax/react-components#d-20160418.frame-embed-candidate-a",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/src/flux/reference-book-exercise.coffee
+++ b/src/flux/reference-book-exercise.coffee
@@ -9,6 +9,8 @@ combineQueries = (multipleUrls) ->
   tags = _.map(multipleUrls, (url) ->
     queryString = decodeURIComponent(url.split(QUERY_START_STRING)[1])
     [param, value] = queryString.split(':')
+    # trim individual tag of double quotes
+    value = value.replace(/^"(.+(?="$))"$/, '$1')
     params[param] ?= []
     params[param].push(value)
 
@@ -16,7 +18,8 @@ combineQueries = (multipleUrls) ->
   )
   urlsAndTags = _.object(multipleUrls, tags)
   queryStrings = _.map(params, (values, paramKey) ->
-    "#{paramKey}:#{values.join(',')}"
+    # join values and wrap all values with a single pair of double quotes
+    "#{paramKey}:\"#{values.join(',')}\""
   )
   queryString = queryStrings.join(' ')
 


### PR DESCRIPTION
Based off the [commit currently on QA](https://github.com/openstax/tutor-js/compare/cd550ac47525462fc079978dbadf0770ea0a1449...hotfix/ref-book-exercises).

the way tags work have changed a little bit, and the FE needs to adjust in reference book when querying for multiple exercises.

Depends on https://github.com/openstax/react-components/pull/58