### PR TITLE
HW / QL details view tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime-types": "2.1.7",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
-    "openstax-react-components": "openstax/react-components#22bb557becc27bfccb9bb274dd3f47397f5b0d51",
+    "openstax-react-components": "openstax/react-components#455a284003968deca6fa5fba923ef94b3151901b",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/resources/styles/components/exercises.less
+++ b/resources/styles/components/exercises.less
@@ -19,6 +19,7 @@
   .controls {
     display: flex;
     justify-content: flex-end;
+    margin-top: 20px;
     z-index: 1; // above details forward/back nav when scrolling up
     .show-cards {
       color: @tutor-neutral;

--- a/resources/styles/components/exercises.less
+++ b/resources/styles/components/exercises.less
@@ -21,6 +21,7 @@
     justify-content: flex-end;
     z-index: 1; // above details forward/back nav when scrolling up
     .show-cards {
+      color: @tutor-neutral;
       cursor: pointer;
     }
   }

--- a/resources/styles/components/exercises.less
+++ b/resources/styles/components/exercises.less
@@ -1,5 +1,8 @@
+@exercise-details-body-height: calc(~"100vh - 150px");
+
 .exercise-details {
-  min-height: calc(~"100vh - 150px");
+
+  min-height: @exercise-details-body-height;
   position: relative;
   display: flex;
   flex-direction: column;
@@ -16,6 +19,7 @@
   .controls {
     display: flex;
     justify-content: flex-end;
+    z-index: 1; // above details forward/back nav when scrolling up
     .show-cards {
       cursor: pointer;
     }
@@ -26,38 +30,27 @@
 
     .controls-overlay {
       transition: none;
-      height: calc(~"100vh - 200px");
-      // .message {
-      //   // height: calc(~"100vh - 150px");
-      // }
-//      display: none;
+      height: @exercise-details-body-height;
     }
   }
 
   .page-navigation {
     .page-navigation-arrows(800px);
 
-    height: calc(~"100vh - 150px");
+    height: @exercise-details-body-height;
     position: absolute;
-    top: 0px;
-
-
-    //display: none; // toggled on at bottom of file when body has pinned navbar
+    top: 0;
   }
-
-  // .pinned-view.pinned-on .exercise-details .exercise-card .controls-overlay {
-
-  // }
 
 }
 
-// re-enable hidden controls when nav is pinned
+// switch controls to fixed when not scrolling up
 .pinned-view.pinned-on {
 
   .exercise-details {
     .exercise-card {
       .controls-overlay {
-        height: calc(~"100vh - 150px");
+        height: @exercise-details-body-height;
         position: fixed;
         top: 150px;
         left: calc(~"50% - " 400px );
@@ -68,14 +61,15 @@
       display: flex;
       cursor: pointer;
 
-      max-height: calc(~"100vh - 150px");
+      max-height: @exercise-details-body-height;
       position: fixed;
-      top: 150px;
-      // .prev {
-      //   left: 0px;
-      // }
+      top: 200px;
 
+      &.prev {
+        left: 0;
+      }
     }
+
   }
 
 }

--- a/resources/styles/components/exercises.less
+++ b/resources/styles/components/exercises.less
@@ -63,9 +63,9 @@
       display: flex;
       cursor: pointer;
 
-      max-height: @exercise-details-body-height;
+      height: 100%;
       position: fixed;
-      top: 200px;
+      top: 0px;
 
       &.prev {
         left: 0;

--- a/resources/styles/components/exercises.less
+++ b/resources/styles/components/exercises.less
@@ -22,16 +22,32 @@
   }
   .exercise-card {
     width: 800px;
+    min-height: 600px;
+
     .controls-overlay {
-      display: none;
+      transition: none;
+      height: calc(~"100vh - 200px");
+      // .message {
+      //   // height: calc(~"100vh - 150px");
+      // }
+//      display: none;
     }
   }
 
   .page-navigation {
     .page-navigation-arrows(800px);
+
+    height: calc(~"100vh - 150px");
     position: absolute;
-    display: none; // toggled on at bottom of file when body has pinned navbar
+    top: 0px;
+
+
+    //display: none; // toggled on at bottom of file when body has pinned navbar
   }
+
+  // .pinned-view.pinned-on .exercise-details .exercise-card .controls-overlay {
+
+  // }
 
 }
 
@@ -40,11 +56,25 @@
 
   .exercise-details {
     .exercise-card {
-      .controls-overlay { display: flex; }
+      .controls-overlay {
+        height: calc(~"100vh - 150px");
+        position: fixed;
+        top: 150px;
+        left: calc(~"50% - " 400px );
+
+      }
     }
     .page-navigation {
       display: flex;
       cursor: pointer;
+
+      max-height: calc(~"100vh - 150px");
+      position: fixed;
+      top: 150px;
+      // .prev {
+      //   left: 0px;
+      // }
+
     }
   }
 

--- a/resources/styles/components/questions-dashboard.less
+++ b/resources/styles/components/questions-dashboard.less
@@ -48,7 +48,7 @@
     background-color: @tutor-white;
   }
 
