### PR TITLE
Course Settings - fix CC Roster not showing students

### DIFF
--- a/src/components/course-settings/period-roster.cjsx
+++ b/src/components/course-settings/period-roster.cjsx
@@ -29,7 +29,7 @@ module.exports = React.createClass
     </tr>
 
   isPeriodEmpty: ->
-    id = @props.activeTab.id
+    id = @props.period.id
     students = RosterStore.getActiveStudentsForPeriod(@props.courseId, id)
     students.length is 0
 


### PR DESCRIPTION
isPeriodEmpty now uses period.id instead of activeTab.id