### PR TITLE
Student Scores - fixed NaN

### DIFF
--- a/src/components/scores/index.cjsx
+++ b/src/components/scores/index.cjsx
@@ -154,7 +154,7 @@ Scores = React.createClass
         (d.last_name or d.name).toLowerCase()
     )
     {
-      overall_average_score: scores.overall_average_score,
+      overall_average_score: scores.overall_average_score or 0,
       headings: scores.data_headings,
       rows: if sort.asc then sortData else sortData.reverse()
     }


### PR DESCRIPTION
fixed NaN when overall_average_score is missing.  A period with all readings may not return this property.