### PR TITLE
Fix exercise selection highlighting

### DIFF
--- a/src/components/task-plan/homework/add-exercises.cjsx
+++ b/src/components/task-plan/homework/add-exercises.cjsx
@@ -12,6 +12,10 @@ ExerciseDetails  = require '../../exercises/details'
 ExerciseCards    = require '../../exercises/cards'
 ScrollTo         = require '../../scroll-to-mixin'
 
+# SELECT_COUNT is a simple incrementing counter that is passed
+# to the ExerciseCards view and incremented to force it to re-render when needed
+SELECT_COUNT = 0
+
 AddExercises = React.createClass
 
   propTypes:
@@ -29,6 +33,7 @@ AddExercises = React.createClass
   onShowCardViewClick:    -> @setState(currentView: 'cards')
 
   onExerciseToggle: (ev, exercise) ->
+    SELECT_COUNT += 1
     if @getExerciseIsSelected(exercise)
       TaskPlanActions.removeExercise(@props.planId, exercise)
     else
@@ -111,6 +116,7 @@ AddExercises = React.createClass
       else
         <ExerciseCards
           {...sharedProps}
+          selectCount={SELECT_COUNT} # re-render flag
           topScrollOffset={110}
           onShowDetailsViewClick={@onShowDetailsViewClick}
         />


### PR DESCRIPTION
The highlight mask on HW builder wasn't being applied since the 'is-selected' flag isn't part of the card view props for homework like it is on QL