### PR TITLE
Progress bar for readings

### DIFF
--- a/resources/styles/components/task/index.less
+++ b/resources/styles/components/task/index.less
@@ -1,4 +1,5 @@
 @import './details';
+@import './progress';
 
 .task {
   max-width: @tutor-task-width;
@@ -30,4 +31,14 @@
       padding-bottom: 1.5 * @tutor-navbar-height;
     }
   }
+}
+
+&.instructions {
+	//Product name and content for instructions
+	.product-name:after {
+		content: 'Tutor';
+	}
+	.feedback-type:after {
+		content: 'personalized feedback';
+	}
 }

--- a/resources/styles/components/task/progress.less
+++ b/resources/styles/components/task/progress.less
@@ -1,0 +1,32 @@
+.task-view .task-reading .pinned-header {
+	padding: 0;
+
+	.reading-task-progress {
+		height: 4px;
+		overflow: hidden;
+		margin-bottom: 0;
+	}
+}
+
+.arrow {
+	top: 40%;
+	cursor: pointer;
+	position: fixed;
+
+	&.left {
+		left: 50px;
+	}
+
+	&.right {
+		right: 50px;
+	}
+
+	i.fa {
+		color: #e5e5e5;
+		font-size: 150px;
+	}
+
+	&:hover i.fa{
+		color: #d5d5d5;
+	}
+}

--- a/resources/styles/components/task/progress.less
+++ b/resources/styles/components/task/progress.less
@@ -12,13 +12,14 @@
 	top: 40%;
 	cursor: pointer;
 	position: fixed;
