### PR TITLE
example edits

### DIFF
--- a/resources/styles/components/questions-dashboard.less
+++ b/resources/styles/components/questions-dashboard.less
@@ -238,7 +238,20 @@
       .exercise-card {
         .controls-overlay { display: flex; }
       }
-      .page-navigation { display: flex; }
+      .page-navigation {
+        display: flex;
+        cursor: pointer;
+      }
     }
   }
+}
+
+
+// TODO put in shared instead, this is just for quick edits
+.openstax-exercise-preview.actions-on-side {
+  .panel-body {
+    // add left padding to make space for action buttons.
+    padding-left: 90px;
+  }
+
 }


### PR DESCRIPTION
![screen shot 2016-05-19 at 11 31 47 pm](https://cloud.githubusercontent.com/assets/2483873/15429228/98b59ff6-1e65-11e6-8fac-b329d32bbebe.png)


makes space for the action bar?