### PR TITLE
grab bag of style tweaks for Question Library

### DIFF
--- a/resources/styles/components/exercise-preview.less
+++ b/resources/styles/components/exercise-preview.less
@@ -1,0 +1,7 @@
+.openstax-exercise-preview .panel-footer .controls {
+
+  .exercise-identifier-link a {
+    color: @link-color;
+  }
+
+}

--- a/resources/styles/components/questions-dashboard.less
+++ b/resources/styles/components/questions-dashboard.less
@@ -8,7 +8,7 @@
   >.header {
     margin-top: @tutor-panel-padding-vertical;
     background-color: @tutor-white;
-    padding: 0 @padding;
+    padding: 0 @padding+5px;
     .wrapper {
       display: flex;
       justify-content: space-between;
@@ -26,8 +26,13 @@
     font-weight: 700;
     font-style: italic;
     margin: 0;
-    padding: @padding;
-    .tutor-icon { margin-left: 0.5rem; }
+    padding: @padding - 5px;
+
+    .tutor-icon {
+      position: relative;
+      left: 0.5rem;
+      top: -0.5rem;
+    }
   }
 
   .sections-list {

--- a/resources/styles/components/questions-dashboard.less
+++ b/resources/styles/components/questions-dashboard.less
@@ -125,9 +125,10 @@
   }
 
   .exercise-card {
-    -webkit-column-break-inside: avoid;
     page-break-inside: avoid;
     break-inside: avoid;
+    display: inline-block;
+    width: 100%;
     .exercise-card-hover-styles( @color: @tutor-neutral-lighter,
                                  @background-color: lighten(@tutor-primary, 10%),
                                  @selection-icon: @fa-var-minus,

--- a/resources/styles/components/questions-dashboard.less
+++ b/resources/styles/components/questions-dashboard.less
@@ -125,7 +125,9 @@
   }
 
   .exercise-card {
-    display: inline-block; // <- prevents column display from wrapping mid-card
+    -webkit-column-break-inside: avoid;
+    page-break-inside: avoid;
+    break-inside: avoid;
     .exercise-card-hover-styles( @color: @tutor-neutral-lighter,
                                  @background-color: lighten(@tutor-primary, 10%),
                                  @selection-icon: @fa-var-minus,
@@ -136,7 +138,7 @@
     .panel-body { background-color: @tutor-neutral-light; }
 
     .exercise-card-hover-styles( @color: @tutor-neutral-lighter,
-                                 @background-color: lighten(@homework-color, 10%),
+                                 @background-color: rgba(133, 193, 202, 0.8),
                                  @selection-icon: @fa-var-minus,
                                  @de-selection-icon: @fa-var-plus );
 

--- a/resources/styles/components/questions-dashboard.less
+++ b/resources/styles/components/questions-dashboard.less
@@ -138,6 +138,7 @@
   }
 
   .exercise-card {
+    display: inline-block; // <- prevents column display from wrapping mid-card
     .exercise-card-hover-styles( @color: @tutor-neutral-lighter,
                                  @background-color: lighten(@tutor-primary, 10%),
                                  @selection-icon: @fa-var-minus,

--- a/resources/styles/components/questions-dashboard.less
+++ b/resources/styles/components/questions-dashboard.less
@@ -34,7 +34,10 @@
       top: -0.5rem;
     }
   }
-
+  .secondary-help {
+    text-align: center;
+    color: @tutor-neutral;
+  }
   .sections-list {
     margin-top: @tutor-panel-padding-vertical;
     padding: @padding;

--- a/resources/styles/components/questions-dashboard.less
+++ b/resources/styles/components/questions-dashboard.less
@@ -109,29 +109,11 @@
     margin-top: @tutor-panel-padding-vertical;
     @column-width: 450px;
 
-    // The below .cols and .rows is a UX test to choose between the two layouts
-    // one will be choosen and the other removed once test is concluded
-    &.cols {
-      .exercises {
-        -webkit-column-width: @column-width;
-        -moz-column-width: @column-width;
-        column-width: @column-width;
-
-      }
+    .exercises {
+      -webkit-column-width: @column-width;
+      -moz-column-width: @column-width;
+      column-width: @column-width;
     }
-    &.rows {
-      .exercises {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: baseline;
-        .exercise-card {
-          min-width: @column-width;
-          flex: 1;
-          margin-right: 20px;
-        }
-      }
-    }
-
     .exercise-sections {
       margin-top: @tutor-panel-padding-vertical;
     }

--- a/resources/styles/mixins/exercise-card-hover-styles.less
+++ b/resources/styles/mixins/exercise-card-hover-styles.less
@@ -8,10 +8,14 @@
     background-color: fade(@background-color, 0%);
     .message {
       color: fade(@color, 0%);
+      font-size: 1.3em;
       &::before {
         background-color: fade(@background-color, 0%);
         border: 1px solid fade(@color, 0%);
         content: @selection-icon;
+        line-height: 70px;
+        height: 80px;
+        width: 80px;
       }
     }
   }

--- a/resources/styles/tutor.less
+++ b/resources/styles/tutor.less
@@ -61,6 +61,7 @@
 @import './components/reference-book/index';
 @import './components/notifications-bar';
 @import './components/tri-state-checkbox';
+@import './components/exercise-preview';
 
 body[data-js-error]::before {
   content: attr(data-js-error);

--- a/src/components/icon.cjsx
+++ b/src/components/icon.cjsx
@@ -17,7 +17,9 @@ module.exports = React.createClass
     @setState({uniqueId: uniqueId})
 
   getDefaultProps: ->
-    tooltipProps: { placement: 'bottom' }
+    tooltipProps:
+      placement: 'bottom',
+      trigger: 'click'
 
   render: ->
     classNames = classnames('tutor-icon', 'fa', "fa-#{@props.type}", @props.className, {

--- a/src/components/questions/dashboard.cjsx
+++ b/src/components/questions/dashboard.cjsx
@@ -2,7 +2,6 @@ React = require 'react'
 BS = require 'react-bootstrap'
 {RouteHandler} = require 'react-router'
 
-{EcosystemsStore, EcosystemsActions} = require '../../flux/ecosystems'
 {CourseStore} = require '../../flux/course'
 {ExerciseActions} = require '../../flux/exercise'
 {TocStore, TocActions} = require '../../flux/toc'
@@ -25,8 +24,7 @@ scores once your students start using Concept Coach.
 
 CC_SECONDARY_HELP = <div className="secondary-help">
   <b>Best Practice:</b>
-  Exclude desired questions <u>before</u> giving students
-  access to Concept Coach.
+  Exclude desired questions <u>before</u> giving students access to Concept Coach.
 </div>
 
 TUTOR_HELP = '''
@@ -51,6 +49,7 @@ QuestionsDashboard = React.createClass
 
   render: ->
     course = CourseStore.get(@props.courseId)
+
     helpText = if course.is_concept_coach then CC_HELP else TUTOR_HELP
     secondaryHelp = if course.is_concept_coach then CC_SECONDARY_HELP else null
 

--- a/src/components/questions/dashboard.cjsx
+++ b/src/components/questions/dashboard.cjsx
@@ -48,7 +48,7 @@ QuestionsDashboard = React.createClass
         <div className="wrapper">
           Select sections below to review and exclude questions from your
            students’ experience.
-          <Icon type='question-circle' tooltip={HELPTOOLTIP} />
+          <Icon type='info-circle' tooltip={HELPTOOLTIP} />
         </div>
       </div>
 

--- a/src/components/questions/dashboard.cjsx
+++ b/src/components/questions/dashboard.cjsx
@@ -3,6 +3,7 @@ BS = require 'react-bootstrap'
 {RouteHandler} = require 'react-router'
 
 {EcosystemsStore, EcosystemsActions} = require '../../flux/ecosystems'
+{CourseStore} = require '../../flux/course'
 {ExerciseActions} = require '../../flux/exercise'
 {TocStore, TocActions} = require '../../flux/toc'
 
@@ -13,7 +14,22 @@ BindStore = require '../bind-store-mixin'
 Icon = require '../icon'
 LoadingDisplay = require './loading-display'
 
-HELPTOOLTIP = '''
+CC_HELP = '''
+By default, Concept Coach will use all questions in the Library
+to deliver practice questions to your students.
+The Library gives you the option to exclude questions from your
+students' experiences. However, please note that you will
+not be able to exclude questions from assignments or
+scores once your students start using Concept Coach.
+'''
+
+CC_SECONDARY_HELP = <div className="secondary-help">
+  <b>Best Practice:</b>
+  Exclude desired questions <u>before</u> giving students
+  access to Concept Coach.
+</div>
+
+TUTOR_HELP = '''
     Tutor uses these questions for your assignments,
     spaced practice, personalization, and Performance Forecast practice.
 '''
@@ -34,6 +50,10 @@ QuestionsDashboard = React.createClass
 
 
   render: ->
+    course = CourseStore.get(@props.courseId)
+    helpText = if course.is_concept_coach then CC_HELP else TUTOR_HELP
+    secondaryHelp = if course.is_concept_coach then CC_SECONDARY_HELP else nil
+
     <div className="questions-dashboard">
       <LoadingDisplay chapterIds={@state.chapterIds} sectionIds={@state.sectionIds} />
       <div className="header">
@@ -48,10 +68,10 @@ QuestionsDashboard = React.createClass
         <div className="wrapper">
           Select sections below to review and exclude questions from your
            students’ experience.
-          <Icon type='info-circle' tooltip={HELPTOOLTIP} />
+          <Icon type='info-circle' tooltip={helpText} />
         </div>
       </div>
-
+      {secondaryHelp}
       <div className="sections-list">
         <SectionsChooser
           onSelectionChange={@onSectionChange}
@@ -73,7 +93,7 @@ QuestionsDashboard = React.createClass
         </div>
       </div>
 
-      <QuestionsList helpTooltip={HELPTOOLTIP} {...@props}
+      <QuestionsList helpTooltip={helpText} {...@props}
         sectionIds={@state.displayingIds} />
 
     </div>

--- a/src/components/questions/dashboard.cjsx
+++ b/src/components/questions/dashboard.cjsx
@@ -52,7 +52,7 @@ QuestionsDashboard = React.createClass
   render: ->
     course = CourseStore.get(@props.courseId)
     helpText = if course.is_concept_coach then CC_HELP else TUTOR_HELP
-    secondaryHelp = if course.is_concept_coach then CC_SECONDARY_HELP else nil
+    secondaryHelp = if course.is_concept_coach then CC_SECONDARY_HELP else null
 
     <div className="questions-dashboard">
       <LoadingDisplay chapterIds={@state.chapterIds} sectionIds={@state.sectionIds} />

--- a/src/components/questions/index.cjsx
+++ b/src/components/questions/index.cjsx
@@ -5,19 +5,19 @@ React = require 'react'
 LoadableItem = require '../loadable-item'
 {UnsavedStateMixin} = require '../unsaved-state'
 {ExerciseStore} = require '../../flux/exercise'
-TutorDialog = require '../tutor-dialog'
 
-
+showDialog = require './unsaved-dialog'
 Dashboard = require './dashboard'
-showDialog = ->
-  body =
-    <div>
-      <h4>You have excluded exercises that have not been saved</h4>
-      <p className="lead">Are you sure you want to leave the Question Library?</p>
-    </div>
-  TutorDialog.show({
-    title: null, body
-  })
+
+# showDialog = ->
+#   body =
+#     <div>
+#       <h4>You have excluded exercises that have not been saved</h4>
+#       <p className="lead">Are you sure you want to leave the Question Library?</p>
+#     </div>
+#   TutorDialog.show({
+#     title: null, body
+#   })
 
 
 QuestionsDashboardShell = React.createClass
@@ -33,7 +33,7 @@ QuestionsDashboardShell = React.createClass
     willTransitionFrom: (transition, element) ->
       return if element.transitionConfirmed or not element.hasUnsavedState()
       transition.abort()
-      showDialog().then ->
+      showDialog('Are you sure you want to leave the Question Library?').then ->
         element.transitionConfirmed = true
         transition.retry()
 

--- a/src/components/questions/index.cjsx
+++ b/src/components/questions/index.cjsx
@@ -3,14 +3,39 @@ React = require 'react'
 {TocStore, TocActions} = require '../../flux/toc'
 {CourseStore} = require '../../flux/course'
 LoadableItem = require '../loadable-item'
+{UnsavedStateMixin} = require '../unsaved-state'
+{ExerciseStore} = require '../../flux/exercise'
+TutorDialog = require '../tutor-dialog'
 
 
 Dashboard = require './dashboard'
+showDialog = ->
+  body =
+    <div>
+      <h4>You have excluded exercises that have not been saved</h4>
+      <p className="lead">Are you sure you want to leave the Question Library?</p>
+    </div>
+  TutorDialog.show({
+    title: null, body
+  })
+
 
 QuestionsDashboardShell = React.createClass
 
   contextTypes:
     router: React.PropTypes.func
+  mixins: [UnsavedStateMixin]
+  hasUnsavedState: ->
+    ExerciseStore.hasUnsavedExclusions()
+
+  statics:
+    # Called before the Router unmounts and transistions to another screen
+    willTransitionFrom: (transition, element) ->
+      return if element.transitionConfirmed or not element.hasUnsavedState()
+      transition.abort()
+      showDialog().then ->
+        element.transitionConfirmed = true
+        transition.retry()
 
   render: ->
     {courseId} = @context.router.getCurrentParams()

--- a/src/components/questions/questions-list.cjsx
+++ b/src/components/questions/questions-list.cjsx
@@ -13,7 +13,9 @@ QuestionsList = React.createClass
     courseId: React.PropTypes.string.isRequired
     helpTooltip: React.PropTypes.string.isRequired
     sectionIds: React.PropTypes.array
-
+  getInitialState: -> {
+    filter: 'reading'
+  }
   componentWillMount:   -> ExerciseStore.on('change',  @update)
   componentWillUnmount: -> ExerciseStore.off('change', @update)
   update: -> @forceUpdate()
@@ -57,7 +59,7 @@ QuestionsList = React.createClass
         <div className="wrapper">
           Click each question that you would like to exclude from
           all aspects of your students’ Tutor experience.
-          <Icon type='question-circle' tooltip={@props.helpTooltip} />
+          <Icon type='info-circle' tooltip={@props.helpTooltip} />
         </div>
       </div>
 

--- a/src/components/questions/questions-list.cjsx
+++ b/src/components/questions/questions-list.cjsx
@@ -14,7 +14,6 @@ QuestionsList = React.createClass
     helpTooltip: React.PropTypes.string.isRequired
     sectionIds: React.PropTypes.array
 
-  getInitialState:      -> {displayType: 'cols'}
   componentWillMount:   -> ExerciseStore.on('change',  @update)
   componentWillUnmount: -> ExerciseStore.off('change', @update)
   update: -> @forceUpdate()
@@ -43,9 +42,6 @@ QuestionsList = React.createClass
       <SectionQuestions key={cs} {...@props}
         chapter_section={cs} exercises={exercises.grouped[cs]} />
 
-  changeDisplay: (ev) ->
-    @setState({displayType: ev.currentTarget.value})
-
   render: ->
     return null if ExerciseStore.isLoading() or _.isEmpty(@props.sectionIds)
 
@@ -56,7 +52,7 @@ QuestionsList = React.createClass
     else
       @renderEmpty()
 
-    <div className={"questions-list #{@state.displayType}"}>
+    <div className="questions-list">
       <div className="instructions">
         <div className="wrapper">
           Click each question that you would like to exclude from
@@ -70,24 +66,6 @@ QuestionsList = React.createClass
         header={@renderQuestionControls(exercises)}
         cardType='sections-questions'
       >
-
-      <div>
-        <b>UX DISPLAY TEST:</b>
-        <br />
-        <label>
-          <input type="radio" name='coldisplay'
-            checked={@state.displayType is 'cols'}
-            value="cols" onChange={@changeDisplay}
-          /> Vertical Columns
-        </label>
-        <br />
-        <label>
-          <input type="radio" name='coldisplay'
-            checked={@state.displayType is 'rows'}
-            value="rows" onChange={@changeDisplay}
-          /> Horizontal Rows
-        </label>
-      </div>
 
       {questions}
 

--- a/src/components/questions/section-questions.cjsx
+++ b/src/components/questions/section-questions.cjsx
@@ -78,11 +78,11 @@ SectionsQuestions = React.createClass
       ExerciseActions.setExerciseExclusion(exercise.id, isSelected)
 
   render: ->
-    section = TocStore.getSectionLabel(@props.chapter_section)
+    title = TocStore.getSectionLabel(@props.chapter_section)?.title
 
-    <div className='exercise-sections' data-section={section.chapter_section.join('.')}>
+    <div className='exercise-sections' data-section={@props.chapter_section}>
       <label className='exercises-section-label'>
-        <ChapterSection section={section.chapter_section}/> {section.title}
+        <ChapterSection section={@props.chapter_section}/> {title}
       </label>
       <div className="exercises">
       {for exercise in @props.exercises

--- a/src/components/questions/sectionizer.cjsx
+++ b/src/components/questions/sectionizer.cjsx
@@ -15,7 +15,7 @@ Sectionizer = React.createClass
 
   # the below properties are read by the ScrollTo mixin
   scrollingTargetDOM: -> window.document
-  getScrollTopOffset: -> 140 # 70px high control bar and 50px spacing for label
+  getScrollTopOffset: -> 80 # 70px high control bar and a bit of padding
 
   componentDidMount: ->
     @scrollToSelector(".questions-list")

--- a/src/components/questions/unsaved-dialog.cjsx
+++ b/src/components/questions/unsaved-dialog.cjsx
@@ -1,0 +1,11 @@
+React = require 'react'
+TutorDialog = require '../tutor-dialog'
+
+module.exports = (message) ->
+  body =
+    <div>
+      <p className="lead">{message}</p>
+    </div>
+  TutorDialog.show({
+    body, title: 'You have excluded exercises that have not been saved'
+  })

--- a/test/components/questions/dashboard.spec.coffee
+++ b/test/components/questions/dashboard.spec.coffee
@@ -1,0 +1,31 @@
+{Testing, expect, sinon, _, ReactTestUtils} = require '../helpers/component-testing'
+
+ld = require 'lodash'
+
+Dashboard = require '../../../src/components/questions/dashboard'
+
+{TocStore, TocActions} = require '../../../src/flux/toc'
+{CourseActions} = require '../../../src/flux/course'
+COURSE = require '../../../api/user/courses/1.json'
+TOC = require '../../../api/ecosystems/2/readings.json'
+COURSE_ID = '1'
+ECOSYSTEM_ID = '2'
+
+describe 'Questions Dashboard Component', ->
+
+  beforeEach ->
+    @props = {
+      courseId: COURSE_ID
+      ecosystemId: ECOSYSTEM_ID
+    }
+    CourseActions.loaded(COURSE, COURSE_ID)
+    TocActions.loaded([TOC[0]], ECOSYSTEM_ID)
+
+  it 'displays cc help when course is cc', ->
+    course = ld.cloneDeep(COURSE)
+    course.is_concept_coach = true
+    CourseActions.loaded(course, COURSE_ID)
+    Testing.renderComponent( Dashboard, props: @props ).then ({dom}) ->
+      expect(dom.textContent).to.contain(
+        'Exclude desired questions before giving students access to Concept Coach'
+      )


### PR DESCRIPTION
cc @rvnewell 

Tweaks are:
* remove UX design test toggle, use chosen column style.
  * fix column style to not break across columns
* bring green header all the way to top after question selection
* select reading type by default
* more white padding on header, less on green
* icon should be i and superscript, and show popover on click
* "Report an error" should be tutor blue link style
* Match hover blue from mockup
* exclude/include icon larger with smaller text
* Concept Coach specific wording when displaying for a CC course
* Display warning dialog when navigating away with unsaved exercise exclusions, and when canceling
* Keep save/cancel button on screen after save, but change button to read "Saved"

<img width="986" alt="screen shot 2016-05-04 at 5 27 38 pm" src="https://cloud.githubusercontent.com/assets/79566/15031358/ac4d64f8-121d-11e6-99b9-d41180304be5.png">


CC Wording:

<img width="1048" alt="screen shot 2016-05-04 at 6 12 41 pm" src="https://cloud.githubusercontent.com/assets/79566/15034569/7db34d78-123c-11e6-9746-4b168d5a1bba.png">

<img width="1057" alt="screen shot 2016-05-04 at 6 05 14 pm" src="https://cloud.githubusercontent.com/assets/79566/15034572/8bae5530-123c-11e6-9df8-460983820db9.png">


Dialog:
<img width="1323" alt="screen shot 2016-05-04 at 9 06 19 pm" src="https://cloud.githubusercontent.com/assets/79566/15034560/6b6df352-123c-11e6-98aa-408e77bb27b8.png">
