### PR TITLE
Compare exercise excluded count against the modules it belongs to

### DIFF
--- a/resources/styles/components/questions-dashboard.less
+++ b/resources/styles/components/questions-dashboard.less
@@ -86,15 +86,16 @@
 .question-library-min-exercise-exclusions {
   top: 30%;
   .modal-dialog {
-    width: 400px;
+    width: 500px;
   }
   .modal-body {
     #fonts >.sans(1.8rem, 1.8rem);
-    padding: 3rem;
+    padding: 1rem 3rem 3rem 3rem;
+    min-width: 500px;
     display: flex;
     .tutor-icon {
       font-size: 4rem;
-      margin-right: 1rem;
+      margin: 0 2.5rem 0 1rem;
       color: @tutor-primary;
     }
   }

--- a/src/components/questions/exercises-display.cjsx
+++ b/src/components/questions/exercises-display.cjsx
@@ -13,6 +13,7 @@ Sectionizer      = require '../exercises/sectionizer'
 NoExercisesFound = require './no-exercises-found'
 ExerciseHelpers  = require '../../helpers/exercise'
 Dialog           = require '../tutor-dialog'
+CourseGroupingLabel = require '../course-grouping-label'
 
 ExercisesDisplay = React.createClass
 
@@ -85,15 +86,17 @@ ExercisesDisplay = React.createClass
     @props.onShowCardViewClick(ev, exercise)
 
   renderMinimumExclusionWarning: ->
+    section = <CourseGroupingLabel courseId={@props.courseId} lowercase />
     [
       <Icon key="icon" type="exclamation" />
       <div key="message" className="message">
         <p>
-          Tutor needs at least 5 questions for this topic to be
+          Tutor needs at least 5 questions for this {section} to be
           included in spaced practice and personalized learning.
         </p>
         <p>
-          If you exclude too many, your students will not get to practice on this topic.
+          If you exclude too many, your students will not get
+          to practice on topics in this {section}.
         </p>
       </div>
     ]

--- a/src/components/questions/exercises-display.cjsx
+++ b/src/components/questions/exercises-display.cjsx
@@ -85,13 +85,13 @@ ExercisesDisplay = React.createClass
     @setState({currentView: 'cards', showingCardsFromDetailsView: true})
     @props.onShowCardViewClick(ev, exercise)
 
-  renderMinimumExclusionWarning: ->
+  renderMinimumExclusionWarning: (minExerciseCount) ->
     section = <CourseGroupingLabel courseId={@props.courseId} lowercase />
     [
       <Icon key="icon" type="exclamation" />
       <div key="message" className="message">
         <p>
-          Tutor needs at least 5 questions for this {section} to be
+          Tutor needs at least {minExerciseCount} questions for this {section} to be
           included in spaced practice and personalized learning.
         </p>
         <p>
@@ -103,10 +103,11 @@ ExercisesDisplay = React.createClass
 
   onExerciseToggle: (ev, exercise) ->
     isSelected = not ExerciseStore.isExerciseExcluded(exercise.id)
-    if isSelected and ExerciseStore.isExcludedAtMinimum(exercise)
+    minExerciseCount = ExerciseStore.excludedAtMinimum(exercise)
+    if isSelected and minExerciseCount isnt false
       Dialog.show(
         className: 'question-library-min-exercise-exclusions'
-        title: '', body: @renderMinimumExclusionWarning()
+        title: '', body: @renderMinimumExclusionWarning(minExerciseCount)
         buttons: [
           <BS.Button key='exclude'
             onClick={=>

--- a/src/components/questions/exercises-display.cjsx
+++ b/src/components/questions/exercises-display.cjsx
@@ -100,7 +100,7 @@ ExercisesDisplay = React.createClass
 
   onExerciseToggle: (ev, exercise) ->
     isSelected = not ExerciseStore.isExerciseExcluded(exercise.id)
-    if isSelected and ExerciseStore.isExcludedAtMinimum(ExerciseStore.get(@props.sectionIds))
+    if isSelected and ExerciseStore.isExcludedAtMinimum(exercise)
       Dialog.show(
         className: 'question-library-min-exercise-exclusions'
         title: '', body: @renderMinimumExclusionWarning()

--- a/src/flux/exercise.coffee
+++ b/src/flux/exercise.coffee
@@ -132,13 +132,15 @@ ExerciseConfig =
     get: (pageIds) ->
       @_exercises[pageIds.toString()] or throw new Error('BUG: Invalid page ids')
 
-    isExcludedAtMinimum: (exercise) ->
+    # returns the available count if at minimum or `false` if not at minimum amount
+    excludedAtMinimum: (exercise) ->
       isExcluded = _.bind(@.exports.isExerciseExcluded, @)
       for uuid in getExerciseCnxModUuids(exercise)
         exercises = @exports.forCnxModuleUuid.call(@, uuid)
         excluded = _.filter _.pluck(exercises, 'id'), isExcluded
-        if ((exercises.length - excluded.length) is 5 ) or (excluded.length is 0 and exercises.length <= 5)
-          return true
+        availableCount = exercises.length - excluded.length
+        if (availableCount is 5) or (excluded.length is 0 and exercises.length <= 5)
+          return availableCount
       false
 
     hasUnsavedExclusions: ->

--- a/src/flux/exercise.coffee
+++ b/src/flux/exercise.coffee
@@ -134,20 +134,12 @@ ExerciseConfig =
 
     isExcludedAtMinimum: (exercise) ->
       isExcluded = _.bind(@.exports.isExerciseExcluded, @)
-
       for uuid in getExerciseCnxModUuids(exercise)
         exercises = @exports.forCnxModuleUuid.call(@, uuid)
-        excluded = _.filter _.pluck(exercises, 'id'),
-          _.bind(@.exports.isExerciseExcluded, @)
-        if (exercises.length - excluded.length) is 5
+        excluded = _.filter _.pluck(exercises, 'id'), isExcluded
+        if ((exercises.length - excluded.length) is 5 ) or (excluded.length is 0 and exercises.length <= 5)
           return true
       false
-
-      # @exports.forCnxModuleUuid
-      # ExerciseStore.get(@props.sectionIds)
-      # excluded = _.filter _.pluck(exercises, 'id'),
-      #   _.bind(@.exports.isExerciseExcluded, @)
-      # (exercises.length - excluded.length) is 5
 
     hasUnsavedExclusions: ->
       not _.isEmpty @_unsavedExclusions

--- a/test/flux/exercise.spec.coffee
+++ b/test/flux/exercise.spec.coffee
@@ -19,6 +19,7 @@ describe 'exercises store', ->
 
   beforeEach (done) ->
     @exercise = ld.cloneDeep(EXERCISE)
+    ExerciseActions.reset()
     @tags = _.clone @exercise.tags
     ExerciseActions.loadedForCourse(EXERCISES, COURSE_ID, PAGE_IDS)
     TocActions.loaded(READINGS, ECOSYSTEM_ID)
@@ -66,6 +67,21 @@ describe 'exercises store', ->
     exercise = exercises[0]
     expect(exercises).to.have.lengthOf(5)
     expect(ExerciseStore.isExcludedAtMinimum(exercise)).to.be.true
-    ExerciseActions.updateExercises([_.extend(exercise, is_excluded: true)])
+    ExerciseActions.updateExercises([_.extend({}, exercise, is_excluded: true)])
     # it should not warn when the count is below minimum
+    expect(ExerciseStore.isExcludedAtMinimum(exercise)).to.be.false
+
+  it 'warns immediatly if exercise count is less than 5', ->
+    ExerciseActions.reset()
+    exercises = EXERCISES.items[0..2]
+    ExerciseActions.loadedForCourse(
+      {total_count: 2, items: exercises},
+      COURSE_ID, PAGE_IDS
+    )
+    exercises = ExerciseStore.forCnxModuleUuid('0e58aa87-2e09-40a7-8bf3-269b2fa16509')
+    expect(exercises).to.have.lengthOf(3)
+    exercise = exercises[0]
+    expect(ExerciseStore.isExcludedAtMinimum(exercise)).to.be.true
+    ExerciseActions.updateExercises([_.extend({}, exercise, is_excluded: true)])
+    # now that there is exclusions, it shouldn't warn
     expect(ExerciseStore.isExcludedAtMinimum(exercise)).to.be.false

--- a/test/flux/exercise.spec.coffee
+++ b/test/flux/exercise.spec.coffee
@@ -60,3 +60,12 @@ describe 'exercises store', ->
     teksTag = findTagByType(exercise, 'teks')
     teks = ExerciseStore.getTeksString(exercise.id)
     expect(teksTag.name.indexOf(teks)).to.not.equal(-1)
+
+  it 'calulates exclusion minimum threshold', ->
+    exercises = ExerciseStore.forCnxModuleUuid('0e58aa87-2e09-40a7-8bf3-269b2fa16509')
+    exercise = exercises[0]
+    expect(exercises).to.have.lengthOf(5)
+    expect(ExerciseStore.isExcludedAtMinimum(exercise)).to.be.true
+    ExerciseActions.updateExercises([_.extend(exercise, is_excluded: true)])
+    # it should not warn when the count is below minimum
+    expect(ExerciseStore.isExcludedAtMinimum(exercise)).to.be.false

--- a/test/flux/exercise.spec.coffee
+++ b/test/flux/exercise.spec.coffee
@@ -66,10 +66,10 @@ describe 'exercises store', ->
     exercises = ExerciseStore.forCnxModuleUuid('0e58aa87-2e09-40a7-8bf3-269b2fa16509')
     exercise = exercises[0]
     expect(exercises).to.have.lengthOf(5)
-    expect(ExerciseStore.isExcludedAtMinimum(exercise)).to.be.true
+    expect(ExerciseStore.excludedAtMinimum(exercise)).to.equal(5)
     ExerciseActions.updateExercises([_.extend({}, exercise, is_excluded: true)])
     # it should not warn when the count is below minimum
-    expect(ExerciseStore.isExcludedAtMinimum(exercise)).to.be.false
+    expect(ExerciseStore.excludedAtMinimum(exercise)).to.be.false
 
   it 'warns immediatly if exercise count is less than 5', ->
     ExerciseActions.reset()
@@ -81,7 +81,7 @@ describe 'exercises store', ->
     exercises = ExerciseStore.forCnxModuleUuid('0e58aa87-2e09-40a7-8bf3-269b2fa16509')
     expect(exercises).to.have.lengthOf(3)
     exercise = exercises[0]
-    expect(ExerciseStore.isExcludedAtMinimum(exercise)).to.be.true
+    expect(ExerciseStore.excludedAtMinimum(exercise)).to.equal(3)
     ExerciseActions.updateExercises([_.extend({}, exercise, is_excluded: true)])
     # now that there is exclusions, it shouldn't warn
-    expect(ExerciseStore.isExcludedAtMinimum(exercise)).to.be.false
+    expect(ExerciseStore.excludedAtMinimum(exercise)).to.be.false


### PR DESCRIPTION
previously it was counting exclusions on all the modules that were loaded, which wasn't very accurate

Also adjusts the wording on the dialog from updated mockup

![screen shot 2016-07-20 at 9 45 17 am](https://cloud.githubusercontent.com/assets/79566/16990750/cf307816-4e5e-11e6-8100-891afb45d42a.png)
