### PR TITLE
De-activate teacher content link when no teacher content exists

### DIFF
--- a/resources/styles/components/reference-book/navbar.less
+++ b/resources/styles/components/reference-book/navbar.less
@@ -41,6 +41,9 @@
       }
     }
   }
+  .teacher-edition {
+    .no-content { color: @tutor-neutral-light; }
+  }
   // hide non-important items when the screen gets narrow
   @media screen and ( max-width: @reference-book-page-width ){
     .full-width-only { display: none; }

--- a/resources/styles/components/reference-book/page.less
+++ b/resources/styles/components/reference-book/page.less
@@ -19,7 +19,8 @@
       border: 1px solid @tutor-neutral-bright;
       background-color: @tutor-white;
       .tutor-book-content();
-      // shown if parent is-teacher present below
+      // shown if parent is-teacher present below.
+      // Must be kept in sync with reference-book/teacher-content-toggle.cjsx
       .os-teacher {
         display: none;
       }

--- a/src/components/reference-book/index.cjsx
+++ b/src/components/reference-book/index.cjsx
@@ -49,7 +49,10 @@ ReferenceBookShell = React.createClass
   renderNavbarControls: ->
     return null unless CourseStore.isTeacher(@state.courseId)
     <BS.Nav navbar right>
-      <TeacherContentToggle isShowing={@state.isShowingTeacherContent} onChange={@setTeacherContent} />
+      <TeacherContentToggle
+        section={@state.section}
+        isShowing={@state.isShowingTeacherContent}
+        onChange={@setTeacherContent} />
     </BS.Nav>
 
 

--- a/src/components/reference-book/teacher-content-toggle.cjsx
+++ b/src/components/reference-book/teacher-content-toggle.cjsx
@@ -1,6 +1,8 @@
 React = require 'react'
 BS = require 'react-bootstrap'
 
+# NOTE: this selector must be kept in sync with CNX as well as
+# the style in components/reference-book/page.less
 TEACHER_CONTENT_SELECTOR = '.os-teacher'
 
 TeacherContentToggle = React.createClass

--- a/src/components/reference-book/teacher-content-toggle.cjsx
+++ b/src/components/reference-book/teacher-content-toggle.cjsx
@@ -1,14 +1,42 @@
 React = require 'react'
 BS = require 'react-bootstrap'
 
+TEACHER_CONTENT_SELECTOR = '.os-teacher'
+
 TeacherContentToggle = React.createClass
 
   propTypes:
-    onChange: React.PropTypes.func.isRequired
-    isShowing: React.PropTypes.bool.isRequired
+    onChange:   React.PropTypes.func.isRequired
+    isShowing:  React.PropTypes.bool
+    section:    React.PropTypes.string
+    windowImpl: React.PropTypes.object
+
+  getDefaultProps: ->
+    windowImpl: window
+
+  getInitialState: ->
+    hasTeacherContent: false
 
   onClick: ->
-    @props.onChange(not @props.isShowing)
+    @props.onChange(not @props.isShowing) if @state.hasTeacherContent is true
+
+  componentDidMount:      -> @scheduleCheckForTeacherContent()
+  componentDidUpdate:     -> @scheduleCheckForTeacherContent()
+  componentWillUnmount:   -> clearTimeout(@state.pendingCheck) if @state.pendingCheck
+  scheduleCheckForTeacherContent: ->
+    return if @state.pendingCheck
+    @setState(pendingCheck: _.defer(@checkForTeacherContent))
+
+  checkForTeacherContent: ->
+    @setState(
+      pendingCheck: false
+      hasTeacherContent: !!@props.windowImpl.document.querySelector(TEACHER_CONTENT_SELECTOR)
+    )
+
+  renderNoContentTooltip: ->
+    <BS.Popover id='no-content'>
+      No teacher edition content is available for this page.
+    </BS.Popover>
 
   render: ->
     teacherLinkText = if @props.isShowing
@@ -16,8 +44,18 @@ TeacherContentToggle = React.createClass
     else
       'Show Teacher Edition'
 
+    content = if @state.hasTeacherContent
+      <span className="has-content">{teacherLinkText}</span>
+    else
+      <BS.OverlayTrigger
+        placement='bottom' trigger='click' overlay={@renderNoContentTooltip()}
+      >
+        <span className="no-content">{teacherLinkText}</span>
+      </BS.OverlayTrigger>
+
+
     <BS.NavItem className='teacher-edition' onClick={@onClick}>
-      {teacherLinkText}
+      {content}
     </BS.NavItem>
 
 module.exports = TeacherContentToggle

--- a/test/components/reference-book/teacher-content-toggle.spec.coffee
+++ b/test/components/reference-book/teacher-content-toggle.spec.coffee
@@ -1,0 +1,42 @@
+{Testing, expect, sinon, _} = require '../helpers/component-testing'
+
+Toggle = require '../../../src/components/reference-book/teacher-content-toggle'
+
+describe 'Teacher Content Toggle', ->
+
+  beforeEach ->
+    @props =
+      onChange: sinon.spy()
+      isShowing: false
+      windowImpl:
+        document: document.createElement('div')
+
+  it 'defaults to not showing teacher content', (done) ->
+    Testing.renderComponent( Toggle, props: @props ).then ({element}) =>
+      expect(element.getDOMNode().querySelector('.no-content')).to.exist
+      Testing.actions.click(element.getDOMNode())
+      _.defer =>
+        expect(@props.onChange).not.to.have.been.called
+        done()
+
+  it 'can detect teacher selector', (done) ->
+    @props.windowImpl.document.innerHTML = """
+      <div><p class='os-teacher'>Hai I AM TEACHER</p></div>
+    """
+    Testing.renderComponent( Toggle, props: @props, unmountAfter: 10 ).then ({element}) ->
+      _.defer ->
+        expect(element.state.hasTeacherContent).to.be.true
+        done()
+
+
+  it 'calls callback when clicked and content is available', (done) ->
+    @props.windowImpl.document.innerHTML = """
+      <div><p class='os-teacher'>Hai I AM TEACHER</p></div>
+    """
+    Testing.renderComponent( Toggle, props: @props, unmountAfter: 10 ).then ({element}) =>
+
+      Testing.actions.click(element.getDOMNode())
+      _.defer =>
+        expect(element.getDOMNode().textContent).to.include("Show")
+        expect(@props.onChange).to.have.been.calledWith(true)
+        done()


### PR DESCRIPTION
This checks the page DOM for `.os-teacher` and will display the link as inactive with a popover explaining why.

![screen shot 2016-07-20 at 3 53 29 pm](https://cloud.githubusercontent.com/assets/79566/17003319/ff197a6a-4e94-11e6-93e5-548457ba1bf1.png)
