### PR TITLE
Fixes the main nav bar's bottom border not drawing all the way across.

### DIFF
--- a/resources/styles/global/navbar.less
+++ b/resources/styles/global/navbar.less
@@ -35,9 +35,7 @@
   // override the bootstrap defaults with tutor defaults
   &.navbar.navbar{
     border-bottom: 1px solid @border-color;
-    &, .navbar-collapse{
-      background-color: @tutor-white;
-    }
+    background-color: @tutor-white;
   }
 
   .container-fluid { padding: 0 @tutor-navbar-padding-horizontal; }
@@ -129,8 +127,7 @@
   .center-control-assignment {
     white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;    
-    
+    text-overflow: ellipsis;
     min-width: 0;
   }
 

--- a/resources/styles/global/navbar.less
+++ b/resources/styles/global/navbar.less
@@ -35,7 +35,10 @@
   // override the bootstrap defaults with tutor defaults
   &.navbar.navbar{
     border-bottom: 1px solid @border-color;
-    background-color: @tutor-white;
+
+    &, .navbar-collapse.collapsing, .navbar-collapse.in {
+      background-color: @tutor-white;
+    }
   }
 
   .container-fluid { padding: 0 @tutor-navbar-padding-horizontal; }


### PR DESCRIPTION
Before:
<img width="1343" alt="screen shot 2016-07-18 at 11 18 49 am" src="https://cloud.githubusercontent.com/assets/7595652/16925596/c809aeb2-4cd9-11e6-8972-5dab2843b49a.png">

After:
<img width="1342" alt="screen shot 2016-07-18 at 11 18 20 am" src="https://cloud.githubusercontent.com/assets/7595652/16925604/ce2f5ef4-4cd9-11e6-84d0-eb76cdd08024.png">
