### PR TITLE
Moving redirect logic for concept coach students

### DIFF
--- a/src/components/course-listing.cjsx
+++ b/src/components/course-listing.cjsx
@@ -14,17 +14,14 @@ CourseDataMixin = require './course-data-mixin'
 DisplayOrRedirect = (transition, callback) ->
   courses = CourseListingStore.allCourses() or []
   [course] = courses
-  if courses.length is 1 and course.roles?.length is 1
+  if courses.length is 1
     roleType = courses[0].roles[0].type
     conceptCoach = courses[0].is_concept_coach
 
-    if roleType is 'student'
-      if conceptCoach and course.webview_url
-        WindowHelpers.replaceBrowserLocation(course.webview_url)
-      else
-        view = 'viewStudentDashboard'
-    else if roleType is 'teacher'
+    if roleType is 'teacher'
       view = if conceptCoach then 'cc-dashboard' else 'taskplans'
+    else if roleType is 'student'
+      view = 'viewStudentDashboard'
     else
       throw new Error("BUG: Unrecognized role type #{roleType}")
 

--- a/src/components/student-dashboard/index.cjsx
+++ b/src/components/student-dashboard/index.cjsx
@@ -1,15 +1,23 @@
 React = require 'react'
-
+{CourseStore} = require '../../flux/course'
 {StudentDashboardStore, StudentDashboardActions} = require '../../flux/student-dashboard'
 LoadableItem = require '../loadable-item'
 isStepComplete = (step) -> step.is_completed
 StudentDashboard = require './dashboard'
+WindowHelpers = require '../../helpers/window'
 
 StudentDashboardShell = React.createClass
   displayName: 'StudentDashboardShell'
 
   contextTypes:
     router: React.PropTypes.func
+
+  componentWillMount: ->
+    {courseId} = @context.router.getCurrentParams()
+    {is_concept_coach, webview_url} = CourseStore.get(courseId)
+
+    if is_concept_coach and webview_url
+      WindowHelpers.replaceBrowserLocation(webview_url)
 
   render: ->
     {courseId} = @context.router.getCurrentParams()

--- a/test/components/course-listing.spec.coffee
+++ b/test/components/course-listing.spec.coffee
@@ -61,18 +61,18 @@ describe 'Course Listing Component', ->
     renderListing().then (state) ->
       expect(state.div.querySelector(".refresh-button")).not.to.be.null
 
-  it 'redirects to student dashboard', ->
-    CourseListingActions.loaded([STUDENT_COURSE_ONE_MODEL])
-    renderListing().then (state) ->
-      expect(state.listing).to.be.undefined # Won't have rendered the listing
-      expect(ReactTestUtils.scryRenderedComponentsWithType(state.component, StudentDashboardShell))
-        .to.have.length(1)
-
   it 'redirects to teacher calendar', ->
     CourseListingActions.loaded([TEACHER_COURSE_TWO_MODEL])
     renderListing().then (state) ->
       expect(state.listing).to.be.undefined # Won't have rendered the listing
       expect(ReactTestUtils.scryRenderedComponentsWithType(state.component, CourseCalendar))
+        .to.have.length(1)
+
+  it 'redirects to student dashboard', ->
+    CourseListingActions.loaded([STUDENT_COURSE_ONE_MODEL])
+    renderListing().then (state) ->
+      expect(state.listing).to.be.undefined # Won't have rendered the listing
+      expect(ReactTestUtils.scryRenderedComponentsWithType(state.component, StudentDashboardShell))
         .to.have.length(1)
 
   it 'renders a "no membership" page when not a member of any courses', ->
@@ -82,22 +82,4 @@ describe 'Course Listing Component', ->
     renderListing().then (state) ->
       expect(state.div.textContent).to.include('We cannot find an OpenStax course associated with your account')
 
-  describe 'redirecting to CC', ->
-    beforeEach ->
-      sinon.stub(WindowHelpers, 'replaceBrowserLocation')
-      @course = _.clone(STUDENT_COURSE_ONE_MODEL)
-      @course.is_concept_coach = true
-      @course.webview_url = 'http://test.com/cc'
 
-    afterEach ->
-      WindowHelpers.replaceBrowserLocation.restore()
-
-    it 'redirects when a member of a single CC course', ->
-      CourseListingActions.loaded([@course])
-      renderListing().then (state) =>
-        expect(WindowHelpers.replaceBrowserLocation.calledWith(@course.webview_url)).to.be.true
-
-    it 'does not redirect if a member of multiple course', ->
-      CourseListingActions.loaded([@course, TEACHER_COURSE_TWO_MODEL])
-      renderListing().then (state) ->
-        expect(WindowHelpers.replaceBrowserLocation.callCount).equal(0)


### PR DESCRIPTION
I don't think there are any UI changes
- [x] Simplify redirect logic in course listing
- [x] Update unit tests