### PR TITLE
Updating role checking on course listing

### DIFF
--- a/src/components/course-listing.cjsx
+++ b/src/components/course-listing.cjsx
@@ -5,6 +5,7 @@ Router = require 'react-router'
 WindowHelpers = require '../helpers/window'
 
 {CourseListingActions, CourseListingStore} = require '../flux/course-listing'
+{CourseStore} = require '../flux/course'
 {RefreshButton} = require 'openstax-react-components'
 EmptyCourses    = require './course-listing/empty'
 CourseDataMixin = require './course-data-mixin'
@@ -15,14 +16,15 @@ DisplayOrRedirect = (transition, callback) ->
   courses = CourseListingStore.allCourses() or []
   [course] = courses
   if courses.length is 1
-    roleType = courses[0].roles[0].type
+    courseId = courses[0].id
     conceptCoach = courses[0].is_concept_coach
 
-    if roleType is 'teacher'
+    if CourseStore.isTeacher(courseId)
       view = if conceptCoach then 'cc-dashboard' else 'taskplans'
-    else if roleType is 'student'
+    else if CourseStore.isStudent(courseId)
       view = 'viewStudentDashboard'
     else
+      roleType = courses[0].roles[0].type
       throw new Error("BUG: Unrecognized role type #{roleType}")
 
     transition.redirect(view, {courseId: _.first(courses).id}) if view

--- a/src/flux/course.coffee
+++ b/src/flux/course.coffee
@@ -129,6 +129,9 @@ CourseConfig =
     isTeacher: (courseId) ->
       !!_.findWhere(@_get(courseId)?.roles, type: 'teacher')
 
+    isStudent: (courseId) ->
+      !!_.findWhere(@_get(courseId)?.roles, type: 'student')
+
     getByEcosystemId: (ecosystemId) ->
       _.findWhere(@_local, ecosystem_id: ecosystemId)
 

--- a/test/components/course-listing.spec.coffee
+++ b/test/components/course-listing.spec.coffee
@@ -61,6 +61,14 @@ describe 'Course Listing Component', ->
     renderListing().then (state) ->
       expect(state.div.querySelector(".refresh-button")).not.to.be.null
 
+  it 'redirects to teacher calendar with multiple course roles', ->
+    CourseListingActions.loaded([TEACHER_AND_STUDENT_COURSE_THREE_MODEL])
+    renderListing().then (state) ->
+      expect(state.listing).to.be.undefined # Won't have rendered the listing
+      expect(ReactTestUtils.scryRenderedComponentsWithType(state.component, CourseCalendar))
+        .to.have.length(1)
+
+
   it 'redirects to teacher calendar', ->
     CourseListingActions.loaded([TEACHER_COURSE_TWO_MODEL])
     renderListing().then (state) ->


### PR DESCRIPTION
We were only checking the first role before, which was causing the error seen here: https://www.pivotaltracker.com/story/show/126045715

Now we check all roles, and give priority to the teacher.