### PR TITLE
Remove hardcoded open/close time from instructions

### DIFF
--- a/src/components/student-dashboard/event-row.cjsx
+++ b/src/components/student-dashboard/event-row.cjsx
@@ -45,7 +45,7 @@ module.exports = React.createClass
       </BS.Button>
       feedback = <span>Withdrawn</span>
     else
-      time = <Time date={@props.event.due_at} />
+      time = <Time date={@props.event.due_at} format='concise'/>
       feedback = [
         <span>{@props.feedback}</span>
         <EventInfoIcon event={@props.event} />

--- a/src/components/student-dashboard/events-panel.cjsx
+++ b/src/components/student-dashboard/events-panel.cjsx
@@ -48,7 +48,7 @@ module.exports = React.createClass
         <BS.Col xs={5} xsOffset={2} smOffset={0} sm={3} className='progress-label'>
           Progress
         </BS.Col>
-        <BS.Col xs={5} sm={2} className='due-at-label'>Due (7:00am)</BS.Col>
+        <BS.Col xs={5} sm={2} className='due-at-label'>Due</BS.Col>
       </div>
       {_.map(@props.events, @renderEvent)}
     </BS.Panel>

--- a/src/components/task-plan/builder/index.cjsx
+++ b/src/components/task-plan/builder/index.cjsx
@@ -259,7 +259,7 @@ TaskPlanBuilder = React.createClass
       <BS.Row>
         <BS.Col sm=12>
           <div className="instructions">
-            Set date to today to open immediately.
+            Set date and time to now to open immediately.
             {cannotEditNote}
           </div>
         </BS.Col>

--- a/src/components/task-plan/builder/index.cjsx
+++ b/src/components/task-plan/builder/index.cjsx
@@ -259,9 +259,7 @@ TaskPlanBuilder = React.createClass
       <BS.Row>
         <BS.Col sm=12>
           <div className="instructions">
-            Open time is 12:01am.
             Set date to today to open immediately.
-            Due time is 7:00am.
             {cannotEditNote}
           </div>
         </BS.Col>

--- a/src/components/time.cjsx
+++ b/src/components/time.cjsx
@@ -20,6 +20,7 @@ module.exports = React.createClass
     format = switch @props.format
       when 'shortest' then 'M/D'  # 9/14
       when 'short' then 'MMM DD, YYYY'  # Feb 14, 2010
+      when 'concise' then 'MMM DD[,] h:mma'
       when 'long'  then 'dddd, MMMM Do YYYY, h:mm:ss a' # Sunday, February 14th 2010, 3:25:50 pm
       else @props.format
 


### PR DESCRIPTION
The student dashboard said all due times were 7:00am, and task builder said similar

![screen shot 2016-06-16 at 12 45 20 pm](https://cloud.githubusercontent.com/assets/79566/16127080/8a6d73b8-33c0-11e6-93a2-966ee810855a.png)

![screen shot 2016-06-16 at 12 25 41 pm](https://cloud.githubusercontent.com/assets/79566/16126475/f1b6ba46-33bd-11e6-88e8-5ca4f825772d.png)
