### PR TITLE
References Drop Cap Styles

### DIFF
--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -42,6 +42,7 @@ ul {
   }
 }
 
+// References should not get drop-cap styling
 section:not(.references) h1 + p:first-of-type,
 div[data-type="document-title"] ~ p:first-of-type {
   .tutor-reading-first-letter();

--- a/resources/styles/book-content/base.less
+++ b/resources/styles/book-content/base.less
@@ -42,7 +42,7 @@ ul {
   }
 }
 
-section h1 + p:first-of-type,
+section:not(.references) h1 + p:first-of-type,
 div[data-type="document-title"] ~ p:first-of-type {
   .tutor-reading-first-letter();
 }


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/121865049

Regular drop caps should still work:
![screen shot 2016-07-06 at 10 43 16 pm](https://cloud.githubusercontent.com/assets/6434717/16641129/a5c3c110-43cb-11e6-8dc9-5759542dd49e.png)

References drop caps aren't there anymore:
![screen shot 2016-07-06 at 10 43 03 pm](https://cloud.githubusercontent.com/assets/6434717/16641130/a73b7d12-43cb-11e6-9342-5527ac006abe.png)
