### PR TITLE
Fix clicking scrolling to section on sectionizer click in HW builder

### DIFF
--- a/src/components/exercises/cards.cjsx
+++ b/src/components/exercises/cards.cjsx
@@ -79,7 +79,7 @@ ExerciseCards = React.createClass
   getDefaultProps: ->
     topScrollOffset: 110
 
-  # Important! - as an optimization, this component will only update if exercises has changed.
+  # Important! - as an optimization, this component will only update if props have changed.
   # This is necessary because there can be a very large number of exercise previews displaying at once
   shouldComponentUpdate: (nextProps) ->
     not _.isEqual(nextProps, @props)

--- a/src/components/exercises/cards.cjsx
+++ b/src/components/exercises/cards.cjsx
@@ -52,7 +52,7 @@ SectionsExercises = React.createClass
 
   render: ->
     title = TocStore.getSectionLabel(@props.chapter_section)?.title
-
+    # IMPORTANT: the 'data-section' attribute is used as a scroll-to target and must be present
     <div className='exercise-sections' data-section={@props.chapter_section}>
       <label className='exercises-section-label'>
         <ChapterSection section={@props.chapter_section}/> {title}

--- a/src/components/exercises/cards.cjsx
+++ b/src/components/exercises/cards.cjsx
@@ -1,6 +1,5 @@
 React = require 'react'
 BS = require 'react-bootstrap'
-{addons} = require 'react/addons'
 
 {TocStore} = require '../../flux/toc'
 {ExerciseActions, ExerciseStore} = require '../../flux/exercise'
@@ -15,8 +14,6 @@ ChapterSection = require '../task-plan/chapter-section'
 Icon = require '../icon'
 
 SectionsExercises = React.createClass
-
-  mixins: [addons.PureRenderMixin]
 
   propTypes:
     exercises:              React.PropTypes.array.isRequired
@@ -77,10 +74,15 @@ ExerciseCards = React.createClass
     onShowDetailsViewClick: React.PropTypes.func.isRequired
     topScrollOffset:        React.PropTypes.number
 
-  mixins: [ScrollTo, addons.PureRenderMixin]
+  mixins: [ScrollTo]
 
   getDefaultProps: ->
     topScrollOffset: 110
+
+  # Important! - as an optimization, this component will only update if exercises has changed.
+  # This is necessary because there can be a very large number of exercise previews displaying at once
+  shouldComponentUpdate: (nextProps) ->
+    not _.isEqual(nextProps, @props)
 
   componentDidMount:   ->
     @scrollToSelector('.exercise-sections')

--- a/src/components/task-plan/homework/add-exercises.cjsx
+++ b/src/components/task-plan/homework/add-exercises.cjsx
@@ -10,6 +10,7 @@ ExerciseHelpers  = require '../../../helpers/exercise'
 ExerciseControls = require './exercise-controls'
 ExerciseDetails  = require '../../exercises/details'
 ExerciseCards    = require '../../exercises/cards'
+ScrollTo         = require '../../scroll-to-mixin'
 
 AddExercises = React.createClass
 
@@ -22,7 +23,7 @@ AddExercises = React.createClass
   getInitialState: ->
     { currentView: 'cards' }
 
-  mixins: [LoadingExercises]
+  mixins: [ScrollTo, LoadingExercises]
 
   onShowDetailsViewClick: -> @setState(currentView: 'details')
   onShowCardViewClick:    -> @setState(currentView: 'cards')
@@ -81,7 +82,9 @@ AddExercises = React.createClass
     TaskPlanStore.hasExercise(@props.planId, exercise.id)
 
   setCurrentSection: (currentSection) ->
+    @scrollToSelector("[data-section='#{currentSection}']")
     @setState({currentSection})
+
 
   render: ->
     return @renderLoading() if @exercisesAreLoading()


### PR DESCRIPTION
Scrolling was extremely sluggish when the control was clicked.  I traced it back to the card view was re-rendering excessively because the pure render wasn't having any effect.

Using `_.isEqual` seems to work well and improves performance considerably.