### PR TITLE
change label from "Average" to "Percent Complete" on teacher review

### DIFF
--- a/resources/styles/components/icon.less
+++ b/resources/styles/components/icon.less
@@ -1,0 +1,3 @@
+.tutor-icon {
+  &.clickable { cursor: pointer; }
+}

--- a/resources/styles/components/task-plan/reading-stats.less
+++ b/resources/styles/components/task-plan/reading-stats.less
@@ -142,6 +142,11 @@
 .data-container {
   text-align: center;
   margin-bottom: 1.75rem;
+  .stats {
+    display: flex;
+    align-items: flex-end;
+    .stat { padding: 0; }
+  }
 
   &.container {
     width: 100%;
@@ -149,8 +154,8 @@
 
   label {
     font-weight: 300;
-    margin: 0;
-    line-height: 2.5rem;
+    margin: 0 0 10px 0;
+    line-height: 1.8rem;
     display: block;
   }
 

--- a/resources/styles/tutor.less
+++ b/resources/styles/tutor.less
@@ -62,6 +62,7 @@
 @import './components/tri-state-checkbox';
 @import './components/exercise-preview';
 @import './components/assignment-links';
+@import './components/icon';
 
 body[data-js-error]::before {
   content: attr(data-js-error);

--- a/src/components/icon.cjsx
+++ b/src/components/icon.cjsx
@@ -24,6 +24,7 @@ module.exports = React.createClass
   render: ->
     classNames = classnames('tutor-icon', 'fa', "fa-#{@props.type}", @props.className, {
       'fa-spin': @props.spin
+      'clickable': @props.tooltip and @props.tooltipProps.trigger is 'click'
     })
 
     icon = <i {...@props} className={classNames} />

--- a/src/components/plan-stats/course-bar.cjsx
+++ b/src/components/plan-stats/course-bar.cjsx
@@ -2,6 +2,8 @@ React = require 'react'
 _ = require 'underscore'
 BS = require 'react-bootstrap'
 
+Icon = require '../icon'
+
 CourseBar = React.createClass
   displayName: 'CourseBar'
   propTypes:
@@ -10,6 +12,22 @@ CourseBar = React.createClass
     totalCols: React.PropTypes.number
   getDefaultProps: ->
     totalCols: 12
+
+  getCorrectLabel: (data) ->
+    tooltipMsg = '''
+      Percent correct out of total attempted.
+      This score does not take unanswered questions into account,
+      so it may differ from the average you see in Student Scores.
+    '''
+    icon =
+      <Icon type='info-circle' tooltip={tooltipMsg}
+        tooltipProps={placement: 'top', trigger: 'click'}
+      />
+    label =
+      <span>
+        Percent Correct {icon}
+      </span>
+    { label, type: 'average', value: "#{data.mean_grade_percent}%" }
 
   getStats: ->
     {data, type} = @props
@@ -47,16 +65,12 @@ CourseBar = React.createClass
       }]
 
     if type is 'homework' and data.mean_grade_percent
-      stats.unshift(
-        type: 'average'
-        label: 'Average'
-        value: "#{data.mean_grade_percent}%"
-      )
+      stats.unshift(@getCorrectLabel(data))
 
     stats
 
   renderCourseStat: (stat, cols = 4) ->
-    key = "reading-stats-#{stat.type}"
+    key = "stat #{stat.type}"
     <BS.Col xs={cols} className={key} key={key}>
       <label>{stat.label}</label>
       <div className = "data-container-value text-#{stat.type}">
@@ -72,7 +86,7 @@ CourseBar = React.createClass
     statsColumns = _.map stats, _.partial(@renderCourseStat, _, cols)
 
     <BS.Grid className='data-container' key='course-bar'>
-      <BS.Row>
+      <BS.Row className='stats'>
         {statsColumns}
       </BS.Row>
     </BS.Grid>


### PR DESCRIPTION
Since average isn't really what it's calculating and it didn't match student scores.  Adds a info icon with additional explanation.

Quick metrics:
![screen shot 2016-07-05 at 2 04 56 pm](https://cloud.githubusercontent.com/assets/79566/16596421/7c0a05e0-42b9-11e6-96be-aa1e780ebc65.png)


full metrics version:
![screen shot 2016-07-05 at 2 05 41 pm](https://cloud.githubusercontent.com/assets/79566/16596449/98764568-42b9-11e6-8495-2222f74981d3.png)
