### PR TITLE
Fix for pages trying to render before loaded

### DIFF
--- a/src/components/reference-book/page-shell.cjsx
+++ b/src/components/reference-book/page-shell.cjsx
@@ -12,19 +12,13 @@ ReferenceBookPageShell = React.createClass
   propTypes:
     cnxId: React.PropTypes.string.isRequired
 
-  getDefaultState: ->
-    previousPageProps: null
+  isAnotherPage: (currentProps) ->
+    @lastLoadedProps? and @lastLoadedProps.cnxId? and @lastLoadedProps.cnxId != currentProps.cnxId
 
-  componentWillReceiveProps: (nextProps) ->
-    @setState(previousPageProps: @props)
-
-  isAnotherPage: (previousPageProps, currentProps) ->
-    previousPageProps? and previousPageProps.cnxId? and not _.isEqual(previousPageProps, currentProps)
-
-  renderLoading: (previousPageProps, currentProps, refreshButton) ->
-    if @isAnotherPage(previousPageProps, currentProps)
+  renderLoading: (currentProps, refreshButton) ->
+    if @isAnotherPage(currentProps)
       loading = <ReferenceBookPage
-        {...previousPageProps}
+        {...@lastLoadedProps}
         className='page-loading loadable is-loading'>
         {refreshButton}
       </ReferenceBookPage>
@@ -34,6 +28,8 @@ ReferenceBookPageShell = React.createClass
     loading
 
   renderLoaded: ->
+    # Keep track of the last page that is actually loaded because we'll render it under the loading overlay
+    @lastLoadedProps = @props
     <ReferenceBookPage {...@props}/>
 
   render: ->
@@ -42,7 +38,7 @@ ReferenceBookPageShell = React.createClass
         id={@props.cnxId}
         store={ReferenceBookPageStore}
         actions={ReferenceBookPageActions}
-        renderLoading={_.partial(@renderLoading, @state?.previousPageProps, @props)}
+        renderLoading={_.partial(@renderLoading, @props)}
         renderItem={@renderLoaded}
       />
     else

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -6,10 +6,11 @@ classnames = require 'classnames'
 
 {BookContentMixin} = require '../book-content-mixin'
 {ArbitraryHtmlAndMath, GetPositionMixin} = require 'openstax-react-components'
+LoadableItem = require '../loadable-item'
 
 {ReferenceBookExerciseShell} = require './exercise'
 
-{ReferenceBookPageStore} = require '../../flux/reference-book-page'
+{ReferenceBookPageActions, ReferenceBookPageStore} = require '../../flux/reference-book-page'
 {ReferenceBookStore} = require '../../flux/reference-book'
 {ReferenceBookExerciseActions, ReferenceBookExerciseStore} = require '../../flux/reference-book-exercise'
 
@@ -52,7 +53,7 @@ module.exports = React.createClass
     exerciseNode = link.parentNode.parentNode
     React.render(<ReferenceBookExerciseShell exerciseAPIUrl={exerciseAPIUrl}/>, exerciseNode) if exerciseNode?
 
-  render: ->
+  renderPage: ->
     {courseId, cnxId, ecosystemId} = @props
     # read the id from props, or failing that the url
     page = ReferenceBookPageStore.get(cnxId)
@@ -74,3 +75,12 @@ module.exports = React.createClass
       </SpyMode.Content>
 
     </div>
+
+  render: ->
+    {cnxId} = @props
+
+    <LoadableItem
+      id={cnxId}
+      store={ReferenceBookPageStore}
+      actions={ReferenceBookPageActions}
+      renderItem={@renderPage} />

--- a/src/components/reference-book/page.cjsx
+++ b/src/components/reference-book/page.cjsx
@@ -6,11 +6,10 @@ classnames = require 'classnames'
 
 {BookContentMixin} = require '../book-content-mixin'
 {ArbitraryHtmlAndMath, GetPositionMixin} = require 'openstax-react-components'
-LoadableItem = require '../loadable-item'
 
 {ReferenceBookExerciseShell} = require './exercise'
 
-{ReferenceBookPageActions, ReferenceBookPageStore} = require '../../flux/reference-book-page'
+{ReferenceBookPageStore} = require '../../flux/reference-book-page'
 {ReferenceBookStore} = require '../../flux/reference-book'
 {ReferenceBookExerciseActions, ReferenceBookExerciseStore} = require '../../flux/reference-book-exercise'
 
@@ -53,12 +52,12 @@ module.exports = React.createClass
     exerciseNode = link.parentNode.parentNode
     React.render(<ReferenceBookExerciseShell exerciseAPIUrl={exerciseAPIUrl}/>, exerciseNode) if exerciseNode?
 
-  renderPage: ->
+  render: ->
     {courseId, cnxId, ecosystemId} = @props
     # read the id from props, or failing that the url
     page = ReferenceBookPageStore.get(cnxId)
 
-    html = page.content_html
+    html = page?.content_html or ''
     # FIXME the BE sends HTML with head and body
     # Fixing it with nasty regex for now
     html = html
@@ -71,16 +70,7 @@ module.exports = React.createClass
       <ArbitraryHtmlAndMath className='page center-panel' block html={html} />
 
       <SpyMode.Content className="ecosystem-info">
-        PageId: {@props.cnxId}, Ecosystem: {page.spy}
+        PageId: {@props.cnxId}, Ecosystem: {page?.spy}
       </SpyMode.Content>
 
     </div>
-
-  render: ->
-    {cnxId} = @props
-
-    <LoadableItem
-      id={cnxId}
-      store={ReferenceBookPageStore}
-      actions={ReferenceBookPageActions}
-      renderItem={@renderPage} />


### PR DESCRIPTION
Made `ReferenceBookPage` use `LoadableItem` so it wouldn't try to render them before they were loaded.  For a partial history of the investigation, see https://www.pivotaltracker.com/n/projects/1156756/stories/121528127