### PR TITLE
Load section title only for current ecosystem

### DIFF
--- a/api/ecosystems/1/readings.json
+++ b/api/ecosystems/1/readings.json
@@ -14,21 +14,23 @@
           "chapter_section": [1, 1],
           "id": "234",
           "cnx_id": "0e58aa87-2e09-40a7-8bf3-269b2fa16509",
-          "uuid": "d52e93f4-8653-4273-86da-3850001c0786"
+          "uuid": "0e58aa87-2e09-40a7-8bf3-269b2fa16509"
         },
         {
           "type": "page",
           "title": "Kinematics in 2 dim",
           "chapter_section": [1, 2],
           "id": "235",
-          "cnx_id": "0e58aa87-2e09-40a7-8bf3-269b2fa16510"
+          "cnx_id": "0e58aa87-2e09-40a7-8bf3-269b2fa16510",
+          "uuid": "0e58aa87-2e09-40a7-8bf3-269b2fa16510"
         },
         {
           "type": "page",
           "title": "Kinematics in 3 dim",
           "chapter_section": [1, 3],
           "id": "236",
-          "cnx_id": "0e58aa87-2e09-40a7-8bf3-269b2fa16511"
+          "cnx_id": "0e58aa87-2e09-40a7-8bf3-269b2fa16511",
+          "uuid": "0e58aa87-2e09-40a7-8bf3-269b2fa16510"
         }
       ]
     },
@@ -41,19 +43,25 @@
           "type": "page",
           "title": "Mechanics in 1 dim",
           "chapter_section": [2, 1],
-          "id": "237"
+          "id": "237",
+          "cnx_id": "1e58aa87-2e09-40a7-8bf3-269b2fa16511",
+          "uuid": "1e58aa87-2e09-40a7-8bf3-269b2fa16510"
         },
         {
           "type": "page",
           "title": "Mechanics in 2 dim",
           "chapter_section": [2, 2],
-          "id": "238"
+          "id": "238",
+          "cnx_id": "2e58aa87-2e09-40a7-8bf3-269b2fa16511",
+          "uuid": "2e58aa87-2e09-40a7-8bf3-269b2fa16510"
         },
         {
           "type": "page",
           "title": "Mechanics in 3 dim",
           "chapter_section": [2, 3],
-          "id": "239"
+          "id": "239",
+          "cnx_id": "3e58aa87-2e09-40a7-8bf3-269b2fa16511",
+          "uuid": "3e58aa87-2e09-40a7-8bf3-269b2fa16510"
         }
       ]
     },
@@ -66,19 +74,25 @@
           "type": "page",
           "title": "Thermodynamics in 1 dim",
           "chapter_section": [3, 1],
-          "id": "240"
+          "id": "240",
+          "cnx_id": "4e58aa87-2e09-40a7-8bf3-269b2fa16511",
+          "uuid": "4e58aa87-2e09-40a7-8bf3-269b2fa16510"
         },
         {
           "type": "page",
           "title": "Thermodynamics in 2 dim",
           "chapter_section": [3, 2],
-          "id": "241"
+          "id": "241",
+          "cnx_id": "5e58aa87-2e09-40a7-8bf3-269b2fa16511",
+          "uuid": "5e58aa87-2e09-40a7-8bf3-269b2fa16510"
         },
         {
           "type": "page",
           "title": "Thermodynamics in 3 dim",
           "chapter_section": [3, 2],
-          "id": "242"
+          "id": "242",
+          "cnx_id": "6e58aa87-2e09-40a7-8bf3-269b2fa16511",
+          "uuid": "6e58aa87-2e09-40a7-8bf3-269b2fa16510"
         }
       ]
     }]

--- a/api/ecosystems/1/readings.json
+++ b/api/ecosystems/1/readings.json
@@ -30,7 +30,7 @@
           "chapter_section": [1, 3],
           "id": "236",
           "cnx_id": "0e58aa87-2e09-40a7-8bf3-269b2fa16511",
-          "uuid": "0e58aa87-2e09-40a7-8bf3-269b2fa16510"
+          "uuid": "0e58aa87-2e09-40a7-8bf3-269b2fa16511"
         }
       ]
     },

