### PR TITLE
Calculate height of days based on max plan order

### DIFF
--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -77,7 +77,7 @@ CourseDuration = React.createClass
     groupedDurations = _.chain(groupingDurations)
       .map(@groupByRanges(durationsInView))
       .tap(@calcTopOffset)
-      .tap( (ranges) => _.each( ranges, @setWeeksHeight) )
+      .each(@setWeeksHeight)
       .value()
 
   setWeeksHeight: (range) ->
@@ -85,12 +85,7 @@ CourseDuration = React.createClass
       durationMax = _.max(plansOnDay, (plan) -> plan.order + 1 ).order or 0
       Math.max(durationMax, maxOrder)
     , 0)
-
-    calculatedHeight = @_calcDayHeight(height)
-    if calculatedHeight > range.dayHeight
-      range.dayHeight = calculatedHeight
-    range
-
+    range.dayHeight = Math.max(@_calcDayHeight(height), range.dayHeight)
 
   calcTopOffset: (ranges) ->
     dayHeights = _.pluck(ranges, 'dayHeight')

--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -197,15 +197,6 @@ CourseDuration = React.createClass
   _calcDayHeight: (plans) ->
     plans * 3.6 + 1
 
-  _setDayHeightToMaxOverlaps: (currentOverlap, rangeData) ->
-    # calculate day height based on the number of durations that overlap
-    calcedHeight = @_calcDayHeight(currentOverlap.length)
-
-    # if the day height is more than previously calculated day height,
-    # update with the larger day height
-    if calcedHeight > rangeData.dayHeight
-      rangeData.dayHeight = calcedHeight
-
   _getSimplePlan: (plan) ->
     # Make a simple plan that omits duration/time related information
     # and adds back in only the relevant time information needed by the

--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -77,7 +77,20 @@ CourseDuration = React.createClass
     groupedDurations = _.chain(groupingDurations)
       .map(@groupByRanges(durationsInView))
       .tap(@calcTopOffset)
+      .tap( (ranges) => _.each( ranges, @setWeeksHeight) )
       .value()
+
+  setWeeksHeight: (range) ->
+    height = 1 + _.reduce(range.plansByDays, (maxOrder, plansOnDay) ->
+      durationMax = _.max(plansOnDay, (plan) -> plan.order + 1 ).order or 0
+      Math.max(durationMax, maxOrder)
+    , 0)
+
+    calculatedHeight = @_calcDayHeight(height)
+    if calculatedHeight > range.dayHeight
+      range.dayHeight = calculatedHeight
+    range
+
 
   calcTopOffset: (ranges) ->
     dayHeights = _.pluck(ranges, 'dayHeight')

--- a/src/components/course-calendar/duration.cjsx
+++ b/src/components/course-calendar/duration.cjsx
@@ -255,10 +255,13 @@ CourseDuration = React.createClass
         plansOnDay.length
       ).length
 
-      # set day height to fit the number of overlapping durations
-      dayHeight = @_calcDayHeight(rangeData.maxPlansOnDay)
-      rangeData.dayHeight = dayHeight if dayHeight > rangeData.dayHeight
+      # set day height to the best-guess for this range based on how many plans it has.
+      # It'll be fine-tuned later across all ranges
+      rangeData.dayHeight = Math.max(
+        @_calcDayHeight(rangeData.maxPlansOnDay), rangeData.dayHeight
+      )
       rangeData
+
 
   renderChildren: (item) ->
     {courseId} = @props


### PR DESCRIPTION
Check the order of each plan and sets the height of week's days based on
the higest plan order. 

Turns this:

<img width="989" alt="screen shot 2016-07-18 at 8 09 53 pm" src="https://cloud.githubusercontent.com/assets/79566/16935283/ad17798c-4d23-11e6-88d1-d225b7d8b392.png">


Into:
<img width="991" alt="screen shot 2016-07-18 at 8 10 15 pm" src="https://cloud.githubusercontent.com/assets/79566/16935282/abf4ce6a-4d23-11e6-9de4-a04997505794.png">
