### PR TITLE
Prevent duplicate loads when reload is triggered

### DIFF
--- a/src/components/loadable-item.cjsx
+++ b/src/components/loadable-item.cjsx
@@ -40,7 +40,7 @@ module.exports = React.createClass
 
     load ?= actions.load
     isLoading ?= store.isLoading
-    unless store.isNew(id, options) or isLoading(id, options)
+    unless store.isNew(id, options) and not isLoading?(id, options)
       load(id, options)
 
   render: ->

--- a/src/components/loadable-item.cjsx
+++ b/src/components/loadable-item.cjsx
@@ -31,7 +31,7 @@ module.exports = React.createClass
   componentDidUpdate: (oldProps) -> @reload(oldProps)
 
   reload: (oldProps) ->
-    {id, store, load, actions, options} = @props
+    {id, store, load, actions, options, isLoading} = @props
     return unless id?
 
     # Skip reloading if all the props are the same (the case in the Calendar for some reason)
@@ -39,7 +39,8 @@ module.exports = React.createClass
       oldProps.load is load and _.isEqual(oldProps.options, options)
 
     load ?= actions.load
-    unless store.isNew(id, options)
+    isLoading ?= store.isLoading
+    unless store.isNew(id, options) or isLoading(id, options)
       load(id, options)
 
   render: ->


### PR DESCRIPTION
This was discovered by new code in `TeacherTaskPlanListing` which has a `LoadableItem` for the dashboard. The Dashboard's props are updated quite a few times (300+) when it's loaded directly. 

`LoadableItem` in turn has a `componentDidUpdate` that calls it's `reload` method every time, which blindly fires a load request.  This adds a check to only fire the load if it's not already loading.

I **think** this is safe but should be reviewed carefully since it does change the behavior of `LoadableItem`, which is used pervasively throughout our code-base.

Intended to prevent shenanigans like this:

![screen shot 2016-06-28 at 10 11 29 am](https://cloud.githubusercontent.com/assets/79566/16421103/7a88b1b2-3d19-11e6-9ed4-6021d18a08a6.png)