### PR TITLE
Fixing more embedded sim styling

### DIFF
--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -36,6 +36,11 @@
       }
     }
 
+    .interactive-content > .note {
+      iframe.interactive {
+        margin-left: -160px;
+      }
+    }
   }
 
   .openstax-exercise-card {


### PR DESCRIPTION
When an interactive iframe is a child of `.interactive-content > .note`, it gets offset by 160px instead of just 120px, because the note adds an extra 40px of padding.  

This was the screenshot from QA: https://www.pivotaltracker.com/file_attachments/66030327/download?inline=true