### PR TITLE
Updating drop cap first letter color rule

### DIFF
--- a/resources/styles/book-content/theming-mixins.less
+++ b/resources/styles/book-content/theming-mixins.less
@@ -42,7 +42,7 @@
 }
 
 .tutor-book-theme-first-letter(@letter-color: @tutor-book-secondary) {
- section h1 + p:first-of-type,
+  section:not(.references) h1 + p:first-of-type,
   div[data-type="document-title"] ~ p:first-of-type {
     &::first-letter {
       color: @letter-color;

--- a/resources/styles/book-content/theming-mixins.less
+++ b/resources/styles/book-content/theming-mixins.less
@@ -42,6 +42,7 @@
 }
 
 .tutor-book-theme-first-letter(@letter-color: @tutor-book-secondary) {
+  // References should not get drop-cap styling or color
   section:not(.references) h1 + p:first-of-type,
   div[data-type="document-title"] ~ p:first-of-type {
     &::first-letter {


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/121865049

I missed a color style that should be fixed in this commit:
![screen shot 2016-07-12 at 11 14 20 am](https://cloud.githubusercontent.com/assets/6434717/16774347/9430596a-4829-11e6-95e2-332ec2c4bf50.png)
