### PR TITLE
Display notices from flash key of bootstrap data

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -3,10 +3,11 @@ Recordo = require('recordo')
 Recordo.initialize()
 # Recordo.start()
 
-{BootrapURLs, NotificationActions}  = require 'openstax-react-components'
+{BootrapURLs}  = require 'openstax-react-components'
 
 api = require './src/api'
 router = require './src/router'
+Notices = require './src/helpers/notifications'
 dom = require './src/helpers/dom'
 {startMathJax} = require 'openstax-react-components/src/helpers/mathjax'
 {TransitionAssistant} = require './src/components/unsaved-state'
@@ -35,7 +36,7 @@ loadApp = ->
   bootstrapData = dom.readBootstrapData()
   api.start(bootstrapData)
   BootrapURLs.update(bootstrapData)
-  NotificationActions.startPolling()
+  Notices.start(bootstrapData)
 
   startMathJax()
   TransitionAssistant.startMonitoring()

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime-types": "2.1.7",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
-    "openstax-react-components": "openstax/react-components#1d4a3d631d50d989bb4104b0663af5cdf0259d52",
+    "openstax-react-components": "openstax/react-components#8d0407c0b0c2560088a180fe2e80852ae9cfe900",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime-types": "2.1.7",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
-    "openstax-react-components": "openstax/react-components#d-20160526.mpq-with-preview-and-help-link-candidate.c",
+    "openstax-react-components": "openstax/react-components#1d4a3d631d50d989bb4104b0663af5cdf0259d52",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/resources/styles/global/notifications-bar.less
+++ b/resources/styles/global/notifications-bar.less
@@ -1,0 +1,16 @@
+.openstax-notifications-bar {
+
+  .email {
+    // input styles to override material-design styles
+    input {
+      background-color: white;
+      border-radius: @border-radius-large;
+      padding-left: 1rem;
+      color: @tutor-neutral;
+      &.form-control {
+        background-image: inherit;
+      }
+    }
+  }
+
+}

--- a/resources/styles/tutor.less
+++ b/resources/styles/tutor.less
@@ -16,6 +16,7 @@
 @import './global/scaffold';
 @import './global/typography';
 @import './global/navbar';
+@import './global/notifications-bar';
 @import './global/forms';
 @import './global/maths';
 @import './global/panel';

--- a/src/helpers/notifications.coffee
+++ b/src/helpers/notifications.coffee
@@ -1,0 +1,9 @@
+{NotificationActions} = require 'openstax-react-components'
+
+
+module.exports =
+
+  start: (bootstrapData) ->
+    NotificationActions.startPolling()
+    for level, message of (bootstrapData.flash or {})
+      NotificationActions.display({message, level})


### PR DESCRIPTION
As part of https://github.com/openstax/tutor-server/pull/1099 the BE is sending notices that should be immediately displayed .

Components PR: https://github.com/openstax/react-components/pull/74


Also fixes unrelated bug where material design styles where leaking into the email verification box.


![screen shot 2016-05-31 at 1 46 26 pm](https://cloud.githubusercontent.com/assets/79566/15686535/6f56a068-2736-11e6-9311-0bf26af3f36d.png)

All notice types:

![screen shot 2016-05-31 at 2 11 41 pm](https://cloud.githubusercontent.com/assets/79566/15687331/c31e09f4-2739-11e6-8941-ded98d0204e2.png)
