### PR TITLE
CC no rounding for 0% and 100%

### DIFF
--- a/resources/styles/components/cc-dashboard/index.less
+++ b/resources/styles/components/cc-dashboard/index.less
@@ -102,6 +102,19 @@
         width: 100%;
       }
 
+      .progress-bar.small-percentage {
+        position: relative;
+
+        &.progress-bar-info {
+          color: @progress-bar-info-bg;
+        }
+
+        > span {
+          left: 100%;
+          margin-left: 8px;
+        }
+      }
+
       .empty-spaced-practice {
         text-align: center;
       }

--- a/src/components/cc-dashboard/section-progress.cjsx
+++ b/src/components/cc-dashboard/section-progress.cjsx
@@ -14,17 +14,19 @@ SectionProgress = React.createClass
       when (p > 1) then 100             # Don't let it go over 100%!
       else Math.round(p * 100)
 
-    completedLabel = "#{percent}%"
-    completedLabel = if percent is 100 then "#{completedLabel} completed" else completedLabel
-
-    incompleteClass = ""
-
     progressClass = classnames 'reading-progress-group',
       'none-completed': percent is 0
 
     if percent > 0
+      completedLabel = if percent is 100 then "#{completedLabel} completed" else "#{percent}%"
+
+      # The threshold under which the filled-in part of the progress bar is too small
+      # to fit the percentage text on top, forcing us to add a css class that will
+      # make it more legible
+      maxSmallPercent = 10
+
       completed = <BS.ProgressBar
-        className="reading-progress-bar"
+        className={classnames "reading-progress-bar", { 'small-percentage': percent <= maxSmallPercent }}
         bsStyle="info"
         label={completedLabel}
         now={percent}

--- a/src/components/cc-dashboard/section-progress.cjsx
+++ b/src/components/cc-dashboard/section-progress.cjsx
@@ -6,8 +6,14 @@ classnames = require 'classnames'
 SectionProgress = React.createClass
 
   render: ->
-    percent = Math.round(@props.section.completed_percentage * 100)
-    if (percent > 100) then percent = 100
+    p = @props.section.completed_percentage
+
+    percent = switch
+      when (p < 1 and p > 0.99) then 99 # Don't round to 100% when it's not 100%!
+      when (p > 0 and p < 0.01) then 1  # Don't round to 0% when it's not 0%!
+      when (p > 1) then 100             # Don't let it go over 100%!
+      else Math.round(p * 100)
+
     completedLabel = "#{percent}%"
     completedLabel = if percent is 100 then "#{completedLabel} completed" else completedLabel
 

--- a/src/components/cc-dashboard/section-progress.cjsx
+++ b/src/components/cc-dashboard/section-progress.cjsx
@@ -18,15 +18,19 @@ SectionProgress = React.createClass
       'none-completed': percent is 0
 
     if percent > 0
-      completedLabel = if percent is 100 then "#{completedLabel} completed" else "#{percent}%"
+      completedLabel = "#{percent}%"
+      if percent is 100
+        completedLabel = "#{completedLabel} completed"
 
-      # The threshold under which the filled-in part of the progress bar is too small
-      # to fit the percentage text on top, forcing us to add a css class that will
-      # make it more legible
+      # The threshold under which the filled-in part of the progress bar is too
+      # smallto fit the percentage text on top, forcing us to add a css class
+      # that will make it more legible
       maxSmallPercent = 10
 
       completed = <BS.ProgressBar
-        className={classnames "reading-progress-bar", { 'small-percentage': percent <= maxSmallPercent }}
+        className={classnames "reading-progress-bar",
+          { 'small-percentage': percent <= maxSmallPercent }
+        }
         bsStyle="info"
         label={completedLabel}
         now={percent}


### PR DESCRIPTION
Made the logic so it doesn't round down to 0% when it's not 0% and doesn't round up to 100% when it's not 100%.

I also needed to make some styling changes so small percentages were legible.

Before:
<img width="393" alt="screen shot 2016-07-18 at 2 36 57 pm" src="https://cloud.githubusercontent.com/assets/7595652/16960745/9698982c-4d9f-11e6-9f10-b28ec233dec6.png">

After:
<img width="1180" alt="screen shot 2016-07-19 at 10 54 32 am" src="https://cloud.githubusercontent.com/assets/7595652/16960796/bcf077d8-4d9f-11e6-9bde-ada9c0bc73fa.png">
