### PR TITLE
Set Period Default Plan

### DIFF
--- a/src/components/task-plan/builder.cjsx
+++ b/src/components/task-plan/builder.cjsx
@@ -368,7 +368,7 @@ module.exports = React.createClass
 
     #enable all periods
     periods = _.map CourseStore.getPeriods(@props.courseId), (period) -> id: period.id
-    TaskPlanActions.setPeriods(@props.id, courseId, periods)
+    TaskPlanActions.setPeriods(@props.id, courseId, periods, false)
 
     #set dates for all periods
     taskingDueAt = TaskPlanStore.getDueAt(@props.id) or @getQueriedDueAt()

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -134,7 +134,7 @@ TaskPlanConfig =
 
     periodTimes
 
-  setPeriods: (id, courseId, periods) ->
+  setPeriods: (id, courseId, periods, isDefault = false) ->
     plan = @_getPlan(id)
     course = CourseStore.get(courseId)
 
@@ -155,7 +155,7 @@ TaskPlanConfig =
 
     @_change(id, {tasking_plans})
 
-    @_setInitialPlan(id)
+    @_setInitialPlan(id) if isDefault
 
   replaceTaskings: (id, taskings) ->
     @_change(id, {tasking_plans: taskings})


### PR DESCRIPTION
For: https://www.pivotaltracker.com/story/show/121087051

This adds a parameter to the set period function in the flux store.  This way, when the dates are updated, the defaultPlan of the store is only updated when the component is loaded, not when it's updated.

This is why the plan wasn't marked as changed, and the confirm dialog was not showing when cancelling the task plan changes.