### PR TITLE
Fix/deep server task plan copy

### DIFF
--- a/src/components/task-plan/plan-mixin.coffee
+++ b/src/components/task-plan/plan-mixin.coffee
@@ -67,9 +67,12 @@ PlanMixin =
     saveable = TaskPlanStore.isValid(id)
     # The logic here is this way because we need to be able to add an invalid
     # state to the form.  Blame @fredasaurus
-    if (saveable)
-      TaskPlanActions.saved.addListener(@saved)
-      TaskPlanActions.save(id)
+    if saveable
+      if TaskPlanStore.hasChanged(id)
+        TaskPlanActions.saved.addListener(@saved)
+        TaskPlanActions.save(id)
+      else
+        @saved()
     else
       @setState({invalid: true})
 

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -48,13 +48,13 @@ TaskPlanConfig =
   _server_copy: {}
 
   _loaded: (obj, planId) ->
-    @_server_copy[planId] = obj
+    @_server_copy[planId] = JSON.stringify(obj)
     obj
 
   # Somewhere, the local copy gets taken apart and rebuilt.
   # Keep a copy of what was served.
   _getOriginal: (planId) ->
-    @_server_copy[planId]
+    JSON.parse(@_server_copy[planId])
 
   _getPlan: (planId) ->
     @_local[planId] ?= {}


### PR DESCRIPTION
To fix a bug i made recently to prevent posting of unchanged tasking-plans, especially important for when due dates are untouched but in the past.

this will keep that fix, but also fix a bug in which the "server_copy" of the task plan was being unintentionally mutated and making the change comparisons wrong