### PR TITLE
Enable QuestionLibrary, fix dropdown menu vertical position

### DIFF
--- a/resources/styles/global/menus.less
+++ b/resources/styles/global/menus.less
@@ -2,17 +2,4 @@
 
   border: 1px solid @tutor-neutral-light;
 
-  // The QuestionLibrary is hidden until it's ready for release
-  // it's re-enabled below when spy mode is engaged
-  .viewQuestionsLibrary {
-    display: none;
-  }
-
-}
-
-// enable the Question Library link when spy mode is active
-// This and the above 'display: none' should be removed when the
-// Question Library is released
-.openstax-debug-content.is-enabled {
-  .dropdown-menu .viewQuestionsLibrary { display: block; }
 }

--- a/resources/styles/global/navbar.less
+++ b/resources/styles/global/navbar.less
@@ -50,6 +50,10 @@
     line-height: 2.7rem;
   }
 
+  .dropdown-toggle {
+    margin: 5px;
+  }
+
   .dropdown-menu .logout {
     input[type=submit] {
       #fonts .sans(1.4rem, 1.4rem);


### PR DESCRIPTION
This enables the question library and fixes a positioning bug I noticed with the dropdown menu.

Before:
![screen shot 2016-05-10 at 9 27 35 am](https://cloud.githubusercontent.com/assets/79566/15150084/73db0274-1691-11e6-9cb1-48dedb350a5d.png)


After:
![screen shot 2016-05-10 at 9 28 13 am](https://cloud.githubusercontent.com/assets/79566/15150104/88d1fc32-1691-11e6-8ed7-2154914fdc28.png)
