### PR TITLE
Teacher review navigation logic

### DIFF
--- a/src/components/task-teacher-review/breadcrumbs.cjsx
+++ b/src/components/task-teacher-review/breadcrumbs.cjsx
@@ -2,8 +2,6 @@ React = require 'react'
 BS = require 'react-bootstrap'
 _ = require 'underscore'
 
-CrumbMixin = require './crumb-mixin'
-{ChapterSectionMixin} = require 'openstax-react-components'
 {BreadcrumbStatic} = require '../breadcrumb'
 
 BackButton = require '../buttons/back-button'
@@ -11,25 +9,21 @@ BackButton = require '../buttons/back-button'
 module.exports = React.createClass
   displayName: 'Breadcrumbs'
 
-  mixins: [ChapterSectionMixin, CrumbMixin]
-
   propTypes:
     id: React.PropTypes.string.isRequired
     currentStep: React.PropTypes.number
     goToStep: React.PropTypes.func.isRequired
+    scrollToStep: React.PropTypes.func.isRequired
     title: React.PropTypes.string.isRequired
     courseId: React.PropTypes.string.isRequired
-
-  getInitialState: ->
-    crumbs: @getCrumableCrumbs()
+    crumbs: React.PropTypes.array.isRequired
 
   goToStep: (key) ->
     @props.goToStep(key)
     @props.scrollToStep(key)
 
   render: ->
-    {crumbs} = @state
-    {currentStep, title, courseId} = @props
+    {currentStep, title, courseId, crumbs} = @props
 
     stepButtons = _.map crumbs, (crumb) =>
       stepSelector = "[data-section='#{crumb.key}']"

--- a/src/components/task-teacher-review/breadcrumbs.cjsx
+++ b/src/components/task-teacher-review/breadcrumbs.cjsx
@@ -25,6 +25,7 @@ module.exports = React.createClass
 
   goToStep: (key) ->
     @props.goToStep(key)
+    @props.scrollToStep(key)
 
   render: ->
     {crumbs} = @state

--- a/src/components/task-teacher-review/breadcrumbs.cjsx
+++ b/src/components/task-teacher-review/breadcrumbs.cjsx
@@ -26,14 +26,11 @@ module.exports = React.createClass
     {currentStep, title, courseId, crumbs} = @props
 
     stepButtons = _.map crumbs, (crumb) =>
-      stepSelector = "[data-section='#{crumb.key}']"
-
       <BreadcrumbStatic
         crumb={crumb}
         currentStep={currentStep}
         goToStep={@goToStep}
         key="breadcrumb-#{crumb.type}-#{crumb.key}"/>
-
 
     fallbackLink =
       to: 'taskplans'

--- a/src/components/task-teacher-review/crumb-mixin.cjsx
+++ b/src/components/task-teacher-review/crumb-mixin.cjsx
@@ -51,12 +51,12 @@ module.exports =
 
       _.each crumb.data, (data) ->
         data.sectionLabel = crumb.sectionLabel
-        data.content = JSON.parse(data.content)
+        data.content = JSON.parse(data.content) if _.isString(data.content)
 
     else
       crumb.sectionLabel = @_buildSectionLabel(data.chapter_section)
       crumb.data.sectionLabel = crumb.sectionLabel
-      crumb.data.content = JSON.parse(crumb.data.content)
+      crumb.data.content = JSON.parse(crumb.data.content) if _.isString(crumb.data.content)
 
     crumb
 
@@ -153,15 +153,19 @@ module.exports =
 
     crumbs = @_generateCrumbsFromStats(stats, review.type)
 
-  generateCrumbs: ->
-    {id, period} = @props
+  generateCrumbs: (period) ->
+    {id} = @props
+    period ?= @state.period
+
     periodCrumbs = @_generateCrumbs id, period
     _.sortBy(periodCrumbs, (crumb) ->
       crumb.data.average_step_number
     )
 
-  getContents: ->
-    {id, period} = @props
+  getContents: (period) ->
+    {id} = @props
+    period ?= @state.period
+
     review = TaskTeacherReviewStore.get(id)
 
     allCrumbs = @generateCrumbs()

--- a/src/components/task-teacher-review/crumb-mixin.cjsx
+++ b/src/components/task-teacher-review/crumb-mixin.cjsx
@@ -51,10 +51,12 @@ module.exports =
 
       _.each crumb.data, (data) ->
         data.sectionLabel = crumb.sectionLabel
