### PR TITLE
calendar related fixes

### DIFF
--- a/resources/styles/components/course-calendar/month.less
+++ b/resources/styles/components/course-calendar/month.less
@@ -48,6 +48,9 @@
     .rc-Month {
       .tutor-subtle-load(loading);
     }
+    .plan {
+      opacity: 0.1;
+    }
   }
 
   .rc {

--- a/src/components/loadable-item.cjsx
+++ b/src/components/loadable-item.cjsx
@@ -17,6 +17,7 @@ module.exports = React.createClass
     store: React.PropTypes.object.isRequired
     actions: React.PropTypes.object.isRequired
     renderItem: React.PropTypes.func.isRequired
+    isLoadingOrLoad: React.PropTypes.func
     saved: React.PropTypes.func
     load: React.PropTypes.func
     renderLoading: React.PropTypes.func
@@ -43,14 +44,14 @@ module.exports = React.createClass
       load(id, options)
 
   render: ->
-    { id, store, actions, load, isLoaded, isLoading, renderItem,
+    { id, store, actions, load, isLoaded, isLoading, isLoadingOrLoad, renderItem,
       saved, renderLoading, renderError, renderBug, update, options, bindEvent} = @props
 
     load ?= actions.load
     isLoaded ?= store.isLoaded
     isLoading ?= store.isLoading
 
-    isLoadingOrLoad = ->
+    isLoadingOrLoad ?= ->
       # if id is undefined, render as loading. loadableItem is waiting for id to be retrieved.
       return true unless id?
 

--- a/src/flux/plan-publish.coffee
+++ b/src/flux/plan-publish.coffee
@@ -13,7 +13,7 @@ PlanPublishConfig =
   exports:
     _getIds: getIds
 
-extendConfig(PlanPublishConfig, new JobListenerConfig(2000, 100))
+extendConfig(PlanPublishConfig, new JobListenerConfig(2000, 200))
 
 PlanPublishConfig.exports.isPublishing = PlanPublishConfig.exports.isProgressing
 PlanPublishConfig.exports.isPublished = PlanPublishConfig.exports.isSucceeded

--- a/src/flux/teacher-task-plan.coffee
+++ b/src/flux/teacher-task-plan.coffee
@@ -3,10 +3,11 @@ _ = require 'underscore'
 {TaskPlanStore} = require './task-plan'
 
 TeacherTaskPlanConfig =
+  _ranges: {}
 
   # The load returns a JSON containing `{total_count: 0, items: [...]}`.
   # Unwrap the JSON and store the items.
-  _loaded: (obj, id) ->
+  _loaded: (obj, id, startAt, endAt) ->
     {plans} = obj
 
     @_local[id] ?= []
@@ -20,7 +21,12 @@ TeacherTaskPlanConfig =
       else
         @_local[id].push(plan)
 
+    @_ranges[id] ?= {}
+    @_ranges[id]["#{startAt}-#{endAt}"] = true
     @_local[id]
+
+  _reset: ->
+    @_ranges = {}
 
   exports:
     getPlanId: (courseId, planId) ->
@@ -32,6 +38,8 @@ TeacherTaskPlanConfig =
       _.filter plans, (plan) ->
         not TaskPlanStore.isDeleteRequested(plan.id)
 
+    isLoadingRange: (id, startAt, endAt) ->
+      not @_ranges[id]?["#{startAt}-#{endAt}"]
 
 extendConfig(TeacherTaskPlanConfig, new CrudConfig())
 {actions, store} = makeSimpleStore(TeacherTaskPlanConfig)


### PR DESCRIPTION
Includes
* extend plan publish status checking
* make is loading or load range specific for calendar so that load calendar can show for each new month range being loaded
  * for you, @Dantemss, this will add the month to month loading effect where appropo.
- [ ] ~~plan publishing and weird month switching messed up plan status bug on calendar~~