### PR TITLE
period should be enabled for checking and unchecking

### DIFF
--- a/src/components/task-plan/builder/tasking.cjsx
+++ b/src/components/task-plan/builder/tasking.cjsx
@@ -43,12 +43,13 @@ Tasking = React.createClass
         <TaskingDateTimes {...@props} taskingIdentifier={taskingIdentifier}/>
     else
       if period?
+        # if isVisibleToStudents, we cannot re-enable this task for the period.
         <BS.Row key="tasking-disabled-#{period.id}" className="tasking-plan disabled">
           <BS.Col sm=12>
             <input
               id={"period-toggle-#{period.id}"}
               type='checkbox'
-              disabled={not isVisibleToStudents}
+              disabled={isVisibleToStudents}
               onChange={_.partial(togglePeriodEnabled, period)}
               checked={false}/>
             <label className="period" htmlFor={"period-toggle-#{period.id}"}>{period.name}</label>


### PR DESCRIPTION
...unless it is visible to students

## Before
1. Switching from all periods to individual
2. Uncheck a period.
  Now you are stuck with period 2 being disabled and you cannot re-check it.
  ![check-uncheck-bug](https://cloud.githubusercontent.com/assets/2483873/16165603/720d698c-34aa-11e6-87e0-844588eb4cfa.gif)

## After
![check-uncheck-fixed](https://cloud.githubusercontent.com/assets/2483873/16165608/790b0e7e-34aa-11e6-9680-d9f69b8b3dbc.gif)



