### PR TITLE
Fix/api prevent multiple same requests

### DIFF
--- a/src/flux/app.coffee
+++ b/src/flux/app.coffee
@@ -89,6 +89,9 @@ AppConfig =
       pending: @_pending
       statuses: @_statuses
 
+    isPending: (requestConfig) ->
+      @_getRequestInfo(requestConfig)?
+
     errorNavigation: ->
       return {} unless @_currentServerError
       {statusCode, request} = @_currentServerError

--- a/src/helpers/api.coffee
+++ b/src/helpers/api.coffee
@@ -89,7 +89,8 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker, option
         # For now, the backend is expecting JSON and cannot accept url-encoded forms
         opts.contentType = 'application/json'
 
-      opts = _.extend({}, opts, options)
+      requestConfig = _.extend({url}, opts, options)
+      return if AppStore.isPending(requestConfig)
 
       resolved = ({headers, data}) ->
         setNow(headers)
@@ -126,7 +127,7 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker, option
 
           Actions.FAILED(statusCode, msg, args...)
 
-      axios(url, opts)
+      axios(requestConfig)
         .then(resolved, rejected)
 
 setUpXHRInterceptors()

--- a/src/helpers/api.coffee
+++ b/src/helpers/api.coffee
@@ -95,9 +95,9 @@ interceptors =
     mockMethods = ['PUT', 'PATCH']
 
     # Hack for local testing, fake successful PUT and PATCH
-    if _.contains(mockMethods, mockMethod or method)
-      data = JSON.parse(errorResponse.config.data)
-      return Promise.resolve({data})
+    if _.contains(mockMethods, mockMethod or method) and status is 404
+      errorResponse.statusText = """No mock data found at #{config.url}.
+      This error only happens locally."""
 
     # Hack for local testing. Webserver returns 200 + HTML for 404's
     if statusText is 'parsererror' and status is 200


### PR DESCRIPTION
Alternative to #1133, handles and prevents multiple for all requests as opposed to just those in loadable

fix is in ea53f8c, some refactoring in 35accc7, can be reset if needed.