### PR TITLE
Fixed HW spinning forever after ecosystem update

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -171,8 +171,10 @@ start = (bootstrapData) ->
       url: "/api/ecosystems/#{ecosystemId}/exercises/#{requestType}?#{toParams({page_ids})}"
   # And this one loads using a courseId
   apiHelper ExerciseActions, ExerciseActions.loadForCourse,
-    ExerciseActions.loadedForCourse, 'GET', (courseId, page_ids, requestType = 'homework_core') ->
-      url: "/api/courses/#{courseId}/exercises/#{requestType}?#{toParams({page_ids})}"
+    ExerciseActions.loadedForCourse, 'GET', (courseId, pageIds, ecosystemId = null, requestType = 'homework_core') ->
+      params = { page_ids: pageIds }
+      params['ecosystem_id'] = ecosystemId if ecosystemId?
+      url: "/api/courses/#{courseId}/exercises/#{requestType}?#{toParams(params)}"
 
   apiHelper ExerciseActions, ExerciseActions.saveExerciseExclusion,
     ExerciseActions.exclusionsSaved, 'PUT', (courseId) ->

--- a/src/components/questions/sections-chooser.cjsx
+++ b/src/components/questions/sections-chooser.cjsx
@@ -23,7 +23,7 @@ QLSectionsChooser = React.createClass
   getInitialState: -> {}
 
   showQuestions: ->
-    ExerciseActions.loadForCourse( @props.courseId, @state.sectionIds, '' )
+    ExerciseActions.loadForCourse( @props.courseId, @state.sectionIds, null, '' )
     @props.onSelectionsChange(@state.sectionIds)
 
   clearQuestions: ->

--- a/src/components/task-plan/homework.cjsx
+++ b/src/components/task-plan/homework.cjsx
@@ -86,6 +86,7 @@ HomeworkPlan = React.createClass
         showSectionTopics={@showSectionTopics}
         courseId={courseId}
         sectionIds={topics}
+        ecosystemId={ecosystemId}
         planId={id}
       /> if hasExercises and not @state.showSectionTopics}
 

--- a/src/components/task-plan/homework/loading-exercises-mixin.cjsx
+++ b/src/components/task-plan/homework/loading-exercises-mixin.cjsx
@@ -11,7 +11,7 @@ LoadingExercisesMixin =
   componentWillUnmount: -> ExerciseStore.removeChangeListener(@exerciseLoadListenerOnUpdate)
 
   requestExerciseLoad: ->
-    ExerciseActions.loadForCourse(@props.courseId, @props.sectionIds)
+    ExerciseActions.loadForCourse(@props.courseId, @props.sectionIds, @props.ecosystemId)
 
   exercisesNeedLoading: ->
     not _.isEmpty(@props.sectionIds) and


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/121532729

Needs https://github.com/openstax/tutor-server/pull/1142

This should take care of HW spinning forever after ecosystem updates. Might need a different PR to prevent people from selecting exercises then unselecting their pages, which I think will also mess up the display.