### PR TITLE
Fixing source maps

### DIFF
--- a/webpack.config.coffee
+++ b/webpack.config.coffee
@@ -20,7 +20,7 @@ else
 module.exports =
   cache: true
 
-  devtool: 'source-map' # Always include source maps!
+  devtool: '#inline-source-map' # Always include source maps!
 
   entry:
     tutor: [


### PR DESCRIPTION
This PR fixes source maps so they can be parsed, I believe it's actually a chrome error.  From this conversation here: https://github.com/webpack/webpack/issues/2145, I've changed webpack to use: `devtool: '#inline-source-map'` to fix the issue.

