### PR TITLE
Add check for due time past in the builder

### DIFF
--- a/src/flux/tasking.coffee
+++ b/src/flux/tasking.coffee
@@ -90,6 +90,9 @@ isTaskingValidDate = (tasking) ->
 isProperRange = (tasking) ->
   moment(tasking.due_at).isAfter(tasking.opens_at)
 
+isDueAfterNow = (tasking) ->
+  moment(tasking.due_at).isAfter(TimeStore.getNow())
+
 hasAtLeastOneTasking = (taskings) ->
   not _.chain(taskings)
     .compact()
@@ -101,6 +104,7 @@ ERRORS =
   'INVALID_TIME': 'Please type a time.'
   'DUE_BEFORE_OPEN': 'Due time cannot be before open time.'
   'MISSING_TASKING': 'Please select at least one period'
+  'DUE_AFTER_NOW': 'Due time has already passed'
 
 TASKING_VALIDITY_CHECKS = [{
   check: isTaskingValidTime,
@@ -111,11 +115,14 @@ TASKING_VALIDITY_CHECKS = [{
 }, {
   check: isProperRange,
   errorType: 'DUE_BEFORE_OPEN'
+}, {
+  check: isDueAfterNow,
+  errorType: 'DUE_AFTER_NOW'
 }]
 
 TASK_VALIDITY_CHECKS = [{
   check: hasAtLeastOneTasking
-  errorType: 'MISSING_TASKING'  
+  errorType: 'MISSING_TASKING'
 }]
 
 getErrorsFor = (thingToCheck, {check, errorType}) ->


### PR DESCRIPTION
Pivotal Ticket: https://www.pivotaltracker.com/story/show/126241577

Since we updated the builder to allow same dates for the open date and due date, we weren't checking if the due time was had already passed before.  This PR adds that check, along with an error message, and some unit tests.  

@openstax/ux see screenshot below for error message.  Please let me know if that wording is acceptable.
![screen shot 2016-07-13 at 8 28 16 pm](https://cloud.githubusercontent.com/assets/6434717/16840599/8736af90-49a3-11e6-983f-53c3ddb87432.png)
