### PR TITLE
Set defaults when switching from periods to combined

### DIFF
--- a/src/components/task-plan/builder/index.cjsx
+++ b/src/components/task-plan/builder/index.cjsx
@@ -148,6 +148,12 @@ TaskPlanBuilder = React.createClass
     value = value.format(TimeHelper.ISO_DATE_FORMAT) if moment.isMoment(value)
     TaskPlanActions.updateDueAt(id, value, period?.id)
 
+  setTaskingsToDefaults: ->
+    dueAt = TaskPlanStore.getDueAt(@props.id)
+    opensAt = TaskPlanStore.getOpensAt(@props.id)
+    periods = @mapPeriods(opensAt or @getQueriedOpensAt(), dueAt or @getQueriedDueAt())
+    TaskPlanActions.setDefaultTimesForPeriods(@props.id, @props.courseId, periods)
+
   setAllPeriods: ->
     {courseId} = @props
     {showingPeriods, savedAllTaskings} = @state
@@ -158,8 +164,7 @@ TaskPlanBuilder = React.createClass
     if savedAllTaskings
       TaskPlanActions.replaceTaskings(@props.id, savedAllTaskings)
     else
-      periods = _.pluck(CourseStore.getPeriods(@props.courseId), 'id')
-      TaskPlanActions.setDefaultTimesForCourse(@props.id, courseId, periods)
+      @setTaskingsToDefaults()
 
     @setState(
       showingPeriods: false
@@ -174,13 +179,7 @@ TaskPlanBuilder = React.createClass
     if (@state.savedIndividualTaskings)
       TaskPlanActions.replaceTaskings(@props.id, @state.savedIndividualTaskings)
     else
-      # check for common open/due dates, remember it now before we set defaults
-      dueAt = TaskPlanStore.getDueAt(@props.id)
-      opensAt = TaskPlanStore.getOpensAt(@props.id)
-      #map tasking plans
-      periods = @mapPeriods(opensAt or @getQueriedOpensAt(), dueAt or @getQueriedDueAt())
-
-      TaskPlanActions.setDefaultTimesForPeriods(@props.id, @props.courseId, periods)
+      @setTaskingsToDefaults()
 
     #clear saved taskings
     @setState(

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -605,7 +605,6 @@ TaskPlanConfig =
 
     getEnabledTaskings: (id) ->
       plan = @_getPlan(id)
-      console.log "Get Enabled", plan
       plan?.tasking_plans
 
     isStatsLoading: (id) -> @_asyncStatusStats[id] is 'loading'

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -172,12 +172,6 @@ TaskPlanConfig =
     tasking_plans = @_getDefaultTaskingTimes(id, courseId, periods)
     @_change(id, {tasking_plans})
 
-  # set taskings that lack an opens_at to the default
-  setBlankOpensAtDateForCourse: (id, courseId, opensAtDate) ->
-    opensAt = "#{opensAtDate} #{CourseStore.get(courseId)?.default_open_time}"
-    _.each @_getPlan(id)?.tasking_plans, (tasking) ->
-      tasking.opens_at ?= opensAt
-
   setPeriods: (id, courseId, periods, isDefault = false, useCourseDefault = true) ->
     plan = @_getPlan(id)
     course = CourseStore.get(courseId)


### PR DESCRIPTION
This fixes a bug where the HW builder would have invisible errors when validating.  The sequence to trigger was:

* Have some differing default times set for periods
* Load the builder 
* Note that individual periods are displayed at the start
* switch to "All Periods" and set the end date
* set title and add some exercises (this can be done at any time)
* attempt to publish

Nothing would happen because the opens_at wasn't set on the taskings, because that date was never manipulated. 


