### PR TITLE
Switch tab from period after archiving

### DIFF
--- a/src/components/course-settings/roster.cjsx
+++ b/src/components/course-settings/roster.cjsx
@@ -30,11 +30,10 @@ CourseRoster = React.createClass
 
   getInitialState: ->
     tabIndex: 0
-    activePeriod: _.first PH.activePeriods(CourseStore.get(@props.courseId))
 
   handleSelection: (ev, tabIndex) ->
-    periods = PH.activePeriods(CourseStore.get(@props.courseId))
-    activePeriod = periods[tabIndex] or _.first(periods)
+    unless PH.activePeriods(CourseStore.get(@props.courseId))[tabIndex]
+      tabIndex = 0
     @setState({tabIndex})
 
   selectPreviousTab: ->
@@ -98,10 +97,12 @@ CourseRoster = React.createClass
 
         <TabsWithChildren
           tabs={_.pluck(periods, 'name')}
+          tabIndex={tabIndex}
           onClick={@handleSelection}
         >
           <AddPeriodLink courseId={@props.courseId} periods={periods} />
-          <ViewArchivedPeriods courseId={@props.courseId} />
+          <ViewArchivedPeriods courseId={@props.courseId}
+            afterRestore={@selectPreviousTab} />
         </TabsWithChildren>
 
       </div>

--- a/src/components/course-settings/view-archived-periods.cjsx
+++ b/src/components/course-settings/view-archived-periods.cjsx
@@ -16,7 +16,8 @@ CourseGroupingLabel = require '../course-grouping-label'
 ViewArchivedPeriods = React.createClass
 
   propTypes:
-    courseId: React.PropTypes.string.isRequired
+    courseId:     React.PropTypes.string.isRequired
+    afterRestore: React.PropTypes.func.isRequired
 
   mixins: [BindStoreMixin]
 
@@ -40,6 +41,7 @@ ViewArchivedPeriods = React.createClass
 
   restore: (period) ->
     PeriodActions.restore(period.id, @props.courseId)
+    PeriodStore.once 'restore', @props.afterRestore
 
   render: ->
     archived = PH.archivedPeriods(CourseStore.get(@props.courseId))

--- a/src/components/tabs-with-children.cjsx
+++ b/src/components/tabs-with-children.cjsx
@@ -10,12 +10,17 @@ TabsWithChildren = React.createClass
 
   propTypes:
     onClick: React.PropTypes.func.isRequired
+    tabIndex: React.PropTypes.number
     tabs: React.PropTypes.arrayOf(
       React.PropTypes.oneOfType([ React.PropTypes.string, React.PropTypes.element ])
     ).isRequired
 
   getInitialState: ->
     tabIndex: 0
+
+  componentWillReceiveProps: (nextProps) ->
+    if _.isNumber(nextProps.tabIndex) # ignore null/undefined, allow 0
+      @setState(tabIndex: nextProps.tabIndex)
 
   onTabClick: (tabIndex, ev) ->
     ev.preventDefault()

--- a/src/flux/period.coffee
+++ b/src/flux/period.coffee
@@ -17,6 +17,7 @@ PeriodConfig = {
 
   restored: (periodData, periodId, courseId) ->
     CourseActions.load(courseId)
+    @emit('restored')
     delete @_asyncStatus[periodId]
 
   _created: (period, courseId) ->


### PR DESCRIPTION
Previously the tab index wouldn't be updated so the contents wouldn't match the tab name after archiving. Unarchiving had the same bug