### PR TITLE
Question Context Styling

### DIFF
--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -1,4 +1,5 @@
 @import '~openstax-react-components/resources/styles/components/breadcrumbs/coach';
+@import '../../book-content/note';
 
 .task {
   iframe {
@@ -45,8 +46,14 @@
       font-size: 2rem;
 
       .question-context {
-        // Copied from styles/book-content/index.less
-        .tutor-book-theme-note();
+        // Copied from styles/book-content/note.less
+        background: @tutor-neutral-lightest;
+        border-top: solid 8px @tutor-neutral-lighter;
+        border-bottom: solid 8px @tutor-neutral-lighter;
+        padding: 20px 40px;
+        width: 100%;
+
+        .tutor-book-note-style();
       }
     }
 

--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -43,6 +43,11 @@
 
     .openstax-exercise {
       font-size: 2rem;
+
+      .question-context {
+        // Copied from styles/book-content/index.less
+        .tutor-book-theme-note();
+      }
     }
 
     .exercise-uid {

--- a/resources/styles/components/task-step/ends.less
+++ b/resources/styles/components/task-step/ends.less
@@ -75,7 +75,7 @@
       .exercise-typography();
     }
   }
-  .openstax-question[data-question-number] {
+  .openstax-question .question-stem[data-question-number] {
     position: relative;
     &::before {
       content: attr(data-question-number) ")";


### PR DESCRIPTION
This puts the standard `.note` styling around question-contexts.

It did look like this:
https://www.pivotaltracker.com/file_attachments/65386851/download?inline=true

Whereas it should look like this:
http://jdy18n.axshare.com/#p=hw_student_view_alt_1

What is should look like now:
<img width="869" alt="screen shot 2016-07-12 at 3 08 30 pm" src="https://cloud.githubusercontent.com/assets/7595652/16785374/8dfaa5b4-4842-11e6-9a73-6caaec362c06.png">
