### PR TITLE
is feedback immediate fix

### DIFF
--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -64,6 +64,9 @@ TaskPlanConfig =
     @_local[planId].settings.page_ids ?= []
 
     if @_local[planId]?.type is PLAN_TYPES.HOMEWORK or @_changed[planId]?.type is PLAN_TYPES.HOMEWORK
+      @_changed[planId] ?= {}
+      # need to default final posting json's is feedback immediate to false
+      @_changed[planId].is_feedback_immediate = false
       @_local[planId].settings.exercise_ids ?= []
       @_local[planId].settings.exercises_count_dynamic ?= TUTOR_SELECTIONS.default
 


### PR DESCRIPTION
is feedback immediate was not being defaulted to false in the json that was being sent for publishing.  new tasks were being set as immediate when the drop down's on change did not fire