### PR TITLE
Allow students to view deleted readings and homeworks

### DIFF
--- a/resources/styles/components/student-dashboard/task.less
+++ b/resources/styles/components/student-dashboard/task.less
@@ -10,8 +10,9 @@
       height: @student-dashboard-row-height;
       padding: 0;
     }
-    &:not(.clickable) {
+    &:not(.workable) {
       opacity: 0.5;
+      cursor: default;
       background-color: @tutor-neutral-lightest;
     }
     .icon {
@@ -61,6 +62,11 @@
         background-color: @tutor-neutral-lightest;
         .icon { .tutor-icon-active(1.2); }
       }
+    }
+    &.deleted {
+      color: @tutor-neutral;
+      filter: grayscale(100%);
+      -webkit-filter: grayscale(100%);
     }
     transition: all 0.1s ease-in;
 

--- a/resources/styles/components/student-dashboard/task.less
+++ b/resources/styles/components/student-dashboard/task.less
@@ -10,9 +10,10 @@
       height: @student-dashboard-row-height;
       padding: 0;
     }
-		&.deleted {
-			opacity: 0.5;
-		}
+    &:not(.clickable) {
+      opacity: 0.5;
+      background-color: @tutor-neutral-lightest;
+    }
     .icon {
       background-position: center;
       // * 10 on icon-size-lg because less doesn't automatically convert icon-size-lg to px

--- a/src/components/student-dashboard/event-row.cjsx
+++ b/src/components/student-dashboard/event-row.cjsx
@@ -37,9 +37,7 @@ module.exports = React.createClass
     {workable} = @props
     workable ?= StudentDashboardStore.canWorkTask(@props.event)
     deleted = StudentDashboardStore.isDeleted(@props.event)
-    started = StudentDashboardStore.hasStarted(@props.event)
-    clickable = workable and not (deleted and not started)
-    classes = classnames("task row #{@props.className}", {workable, clickable})
+    classes = classnames("task row #{@props.className}", {workable, deleted})
 
     if deleted
       hideButton = <BS.Button className="-hide-button" onClick={@hideTask}>
@@ -53,7 +51,7 @@ module.exports = React.createClass
         <EventInfoIcon event={@props.event} />
       ]
 
-    <div className={classes} onClick={@onClick if clickable}
+    <div className={classes} onClick={@onClick if workable}
       data-event-id={@props.event.id}>
       <BS.Col xs={2}  sm={1} className={"column-icon"}>
         <i className={"icon icon-lg icon-#{@props.className}"}/>

--- a/src/components/student-dashboard/event-row.cjsx
+++ b/src/components/student-dashboard/event-row.cjsx
@@ -37,6 +37,8 @@ module.exports = React.createClass
     {workable} = @props
     workable ?= StudentDashboardStore.canWorkTask(@props.event)
     deleted = StudentDashboardStore.isDeleted(@props.event)
+    started = StudentDashboardStore.hasStarted(@props.event)
+    clickable = workable and not (deleted and not started)
     classes = classnames("task row #{@props.className}", {workable, deleted})
 
     if deleted
@@ -51,7 +53,7 @@ module.exports = React.createClass
         <EventInfoIcon event={@props.event} />
       ]
 
-    <div className={classes} onClick={@onClick if workable and not deleted}
+    <div className={classes} onClick={@onClick if clickable}
       data-event-id={@props.event.id}>
       <BS.Col xs={2}  sm={1} className={"column-icon"}>
         <i className={"icon icon-lg icon-#{@props.className}"}/>

--- a/src/components/student-dashboard/event-row.cjsx
+++ b/src/components/student-dashboard/event-row.cjsx
@@ -39,7 +39,7 @@ module.exports = React.createClass
     deleted = StudentDashboardStore.isDeleted(@props.event)
     started = StudentDashboardStore.hasStarted(@props.event)
     clickable = workable and not (deleted and not started)
-    classes = classnames("task row #{@props.className}", {workable, deleted})
+    classes = classnames("task row #{@props.className}", {workable, clickable})
 
     if deleted
       hideButton = <BS.Button className="-hide-button" onClick={@hideTask}>

--- a/src/components/task-step/exercise.cjsx
+++ b/src/components/task-step/exercise.cjsx
@@ -186,6 +186,13 @@ module.exports = React.createClass
     {parts, lastPartId, isSinglePartExercise, task, currentStep} = @state
     part = _.last(parts)
 
+    if TaskStore.isDeleted(taskId)
+      setFreeResponse = _.noop
+      setAnswerId = _.noop
+    else
+      setFreeResponse = TaskStepActions.setFreeResponseAnswer
+      setAnswerId = @onChoiceChange
+
     if @canAllContinue() or not @isSinglePart(parts)
       reviewProps = @getReviewProps()
 
@@ -233,6 +240,6 @@ module.exports = React.createClass
       getWaitingText={getWaitingText}
       getCurrentPanel={getCurrentPanel}
       getReadingForStep={getReadingForStep}
-      setFreeResponseAnswer={TaskStepActions.setFreeResponseAnswer}
+      setFreeResponseAnswer={setFreeResponse}
       onFreeResponseChange={@onFreeResponseChange}
-      setAnswerId={@onChoiceChange}/>
+      setAnswerId={setAnswerId}/>

