### PR TITLE
Hide missing note title pseudo element

### DIFF
--- a/resources/styles/book-content/note.less
+++ b/resources/styles/book-content/note.less
@@ -9,6 +9,11 @@
     display: inline-block;
     margin: @book-content-note-with-background-margin;
   }
+  // hide note title if data-label attribute is blank or missing
+  &[data-label=""],
+  &:not([data-label]) {
+    &:before{ display: none; }
+  }
 
   :last-child {
     padding-bottom: 0;

--- a/resources/styles/book-content/note.less
+++ b/resources/styles/book-content/note.less
@@ -1,18 +1,16 @@
 .tutor-book-note-style() {
-  &:before {
-    position: absolute;
-    content: attr(data-label);
-    #fonts > .sans(@tutor-book-ui-top-height - 18px, @tutor-book-ui-top-height);
-    font-weight: 900;
-    padding: 0 40px;
-    height: @tutor-book-ui-top-height;
-    display: inline-block;
-    margin: @book-content-note-with-background-margin;
-  }
-  // hide note title if data-label attribute is blank or missing
-  &[data-label=""],
-  &:not([data-label]) {
-    &:before{ display: none; }
+  // add a title pseudo element if a data-label attribute is present
+  &[data-label]:not([data-label=""]) {
+    &:before {
+      position: absolute;
+      content: attr(data-label);
+      #fonts > .sans(@tutor-book-ui-top-height - 18px, @tutor-book-ui-top-height);
+      font-weight: 900;
+      padding: 0 40px;
+      height: @tutor-book-ui-top-height;
+      display: inline-block;
+      margin: @book-content-note-with-background-margin;
+    }
   }
 
   :last-child {

--- a/resources/styles/book-content/note.less
+++ b/resources/styles/book-content/note.less
@@ -1,7 +1,7 @@
 .tutor-book-note-style() {
   // add a title pseudo element if a data-label attribute is present
   &[data-label]:not([data-label=""]) {
-    &:before {
+    &::before {
       position: absolute;
       content: attr(data-label);
       #fonts > .sans(@tutor-book-ui-top-height - 18px, @tutor-book-ui-top-height);


### PR DESCRIPTION
Previously we decided against this since the weird blank element makes it obvious that the content needs updating, but Sociology is missing them all, making it impossible to fix by release.

before:
![screen shot 2016-06-30 at 9 21 40 am](https://cloud.githubusercontent.com/assets/79566/16491601/31e52ec2-3ea4-11e6-8069-ccfa880ef66d.png)




after:
![screen shot 2016-06-30 at 9 21 18 am](https://cloud.githubusercontent.com/assets/79566/16491573/20a8e3ce-3ea4-11e6-8bfe-74c8ffb36d08.png)