### PR TITLE
the plan's server returned is_feedback_immediate being overwritten

### DIFF
--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -374,7 +374,6 @@ TaskPlanConfig =
 
     isFeedbackImmediate: (id) ->
       plan = @_getPlan(id)
-      console.info('is fb immediate',  plan?.is_feedback_immediate)
       plan?.is_feedback_immediate
 
     getEcosystemId: (id, courseId) ->

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -64,7 +64,7 @@ TaskPlanConfig =
     if @_local[planId]?.type is PLAN_TYPES.HOMEWORK or @_changed[planId]?.type is PLAN_TYPES.HOMEWORK
       @_changed[planId] ?= {}
       # need to default final posting json's is feedback immediate to false
-      @_local[planId].is_feedback_immediate ?= false
+      @_changed[planId].is_feedback_immediate ?= false unless @_local[planId].is_feedback_immediate?
       @_local[planId].settings.exercise_ids ?= []
       @_local[planId].settings.exercises_count_dynamic ?= TUTOR_SELECTIONS.default
 
@@ -374,6 +374,7 @@ TaskPlanConfig =
 
     isFeedbackImmediate: (id) ->
       plan = @_getPlan(id)
+      console.info('is fb immediate',  plan?.is_feedback_immediate)
       plan?.is_feedback_immediate
 
     getEcosystemId: (id, courseId) ->


### PR DESCRIPTION
…by the default setting of is_feedback_immediate when dropdown select is untouched.  however, server side was returning the expected `is_feedback_immediate` value for whatever the last save was

Amendment to fix for [Unable to change when feedback appears](https://www.pivotaltracker.com/n/projects/1156756/stories/121620619)

the problem with #1112 is that if you never touch the dropdown, the `is_feedback_immediate` defaults to `true` despite the UI suggesting that it will be set to `false`.  This means if that you do not touch the dropdown, all homeworks will default to  `is_feedback_immediate: true`.

![screen shot 2016-06-17 at 4 10 17 pm](https://cloud.githubusercontent.com/assets/2483873/16164932/8d5dc55a-34a6-11e6-8baa-17fec92c7805.png)
![screen shot 2016-06-17 at 4 10 55 pm](https://cloud.githubusercontent.com/assets/2483873/16164936/8ffde376-34a6-11e6-86a0-0a825cb4a2b0.png)

Why does this need to be set on `_change`?  because of this: https://github.com/openstax/tutor-js/blob/master/src/api.coffee#L138
The payload when `TaskPlanActions.save` is triggered is `_change`.  At some point we should clean up the `task-plan` flux and make it behave like our other standard crud fluxes.


See #1065 and #1069 for additional history