### PR TITLE
Details of MPQ UI

### DIFF
--- a/api/courses/1/dashboard.json
+++ b/api/courses/1/dashboard.json
@@ -1,6 +1,16 @@
 {
   "tasks": [
     {
+      "id": "6",
+      "title": "Chapter 6 Homework Before Due, no feedback",
+      "opens_at": "2016-04-02T14:15:58.856Z",
+      "due_at": "2016-04-25T00:45:20.967Z",
+      "type": "homework",
+      "complete": false,
+      "exercise_count": 2,
+      "complete_exercise_count": 0
+    },
+    {
       "id": "4",
       "title": "Chapter 5 and Chapter 6 Reading",
       "opens_at": "2016-04-02T14:15:58.856Z",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime-types": "2.1.7",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
-    "openstax-react-components": "openstax/react-components#dc7a1f5fe5ac4a6ca1ecc2e984b45534fd16c7c3",
+    "openstax-react-components": "openstax/react-components#b61ef0ea6b908fb606fb679119aac3d2dc5313ab",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime-types": "2.1.7",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
-    "openstax-react-components": "openstax/react-components#d-20160715.a",
+    "openstax-react-components": "openstax/react-components#1929602501b7380b08a847351e318da1a6b28971",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime-types": "2.1.7",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
-    "openstax-react-components": "openstax/react-components#1929602501b7380b08a847351e318da1a6b28971",
+    "openstax-react-components": "openstax/react-components#12aaaa89fd327bb9fe5792dd12c5104007f31821",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime-types": "2.1.7",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
-    "openstax-react-components": "openstax/react-components#186772b2043bd238eeaa798212abd621ca66197d",
+    "openstax-react-components": "openstax/react-components#55323a9a2bce6e23983f1099b3401e3ce23fb4c5",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime-types": "2.1.7",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
-    "openstax-react-components": "openstax/react-components#3a56ad7a6e3ea7e84c4375ec7d15809f3899f2b4",
+    "openstax-react-components": "openstax/react-components#dc7a1f5fe5ac4a6ca1ecc2e984b45534fd16c7c3",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime-types": "2.1.7",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
-    "openstax-react-components": "openstax/react-components#55323a9a2bce6e23983f1099b3401e3ce23fb4c5",
+    "openstax-react-components": "openstax/react-components#d-20160726.a",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime-types": "2.1.7",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
-    "openstax-react-components": "openstax/react-components#68aab24023c8327b4a8fbf06b236907dd7a7fd13",
+    "openstax-react-components": "openstax/react-components#3a56ad7a6e3ea7e84c4375ec7d15809f3899f2b4",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime-types": "2.1.7",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
-    "openstax-react-components": "openstax/react-components#b61ef0ea6b908fb606fb679119aac3d2dc5313ab",
+    "openstax-react-components": "openstax/react-components#186772b2043bd238eeaa798212abd621ca66197d",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime-types": "2.1.7",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
-    "openstax-react-components": "openstax/react-components#12aaaa89fd327bb9fe5792dd12c5104007f31821",
+    "openstax-react-components": "openstax/react-components#68aab24023c8327b4a8fbf06b236907dd7a7fd13",
     "pluralize": "1.2.1",
     "promise-loader": "1.0.0",
     "qs": "6.1.0",

--- a/src/components/task-step/exercise.cjsx
+++ b/src/components/task-step/exercise.cjsx
@@ -228,7 +228,6 @@ module.exports = React.createClass
 
       canReview={StepPanel.canReview(part.id)}
       disabled={TaskStepStore.isSaving(part.id)}
-      isContinueEnabled={StepPanel.canContinue(part.id)}
 
       canOnlyContinue={canOnlyContinue}
       getWaitingText={getWaitingText}

--- a/src/components/task-step/exercise.cjsx
+++ b/src/components/task-step/exercise.cjsx
@@ -22,8 +22,8 @@ canOnlyContinue = (id) ->
 
 getWaitingText = (id) ->
   switch
-    when TaskStepStore.isLoading(id) then "Loading…"
-    when TaskStepStore.isSaving(id)  then "Saving…"
+    when TaskStepStore.isSaving(id)  then 'Saving…'
+    when TaskStepStore.isLoading(id) then 'Loading…'
     else null
 
 getReadingForStep = (id, taskId) ->
@@ -180,6 +180,15 @@ module.exports = React.createClass
     TaskStepActions.setAnswerId(id, answerId)
     @setCurrentStep(stepIndex)
 
+  isAnyCompletedPartSaving: ->
+    {parts} = @state
+
+    _.some parts, (part) ->
+      part.is_completed and TaskStepStore.isSaving(part.id)
+
+  getFooterWaitingText: ->
+    'Saving…' if @isAnyCompletedPartSaving()
+
   render: ->
     {id, taskId, courseId, onNextStep, onStepCompleted, goToStep, pinned} = @props
     {parts, lastPartId, isSinglePartExercise, task, currentStep} = @state
@@ -201,6 +210,7 @@ module.exports = React.createClass
     controlButtons = <ExControlButtons
       {...controlProps}
       {...canContinueControlProps}
+      waitingText={@getFooterWaitingText()}
       key='step-control-buttons'/>
 
     unless TaskStore.hasProgress(taskId)

--- a/src/components/task-step/exercise.cjsx
+++ b/src/components/task-step/exercise.cjsx
@@ -186,24 +186,21 @@ module.exports = React.createClass
     {parts, lastPartId, isSinglePartExercise, task, currentStep} = @state
     part = _.last(parts)
 
-    controlProps =
-      panel: 'review'
-      controlText: 'Continue' if task.type is 'reading'
-
     if @canAllContinue()
       reviewProps = @getReviewProps()
 
       canContinueControlProps =
+        panel: 'review'
         isContinueEnabled: true
         onContinue: _.partial onNextStep, currentStep: part.stepIndex
 
       canContinueControlProps = _.extend({}, canContinueControlProps, reviewProps)
+      canContinueControlProps.controlText = 'Continue' if task.type is 'reading'
 
-    controlButtons = <ExControlButtons
-      {...controlProps}
-      {...canContinueControlProps}
-      waitingText={@getFooterWaitingText()}
-      key='step-control-buttons'/>
+      controlButtons = <ExControlButtons
+        {...canContinueControlProps}
+        waitingText={@getFooterWaitingText()}
+        key='step-control-buttons'/>
 
     unless TaskStore.hasProgress(taskId)
       footer = <StepFooter
@@ -215,7 +212,6 @@ module.exports = React.createClass
 
     <ExerciseWithScroll
       {...@props}
-      {...controlProps}
       {...canContinueControlProps}
 
       footer={footer}

--- a/src/components/task-step/exercise.cjsx
+++ b/src/components/task-step/exercise.cjsx
@@ -161,21 +161,23 @@ module.exports = React.createClass
     canTryAnother: TaskStepStore.canTryAnother(lastPartId, task, not @allCorrect())
     isRecovering: TaskStepStore.isRecovering(lastPartId)
 
-  setScrollState: (scrollState) ->
-    return unless scrollState?
-    {key} = scrollState
-    @setCurrentStep(key)
-
   setCurrentStepFromProgress: ({current}) ->
     @setCurrentStep(current)
 
   setCurrentStep: (currentStep) ->
     @setState({currentStep})
+    @props.goToStep(currentStep)
 
   onFreeResponseChange: (id, tempFreeResponse) ->
     {taskId} = @props
     stepIndex = TaskStore.getStepIndex(taskId, id)
     TaskStepActions.updateTempFreeResponse(id, tempFreeResponse)
+    @setCurrentStep(stepIndex)
+
+  onChoiceChange: (id, answerId) ->
+    {taskId} = @props
+    stepIndex = TaskStore.getStepIndex(taskId, id)
+    TaskStepActions.setAnswerId(id, answerId)
     @setCurrentStep(stepIndex)
 
   render: ->
@@ -217,7 +219,6 @@ module.exports = React.createClass
       footer={footer}
 
       project='tutor'
-      setScrollState={@setScrollState}
       goToStep={_.partial(goToStep, _, true)}
       currentStep={currentStep}
 
@@ -239,4 +240,4 @@ module.exports = React.createClass
       getReadingForStep={getReadingForStep}
       setFreeResponseAnswer={TaskStepActions.setFreeResponseAnswer}
       onFreeResponseChange={@onFreeResponseChange}
-      setAnswerId={TaskStepActions.setAnswerId}/>
+      setAnswerId={@onChoiceChange}/>

--- a/src/components/task-step/exercise.cjsx
+++ b/src/components/task-step/exercise.cjsx
@@ -131,21 +131,6 @@ module.exports = React.createClass
     _.every parts, (part) ->
       canOnlyContinue(part.id)
 
-  getAllIndexes: (props, state) ->
-    props ?= @props
-    state ?= @state
-
-    {taskId} = props
-    {parts} = state
-
-    _.map parts, (part) ->
-      TaskStore.getStepIndex(taskId, part.id)
-
-  isIndexInPart: (stepIndex) ->
-    index = stepIndex - 1
-    partsIndexes = @getAllIndexes()
-    _.contains(partsIndexes, index)
-
   allCorrect: ->
     {parts} = @state
 
@@ -165,20 +150,27 @@ module.exports = React.createClass
     @setCurrentStep(current)
 
   setCurrentStep: (currentStep) ->
+    return unless currentStep isnt @state.currentStep
+
     @setState({currentStep})
     @props.goToStep(currentStep)
 
-  onFreeResponseChange: (id, tempFreeResponse) ->
+  setCurrentStepByStepId: (id) ->
     {taskId} = @props
-    stepIndex = TaskStore.getStepIndex(taskId, id)
+    stepNavIndex = TaskStore.getStepNavIndex(taskId, id)
+    @setCurrentStep(stepNavIndex)
+
+  onFreeResponseChange: (id, tempFreeResponse) ->
     TaskStepActions.updateTempFreeResponse(id, tempFreeResponse)
-    @setCurrentStep(stepIndex)
+
+    # set part to be active if part of multipart
+    @setCurrentStepByStepId(id) unless @isSinglePart(@state.parts)
 
   onChoiceChange: (id, answerId) ->
-    {taskId} = @props
-    stepIndex = TaskStore.getStepIndex(taskId, id)
     TaskStepActions.setAnswerId(id, answerId)
-    @setCurrentStep(stepIndex)
+
+    # set part to be active if part of multipart
+    @setCurrentStepByStepId(id) unless @isSinglePart(@state.parts)
 
   isAnyCompletedPartSaving: ->
     {parts} = @state

--- a/src/components/task-step/exercise.cjsx
+++ b/src/components/task-step/exercise.cjsx
@@ -186,12 +186,12 @@ module.exports = React.createClass
     {parts, lastPartId, isSinglePartExercise, task, currentStep} = @state
     part = _.last(parts)
 
-    if @canAllContinue()
+    if @canAllContinue() or not @isSinglePart(parts)
       reviewProps = @getReviewProps()
 
       canContinueControlProps =
         panel: 'review'
-        isContinueEnabled: true
+        isContinueEnabled: @canAllContinue()
         onContinue: _.partial onNextStep, currentStep: part.stepIndex
 
       canContinueControlProps = _.extend({}, canContinueControlProps, reviewProps)
@@ -212,7 +212,6 @@ module.exports = React.createClass
 
     <ExerciseWithScroll
       {...@props}
-      {...canContinueControlProps}
 
       footer={footer}
 
@@ -220,7 +219,6 @@ module.exports = React.createClass
       goToStep={_.partial(goToStep, _, true)}
       currentStep={currentStep}
 
-      getCurrentPanel={getCurrentPanel}
       task={task}
       parts={parts}
       helpLink={@renderHelpLink(part.related_content)}

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -171,7 +171,6 @@ module.exports = React.createClass
 
   goToStep: (stepKey, silent = false) ->
     {id} = @props
-    console.info('trying to step key', stepKey)
     stepKey = parseInt(stepKey)
     params = _.clone(@context.router.getCurrentParams())
     return false if @areKeysSame(params.stepIndex, stepKey + 1)
@@ -179,13 +178,14 @@ module.exports = React.createClass
     params.stepIndex = stepKey + 1
     params.id = id # if we were rendered directly, the router might not have the id
 
+    @scrollToTop() unless @_isSameStep({id}, {currentStep: stepKey})
+
     if silent
       @context.router.replaceWith('viewTaskStep', params)
-      true
     else
-      @scrollToTop() unless @_isSameStep({id}, {currentStep: stepKey})
       @context.router.transitionTo('viewTaskStep', params)
-      true
+
+    true
 
   toggleMilestonesEntered: ->
     @setState(milestonesEntered: not @state.milestonesEntered)

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -136,11 +136,6 @@ module.exports = React.createClass
       @continueAfterRefreshStep()
       return false
 
-    if @_isSameStep(nextProps, nextState)
-      unless @state.currentStep is nextState.currentStep
-        nextStep = TaskStore.getStepByIndex(id, nextState.currentStep)
-        TaskStepActions.load(nextStep.id)
-
     # if we reach this point, assume that we should go ahead and do a normal component update
     true
 

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -168,7 +168,7 @@ module.exports = React.createClass
 
   goToStep: (stepKey, silent = false) ->
     {id} = @props
-
+    console.info('trying to step key', stepKey)
     stepKey = parseInt(stepKey)
     params = _.clone(@context.router.getCurrentParams())
     return false if @areKeysSame(params.stepIndex, stepKey + 1)

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -172,18 +172,20 @@ module.exports = React.createClass
     key is keyToCompare or parseInt(key) is parseInt(keyToCompare)
 
   goToStep: (stepKey, silent = false) ->
+    {id} = @props
+
     stepKey = parseInt(stepKey)
     params = _.clone(@context.router.getCurrentParams())
     return false if @areKeysSame(params.stepIndex, stepKey + 1)
     # url is 1 based so it matches the breadcrumb button numbers
     params.stepIndex = stepKey + 1
-    params.id = @props.id # if we were rendered directly, the router might not have the id
+    params.id = id # if we were rendered directly, the router might not have the id
 
     if silent
       @context.router.replaceWith('viewTaskStep', params)
       true
     else
-      @scrollToTop()
+      @scrollToTop() unless @_isSameStep({id}, {currentStep: stepKey})
       @context.router.transitionTo('viewTaskStep', params)
       true
 

--- a/src/components/task/index.cjsx
+++ b/src/components/task/index.cjsx
@@ -136,6 +136,9 @@ module.exports = React.createClass
       @continueAfterRefreshStep()
       return false
 
+    if @state.currentStep isnt nextState.currentStep and @_isSameStep(nextProps, nextState)
+      return false
+
     # if we reach this point, assume that we should go ahead and do a normal component update
     true
 

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -273,6 +273,24 @@ TaskConfig =
     getStepIndex: (taskId, stepId) ->
       _.findIndex(@_steps[taskId], id: stepId)
 
+
+    # like getStepIndex, but takes into consideration CC spacer step
+    #
+    # TODO clean up by moving this, and stuff within crumb-mixin to a
+    # helper or flux of it's own.
+    getStepNavIndex: (taskId, stepId) ->
+      coachStart = _.findIndex @_steps[taskId], (step) ->
+        not TaskStepStore.isCore(step.id)
+
+      stepIndex = @exports.getStepIndex.call(@, taskId, stepId)
+
+      navIndex = stepIndex
+
+      if coachStart > -1 and stepIndex >= coachStart
+        navIndex = stepIndex + 1
+
+      navIndex
+
     getStepLateness: (taskId, stepId) ->
       result =
         late: false

--- a/src/flux/tasking.coffee
+++ b/src/flux/tasking.coffee
@@ -425,9 +425,16 @@ TaskingConfig =
       isThisTaskValid = isTaskValid(taskings)
       return false unless isThisTaskValid
 
+      # dont check tasking validity if taskings are same as default/loaded
+      return true if @exports.isTaskSame.call(@, taskId)
+
       _.every(taskings, isTaskingValid)
 
     isTaskingValid: (taskId, tasking) ->
+
+      # dont check tasking validity if taskings are same as default/loaded
+      return true if @exports.isTaskSame.call(@, taskId)
+
       tasking = @exports.getTaskingFor.call(@, taskId, tasking)
       isTaskingValid(tasking)
 

--- a/test/components/student-dashboard.spec.coffee
+++ b/test/components/student-dashboard.spec.coffee
@@ -73,7 +73,7 @@ describe 'Student Dashboard Component', ->
       feedback = state.div.querySelectorAll('.-upcoming .task .feedback span')
       expect(_.pluck(feedback, 'textContent'))
         .to.have.deep.equal([
-          '6/7 correct', '7/8 correct', '6/6 answered', '7/3 answered', 'Not started', 'Not started'
+          '6/7 correct', '7/8 correct', '6/6 answered', '7/3 answered', '0/2 answered', 'Not started', 'Not started'
         ])
 
   it 'renders events to week panel', ->
@@ -86,6 +86,7 @@ describe 'Student Dashboard Component', ->
       expect(_.pluck(tasks, 'textContent')).to.have.deep.equal([
         'Homework #3',
         'Homework #4 (final)',
+        'Chapter 6 Homework Before Due, no feedback',
         'Chapter 5 and Chapter 6 Reading',
         'Chapter 10 and Chapter 11 Reading, multi-part'
       ])
@@ -97,7 +98,7 @@ describe 'Student Dashboard Component', ->
         _.without(el.classList, 'task', 'row', 'homework', 'reading')
       )
       expect(classes)
-        .to.have.deep.equal([['workable'], ['workable'], [], [], [], []])
+        .to.have.deep.equal([['workable'], ['workable'], [], [], [], [], []])
 
   it 'displays redirect when a CC course', ->
     @course = _.clone(STUDENT_COURSE_ONE_MODEL)


### PR DESCRIPTION
Fixes:
## "missing" submit button for last part
  * for the last part, after parts have been "completed", the controls for submitting again were on the footer, making for an inconsistent and confusing UI since the controls for previous parts were right underneath the parts they were for
    ![screen shot 2016-07-25 at 3 37 20 pm](https://cloud.githubusercontent.com/assets/2483873/17116530/c88edd18-527d-11e6-9404-b77c05253071.png)
    * Additionally, it was unclear whenever the last part would be being updated, since it had no async button to display it's state underneath.
  * This was fixed with
    * "Submit" being displayed for un-completed parts, with a "Next Question" button displaying separately on footer.
    * After "Submit" or all parts are completed, the part's submit's button would not be shown.
    * Active "Next Question" button will show async state -- "Saving" -- when individual parts are updated and saved afterwards.
    * When MPQ is incomplete, saving will show async state on part's submit button.
    ![screen shot 2016-07-25 at 4 02 28 pm](https://cloud.githubusercontent.com/assets/2483873/17117336/4df2801a-5281-11e6-96ac-1d9b65435581.png)



## scroll to navigation would push extra history to routes
  * i.e. `#react-root-container` or `"#{stepIndex}"` even though route updates was being handled elsewhere
    ![screen shot 2016-07-25 at 3 42 54 pm](https://cloud.githubusercontent.com/assets/2483873/17116710/926c4b3e-527e-11e6-9b91-2e02c2314c35.png)
  * This also means extra react life-cycles stuffs due to unintentional push-states
  * Fixed by
    * Ignoring any history state pushes with `#react-root-container`
    * more specifically controlling when state update from scrolling should be ignored

## mc-keys, route, and active crumb would be active based on whichever part was navigated to directly
  * this would not change regardless of which part on an MPQ i was actually actively -- had started typing an FR for or chosen an MC for -- working on
    ![screen shot 2016-07-25 at 4 25 06 pm](https://cloud.githubusercontent.com/assets/2483873/17118114/ffe29528-5284-11e6-822d-960ca8904856.png)
    * this meant that keypressing for MCs was especially confusing as far as which set of MCs might be the ones being controlled by keypresses
  * fixed by
    * setting the active step/part to whatever has last received action
      ![screen shot 2016-07-25 at 4 30 13 pm](https://cloud.githubusercontent.com/assets/2483873/17118216/4b979112-5285-11e6-866f-8d6944013884.png)
    * switching the active part bypasses extra scrolling to part if part is mostly in view.
    * this means that the keypress MC choices make a lot more sense as far which set of choices you would be controlling with keypresses

## missing ID/Report an error links for multiparts
  * Fixed by displaying those in main card after all parts
  * This was being displayed in footer after the control buttons, probably in an attempt to fix tabbing order.  However, for exercises with control fixed in footer, this would not work since the id/links need to be in the main card body.  this will affect the tabbing order fix for single-part exercises with pinned UI -- single part homework steps only.

## unable to save title or description changes for past due task
  * this would be prevented by the frontend since validation checks for past due
  * however, without any user attempts to change the dates, taskings should not need to go through validation

will update again after openstax/react-components#97 is merged.  blocked because of that PR.