### PR TITLE
Remove unused and now non-existent tasks endpoint

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -279,9 +279,6 @@ start = (bootstrapData) ->
     url: "/api/steps/#{id}"
     payload: {answer_id}
 
-  apiHelper TaskActions, TaskActions.loadUserTasks, TaskActions.loadedUserTasks, 'GET', (courseId) ->
-    url: "/api/courses/#{courseId}/tasks"
-
   apiHelper TaskTeacherReviewActions, TaskTeacherReviewActions.load, TaskTeacherReviewActions.loaded, 'GET', (id) ->
     url: "/api/plans/#{id}/review"
 

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -84,15 +84,6 @@ TaskConfig =
     # explicit return obj to load onto @_local
     obj
 
-  loadUserTasks: (courseId) -> # Used by API
-  loadedUserTasks: (obj) ->
-    tasks = obj.items
-    # Used by API
-    for task in tasks
-      @loaded(task, task.id)
-
-    @emitChange()
-
   exports:
     getSteps: (id) ->
       throw new Error('BUG: Steps not loaded') unless @_steps[id]


### PR DESCRIPTION
BE just removed this in https://github.com/openstax/tutor-server/pull/1135, so no reason keeping it around