-  .questions-controls {
+  .exercise-controls-bar {
     background-color: @tutor-white;
   }
 

--- a/src/components/exercises/cards.cjsx
+++ b/src/components/exercises/cards.cjsx
@@ -71,7 +71,6 @@ ExerciseCards = React.createClass
 
   propTypes:
     exercises:              React.PropTypes.object.isRequired
-    scrollFast:             React.PropTypes.bool
     onExerciseToggle:       React.PropTypes.func.isRequired
     getExerciseIsSelected:  React.PropTypes.func.isRequired
     getExerciseActions:     React.PropTypes.func.isRequired
@@ -84,7 +83,7 @@ ExerciseCards = React.createClass
     topScrollOffset: 110
 
   componentDidMount:   ->
-    @scrollToSelector('.exercise-sections', {immediate: @props.scrollFast})
+    @scrollToSelector('.exercise-sections')
 
   getScrollTopOffset: ->
     # no idea why scrollspeed makes the difference, sorry :(

--- a/src/components/exercises/details.cjsx
+++ b/src/components/exercises/details.cjsx
@@ -36,7 +36,7 @@ ExerciseDetails = React.createClass
   getInitialState: -> {}
 
   componentDidMount:   ->
-    @scrollToSelector('.exercise-controls-bar', {immediate: true})
+    @scrollToSelector('.exercise-controls-bar')
 
   componentWillUnmount: ->
     keymaster.deleteScope(KEYBINDING_SCOPE)

--- a/src/components/questions/exercise-controls.cjsx
+++ b/src/components/questions/exercise-controls.cjsx
@@ -93,22 +93,8 @@ QuestionsControls = React.createClass
         </BS.Button>
       </BS.ButtonGroup>
 
-      <BS.ButtonGroup className="display-types">
-        <BS.Button onClick={@props.onShowCardViewClick}
-          className={if @props.currentView is 'cards' then 'cards active' else 'cards'}
-        >
-          <Icon type="th-large" />
-        </BS.Button>
+      {@props.children}
 
-        <BS.Button onClick={@props.onShowDetailsViewClick}
-          className={if @props.currentView is 'details' then 'details active' else 'details'}
-        >
-          <Icon type="mobile" />
-        </BS.Button>
-      </BS.ButtonGroup>
-
-
-        {@props.children}
       <div className="save-cancel">
         {@renderSaveCancelButtons()}
       </div>

--- a/src/components/questions/exercises-display.cjsx
+++ b/src/components/questions/exercises-display.cjsx
@@ -168,7 +168,6 @@ ExercisesDisplay = React.createClass
     else
       <ExerciseCards
         {...sharedProps}
-        scrollFast={@state.showingCardsFromDetailsView}
         onExerciseToggle={@onExerciseToggle}
         onShowDetailsViewClick={@onShowDetailsViewClick} />
 

--- a/src/components/task-plan/homework/add-exercises.cjsx
+++ b/src/components/task-plan/homework/add-exercises.cjsx
@@ -97,6 +97,7 @@ AddExercises = React.createClass
       when 'details'
         <ExerciseDetails
           {...sharedProps}
+          topScrollOffset={60}
           selectedExercise={@state.selectedExercise}
           onSectionChange={@setCurrentSection}
           selectedSection={@state.currentSection}
@@ -106,7 +107,7 @@ AddExercises = React.createClass
       else
         <ExerciseCards
           {...sharedProps}
-          topScrollOffset={150}
+          topScrollOffset={120}
           onShowDetailsViewClick={@onShowDetailsViewClick}
         />
 

--- a/src/components/task-plan/homework/add-exercises.cjsx
+++ b/src/components/task-plan/homework/add-exercises.cjsx
@@ -79,6 +79,9 @@ AddExercises = React.createClass
   getExerciseIsSelected: (exercise) ->
     TaskPlanStore.hasExercise(@props.planId, exercise.id)
 
+  setCurrentSection: (currentSection) ->
+    @setState({currentSection})
+
   render: ->
     return @renderLoading() if @exercisesAreLoading()
 
@@ -95,6 +98,8 @@ AddExercises = React.createClass
         <ExerciseDetails
           {...sharedProps}
           selectedExercise={@state.selectedExercise}
+          onSectionChange={@setCurrentSection}
+          selectedSection={@state.currentSection}
           displayFeedback={@state.displayFeedback}
           onShowCardViewClick={@onShowCardViewClick}
         />

--- a/src/components/task-plan/homework/add-exercises.cjsx
+++ b/src/components/task-plan/homework/add-exercises.cjsx
@@ -107,7 +107,7 @@ AddExercises = React.createClass
       else
         <ExerciseCards
           {...sharedProps}
-          topScrollOffset={120}
+          topScrollOffset={110}
           onShowDetailsViewClick={@onShowDetailsViewClick}
         />
 

--- a/src/components/task-plan/homework/exercise-controls.cjsx
+++ b/src/components/task-plan/homework/exercise-controls.cjsx
@@ -40,19 +40,6 @@ ExerciseControls = React.createClass
           />
         </ScrollSpy>
 
-        <BS.ButtonGroup className="display-types">
-          <BS.Button onClick={@props.onShowCardViewClick}
-            className={if @props.currentView is 'cards' then 'cards active' else 'cards'}
-          >
-            <Icon type="th-large" />
-          </BS.Button>
-
-          <BS.Button onClick={@props.onShowDetailsViewClick}
-            className={if @props.currentView is 'details' then 'details active' else 'details'}
-          >
-            <Icon type="mobile" />
-          </BS.Button>
-        </BS.ButtonGroup>
       </div>
 
 


### PR DESCRIPTION
This:

  * Keeps controls visible but allows them to scroll when scrolling up to top
  * Removes the details / card view toggle from control bars
  * Colors "Back to card view link grey"
  * Fixes regression where the controls bar background was transparent instead of white
  * Fixes sectionizer controls in HW builder so it updates and can jump to a section
  * Pulls in exercise preview update from react-components for the feature flags

@rvnewell is preparing a few more tweaks to the icons, but I think they'll be fairly stand alone, we can go ahead and merge this 

![scroll](https://cloud.githubusercontent.com/assets/79566/15843274/87c1cf70-2c26-11e6-9073-3ac3540ae8ab.gif)