+        data.content = JSON.parse(data.content)
 
     else
       crumb.sectionLabel = @_buildSectionLabel(data.chapter_section)
       crumb.data.sectionLabel = crumb.sectionLabel
+      crumb.data.content = JSON.parse(crumb.data.content)
 
     crumb
 
@@ -73,9 +75,9 @@ module.exports =
     exercises = @_getExercisesFromStats(stats)
     crumbs = _.chain(exercises)
       .map((data) =>
-        {questions} = JSON.parse(data.content)
         stepCrumbs = []
         mainCrumb = @_makeCrumb(data)
+        {questions} = mainCrumb.data.content
         stepCrumbs.push(mainCrumb)
         _.chain(questions).rest(1).each((question) =>
           stepCrumbs.push(@_makeCrumb(_.pick(data, 'chapter_section', 'average_step_number', 'question_stats')))

--- a/src/components/task-teacher-review/exercise.cjsx
+++ b/src/components/task-teacher-review/exercise.cjsx
@@ -3,7 +3,6 @@ _ = require 'underscore'
 BS = require 'react-bootstrap'
 
 {ArbitraryHtmlAndMath, Question, CardBody, FreeResponse, ExerciseGroup} = require 'openstax-react-components'
-{ScrollTrackerMixin} = require 'openstax-react-components/src/components/scroll-tracker'
 {ExerciseStore} = require '../../flux/exercise'
 
 TaskTeacherReviewQuestion = React.createClass

--- a/src/components/task-teacher-review/exercise.cjsx
+++ b/src/components/task-teacher-review/exercise.cjsx
@@ -84,10 +84,10 @@ TaskTeacherReviewQuestion = React.createClass
 TaskTeacherReviewQuestionTracker = React.createClass
   displayName: 'TaskTeacherReviewQuestionTracker'
   render: ->
-    {scrollState} = @props
+    {sectionKey} = @props
 
     questionProps = _.pick(@props, 'question', 'questionStats')
-    <div data-section={scrollState.key}>
+    <div data-section={sectionKey}>
       <TaskTeacherReviewQuestion {...questionProps}/>
     </div>
 
@@ -105,15 +105,13 @@ TaskTeacherReviewExercise = React.createClass
 
   renderQuestion: (question, index) ->
     questionStats = @getQuestionStatsById(question.id)
-    {scrollState} = @props
-    {key} = scrollState
-    scrollState = _.extend {}, scrollState, {key: key + index}
+    {sectionKey} = @props
 
     <TaskTeacherReviewQuestionTracker
       key={"task-review-question-#{question.id}"}
       question={question}
       questionStats={questionStats}
-      scrollState={scrollState}/>
+      sectionKey={sectionKey}/>
 
   render: ->
     {content} = @props

--- a/src/components/task-teacher-review/index.cjsx
+++ b/src/components/task-teacher-review/index.cjsx
@@ -119,7 +119,8 @@ TaskTeacherReview = React.createClass
     TaskTeacherReviewStore.off('change', @setIsReviewLoaded)
 
     steps = @getContents()
-    @setState({isReviewLoaded: true, steps})
+    crumbs = @getCrumableCrumbs()
+    @setState({isReviewLoaded: true, steps, crumbs})
 
     params = _.clone(@context.router.getCurrentParams())
     @syncStep(params)
@@ -130,7 +131,7 @@ TaskTeacherReview = React.createClass
 
   render: ->
     {id, courseId} = @props
-    {steps} = @state
+    {steps, crumbs} = @state
     periodIndex = @getPeriodIndex()
 
     panel = <ReviewShell
@@ -150,12 +151,13 @@ TaskTeacherReview = React.createClass
 
       breadcrumbs = <Breadcrumbs
         id={id}
+        crumbs={crumbs}
         goToStep={@goToStep}
         scrollToStep={@scrollToStep}
         currentStep={@state.currentStep}
         title={task.title}
         courseId={courseId}
-        key="task-#{id}-breadcrumbs"/>
+        key="task-#{id}-breadcrumbs" />
 
     <PinnedHeaderFooterCard
       className={taskClasses}

--- a/src/components/task-teacher-review/index.cjsx
+++ b/src/components/task-teacher-review/index.cjsx
@@ -82,7 +82,7 @@ TaskTeacherReview = React.createClass
 
   scrollToStep: (currentStep) ->
     stepSelector = "[data-section='#{currentStep}']"
-    @scrollToSelector(stepSelector, updateHistory: false) unless @isSelectorInView(stepSelector)
+    @scrollToSelector(stepSelector, {updateHistory: false, unlessInView: true})
 
   shouldComponentUpdate: (nextProps) ->
     {shouldUpdate} = nextProps

--- a/src/components/task-teacher-review/index.cjsx
+++ b/src/components/task-teacher-review/index.cjsx
@@ -118,19 +118,11 @@ TaskTeacherReview = React.createClass
 
     TaskTeacherReviewStore.off('change', @setIsReviewLoaded)
 
-    steps = @getSteps()
+    steps = @getContents()
     @setState({isReviewLoaded: true, steps})
 
     params = _.clone(@context.router.getCurrentParams())
     @syncStep(params)
-
-  getSteps: ->
-    steps = @getContents()
-    stepsList = _.map steps, (step, index) =>
-      stepInfo = _.pick(step, 'key', 'sectionLabel')
-      stepInfo.index = index
-
-      stepInfo
 
   getActiveStep: ->
     {steps, currentStep} = @state
@@ -138,6 +130,7 @@ TaskTeacherReview = React.createClass
 
   render: ->
     {id, courseId} = @props
+    {steps} = @state
     periodIndex = @getPeriodIndex()
 
     panel = <ReviewShell
@@ -145,6 +138,7 @@ TaskTeacherReview = React.createClass
           review='teacher'
           panel='teacher-review'
           goToStep={@goToStep}
+          steps={steps}
           currentStep={@state.currentStep}
           period={@state.period} />
 

--- a/src/components/task-teacher-review/index.cjsx
+++ b/src/components/task-teacher-review/index.cjsx
@@ -99,7 +99,12 @@ TaskTeacherReview = React.createClass
     @context.router.replaceWith('reviewTaskStep', params)
 
   setPeriod: (period) ->
-    @setState({period})
+    return unless @state.isReviewLoaded
+
+    contentState = @getReviewContents(period)
+    contentState.period = period
+
+    @setState(contentState)
 
   setPeriodIndex: (key) ->
     periodKey = key + 1
@@ -114,14 +119,21 @@ TaskTeacherReview = React.createClass
   setIsReviewLoaded: (id) ->
     return null unless id is @props.id
 
-    TaskTeacherReviewStore.off('change', @setIsReviewLoaded)
-
-    steps = @getContents()
-    crumbs = @getCrumableCrumbs()
-    @setState({isReviewLoaded: true, steps, crumbs})
+    TaskTeacherReviewStore.off('review.loaded', @setIsReviewLoaded)
 
     params = _.clone(@context.router.getCurrentParams())
     @syncStep(params)
+
+    contentState = @getReviewContents()
+    contentState.isReviewLoaded = true
+
+    @setState(contentState)
+
+  getReviewContents: (period) ->
+    steps = @getContents(period)
+    crumbs = @getCrumableCrumbs(period)
+
+    {steps, crumbs}
 
   getActiveStep: ->
     {steps, currentStep} = @state

--- a/src/components/task-teacher-review/index.cjsx
+++ b/src/components/task-teacher-review/index.cjsx
@@ -80,6 +80,7 @@ TaskTeacherReview = React.createClass
     currentStep = sectionIndex - 1
     @setState({currentStep})
 
+  scrollToStep: (currentStep) ->
     stepSelector = "[data-section='#{currentStep}']"
     @scrollToSelector(stepSelector, updateHistory: false) unless @isSelectorInView(stepSelector)
 
@@ -156,6 +157,7 @@ TaskTeacherReview = React.createClass
       breadcrumbs = <Breadcrumbs
         id={id}
         goToStep={@goToStep}
+        scrollToStep={@scrollToStep}
         currentStep={@state.currentStep}
         title={task.title}
         courseId={courseId}

--- a/src/components/task-teacher-review/index.cjsx
+++ b/src/components/task-teacher-review/index.cjsx
@@ -1,6 +1,5 @@
 React = require 'react'
 BS = require 'react-bootstrap'
-Router = require 'react-router'
 
 CrumbMixin = require './crumb-mixin'
 Breadcrumbs = require './breadcrumbs'
@@ -9,7 +8,6 @@ Breadcrumbs = require './breadcrumbs'
 {PinnedHeaderFooterCard, ChapterSectionMixin, ScrollToMixin} = require 'openstax-react-components'
 
 _ = require 'underscore'
-camelCase = require 'camelcase'
 
 {TaskTeacherReviewStore} = require '../../flux/task-teacher-review'
 ScrollSpy = require '../scroll-spy'

--- a/src/components/task-teacher-review/review.cjsx
+++ b/src/components/task-teacher-review/review.cjsx
@@ -4,11 +4,6 @@ _ = require 'underscore'
 TaskTeacherReviewExercise = require './exercise'
 LoadableItem = require '../loadable-item'
 
-CrumbMixin = require './crumb-mixin'
-{ScrollListenerMixin} = require 'react-scroll-components'
-{ChapterSectionMixin, ScrollToMixin} = require 'openstax-react-components'
-{ScrollTrackerMixin, ScrollTrackerParentMixin} = require 'openstax-react-components/src/components/scroll-tracker'
-
 {TaskTeacherReviewActions, TaskTeacherReviewStore} = require '../../flux/task-teacher-review'
 
 ReviewHeadingTracker = React.createClass
@@ -30,6 +25,7 @@ Review = React.createClass
     focus: React.PropTypes.bool.isRequired
     period: React.PropTypes.object.isRequired
     currentStep: React.PropTypes.number
+    steps: React.PropTypes.array.isRequired
 
   getDefaultProps: ->
     focus: false
@@ -39,9 +35,6 @@ Review = React.createClass
     stepsProps = _.omit(@props, 'focus')
 
     stepsList = _.map steps, (step, index) =>
-
-      # scrollState = _.pick(step, 'key', 'sectionLabel')
-
       if step.question_stats?
         return null unless step.content
         stepProps = _.extend({}, stepsProps, step)

--- a/src/components/task-teacher-review/review.cjsx
+++ b/src/components/task-teacher-review/review.cjsx
@@ -14,9 +14,9 @@ CrumbMixin = require './crumb-mixin'
 ReviewHeadingTracker = React.createClass
   displayName: 'ReviewHeadingTracker'
   render: ->
-    {sectionLabel, title, scrollState} = @props
+    {sectionLabel, title, sectionKey} = @props
 
-    <h2 data-section={scrollState.key}>
+    <h2 data-section={sectionKey}>
       <span className='text-success'>
         {sectionLabel}
       </span> {title}
@@ -25,7 +25,6 @@ ReviewHeadingTracker = React.createClass
 
 Review = React.createClass
   displayName: 'Review'
-  mixins: [ChapterSectionMixin, CrumbMixin]
   propTypes:
     id: React.PropTypes.string.isRequired
     focus: React.PropTypes.bool.isRequired
@@ -36,17 +35,15 @@ Review = React.createClass
     focus: false
 
   render: ->
-    {id, focus} = @props
-    steps = @getContents()
+    {id, focus, steps} = @props
     stepsProps = _.omit(@props, 'focus')
 
     stepsList = _.map steps, (step, index) =>
 
-      scrollState = _.pick(step, 'key', 'sectionLabel')
+      # scrollState = _.pick(step, 'key', 'sectionLabel')
 
       if step.question_stats?
         return null unless step.content
-        step.content = JSON.parse(step.content)
         stepProps = _.extend({}, stepsProps, step)
         stepProps.key = "task-review-question-#{step.question_stats[0].question_id}-#{step.stepIndex}"
         stepProps.focus = focus and index is 0
@@ -60,7 +57,7 @@ Review = React.createClass
 
       item = <Tracker
         {...stepProps}
-        scrollState={scrollState}/>
+        sectionKey={step.key}/>
 
     <div>
       {stepsList}

--- a/src/components/task-teacher-review/review.cjsx
+++ b/src/components/task-teacher-review/review.cjsx
@@ -38,7 +38,7 @@ Review = React.createClass
       if step.question_stats?
         return null unless step.content
         stepProps = _.extend({}, stepsProps, step)
-        stepProps.key = "task-review-question-#{step.question_stats[0].question_id}-#{step.stepIndex}"
+        stepProps.key = "task-review-question-#{step.question_stats[0].question_id}-#{index}"
         stepProps.focus = focus and index is 0
 
         Tracker = TaskTeacherReviewExercise


### PR DESCRIPTION
Fixed
- [x] scrolling up to section heading for reading plan review when scrolling changes section
- [x] breadcrumbs update amount when periods switched

also cleaned up code pulled content formatting logic into one place instead of re-building it in multiple places

