### PR TITLE
Question Library Scroll

### DIFF
--- a/src/components/exercises/sectionizer.cjsx
+++ b/src/components/exercises/sectionizer.cjsx
@@ -32,7 +32,7 @@ Sectionizer = React.createClass
 
   # the below properties are read by the ScrollTo mixin
   scrollingTargetDOM: -> window.document
-  getScrollTopOffset: -> 80 # 70px high control bar and a bit of padding
+  getScrollTopOffset: -> 160 # 70px high control bar and a bit of padding
 
   componentDidMount: ->
     @calculateAvailableSpace(@state.windowEl or @_getWindowSize())


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/122202725

Fix for chapter section label being obscured when scrolling up.  I doubled the scroll top offset, because when scrolling up, both pinned headers show up.  See gif below:
![question-library-scroll](https://cloud.githubusercontent.com/assets/6434717/16641259/c84f42da-43cc-11e6-9819-c3e7357f1569.gif)
