### PR TITLE
Scores - fixed absent cell type displaying incorrectly

### DIFF
--- a/src/components/scores/absent-cell.cjsx
+++ b/src/components/scores/absent-cell.cjsx
@@ -5,9 +5,8 @@ module.exports = React.createClass
   displayName: 'AbsentCell'
 
   findTypeFromColumn: ->
-    {refs, columnIndex} = @props
-    type = _.findWhere(_.keys(refs), columnIndex)
-    type?.split('-').pop()
+    {headings, columnIndex} = @props
+    headings[columnIndex]?.type
 
   render: ->
     columnType = @findTypeFromColumn()

--- a/src/components/scores/table.cjsx
+++ b/src/components/scores/table.cjsx
@@ -205,7 +205,6 @@ module.exports = React.createClass
         <span className="group-header">
           <div
           data-assignment-type="#{heading.type}"
-          ref="#{i}-#{heading.type}"
           className="header-cell group title #{groupHeaderClass}">
             {heading.title}
           </div>
@@ -264,7 +263,7 @@ module.exports = React.createClass
       props.task = task
       props.columnIndex = columnIndex
       columns.push switch task?.type or 'null'
-        when 'null'     then <AbsentCell   key='absent' refs={@refs}   {...props} />
+        when 'null'     then <AbsentCell   key='absent' headings={data.headings} {...props} />
         when 'external' then <ExternalCell key='extern'   {...props} />
         when 'reading'  then <ReadingCell  key='reading'  {...props} />
         when 'homework' then <HomeworkCell key='homework'  {...props} />


### PR DESCRIPTION
regarding: https://www.pivotaltracker.com/story/show/121986485

when student assignment data is null (if a student moves and is unassigned), absent cell will render with either split (hw) or single (external, reading), based on the heading type.