### PR TITLE
update version of recordo to log the current URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-router": "0.13.4",
     "react-scroll-components": "0.2.2",
     "react-waypoint": "openstax/react-waypoint#b34b248947feb0b0ebf89fcef6f234f60f3e516c",
-    "recordo": "0.0.3",
+    "recordo": "0.0.5",
     "twix": "1.0.0",
     "ultimate-pagination": "0.7.0",
     "underscore": "1.8.3",


### PR DESCRIPTION
for when a snapshot was taken. It currently only logs when the URL changes.

So, if you load a page while recording, click clear, and then do something, the current URL is not in the log.

Also, I was thinking of adding another feature to recordo: a checkbox to exclude AJAX responses. Currently, when you load the Student Scores, it's a big honking JSON response which isn't terribly useful for devs.

Thoughts?