### PR TITLE
start with extend both export checking times and async button timeouts to an hour

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mime-types": "2.1.7",
     "moment": "2.10.6",
     "moment-timezone": "0.4.1",
-    "openstax-react-components": "openstax/react-components#d-20160418.frame-embed-candidate-a",
+    "openstax-react-components": "openstax/react-components#d-20160429.async-button-strict-delay.candidate.a",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/resources/styles/components/scores/export.less
+++ b/resources/styles/components/scores/export.less
@@ -1,12 +1,18 @@
 .export-button {
-  &.pull-right {
-    .export-button-buttons {
-      text-align: right;
-    }
+  position: absolute;
+  right: 0;
+  top: 0;
+
+  .export-button-buttons {
+    text-align: right;
   }
   .btn {
     margin-top: 0;
     margin-bottom: 0;
+
+    &@{btn-preselector}:disabled {
+      margin: 0;
+    }
   }
   .export-button-time {
     .clearfix();

--- a/resources/styles/components/scores/index.less
+++ b/resources/styles/components/scores/index.less
@@ -20,6 +20,9 @@
   &.panel {
     max-width: 100%;
   }
+  .course-scores-wrap {
+    position: relative;
+  }
   .course-scores-title {
     font-size: 3rem;
     padding-bottom: 20px;

--- a/src/components/scores/export.cjsx
+++ b/src/components/scores/export.cjsx
@@ -1,6 +1,7 @@
 BS = require 'react-bootstrap'
 React = require 'react'
 mime = require 'mime-types'
+classnames = require 'classnames'
 
 BindStoreMixin = require '../bind-store-mixin'
 {AsyncButton} = require 'openstax-react-components'
@@ -124,8 +125,9 @@ ScoresExport = React.createClass
   render: ->
     {courseId, className} = @props
     {downloadUrl, lastExported, downloadHasError, tryToDownload, finalDownloadUrl} = @state
+    isWorking = ScoresExportStore.isExporting(courseId) or tryToDownload
 
-    className += ' export-button'
+    classes = classnames 'export-button', className
     actionButtonClass = 'primary'
 
     failedProps =
@@ -135,7 +137,7 @@ ScoresExport = React.createClass
       <AsyncButton
         bsStyle={actionButtonClass}
         onClick={-> ScoresExportActions.export(courseId)}
-        isWaiting={ScoresExportStore.isExporting(courseId) or tryToDownload}
+        isWaiting={isWorking}
         isFailed={ScoresExportStore.isFailed(courseId) or downloadHasError}
         failedProps={failedProps}
         isJob={true}
@@ -144,11 +146,14 @@ ScoresExport = React.createClass
         Export
       </AsyncButton>
 
-    <span className={className}>
+    exportTimeNotice = <i><small>The export may take up to 10 minutes.</small></i> if isWorking
+
+    <div className={classes}>
       <div className='export-button-buttons'>
         {actionButton}
       </div>
+      {exportTimeNotice}
       <iframe id="downloadExport" src={finalDownloadUrl}></iframe>
-    </span>
+    </div>
 
 module.exports = ScoresExport

--- a/src/components/scores/export.cjsx
+++ b/src/components/scores/export.cjsx
@@ -139,6 +139,7 @@ ScoresExport = React.createClass
         isFailed={ScoresExportStore.isFailed(courseId) or downloadHasError}
         failedProps={failedProps}
         isJob={true}
+        timeoutLength={3600000}
         waitingText='Generating Export…'>
         Export
       </AsyncButton>

--- a/src/components/scores/index.cjsx
+++ b/src/components/scores/index.cjsx
@@ -128,7 +128,7 @@ Scores = React.createClass
 
     data = @getStudentRowData()
 
-    scoresExport = <ScoresExport courseId={courseId} className='pull-right'/>
+    scoresExport = <ScoresExport courseId={courseId}/>
 
     if isConceptCoach
       scoresTable =

--- a/src/flux/scores-export.coffee
+++ b/src/flux/scores-export.coffee
@@ -31,7 +31,7 @@ ScoresExportConfig = {
 
 }
 
-JobCrudConfig = extendConfig(new JobListenerConfig(), new CrudConfig())
+JobCrudConfig = extendConfig(new JobListenerConfig(null, 60 * 60), new CrudConfig())
 extendConfig(ScoresExportConfig, JobCrudConfig)
 
 ScoresExportConfig.exports.isExported = ScoresExportConfig.exports.isSucceeded


### PR DESCRIPTION
**Not based off master**

Off of 1eae2eb, current production

Export job status will be checked 3600 times every second (1 hour) before stopping the check, and the async button will not check for timeout until 1 hour has passed once the job starts

For bug [Concept Coach Export fails](https://www.pivotaltracker.com/story/show/118647541)