### PR TITLE
Text changes for Homework Builder's cancel dialog

### DIFF
--- a/src/components/task-plan/plan-mixin.coffee
+++ b/src/components/task-plan/plan-mixin.coffee
@@ -95,8 +95,10 @@ PlanMixin =
       @reset()
     else
       TutorDialog.show(
-        title: 'Unsaved Changes'
-        body: 'You will lose unsaved changes if you continue.'
+        title: 'Unsaved Changes - Confirm'
+        body: 'You will lose unsaved changes if you continue.  Do you really want to cancel?',
+        okBtnText: 'Yes'
+        cancelBtnText: 'No'
       ).then( =>
         @reset()
       )

--- a/src/components/tutor-dialog.cjsx
+++ b/src/components/tutor-dialog.cjsx
@@ -5,13 +5,15 @@ _ = require 'underscore'
 
 
 DialogProperties =
-  title:     React.PropTypes.string.isRequired
-  onOk:      React.PropTypes.func.isRequired
-  onCancel:  React.PropTypes.func.isRequired
-  body:      React.PropTypes.element.isRequired
-  show:      React.PropTypes.bool
-  buttons:   React.PropTypes.arrayOf( React.PropTypes.element )
-  className: React.PropTypes.string
+  title:         React.PropTypes.string.isRequired
+  onOk:          React.PropTypes.func.isRequired
+  onCancel:      React.PropTypes.func.isRequired
+  body:          React.PropTypes.element.isRequired
+  show:          React.PropTypes.bool
+  buttons:       React.PropTypes.arrayOf( React.PropTypes.element )
+  okBtnText:     React.PropTypes.string
+  cancelBtnText: React.PropTypes.string
+  className:     React.PropTypes.string
 
 # This is the "real" dialog component. It's rendered to a div under document.body
 DetachedTutorDialog = React.createClass
@@ -37,9 +39,9 @@ DetachedTutorDialog = React.createClass
     return null unless @state.show
     buttons = @props.buttons or [
         <BS.Button key='ok'     className='ok'
-          onClick={_.compose(@props.onOk, @_hide)} bsStyle='primary'>OK</BS.Button>
+          onClick={_.compose(@props.onOk, @_hide)} bsStyle='primary'>{@props.okBtnText or 'OK'}</BS.Button>
         <BS.Button key='cancel' className='cancel'
-          onClick={_.compose(@props.onCancel,  @_hide)}>Cancel</BS.Button>
+          onClick={_.compose(@props.onCancel,  @_hide)}>{@props.cancelBtnText or 'Cancel'}</BS.Button>
     ]
     classes = ['tutor-dialog']
     classes.push @props.className if @props.className


### PR DESCRIPTION
Changes the confirm-cancel dialog when cancelling a unsaved changes to a homework assignment so it's less confusing.

https://www.pivotaltracker.com/n/projects/1156756/stories/100222306/comments/144332063

Before:
<img width="600" alt="screen shot 2016-07-19 at 7 34 00 am" src="https://cloud.githubusercontent.com/assets/7595652/16966682/7fecfabc-4dba-11e6-93f5-8352b97b1658.png">

After:
<img width="598" alt="screen shot 2016-07-19 at 2 08 36 pm" src="https://cloud.githubusercontent.com/assets/7595652/16966688/85d3904e-4dba-11e6-8834-20fb3d86eb89.png">