### PR TITLE
fixed opened add assignment button styling

### DIFF
--- a/resources/styles/components/course-calendar/header.less
+++ b/resources/styles/components/course-calendar/header.less
@@ -14,6 +14,11 @@
     font-size: 3rem;
     border-bottom: 1px solid @tutor-neutral-light;
 
+    #add-assignment {
+      text-align: center;
+      padding: 9px;
+    }
+
     .add-assignment {
       .pull-left;
       .caret { margin-left: 0.5rem; }


### PR DESCRIPTION
The add assignment button label was shifting all the way to the left, and the height changing, when selected.

![assignment-button](https://cloud.githubusercontent.com/assets/954569/15981170/f91c80f4-2f3f-11e6-9bd0-2f7d5c71869e.gif)
![assignment-button2](https://cloud.githubusercontent.com/assets/954569/15981198/39d23288-2f40-11e6-9037-37f5ab1f8d8d.gif)

