### PR TITLE
Fixed teacher clicking "Back to Dashboard" from reviewing reading assignment

### DIFF
--- a/src/components/task-step/ends.cjsx
+++ b/src/components/task-step/ends.cjsx
@@ -173,13 +173,14 @@ TaskEnd = React.createClass
   displayName: 'TaskEnd'
   render: ->
     {courseId} = @props
+    console.log(CourseStore.isTeacher(courseId))
     <div className='task task-completed'>
       <CardBody className='-reading-completed'>
         <div className="completed-message">
           <h1>You are done.</h1>
           <h3>Great job completing all the steps.</h3>
           <Router.Link
-            to='viewStudentDashboard'
+            to={if not CourseStore.isTeacher(courseId) then 'viewStudentDashboard' else 'viewTeacherDashBoard'}
             key='step-back'
             params={{courseId}}
             className='btn btn-primary'>

--- a/src/components/task-step/ends.cjsx
+++ b/src/components/task-step/ends.cjsx
@@ -173,7 +173,6 @@ TaskEnd = React.createClass
   displayName: 'TaskEnd'
   render: ->
     {courseId} = @props
-    console.log(CourseStore.isTeacher(courseId))
     <div className='task task-completed'>
       <CardBody className='-reading-completed'>
         <div className="completed-message">


### PR DESCRIPTION
The bug was that when a teacher was reviewing a finished reading assignment and got to the end, the "Back to Dashboard" button would link back to the student's dashboard, which would result in a 403 error when followed.  This makes sure to check whether it's a teacher or a student when naming the action.