### PR TITLE
Fix for CC Course and Settings and Roster tabs keeping bad state

### DIFF
--- a/src/components/course-settings/roster.cjsx
+++ b/src/components/course-settings/roster.cjsx
@@ -98,6 +98,7 @@ CourseRoster = React.createClass
 
         <TabsWithChildren
           tabs={_.pluck(periods, 'name')}
+          tabIndex={tabIndex}
           onClick={@handleSelection}
         >
           <AddPeriodLink courseId={@props.courseId} periods={periods} />

--- a/src/components/tabs-with-children.cjsx
+++ b/src/components/tabs-with-children.cjsx
@@ -13,17 +13,14 @@ TabsWithChildren = React.createClass
     tabs: React.PropTypes.arrayOf(
       React.PropTypes.oneOfType([ React.PropTypes.string, React.PropTypes.element ])
     ).isRequired
-
-  getInitialState: ->
-    tabIndex: 0
+    tabIndex: React.PropTypes.number
 
   onTabClick: (tabIndex, ev) ->
     ev.preventDefault()
-    @setState({tabIndex})
     @props.onClick(ev, tabIndex)
 
   renderTab: (tab, index) ->
-    isSelected = index is @state.tabIndex
+    isSelected = index is @props.tabIndex
     <li key={index} tabIndex={index} className={classnames(active: isSelected)}>
       <a role="tab"
         href="" tabIndex="-1" onClick={_.partial(@onTabClick, index)}


### PR DESCRIPTION
Fixed a problem where after archiving a section (period) on Concept Coach's "Course and Settings Roster" page, it would select the next appropriate period but still show it as unselected.  This would get super confusing when adding a period later or unarchiving a period, because the old selected tab index would be highlighted, but it wouldn't be showing that tab's data.