--- a/src/flux/student-dashboard.coffee
+++ b/src/flux/student-dashboard.coffee
@@ -41,11 +41,15 @@ StudentDashboardConfig = {
       events[moment(day).startOf('isoweek').format('YYYYww')] or []
 
     canWorkTask: (event) ->
-      return new Date(event.opens_at) < TimeStore.getNow()
+      (
+        new Date(event.opens_at) < TimeStore.getNow() and
+        not (
+          event.is_deleted and
+          event.complete_exercise_count is 0
+        )
+      )
 
     isDeleted: (event) -> event.is_deleted
-
-    hasStarted: (event) -> event.complete_exercise_count isnt 0
 
     # Returns events who's due date has not passed
     upcomingEvents: (courseId, now = TimeStore.getNow()) ->

--- a/src/flux/student-dashboard.coffee
+++ b/src/flux/student-dashboard.coffee
@@ -41,6 +41,7 @@ StudentDashboardConfig = {
       events[moment(day).startOf('isoweek').format('YYYYww')] or []
 
     canWorkTask: (event) ->
+      #students cannot work or view a task if it has been deleted and they haven't started it
       (
         new Date(event.opens_at) < TimeStore.getNow() and
         not (

--- a/src/flux/student-dashboard.coffee
+++ b/src/flux/student-dashboard.coffee
@@ -45,6 +45,8 @@ StudentDashboardConfig = {
 
     isDeleted: (event) -> event.is_deleted
 
+    hasStarted: (event) -> event.complete_exercise_count isnt 0
+
     # Returns events who's due date has not passed
     upcomingEvents: (courseId, now = TimeStore.getNow()) ->
       _.chain(@_get(courseId)?.tasks or [])

--- a/src/flux/task.coffee
+++ b/src/flux/task.coffee
@@ -332,6 +332,10 @@ TaskConfig =
       {is_feedback_available} = @_get(taskId)
       is_feedback_available
 
+    isDeleted: (taskId) ->
+      {is_deleted} = @_get(taskId)
+      is_deleted
+
     isSameStep: (taskId, stepIndices...) ->
       contentUrls = _.chain(stepIndices)
         .map (stepIndex) =>

--- a/test/components/student-dashboard.spec.coffee
+++ b/test/components/student-dashboard.spec.coffee
@@ -98,7 +98,7 @@ describe 'Student Dashboard Component', ->
         _.without(el.classList, 'task', 'row', 'homework', 'reading')
       )
       expect(classes)
-        .to.have.deep.equal([['workable', 'clickable'], ['workable', 'clickable'], [], [], [], [], []])
+        .to.have.deep.equal([['workable'], ['workable'], [], [], [], [], []])
 
   it 'displays redirect when a CC course', ->
     @course = _.clone(STUDENT_COURSE_ONE_MODEL)

--- a/test/components/student-dashboard.spec.coffee
+++ b/test/components/student-dashboard.spec.coffee
@@ -98,7 +98,7 @@ describe 'Student Dashboard Component', ->
         _.without(el.classList, 'task', 'row', 'homework', 'reading')
       )
       expect(classes)
-        .to.have.deep.equal([['workable'], ['workable'], [], [], [], [], []])
+        .to.have.deep.equal([['workable', 'clickable'], ['workable', 'clickable'], [], [], [], [], []])
 
   it 'displays redirect when a CC course', ->
     @course = _.clone(STUDENT_COURSE_ONE_MODEL)

--- a/test/components/student-dashboard/event-row.cjsx
+++ b/test/components/student-dashboard/event-row.cjsx
@@ -25,15 +25,35 @@ DELETED_EVENT =
   "exercise_count": 3,
   "complete_exercise_count": 3
 
+DELETED_NOT_STARTED_EVENT =
+  "id": "118",
+  "title": "Read Chapter 1",
+  "opens_at": "2016-05-16T05:01:00.000Z",
+  "due_at": "2016-05-19T12:00:00.000Z",
+  "last_worked_at": "2016-05-19T11:59:00.000Z",
+  "type": "reading",
+  "complete": true,
+  "is_deleted": true,
+  "exercise_count": 3,
+  "complete_exercise_count": 0
+
 regularRow = null
 deletedRow = null
+deletedNotStartedRow = null
 
 describe 'Event Row', ->
   beforeEach ->
     regular = <EventRow className="testing" event={EVENT} courseId="3" feedback="" />
     deleted = <EventRow className="" event={DELETED_EVENT} courseId="3" feedback="" />
+    deletedNotStarted = <EventRow
+      className=""
+      event={DELETED_NOT_STARTED_EVENT}
+      courseId="3"
+      feedback=""
+    />
     regularRow = Testing.shallowRender(regular)
     deletedRow = Testing.shallowRender(deleted)
+    deletedNotStartedRow = Testing.shallowRender(deleted)
 
   it 'passes classnames to containing div', ->
     expect(regularRow.props.className.indexOf("testing")).is.not.equal(-1)
@@ -54,6 +74,10 @@ describe 'Event Row', ->
     feedback = feedbackColumn.props.children
     expect(feedback.props.children).to.equal("Withdrawn")
 
-  it 'disallows onclick for event row if deletable', ->
-    expect(deletedRow.props.onClick).to.be.falsy
+  it 'allows onclick for event row if deleted', ->
+    expect(deletedRow.props.onClick).to.not.be.falsy
+    expect(regularRow.props.onClick).to.not.be.falsy
+
+  it 'disallows onclick for event row if deleted and not started', ->
+    expect(deletedNotStartedRow.props.onClick).to.be.falsy
     expect(regularRow.props.onClick).to.not.be.falsy


### PR DESCRIPTION
For: https://www.pivotaltracker.com/story/show/125339771

Allows students to click into the deleted task.  I still need to finish up some logic inside the exercise itself to hide certain things, and there's a backend PR out for that as well.