--- a/api/exercises.json
+++ b/api/exercises.json
@@ -82,10 +82,10 @@
             "description": "(3D): Explain the impacts of the scientific contributions of a variety of historical and contemporary scientists on scientific thought and society.",
             "chapter_section": [1, 1]
         },{
-            "id": "context-cnxmod:d52e93f4-8653-4273-86da-3850001c0786",
+            "id": "context-cnxmod:0e58aa87-2e09-40a7-8bf3-269b2fa16509",
             "type": "cnxmod",
             "is_visible": false,
-            "data": "d52e93f4-8653-4273-86da-3850001c0786"
+            "data": "0e58aa87-2e09-40a7-8bf3-269b2fa16509"
         },{
             "id": "context-cnxmod:185cbf87-c72e-48f5-b51e-f14f21b5eabd",
             "type": "cnxmod",

--- a/src/components/exercises/cards.cjsx
+++ b/src/components/exercises/cards.cjsx
@@ -17,6 +17,7 @@ ExercisePreview = require './preview'
 SectionsExercises = React.createClass
 
   propTypes:
+    ecosystemId:            React.PropTypes.string.isRequired
     exercises:              React.PropTypes.array.isRequired
     chapter_section:        React.PropTypes.string.isRequired
     onShowDetailsViewClick: React.PropTypes.func.isRequired
@@ -25,7 +26,8 @@ SectionsExercises = React.createClass
     getExerciseActions:     React.PropTypes.func.isRequired
 
   render: ->
-    title = TocStore.getSectionLabel(@props.chapter_section)?.title
+    title = TocStore.findChapterSection(@props.ecosystemId, @props.chapter_section)?.title
+
     # IMPORTANT: the 'data-section' attribute is used as a scroll-to target and must be present
     <div className='exercise-sections' data-section={@props.chapter_section}>
       <label className='exercises-section-label'>
@@ -33,7 +35,7 @@ SectionsExercises = React.createClass
       </label>
       <div className="exercises">
         {for exercise in @props.exercises
-          <ExercisePreview {...@props} exercise={exercise} />}
+          <ExercisePreview key={exercise.id} {...@props} exercise={exercise} />}
       </div>
     </div>
 
@@ -42,6 +44,7 @@ SectionsExercises = React.createClass
 ExerciseCards = React.createClass
 
   propTypes:
+    ecosystemId:            React.PropTypes.string.isRequired
     exercises:              React.PropTypes.object.isRequired
     onExerciseToggle:       React.PropTypes.func.isRequired
     getExerciseIsSelected:  React.PropTypes.func.isRequired

--- a/src/components/task-plan/homework/add-exercises.cjsx
+++ b/src/components/task-plan/homework/add-exercises.cjsx
@@ -88,8 +88,9 @@ AddExercises = React.createClass
 
   render: ->
     return @renderLoading() if @exercisesAreLoading()
+    ecosystemId = CourseStore.get(@props.courseId)?.ecosystem_id
     exercises = ExerciseStore.groupBySectionsAndTypes(
-      CourseStore.get(@props.courseId)?.ecosystem_id, @props.sectionIds
+      ecosystemId, @props.sectionIds
     )
     sharedProps =
         exercises: exercises.all
@@ -111,6 +112,7 @@ AddExercises = React.createClass
       else
         <ExerciseCards
           {...sharedProps}
+          ecosystemId={ecosystemId}
           watchStore={TaskPlanStore}
           watchEvent='change-exercise-'
           topScrollOffset={110}

--- a/src/flux/exercise.coffee
+++ b/src/flux/exercise.coffee
@@ -16,7 +16,7 @@ EXERCISE_TAGS =
 
 getChapterSection = (ecosystemId, exercise) ->
   for tag in exercise.tags when tag.type is 'cnxmod'
-    section = TocStore.findWhere(ecosystemId, uuid: tag.data)
+    section = TocStore.getByUuid(ecosystemId, tag.data)
     return section.chapter_section.join('.') if section?
   '' # return empty string if section wasn't found
 

--- a/src/flux/toc.coffee
+++ b/src/flux/toc.coffee
@@ -15,29 +15,34 @@ TocConfig =
 
   _loaded: (obj, id) ->
     chapters = obj[0].children
-    @_ecosystems[id] = {}
+    map = @_ecosystems[id] = {
+      all: []
+      uuid: {}
+    }
+
     # Load all the section id's for easy lookup later.
     # They are globally unique so we do not have to worry about the ecosystemId.
     for chap in chapters
       for section in chap.children
-        @_ecosystems[id][section.uuid] = section
+        map.all.push map.uuid[section.uuid] = section
         @_sections[section.id] = section
     chapters
 
   exports:
     findWhere: (ecosystemId, query) ->
