### PR TITLE
Fixes Loadable indicator so it re-renders less often (formerly "hey...so...")

### DIFF
--- a/src/components/course-calendar/plan-details.cjsx
+++ b/src/components/course-calendar/plan-details.cjsx
@@ -8,7 +8,6 @@ Router = require 'react-router'
 {EventModalShell} = require '../plan-stats/event'
 {TaskPlanStore} = require '../../flux/task-plan'
 
-LoadableItem = require '../loadable-item'
 LmsInfo = require '../task-plan/lms-info'
 
 # TODO drag and drop, and resize behavior

--- a/src/components/loadable-item.cjsx
+++ b/src/components/loadable-item.cjsx
@@ -28,57 +28,75 @@ module.exports = React.createClass
   getDefaultProps: ->
     bindEvent: 'change'
 
-  componentDidMount: -> @reload({})
-  componentDidUpdate: (oldProps) -> @reload(oldProps)
+  componentWillMount: ->
+    {id, store, options} = @props
+    @load(id, options) if id? and not store.isNew(id, options)
 
-  reload: (oldProps) ->
-    {id, store, load, actions, options} = @props
+  componentWillReceiveProps: (nextProps) ->
+    @reload(@props, nextProps)
+
+  arePropsSame: (prevProps, nextProps) ->
+    {id, store, load, actions, options} = nextProps
+
+    prevProps.id is id and
+      prevProps.store is store and
+      prevProps.actions is actions and
+      prevProps.load is load and
+      _.isEqual(prevProps.options, options)
+
+  reload: (prevProps, nextProps) ->
+    {id, store, load, actions, options} = nextProps
     return unless id?
 
     # Skip reloading if all the props are the same (the case in the Calendar for some reason)
-    return if oldProps.id is id and oldProps.store is store and oldProps.actions is actions and
-      oldProps.load is load and _.isEqual(oldProps.options, options)
+    return if @arePropsSame(prevProps, nextProps)
+    @load(id, options) unless store.isNew(id, options)
 
+  load: (args...) ->
+    {load, actions} = @props
     load ?= actions.load
-    unless store.isNew(id, options)
-      load(id, options)
+    load(args...)
+
+  isLoaded: (args...) ->
+    {isLoaded, store} = @props
+    isLoaded ?= store.isLoaded
+    isLoaded(args...)
+
+  isLoading: (args...) ->
+    {isLoading, store} = @props
+    isLoading ?= store.isLoading
+    isLoading(args...)
+
+  isLoadingOrLoad: ->
+    {id, options, saved, store} = @props
+
+    # if id is undefined, render as loading. loadableItem is waiting for id to be retrieved.
+    return true unless id?
+
+    if store.get(id, options)
+      false
+    else if @isLoading(id, options)
+      true
+    else if @isLoaded(id, options)
+      false
+    else if store.isUnknown(id, options) or store.reload(id, options)
+      true
+    else if store.isNew(id, options) and store.get(id, options).id and saved
+      # If this store was just created, then call the onSaved prop
+      saved()
+    else
+      false
 
   render: ->
-    { id, store, actions, load, isLoaded, isLoading, isLoadingOrLoad, renderItem,
-      saved, renderLoading, renderError, renderBug, update, options, bindEvent} = @props
+    { id, isLoadingOrLoad, renderItem, store} = @props
 
-    load ?= actions.load
-    isLoaded ?= store.isLoaded
-    isLoading ?= store.isLoading
-
-    isLoadingOrLoad ?= ->
-      # if id is undefined, render as loading. loadableItem is waiting for id to be retrieved.
-      return true unless id?
-
-      if store.get(id, options)
-        false
-      else if isLoading(id, options)
-        true
-      else if isLoaded(id, options)
-        false
-      else if store.isUnknown(id, options) or store.reload(id, options)
-        true
-      else if store.isNew(id, options) and store.get(id, options).id and saved
-        # If this store was just created, then call the onSaved prop
-        saved()
-      else
-        false
-
-    renderModes = {renderLoading, renderError, renderBug}
+    propsForLoadable = _.pick(@props, 'store', 'update', 'bindEvent', 'renderLoading', 'renderError')
+    isLoadingOrLoad ?= @isLoadingOrLoad
 
     <Loadable
-      store={store}
+      {...propsForLoadable}
       isLoading={isLoadingOrLoad}
-      isLoaded={-> isLoaded(id)}
-      isFailed={-> store.isFailed(id)}
+      isLoaded={_.partial(@isLoaded, id)}
+      isFailed={_.partial(store.isFailed, id)}
       render={renderItem}
-      renderLoading={renderLoading}
-      update={update}
-      bindEvent={bindEvent}
-      {renderModes}
     />

--- a/src/components/loadable.cjsx
+++ b/src/components/loadable.cjsx
@@ -14,7 +14,6 @@ module.exports = React.createClass
   displayName: 'Loadable'
   propTypes:
     render: React.PropTypes.func.isRequired
-    saved: React.PropTypes.func
     store: React.PropTypes.object.isRequired
     isLoading: React.PropTypes.func.isRequired
     isLoaded: React.PropTypes.func.isRequired

--- a/src/components/media-preview.cjsx
+++ b/src/components/media-preview.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-LoadableItem = require './loadable-item'
 TutorPopover = require './tutor-popover'
 {ArbitraryHtmlAndMath} = require 'openstax-react-components'
 

--- a/src/components/qa/index.cjsx
+++ b/src/components/qa/index.cjsx
@@ -2,7 +2,6 @@ React = require 'react'
 {RouteHandler} = require 'react-router'
 
 {EcosystemsStore, EcosystemsActions} = require '../../flux/ecosystems'
-LoadableItem = require '../loadable-item'
 
 BindStore = require '../bind-store-mixin'
 BookLink  = require './book-link'

--- a/src/components/task/viewing-as-student-name.cjsx
+++ b/src/components/task/viewing-as-student-name.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-LoadableItem = require '../loadable-item'
 Name = require '../name'
 {ScoresStore, ScoresActions} = require '../../flux/scores'
 


### PR DESCRIPTION
loadable item was triggering load AFTER `componentDidUpdate` and then only triggering a load when certain props had been loaded.  it seems like this trigger should happen sooner -- i.e. right when the component will receive the props.  this change should make things feel snappier and also decrease extra re-renderings due to first rendering since props updated and then rendering again once the store is loaded and emits a change

there are also stylistic updates -- putting methods on `@` and using `_.partial` from common practices that have developed since this was first written

![](https://media.giphy.com/media/caRq9KaC8PFQs/giphy.gif)

_Hey, we release soon,
so this is crazy.
But here's this pr.
So merge it, maybe?_