+	z-index: 1;
 
 	&.left {
-		left: 50px;
+		left: 1rem;
 	}
 
 	&.right {
-		right: 50px;
+		right: 1rem;
 	}
 
 	i.fa {

--- a/resources/styles/global/buttons.less
+++ b/resources/styles/global/buttons.less
@@ -52,6 +52,7 @@
   &:focus {
 
     &.dropdown-toggle { 
+			padding: 15px 0;
       color: @tutor-neutral-dark;
       text-align: left;
       border: 1px solid @tutor-neutral-light;

--- a/resources/styles/global/navbar.less
+++ b/resources/styles/global/navbar.less
@@ -3,7 +3,7 @@
 @tutor-navbar-padding-horizontal: 4rem;
 
 .navbar-fixed-top {
-
+	height: @tutor-navbar-height;
   // override bootstrap material design media query for (max-width: 1199px)
   .navbar-brand {
     height: 60px;

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -259,6 +259,7 @@ module.exports = React.createClass
         taskId={id}
         stepId={crumb.data?.id}
         goToStep={@goToStep}
+        isSpacer={crumb?.type is 'spacer'}
         stepKey={@state.currentStep}
       >
         {panel}

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -15,6 +15,9 @@ TaskStep = require '../task-step'
 Ends = require '../task-step/ends'
 Breadcrumbs = require './breadcrumbs'
 
+TaskProgress = require './progress'
+ProgressPanel = require './progress/panel'
+
 {StepPanel} = require '../../helpers/policies'
 
 {UnsavedStateMixin} = require '../unsaved-state'
@@ -249,6 +252,17 @@ module.exports = React.createClass
         id={id}
         goToStep={@goToStep}
         key="task-#{id}-breadcrumbs"/>
+
+    if TaskStore.hasProgress(id)
+      breadcrumbs = <TaskProgress taskId={id} stepKey={@state.currentStep} />
+      panel = <ProgressPanel
+        taskId={id}
+        stepId={crumb.data?.id}
+        goToStep={@goToStep}
+        stepKey={@state.currentStep}
+      >
+        {panel}
+      </ProgressPanel>
 
     <PinnedHeaderFooterCard
       forceShy={true}

--- a/src/components/task/progress/arrow.cjsx
+++ b/src/components/task/progress/arrow.cjsx
@@ -1,0 +1,38 @@
+React = require 'react'
+{TaskStore} = require '../../../flux/task'
+{TaskStepStore, TaskStepActions} = require '../../../flux/task-step'
+
+module.exports = React.createClass
+  propTypes:
+    taskId: React.PropTypes.string
+    stepId: React.PropTypes.string
+    stepKey: React.PropTypes.number
+    goToStep: React.PropTypes.func
+
+
+  transition: ->
+    { stepId, stepKey, direction, goToStep } = @props
+    increment = -1
+    increment = 1 if direction is 'right'
+
+    TaskStepStore.off('step.completed', @transition)
+
+    { stepId, goToStep } = @props
+    goToStep(stepKey + increment)
+
+  arrowClicked: ->
+    { stepId, direction } = @props
+
+    if (direction is 'right' and not TaskStepStore.get(stepId).is_completed)
+      TaskStepStore.on('step.completed', @transition)
+      TaskStepActions.complete(stepId)
+    else
+      @transition()
+
+  render: ->
+    if not @props.shouldShow
+      return null
+
+    <a onClick={@arrowClicked} className="arrow #{@props.direction}">
+      <i className="fa fa-angle-#{@props.direction}" />
+    </a>

--- a/src/components/task/progress/arrow.cjsx
+++ b/src/components/task/progress/arrow.cjsx
@@ -1,6 +1,8 @@
 React = require 'react'
 {TaskStore} = require '../../../flux/task'
 {TaskStepStore, TaskStepActions} = require '../../../flux/task-step'
+keymaster = require 'keymaster'
+KEYBINDING_SCOPE  = 'reading-progress'
 
 module.exports = React.createClass
   propTypes:
@@ -9,6 +11,12 @@ module.exports = React.createClass
     stepKey: React.PropTypes.number
     goToStep: React.PropTypes.func
 
+  componentWillUnmount: ->
+    keymaster.deleteScope(KEYBINDING_SCOPE)
+
+  componentWillMount: ->
+    keymaster(@props.direction,  KEYBINDING_SCOPE, @arrowClicked)
+    keymaster.setScope(KEYBINDING_SCOPE)
 
   transition: ->
     { stepId, stepKey, direction, goToStep } = @props
@@ -23,7 +31,7 @@ module.exports = React.createClass
   arrowClicked: ->
     { stepId, direction } = @props
 
-    if (direction is 'right' and not TaskStepStore.get(stepId).is_completed)
+    if (direction is 'right' and stepId and not TaskStepStore.get(stepId).is_completed)
       TaskStepStore.on('step.completed', @transition)
       TaskStepActions.complete(stepId)
     else

--- a/src/components/task/progress/arrow.cjsx
+++ b/src/components/task/progress/arrow.cjsx
@@ -19,14 +19,10 @@ module.exports = React.createClass
     keymaster.setScope(KEYBINDING_SCOPE)
 
   transition: ->
-    { stepId, stepKey, direction, goToStep } = @props
-    increment = -1
-    increment = 1 if direction is 'right'
+    { stepKey, goToStep } = @props
 
     TaskStepStore.off('step.completed', @transition)
-
-    { stepId, goToStep } = @props
-    goToStep(stepKey + increment)
+    goToStep(stepKey + @getIncrement())
 
   arrowClicked: ->
     { stepId, direction } = @props
@@ -37,10 +33,17 @@ module.exports = React.createClass
     else
       @transition()
 
+  getIncrement: ->
+    { direction } = @props
+    increment = -1
+    increment = 1 if direction is 'right'
+    increment
+
   render: ->
     if not @props.shouldShow
       return null
 
-    <a onClick={@arrowClicked} className="arrow #{@props.direction}">
+    step = @props.stepKey + @getIncrement()
+    <a onClick={@arrowClicked} className="arrow #{@props.direction}" data-step={step}>
       <i className="fa fa-angle-#{@props.direction}" />
     </a>

--- a/src/components/task/progress/index.cjsx
+++ b/src/components/task/progress/index.cjsx
@@ -1,0 +1,14 @@
+React = require 'react'
+{ TaskStore } = require '../../../flux/task'
+BS = require 'react-bootstrap'
+
+module.exports = React.createClass
+  propTypes:
+    taskId: React.PropTypes.string
+    stepKey: React.PropTypes.number
+
+  render: ->
+    progress = TaskStore.getProgress(@props.taskId, @props.stepKey)
+    <div className="reading-task-bar">
+      <BS.ProgressBar now={progress} bsStyle="success"/>
+    </div>

--- a/src/components/task/progress/panel.cjsx
+++ b/src/components/task/progress/panel.cjsx
@@ -29,7 +29,8 @@ module.exports = React.createClass
         step and
         step.type is 'exercise' and
         TaskStepStore.isAnswered(@props.stepId)
-      )
+      ) or
+      @props.isSpacer is true
     )
 
     <div>

--- a/src/components/task/progress/panel.cjsx
+++ b/src/components/task/progress/panel.cjsx
@@ -1,0 +1,37 @@
+React = require 'react'
+Arrow = require './arrow'
+{TaskStore} = require '../../../flux/task'
+{StepPanel} = require '../../../helpers/policies'
+{TaskStepStore} = require '../../../flux/task-step'
+
+module.exports = React.createClass
+  propTypes:
+    taskId: React.PropTypes.string
+    stepId: React.PropTypes.string
+    stepKey: React.PropTypes.number
+    goToStep: React.PropTypes.func
+
+  componentWillMount: -> TaskStepStore.on('step.completed', @update)
+  removeListeners: -> TaskStepStore.off('step.completed', @update)
+  componentWillUnmount: -> @removeListeners()
+
+  update: -> @setState({})
+
+  render: ->
+    step = TaskStepStore.get(@props.stepId)
+
+    shouldShowLeft = @props.stepKey > 0
+    shouldShowRight = (
+      @props.stepKey < TaskStore.getTotalStepsCount(@props.taskId) - 1 and
+      StepPanel.canContinue(@props.stepId) and
+      step.type isnt 'exercise' or (
+        step.type is 'exercise' and
+        TaskStepStore.isAnswered(@props.stepId)
+      )
+    )
+
+    <div>
+      <Arrow {...@props} direction="left" shouldShow={shouldShowLeft} />
+      {@props.children}
+      <Arrow {...@props} direction="right" shouldShow={shouldShowRight} />
+    </div>

--- a/src/components/task/progress/panel.cjsx
+++ b/src/components/task/progress/panel.cjsx
@@ -24,7 +24,9 @@ module.exports = React.createClass
     shouldShowRight = (
       @props.stepKey < TaskStore.getTotalStepsCount(@props.taskId) - 1 and
       StepPanel.canContinue(@props.stepId) and
+      step and
       step.type isnt 'exercise' or (
+        step and
         step.type is 'exercise' and
         TaskStepStore.isAnswered(@props.stepId)
       )

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -133,6 +133,14 @@ TaskConfig =
       steps = getSteps(@_steps[taskId])
       step = getCurrentStep(steps)
 
+    getProgress: (taskId, stepKey) ->
+      steps = getSteps(@_steps[taskId])
+
+      if steps.length
+        stepKey / steps.length * 100
+      else
+        0
+
     getIncompleteSteps: (taskId) ->
       allSteps = getSteps(@_steps[taskId])
       steps = getIncompleteSteps(allSteps)
@@ -184,7 +192,14 @@ TaskConfig =
       not incompleteStep
 
     hasCrumbs: (taskId) ->
-      not (@_steps[taskId].length is 1 and @_get(taskId).type is 'external')
+      not (
+        @_steps[taskId].length is 1 and
+        @_get(taskId).type is 'external' or
+        @_get(taskId).type is 'reading'
+      )
+
+    hasProgress: (taskId) ->
+      @_steps[taskId].length isnt 1 and @_get(taskId).type is 'reading'
 
     doesAllowSeeAhead: (taskId) ->
       allowed = [

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -137,7 +137,7 @@ TaskConfig =
       steps = getSteps(@_steps[taskId])
 
       if steps.length
-        stepKey / steps.length * 100
+        (stepKey + 1) / (steps.length + 1) * 100
       else
         0
 

--- a/test-integration/helpers/ui/task.coffee
+++ b/test-integration/helpers/ui/task.coffee
@@ -48,10 +48,11 @@ class Task extends TestHelper
   canContinue: => @el.enabledContinueButton().isPresent()
 
   getCurrentStep: =>
-    if @isReading()
-      @el.readingNextArrow().get().getAttribute('data-step')
-    else
-      @el.currentBreadcrumbStep().get().getAttribute('data-reactid')
+    @isReading().then (isPresent) =>
+      if (isPresent)
+        @el.readingNextArrow().get().getAttribute('data-step')
+      else
+        @el.currentBreadcrumbStep().get().getAttribute('data-reactid')
 
 
   continue: =>
@@ -69,10 +70,11 @@ class Task extends TestHelper
         selenium.until.elementIsEnabled(@el.continueButton().get())
 
   continueTask: =>
-    if @isReading()
-      @el.readingNextArrow().waitClick()
-    else
-      @el.enabledContinueButton().waitClick()
+    @isReading().then (isPresent) =>
+      if isPresent
+        @el.readingNextArrow().waitClick()
+      else
+        @el.enabledContinueButton().waitClick()
 
   goToHelpLink: =>
     @el.helpLink().waitClick()

--- a/test-integration/helpers/ui/task.coffee
+++ b/test-integration/helpers/ui/task.coffee
@@ -42,7 +42,6 @@ class Task extends TestHelper
   # isHomework: => @el.taskTypeIsHomework().isPresent()
   isReading:  => @el.taskTypeIsReading().isPresent()
   stepIsExercise: =>
-    debugger
     @el.taskStepIsExercise().isPresent()
   # isEvent:    => @el.taskTypeIsEvent().isPresent()
 

--- a/test-integration/helpers/ui/user.coffee
+++ b/test-integration/helpers/ui/user.coffee
@@ -88,10 +88,11 @@ class User extends TestHelper
     @el.usernameLink(username).waitClick()
 
   logInDeployed: (username, password = 'password') =>
-    # Login as dev (using accounts)
-    @el.usernameInput().get().sendKeys(username)
-    @el.passwordInput().get().sendKeys(password)
-    @el.loginSubmit().click()
+    @test.utils.wait.giveTime (2 * 60 * 1000), =>
+      # Login as dev (using accounts)
+      @el.usernameInput().get().sendKeys(username)
+      @el.passwordInput().get().sendKeys(password)
+      @el.loginSubmit().click()
 
   login: (username, password = 'password') =>
     @el.loginLink().get().isDisplayed().then (isDisplayed) =>

--- a/test-integration/task.coffee
+++ b/test-integration/task.coffee
@@ -59,7 +59,9 @@ describe 'Student performing tasks', ->
       @dashboard.el.workableTask().click()
       @task.waitUntilLoaded()
 
-      @task.goToHelpLink()
+      @task.stepIsExercise().then (isPresent) =>
+        debugger
+        @task.goToHelpLink() if isPresent
 
       # Go back to the course selection
       @user.goToHome()

--- a/test-integration/task.coffee
+++ b/test-integration/task.coffee
@@ -60,7 +60,6 @@ describe 'Student performing tasks', ->
       @task.waitUntilLoaded()
 
       @task.stepIsExercise().then (isPresent) =>
-        debugger
         @task.goToHelpLink() if isPresent
 
       # Go back to the course selection

--- a/test/components/helpers/task/checks.coffee
+++ b/test/components/helpers/task/checks.coffee
@@ -8,6 +8,8 @@ React = require 'react/addons'
 {StepPanel} = require '../../../../src/helpers/policies'
 
 {BreadcrumbTaskDynamic} = require '../../../../src/components/breadcrumb'
+ProgressBar = require '../../../../src/components/task/progress'
+ProgressPanel = require '../../../../src/components/task/progress/panel'
 {ExerciseGroup} = require 'openstax-react-components'
 
 checks =
@@ -187,17 +189,22 @@ checks =
 
   _checkHasReviewableBreadcrumbs: ({div, component, stepId, taskId, state, router, history}) ->
     breadcrumbs = React.addons.TestUtils.scryRenderedComponentsWithType(component, BreadcrumbTaskDynamic)
+    progress = React.addons.TestUtils.scryRenderedComponentsWithType(component, ProgressBar)
     completedSteps = TaskStore.getCompletedSteps(taskId)
-    {type} = TaskStore.get(taskId)
+    steps = TaskStore.getSteps(taskId)
+    { type } = TaskStore.get(taskId)
 
-    expectedCrumbs = completedSteps.length + 1
-
-    if type is 'reading'
-      nonCoreIndex = TaskStore.getFirstNonCoreIndex(taskId)
-      if nonCoreIndex > -1 and completedSteps.length >= nonCoreIndex
-        expectedCrumbs = expectedCrumbs + 1
-
+    expectedCrumbs = steps.length + 1 if type is 'homework'
     expect(breadcrumbs.length).to.equal(expectedCrumbs)
+
+    {div, component, stepId, taskId, state, router, history}
+
+  _checkHasReadingProgressBar: ({div, component, stepId, taskId, state, router, history}) ->
+    progress = React.addons.TestUtils.scryRenderedComponentsWithType(component, ProgressBar)
+    progressPanel = React.addons.TestUtils.scryRenderedComponentsWithType(component, ProgressPanel)
+
+    expect(progress.length).to.equal(1)
+    expect(progressPanel.length).to.equal(1)
 
     {div, component, stepId, taskId, state, router, history}
 

--- a/test/components/task.spec.coffee
+++ b/test/components/task.spec.coffee
@@ -12,8 +12,10 @@ _ = require 'underscore'
 COURSE_ID = '1'
 COURSE    = require '../../api/user/courses/1.json'
 TASK_ID = '4'
+HOMEWORK_ID = '5'
 
 VALID_MODEL = require '../../api/tasks/4.json'
+HOMEWORK_MODEL = require '../../api/tasks/5.json'
 VALID_RECOVERY_MODEL = require '../../api/tasks/4-recovered.json'
 VALID_RECOVERY_STEP = require '../../api/steps/step-id-4-2/recovery/PUT.json'
 
@@ -146,17 +148,25 @@ describe 'Task Widget, through routes', ->
         done()
       , done)
 
+
+
   it 'should be able to work through tasks and show progressing breadcrumbs', (done) ->
+    TaskActions.loaded(HOMEWORK_MODEL, HOMEWORK_ID)
+
+    # run a full step through and check each step
+    taskTests
+      .goToTask("/courses/#{COURSE_ID}/tasks/#{HOMEWORK_ID}", HOMEWORK_ID)
+      .then(taskChecks.checkHasReviewableBreadcrumbs)
+      .then( ->
+        done()
+      , done)
+
+  it 'should be able to work through tasks and show progress', (done) ->
     # run a full step through and check each step
 
     taskActions
       .clickContinue(@result)
-      .then(taskActions.completeThisStep)
-      .then(taskActions.advanceStep)
-      .then(taskChecks.checkHasReviewableBreadcrumbs)
-      .then(taskActions.completeThisStep)
-      .then(taskActions.advanceStep)
-      .then(taskChecks.checkHasReviewableBreadcrumbs)
+      .then(taskChecks.checkHasReadingProgressBar)
       .then( ->
         done()
       , done)


### PR DESCRIPTION
New progress bar for readings, see screenshots below.  I still need to finish tests, and I'm putting the keyboard events in another PR.

![screen shot 2016-05-20 at 8 18 54 am](https://cloud.githubusercontent.com/assets/6434717/15413511/862c2dfc-1e63-11e6-8446-5cd6e2e857f3.png)

![screen shot 2016-05-20 at 8 20 03 am](https://cloud.githubusercontent.com/assets/6434717/15413525/ae817e10-1e63-11e6-9a24-f7f402f5afa4.png)