-      _.findWhere(@_ecosystems[ecosystemId], query)
+      _.findWhere(@_ecosystems[ecosystemId]?.all, query)
 
-    getChapterSection: (sectionId) ->
-      @_sections[sectionId]?.chapter_section or throw new Error('BUG: Invalid section')
+    getByUuid: (ecosystemId, uuid) ->
+      @_ecosystems[ecosystemId]?.uuid[uuid]
+
+    findChapterSection: (ecosystemId, chapter_section) ->
+      _.find(@_ecosystems[ecosystemId]?.all, (section) ->
+        section.chapter_section.join('.') is chapter_section
+      )
 
     getSectionInfo: (sectionId) ->
       @_sections[sectionId] or throw new Error('BUG: Invalid section')
 
-    getSectionLabel: (key) ->
-      _.find(@_sections, (section) ->
-        section.chapter_section.join('.') is key
-      )
 
 extendConfig(TocConfig, new CrudConfig())
 {actions, store} = makeSimpleStore(TocConfig)

--- a/test/components/course-calendar/plan.spec.cjsx
+++ b/test/components/course-calendar/plan.spec.cjsx
@@ -405,7 +405,7 @@ describe 'Plan on Course Calendar', ->
 
         checker = _.partial(checkChildrenComponents, element.refs.plan, item, checksIsPublished)
         PlanPublishStore.on("progress.#{item.plan.id}.*", checker)
-  
+
         fakePublished(item.plan)
 
   it 'should check for publishing subscribe if plan isPublishing props update', ->

--- a/test/flux/exercise.spec.coffee
+++ b/test/flux/exercise.spec.coffee
@@ -57,8 +57,6 @@ describe 'exercises store', ->
 
   it 'can get teks tag name', ->
     exercise = EXERCISES.items[0]
-
     teksTag = findTagByType(exercise, 'teks')
     teks = ExerciseStore.getTeksString(exercise.id)
-
     expect(teksTag.name.indexOf(teks)).to.not.equal(-1)

--- a/test/flux/toc.spec.coffee
+++ b/test/flux/toc.spec.coffee
@@ -1,0 +1,26 @@
+{expect} = require 'chai'
+
+_ = require 'underscore'
+
+
+{TocActions, TocStore} = require '../../src/flux/toc'
+
+READINGS  = require '../../api/ecosystems/1/readings.json'
+ECOSYSTEM_ID = 1
+
+
+describe 'TOC store', ->
+
+  beforeEach (done) ->
+    TocActions.loaded(READINGS, ECOSYSTEM_ID)
+    done()
+
+  it 'can find by querying things', ->
+    expect(TocStore.findWhere(ECOSYSTEM_ID, cnx_id: '0e58aa87-2e09-40a7-8bf3-269b2fa16509').id).to.equal('234')
+    expect(TocStore.findWhere(ECOSYSTEM_ID, {"title": "Kinematics in 2 dim"}).id).to.equal('235')
+
+  it 'can find by uuid', ->
+    expect(TocStore.getByUuid(ECOSYSTEM_ID, '0e58aa87-2e09-40a7-8bf3-269b2fa16509').id).to.equal('234')
+
+  it 'searches by ChapterSection', ->
+    expect( TocStore.findChapterSection(ECOSYSTEM_ID, '1.3').id ).to.equal('236')

--- a/test/flux/toc.spec.coffee
+++ b/test/flux/toc.spec.coffee
@@ -16,7 +16,7 @@ describe 'TOC store', ->
     done()
 
   it 'can find by querying things', ->
-    expect(TocStore.findWhere(ECOSYSTEM_ID, cnx_id: '0e58aa87-2e09-40a7-8bf3-269b2fa16509').id).to.equal('234')
+    expect(TocStore.findWhere(ECOSYSTEM_ID, cnx_id: '0e58aa87-2e09-40a7-8bf3-269b2fa16510').id).to.equal('235')
     expect(TocStore.findWhere(ECOSYSTEM_ID, {"title": "Kinematics in 2 dim"}).id).to.equal('235')
 
   it 'can find by uuid', ->


### PR DESCRIPTION
If the TOC store had multiple ecosystems, the first match would be returned for a given chapter_section.  

This would mean that sometimes the incorrect books section titles were displayed in QL/HW Builder if the teacher switched courses.
