### PR TITLE
Be able to change open assignment description and title without 500 error

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -135,7 +135,7 @@ start = (bootstrapData) ->
   #   payload: obj
 
   saveHelper = (id) ->
-    obj = TaskPlanStore.getChanged(id)
+    obj = TaskPlanStore.getChangedCleanedTaskings(id)
     if TaskPlanStore.isNew(id)
       # HACK: to make the JSON valid
       obj.type ?= 'reading'

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -396,6 +396,16 @@ TaskPlanConfig =
       plan = @_getPlan(id)
       plan?.description
 
+    getChangedCleanedTaskings: (id) ->
+      serverPlan = @_getOriginal(id)
+      changes = @exports.getChanged.call(@, id)
+      return changes unless serverPlan?
+
+      if _.isEqual(changes.tasking_plans, serverPlan.tasking_plans)
+        changes = _.omit(changes, 'tasking_plans')
+
+      changes
+
     isHomework: (id) ->
       plan = @_getPlan(id)
       plan.type is PLAN_TYPES.HOMEWORK


### PR DESCRIPTION

unchanged tasking plans should not be sent to server side -- this would cause additional problems when updating a title when past due for example

related to [changing open assignment description](https://www.pivotaltracker.com/n/projects/1156756/stories/121531359) on past due plans, related to this BE PR openstax/tutor-server#1148