### PR TITLE
Various builder bugs

### DIFF
--- a/resources/styles/components/task-plan/builder.less
+++ b/resources/styles/components/task-plan/builder.less
@@ -53,6 +53,10 @@
     font-weight: 400;
     display: block;
 
+    &.tasking-time-default-set {
+      color: @tutor-success;
+    }
+
     &.btn {
       color: @tutor-info;
       text-transform: none;

--- a/resources/styles/components/tutor-input.less
+++ b/resources/styles/components/tutor-input.less
@@ -24,6 +24,12 @@
       color: lighten(@tutor-neutral, 14%);
     }
 
+    &.-tutor-date-input{
+      input[disabled] ~ .date-wrapper {
+        cursor: not-allowed;
+      }
+    }
+
     .form-control {
 
       &:focus,

--- a/src/components/task-plan/builder/date-time.cjsx
+++ b/src/components/task-plan/builder/date-time.cjsx
@@ -28,6 +28,7 @@ DateTime = React.createClass
     date: date
     time: defaultValue
     isSetting: isSetting()
+    isTimeValid: @isTimeValid()
 
   onTimeChange: (time) ->
     @setState({time})
@@ -40,18 +41,23 @@ DateTime = React.createClass
     nextState = @getStateFromProps(nextProps)
     @setState(nextState)
 
-  componentDidUpdate: (prevProps, prevState) ->
+  onUpdated: ->
     {date, time} = @state
 
-    if @hasValidInputs() and not _.isEqual(prevState, @state)
+    if @hasValidInputs()
       dateTime = "#{date} #{time}"
       @props.onChange(dateTime)
+    else
+      @setState(isTimeValid: @isTimeValid())
 
   hasValidInputs: ->
-    _.isEmpty(@refs.date?.state?.errors) and _.isEmpty(@refs.time?.refs.timeInput?.state?.errors)
+    @isDateValid() and @isTimeValid()
 
-  canSetAsDefaultTime: ->
-    _.isEmpty @refs.time?.refs.timeInput?.state?.errors
+  isDateValid: ->
+    _.isEmpty(@refs?.date?.state?.errors)
+
+  isTimeValid: ->
+    _.isEmpty @refs?.time?.refs?.timeInput?.state?.errors
 
   setDefaultTime: ->
     {timeLabel, setDefaultTime} = @props
@@ -64,7 +70,7 @@ DateTime = React.createClass
 
   render: ->
     {isTimeDefault, label, taskingIdentifier} = @props
-    {isSetting} = @state
+    {isSetting, isTimeValid} = @state
 
     type = label.toLowerCase()
 
@@ -74,7 +80,7 @@ DateTime = React.createClass
     timeProps.label = "#{label} Time"
     dateProps.label = "#{label} Date"
 
-    if not isTimeDefault and @canSetAsDefaultTime()
+    if not isTimeDefault and isTimeValid
       setAsDefaultExplanation = <BS.Popover id="tasking-datetime-default-tip-#{label}-#{taskingIdentifier}">
         {label} times for assignments created from now on will have this time set as the default.
       </BS.Popover>
@@ -97,7 +103,7 @@ DateTime = React.createClass
           <TutorDateInput {...dateProps} onChange={@onDateChange} ref='date'/>
         </BS.Col>
         <BS.Col xs=4 md=5 className="tasking-time -assignment-#{type}-time">
-          <TutorTimeInput {...timeProps} onChange={@onTimeChange} ref='time'/>
+          <TutorTimeInput {...timeProps} onChange={@onTimeChange} onUpdated={@onUpdated} ref='time'/>
           {setAsDefault}
         </BS.Col>
       </BS.Row>

--- a/src/components/task-plan/builder/date-time.cjsx
+++ b/src/components/task-plan/builder/date-time.cjsx
@@ -34,6 +34,7 @@ DateTime = React.createClass
     justSet: false
     isSetting: isSetting()
     isTimeValid: @isTimeValid()
+    isTimeDefault: @isTimeDefault()
 
   onTimeChange: (time) ->
     @setState({time})
@@ -64,7 +65,7 @@ DateTime = React.createClass
       dateTime = "#{date} #{time}"
       @props.onChange(dateTime)
     else
-      @setState(isTimeValid: @isTimeValid())
+      @setState(isTimeValid: @isTimeValid(), isTimeDefault: @isTimeDefault())
 
   hasValidInputs: ->
     @isDateValid() and @isTimeValid()
@@ -76,10 +77,15 @@ DateTime = React.createClass
       @props.isTimeDefault
 
   isDateValid: ->
-    _.isEmpty(@refs?.date?.state?.errors)
+    @state?.date? and _.isEmpty(@refs?.date?.state?.errors)
 
   isTimeValid: ->
-    _.isEmpty @refs?.time?.refs?.timeInput?.state?.errors
+    @state?.time? and _.isEmpty @refs?.time?.refs?.timeInput?.state?.errors
+
+  isTimeDefault: ->
+    return true if _.isUndefined(@state?.time)
+    {defaultTime} = @props
+    TimeHelper.makeMoment(@state.time, 'HH:mm').isSame(TimeHelper.makeMoment(defaultTime, 'HH:mm'), 'minute')
 
   setDefaultTime: ->
     {timeLabel, setDefaultTime} = @props
@@ -92,8 +98,8 @@ DateTime = React.createClass
     setDefaultTime(timeChange)
 
   render: ->
-    {isTimeDefault, label, taskingIdentifier} = @props
-    {isSetting, isTimeValid, justSet, setClicked} = @state
+    {label, taskingIdentifier} = @props
+    {isSetting, isTimeValid, justSet, setClicked, isTimeDefault} = @state
 
     type = label.toLowerCase()
 

--- a/src/components/task-plan/builder/date-time.cjsx
+++ b/src/components/task-plan/builder/date-time.cjsx
@@ -54,7 +54,7 @@ DateTime = React.createClass
 
       @setState(justSet: true)
       _.delay =>
-        @setState(justSet: false)
+        @setState(justSet: false, setClicked: null)
       , messageTime
 
   onTimeUpdated: ->
@@ -87,12 +87,13 @@ DateTime = React.createClass
 
     timeChange = {}
     timeChange[timeLabel] = time
+    @setState(setClicked: true)
 
     setDefaultTime(timeChange)
 
   render: ->
     {isTimeDefault, label, taskingIdentifier} = @props
-    {isSetting, isTimeValid, justSet} = @state
+    {isSetting, isTimeValid, justSet, setClicked} = @state
 
     type = label.toLowerCase()
 
@@ -111,7 +112,7 @@ DateTime = React.createClass
         className='tasking-time-default'
         bsStyle='link'
         waitingText='Saving…'
-        isWaiting={isSetting}
+        isWaiting={isSetting and setClicked}
         onClick=@setDefaultTime>
           Set as default
           <BS.OverlayTrigger placement='top' overlay={setAsDefaultExplanation}>

--- a/src/components/task-plan/builder/index.cjsx
+++ b/src/components/task-plan/builder/index.cjsx
@@ -52,7 +52,7 @@ TaskPlanBuilder = React.createClass
       if not TaskPlanStore.hasTasking(planId, period.id) and not isNewPlan
         tasking = id: period.id
       else
-        tasking = id: period.id, due_at: dueAt, opens_at: opensAt
+        tasking = id: period.id
 
       tasking
 

--- a/src/components/task-plan/builder/index.cjsx
+++ b/src/components/task-plan/builder/index.cjsx
@@ -153,14 +153,7 @@ TaskPlanBuilder = React.createClass
     {showingPeriods, savedAllTaskings} = @state
 
     #save current taskings
-    if showingPeriods
-      saveTaskings = TaskPlanStore.getEnabledTaskings(@props.id)
-      @setState(showingPeriods: false, savedIndividualTaskings: saveTaskings, savedAllTaskings: null)
-
-    # #get opens at and due at
-    # taskingOpensAt = TaskPlanStore.getOpensAt(@props.id) or
-    #   TimeHelper.makeMoment(TimeStore.getNow()).format(TimeHelper.ISO_DATE_FORMAT)
-    # @setOpensAt(taskingOpensAt)
+    saveTaskings = TaskPlanStore.getEnabledTaskings(@props.id)
 
     if savedAllTaskings
       TaskPlanActions.replaceTaskings(@props.id, savedAllTaskings)
@@ -168,13 +161,11 @@ TaskPlanBuilder = React.createClass
       periods = _.map CourseStore.getPeriods(@props.courseId), (period) -> id: period.id
       TaskPlanActions.setDefaultTimesForCourse(@props.id, courseId, periods)
 
-    # #set dates for all periods
-    # taskingDueAt = TaskPlanStore.getDueAt(@props.id) or @getQueriedDueAt()
-
-    # if taskingDueAt
-    #   @setDueAt(taskingDueAt)
-    # else
-    #   TaskPlanActions.clearDueAt(@props.id)
+    @setState(
+      showingPeriods: false
+      savedIndividualTaskings: saveTaskings
+      savedAllTaskings: null
+    )
 
   setIndividualPeriods: ->
     savedAllTaskings = TaskPlanStore.getEnabledTaskings(@props.id)

--- a/src/components/task-plan/builder/index.cjsx
+++ b/src/components/task-plan/builder/index.cjsx
@@ -31,9 +31,11 @@ TaskPlanBuilder = React.createClass
     label: React.PropTypes.string
 
   getInitialState: ->
-    isNewPlan = TaskPlanStore.isNew(@props.id)
+    {courseId, id} = @props
 
-    showingPeriods: not isNewPlan
+    isNewPlan = TaskPlanStore.isNew(id)
+
+    showingPeriods: not isNewPlan or (isNewPlan and not TaskPlanStore.areDefaultsCommon(courseId))
     currentLocale: TimeHelper.getCurrentLocales()
 
   getDefaultProps: ->

--- a/src/components/task-plan/builder/tasking-date-times.cjsx
+++ b/src/components/task-plan/builder/tasking-date-times.cjsx
@@ -26,11 +26,8 @@ TaskingDateTimes = React.createClass
     isVisibleToStudents: React.PropTypes.bool
     period:              React.PropTypes.object
 
-  isTimeDefault: (time, defaultTime) ->
-    return true if _.isUndefined(time)
-    TimeHelper.makeMoment(time, 'HH:mm').isSame(TimeHelper.makeMoment(defaultTime, 'HH:mm'), 'minute')
-
   isPastDue: (date, time) ->
+    return false unless date?
     TimeHelper.makeMoment("#{date} #{time}").isBefore(TimeHelper.makeMoment())
 
   setDefaultTime: (timeChange) ->
@@ -67,9 +64,6 @@ TaskingDateTimes = React.createClass
 
     commonDateTimesProps = _.pick @props, 'required', 'currentLocale', 'taskingIdentifier'
 
-    isDueTimeDefault = @isTimeDefault dueTime, defaultDueTime
-    isOpenTimeDefault = @isTimeDefault openTime, defaultOpenTime
-
     maxOpensAt = TaskPlanStore.getMaxDueAt(id, period?.id)
     minDueAt = TaskPlanStore.getMinDueAt(id, period?.id)
 
@@ -84,9 +78,9 @@ TaskingDateTimes = React.createClass
         onChange={_.partial(setOpensAt, _, period)}
         value={ taskingOpensAt }
         defaultValue={openTime or defaultOpenTime}
+        defaultTime={defaultOpenTime}
         setDefaultTime={@setDefaultTime}
         timeLabel='default_open_time'
-        isTimeDefault={isOpenTimeDefault}
         isSetting={@isSetting} />
       <DateTime
         {...commonDateTimesProps}
@@ -97,9 +91,9 @@ TaskingDateTimes = React.createClass
         onChange={_.partial(setDueAt, _, period)}
         value={taskingDueAt}
         defaultValue={dueTime or defaultDueTime}
+        defaultTime={defaultDueTime}
         setDefaultTime={@setDefaultTime}
         timeLabel='default_due_time'
-        isTimeDefault={isDueTimeDefault}
         isSetting={@isSetting} />
     </BS.Col>
 

--- a/src/components/task-plan/builder/tasking-date-times.cjsx
+++ b/src/components/task-plan/builder/tasking-date-times.cjsx
@@ -6,7 +6,7 @@ _     = require 'underscore'
 {TimeStore} = require '../../../flux/time'
 TimeHelper  = require '../../../helpers/time'
 {PeriodActions, PeriodStore}     = require '../../../flux/period'
-{TaskPlanStore, TaskPlanActions} = require '../../../flux/task-plan'
+{TaskPlanStore} = require '../../../flux/task-plan'
 {CourseStore, CourseActions}     = require '../../../flux/course'
 
 DateTime = require './date-time'
@@ -29,6 +29,9 @@ TaskingDateTimes = React.createClass
   isTimeDefault: (time, defaultTime) ->
     return true if _.isUndefined(time)
     TimeHelper.makeMoment(time, 'HH:mm').isSame(TimeHelper.makeMoment(defaultTime, 'HH:mm'), 'minute')
+
+  isPastDue: (date, time) ->
+    TimeHelper.makeMoment("#{date} #{time}").isBefore(TimeHelper.makeMoment())
 
   setDefaultTime: (timeChange) ->
     {courseId, period} = @props
@@ -87,7 +90,7 @@ TaskingDateTimes = React.createClass
         isSetting={@isSetting} />
       <DateTime
         {...commonDateTimesProps}
-        disabled={not isEditable}
+        disabled={@isPastDue(taskingDueAt, dueTime) or not isEditable}
         label="Due"
         ref="due"
         min={minDueAt}

--- a/src/components/task-plan/builder/tasking-date-times.cjsx
+++ b/src/components/task-plan/builder/tasking-date-times.cjsx
@@ -45,7 +45,7 @@ TaskingDateTimes = React.createClass
     {courseId, period} = @props
 
     if period?
-      PeriodStore.isSaving(courseId)
+      CourseStore.isLoading(courseId)
     else
       CourseStore.isSaving(courseId)
 

--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -101,7 +101,8 @@ PlanFooter = React.createClass
       if TaskPlanStore.isPublished(id)
         saveButton = <AsyncButton {...publishButtonProps}
           onClick={@onSave}
-          isWaiting={isWaiting and @state.saving}
+          isJob={true}
+          isWaiting={isWaiting and (@state.saving or @state.publishing)}
           waitingText='Saving…'>
           Save
         </AsyncButton>

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -272,7 +272,12 @@ TutorTimeInput = React.createClass
     {selection} = @getMask()
     selection = _.clone(selection)
 
-    if cursorChange > 0
+    if /^(_+[2-9])/.test(timeValue)
+      timeValue = S.removeAt(timeValue, 0)
+      selection.start = 2
+      selection.end = 2
+
+    else if cursorChange > 0
       timeValue = S.insertAt(timeValue, 1, @getMask()?.placeholderChar)
       selection.start = 1
       selection.end = 1
@@ -306,21 +311,22 @@ TutorTimeInput = React.createClass
     @getMask()?.setValue(@state.timeValue) if @state.timeValue isnt prevState.timeValue
     if @state.selection? and not _.isEqual(@getMask()?.selection, @state.selection)
       # update cursor to expected time, doesnt quite work for some reason for expanding mask
-      @getMask()?.setSelection(@state.selection)
-      @getInput()?._updateInputSelection()
+      _.defer =>
+        @getMask()?.setSelection(@state.selection)
+        @getInput()?._updateInputSelection()
 
     @refs.timeInput.validate(@state.timeValue)
 
   getPatternFromValue: (value, changeEvent) ->
-    if /^[2-9]/.test(value)
+    if /^([2-9])/.test(value) or /^(_+[2-9])/.test(value)
       patten = 'h:Mm P'
     else if /^1:/.test(value)
       if changeEvent? and not @shouldShrinkMask(changeEvent)
-        pattern = 'hi:Mm P'
+        pattern = 'hh:Mm P'
       else
         pattern = 'h:Mm P'
     else
-      pattern = 'hi:Mm P'
+      pattern = 'hh:Mm P'
 
   isValidTime: (value) ->
     not /_/.test(value)

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -32,7 +32,7 @@ TutorInput = React.createClass
     errors: errors or []
 
   componentDidUpdate: (prevProps, prevState) ->
-    @props.onUpdated?(@state) if not _.isEqual(prevState, @state)
+    @props.onUpdated?(@state) unless _.isEqual(prevState, @state)
 
   onChange: (event) ->
     # TODO make this more intuitive to parent elements

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -194,7 +194,7 @@ TutorDateInput = React.createClass
       displayValue = value.format(TutorDateFormat)
 
     <div className={wrapperClasses}>
-      <input type='text' disabled readonly className={classes} value={displayValue}/>
+      <input type='text' disabled readOnly className={classes} value={displayValue}/>
       <div className="floating-label">{@props.label}</div>
       <div className="hint required-hint">
         Required Field <i className="fa fa-exclamation-circle"></i>

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -31,6 +31,9 @@ TutorInput = React.createClass
     errors = @props.validate(@props.default)
     errors: errors or []
 
+  componentDidUpdate: (prevProps, prevState) ->
+    @props.onUpdated?(@state) if not _.isEqual(prevState, @state)
+
   onChange: (event) ->
     # TODO make this more intuitive to parent elements
     @props.onChange(event.target?.value, event.target, event)
@@ -39,7 +42,6 @@ TutorInput = React.createClass
   validate: (inputValue) ->
     errors = @props.validate(inputValue)
     errors ?= []
-
     @setState({errors})
 
   focus: ->

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -150,6 +150,9 @@ TutorDateInput = React.createClass
     @props.onChange(value)
     @setState({expandCalendar: false, valid, value, errors})
 
+  onBlur: ->
+    @setState({hasFocus: false})
+
   getValue: ->
     @props.value or @state.value
 
@@ -186,6 +189,7 @@ TutorDateInput = React.createClass
           ref="picker"
           className={classes}
           onChange={@dateSelected}
+          onBlur={@onBlur}
           disabled={@props.disabled}
           selected={value}
           weekStart={"#{@props.currentLocale.week.dow}"}

--- a/src/components/tutor-input.cjsx
+++ b/src/components/tutor-input.cjsx
@@ -276,7 +276,7 @@ TutorTimeInput = React.createClass
     {selection} = @getMask()
     selection = _.clone(selection)
 
-    if /^(_+[2-9])/.test(timeValue)
+    if /^(_+[1-9])/.test(timeValue)
       timeValue = S.removeAt(timeValue, 0)
       selection.start = 2
       selection.end = 2
@@ -322,7 +322,7 @@ TutorTimeInput = React.createClass
     @refs.timeInput.validate(@state.timeValue)
 
   getPatternFromValue: (value, changeEvent) ->
-    if /^([2-9])/.test(value) or /^(_+[2-9])/.test(value)
+    if /^([2-9])/.test(value) or /^(_+[1-9])/.test(value)
       patten = 'h:Mm P'
     else if /^1:/.test(value)
       if changeEvent? and not @shouldShrinkMask(changeEvent)
@@ -330,7 +330,7 @@ TutorTimeInput = React.createClass
       else
         pattern = 'h:Mm P'
     else
-      pattern = 'hh:Mm P'
+      pattern = 'hi:Mm P'
 
   isValidTime: (value) ->
     not /_/.test(value)

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -35,7 +35,7 @@ sortTopics = (topics) ->
 
 
 isSameOrBeforeNow = (time) ->
-  moment(time).isSame(TimeStore.getNow()) or moment(time).isBefore(TimeStore.getNow())
+  moment(time).isSameOrBefore(TimeStore.getNow())
 
 isDateStringOnly = (timeString) ->
   ISO_DATE_ONLY_REGEX.test(timeString)

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -438,6 +438,19 @@ TaskPlanConfig =
     getFirstDueDate: (id) ->
       due_at = @_getFirstTaskingByDueDate(id)?.due_at
 
+    areDefaultsCommon: (courseId) ->
+      course = CourseStore.get(courseId)
+
+      areOpenTimesSame = _.every course.periods, (period) ->
+        {default_open_time} = period
+        default_open_time is _.first(course.periods).default_open_time
+
+      areDueTimesSame = _.every course.periods, (period) ->
+        {default_due_time} = period
+        default_due_time is _.first(course.periods).default_due_time
+
+      areOpenTimesSame and areDueTimesSame
+
     isEditable: (id) ->
       # cannot be/being deleted
       not @_isDeleteRequested(id)

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -146,10 +146,13 @@ TaskPlanConfig =
       tasking = findTasking(curTaskings, period.id)
       tasking ?= target_id: period.id, target_type:'period'
 
-      period.opens_at = TimeHelper.makeMoment(period.opens_at or tasking.opens_at).format(TimeHelper.ISO_DATE_FORMAT)
-      period.due_at = TimeHelper.makeMoment(period.due_at or tasking.due_at).format(TimeHelper.ISO_DATE_FORMAT)
+      opens_at = period.opens_at or tasking.opens_at
+      due_at = period.due_at or tasking.due_at
 
-      periodTimes = @setDefaultTimes(course, period, useCourseDefault)
+      period.opens_at = TimeHelper.makeMoment(opens_at).format(TimeHelper.ISO_DATE_FORMAT) if opens_at?
+      period.due_at = TimeHelper.makeMoment(due_at).format(TimeHelper.ISO_DATE_FORMAT) if due_at?
+
+      periodTimes = @setDefaultTimes(course, period, useCourseDefault) if opens_at? or due_at?
 
       _.extend({}, tasking, periodTimes)
 

--- a/src/helpers/plan.coffee
+++ b/src/helpers/plan.coffee
@@ -9,6 +9,7 @@ PlanHelper =
     isPublishing = (plan.is_publish_requested? and plan.is_publish_requested) or plan.publish_last_requested_at?
 
     if plan.published_at and plan.publish_job?.status?
+      # TODO could add publish job from plan to PlanPublishStore if we really want to.
       isPublishing = plan.publish_job.status isnt 'succeeded'
     else if plan.published_at? and plan.publish_last_requested_at?
       # is the last requested publishing after the last successful publish?

--- a/src/helpers/plan.coffee
+++ b/src/helpers/plan.coffee
@@ -7,7 +7,10 @@ _ = require 'underscore'
 PlanHelper =
   isPublishing: (plan, recentTolerance = 3600000) ->
     isPublishing = (plan.is_publish_requested? and plan.is_publish_requested) or plan.publish_last_requested_at?
-    if plan.published_at? and plan.publish_last_requested_at?
+
+    if plan.published_at and plan.publish_job?.status?
+      isPublishing = plan.publish_job.status isnt 'succeeded'
+    else if plan.published_at? and plan.publish_last_requested_at?
       # is the last requested publishing after the last successful publish?
       isPublishing = moment(plan.publish_last_requested_at).diff(plan.published_at) > 0
     else if plan.published_at? and not plan.publish_last_requested_at?


### PR DESCRIPTION
### Fixes include

- [x] "Set as default" will show as expected for valid times
- [x] "Default set" message will show for a bit after default set
- [x] cursor does not jump when typing time
- [x] default times fill in as default times as expected when making new assignment and switching between all vs individual periods
- [x] show individual periods by default if default times for periods are different from each other
- [x] only subscribe to job status when publish is in progress
- [x] cancel will better track if there's been changes
- [x] if new assignment being created without default due date, due date will remain blank until deliberately selected
- [x] datepicker blur will return input label to expected location