### PR TITLE
Fix iframe display when wrapped by embed-responsive

### DIFF
--- a/resources/styles/book-content/note.less
+++ b/resources/styles/book-content/note.less
@@ -13,7 +13,9 @@
     }
   }
 
-  :last-child {
+
+  // padding-bottom breaks embed responsive rules
+  :last-child:not(.embed-responsive){
     padding-bottom: 0;
   }
 

--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -7,7 +7,10 @@
     border: none;
     margin: auto;
   }
-
+  .embed-responsive > iframe {
+    width: 100%;
+    height: 100%;
+  }
   .spacer-step {
     padding: @tutor-card-body-padding;
   }


### PR DESCRIPTION
the bootstrap responsive-embed class was broken when it was the last-child by the explicit setting of padding-bottom, and then the iframe wasn't sized properly to fit

Before the video was invisible, after it's:

![screen shot 2016-07-07 at 1 49 51 pm](https://cloud.githubusercontent.com/assets/79566/16665557/b3f5405a-4449-11e6-825d-605040f0b72d.png)
