### PR TITLE
CC QL no longer shows filter buttons

### DIFF
--- a/resources/styles/components/exercises.less
+++ b/resources/styles/components/exercises.less
@@ -89,6 +89,16 @@
   justify-content: space-between;
   align-items: center;
   padding: 0 @padding;
+
+  .filters-wrapper,
+  .actions-wrapper {
+    width: 300px;
+  }
+
+  .actions-wrapper {
+    text-align: right;
+  }
+
   .sectionizer {
     @size: 40px;
     flex-wrap: nowrap;

--- a/src/components/questions/exercise-controls.cjsx
+++ b/src/components/questions/exercise-controls.cjsx
@@ -3,6 +3,7 @@ BS = require 'react-bootstrap'
 cn = require 'classnames'
 
 {ExerciseStore, ExerciseActions} = require '../../flux/exercise'
+{CourseStore} = require '../../flux/course'
 {AsyncButton, ScrollToMixin} = require 'openstax-react-components'
 showDialog = require './unsaved-dialog'
 
@@ -46,9 +47,10 @@ QuestionsControls = React.createClass
 
     selected = @props.selectedSection or _.first(sections)
 
-    <div className="exercise-controls-bar">
-      <BS.ButtonGroup className="filters">
+    isConceptCoach = CourseStore.isConceptCoach(@props.courseId)
 
+    filters =
+      <BS.ButtonGroup className="filters">
         <BS.Button data-filter='all' onClick={@onFilterClick}
           className={if _.isEmpty(@props.filter) then 'all active' else 'all'}
         >
@@ -68,11 +70,18 @@ QuestionsControls = React.createClass
         </BS.Button>
       </BS.ButtonGroup>
 
+    <div className="exercise-controls-bar">
+      <div className="filters-wrapper">
+        {if not isConceptCoach then filters}
+      </div>
+
       {@props.children}
 
-      <BS.Button onClick={@scrollToTop}>
-        Select more sections
-      </BS.Button>
+      <div className="actions-wrapper">
+        <BS.Button onClick={@scrollToTop}>
+          Select more sections
+        </BS.Button>
+      </div>
 
     </div>
 


### PR DESCRIPTION
Removes the type tab buttons from the toolbar in Question Library for Concept Coach and maintains the centering when they're not there.  (It also fixes the centering of that pagination block in the middle, but shhh...)

https://www.pivotaltracker.com/n/projects/1156756/stories/126084281