### PR TITLE
This allows the same date to be set in the builder

### DIFF
--- a/resources/styles/components/task-plan/builder.less
+++ b/resources/styles/components/task-plan/builder.less
@@ -75,6 +75,13 @@
   }
 }
 
+.due-before-open {
+	text-align: right;
+	line-height: 1.2rem;
+	margin: -10px 0 30px;
+}
+
+.due-before-open,
 .readings-required,
 .problems-required {
   color: @form-error-color;

--- a/src/components/task-plan/builder/tasking-date-times.cjsx
+++ b/src/components/task-plan/builder/tasking-date-times.cjsx
@@ -9,6 +9,7 @@ TimeHelper  = require '../../../helpers/time'
 {TaskPlanStore} = require '../../../flux/task-plan'
 {CourseStore, CourseActions}     = require '../../../flux/course'
 
+Icon = require '../../icon'
 DateTime = require './date-time'
 
 TaskingDateTimes = React.createClass
@@ -46,6 +47,14 @@ TaskingDateTimes = React.createClass
     else
       CourseStore.isSaving(courseId)
 
+  dueDateBeforeOpenDate: ->
+    {
+      taskingOpensAt,
+      taskingDueAt,
+    } = @props
+
+    taskingDueAt and taskingDueAt <= taskingOpensAt
+
   render: ->
     {
       isVisibleToStudents,
@@ -67,6 +76,15 @@ TaskingDateTimes = React.createClass
     maxOpensAt = TaskPlanStore.getMaxDueAt(id, period?.id)
     minDueAt = TaskPlanStore.getMinDueAt(id, period?.id)
 
+    dueBeforeOpen = <BS.Row>
+      <BS.Col xs=12 md=6 mdOffset=6>
+        <p className="due-before-open">
+          Due date cannot be before open date
+          <Icon type='exclamation-circle' />
+        </p>
+      </BS.Col>
+    </BS.Row> if @dueDateBeforeOpenDate()
+
     <BS.Col sm=8 md=9>
       <DateTime
         {...commonDateTimesProps}
@@ -81,7 +99,8 @@ TaskingDateTimes = React.createClass
         defaultTime={defaultOpenTime}
         setDefaultTime={@setDefaultTime}
         timeLabel='default_open_time'
-        isSetting={@isSetting} />
+        isSetting={@isSetting}
+      />
       <DateTime
         {...commonDateTimesProps}
         disabled={not isEditable}
@@ -94,7 +113,10 @@ TaskingDateTimes = React.createClass
         defaultTime={defaultDueTime}
         setDefaultTime={@setDefaultTime}
         timeLabel='default_due_time'
-        isSetting={@isSetting} />
+        isSetting={@isSetting}
+      />
+
+      { dueBeforeOpen }
     </BS.Col>
 
 module.exports = TaskingDateTimes

--- a/src/components/task-plan/builder/tasking-date-times.cjsx
+++ b/src/components/task-plan/builder/tasking-date-times.cjsx
@@ -79,7 +79,7 @@ TaskingDateTimes = React.createClass
     dueBeforeOpen = <BS.Row>
       <BS.Col xs=12 md=6 mdOffset=6>
         <p className="due-before-open">
-          Due date cannot be before open date
+          Due time cannot be before open time
           <Icon type='exclamation-circle' />
         </p>
       </BS.Col>

--- a/src/flux/task-plan.coffee
+++ b/src/flux/task-plan.coffee
@@ -455,7 +455,11 @@ TaskPlanConfig =
         flag = true
         # TODO: check that all periods are filled in
         _.each plan.tasking_plans, (tasking) ->
-          unless tasking.due_at and tasking.opens_at
+          unless (
+            tasking.due_at and
+            tasking.opens_at and
+            tasking.opens_at < tasking.due_at
+          )
             flag = false
         flag and plan.tasking_plans?.length?
 
@@ -578,7 +582,7 @@ TaskPlanConfig =
       if opensAt.isBefore(TimeStore.getNow())
         opensAt = moment(TimeStore.getNow())
 
-      opensAt.startOf('day').add(1, 'day').format(TimeHelper.ISO_DATE_FORMAT)
+      opensAt.startOf('day').add(1, 'minute').format(TimeHelper.ISO_DATE_FORMAT)
 
     hasTasking: (id, periodId) ->
       plan = @_getPlan(id)

--- a/test/components/task-plan/builder/index.spec.coffee
+++ b/test/components/task-plan/builder/index.spec.coffee
@@ -231,3 +231,12 @@ describe 'Task Plan Builder', ->
       expect(getISODateString(dueAt)).to.be.equal(getISODateString(dayAfter))
       expect(dom.querySelector('.-assignment-due-date .datepicker__input-container input').value)
         .to.be.equal(getDateString(dayAfter))
+
+  it 'shows a message when due date is before open date', ->
+    firstPeriod = COURSES[0].periods[0]
+    extendedReading =
+      due_at: getISODateString(yesterday)
+      opens_at: getISODateString(dayAfter)
+
+    helper(NEW_READING, extendedReading).then ({dom, element}) ->
+      expect(dom.querySelector('.due-before-open')).to.not.be.null


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/123488831

This needs some UX love, if we want the same date, we'll need to show error message for when they enter the wrong time.  See screenshots below.

![screen shot 2016-07-01 at 1 09 20 am](https://cloud.githubusercontent.com/assets/6434717/16527159/3bfbbf90-3f83-11e6-9606-68fc5f880427.png)
![screen shot 2016-07-01 at 1 08 52 am](https://cloud.githubusercontent.com/assets/6434717/16527165/3f3454e2-3f83-11e6-86a0-489321965f27.png)
