### PR TITLE
Update CC & Tutor QL help text

### DIFF
--- a/resources/styles/components/questions-dashboard.less
+++ b/resources/styles/components/questions-dashboard.less
@@ -43,7 +43,12 @@
       top: -0.5rem;
     }
   }
-
+  .instructions-addon {
+    margin: 0 @padding;
+    font-size: 1.4rem;
+    text-align: center;
+    color: @tutor-neutral-lite;
+  }
   .secondary-help {
     text-align: center;
     color: @tutor-neutral;

--- a/resources/styles/components/questions-dashboard.less
+++ b/resources/styles/components/questions-dashboard.less
@@ -23,11 +23,6 @@
     }
   }
 
-  .exercises-display {
-    max-width: @tutor-max-panel-width;
-    margin: 0 auto;
-  }
-
   .instructions {
     background-color: @tutor-secondary;
     color: @tutor-white;
@@ -43,6 +38,13 @@
       top: -0.5rem;
     }
   }
+
+  .exercises-display {
+    max-width: @tutor-max-panel-width;
+    margin: 0 auto;
+    .instructions { margin-top: @padding; }
+  }
+
   .instructions-addon {
     margin: 0 @padding;
     font-size: 1.4rem;

--- a/resources/styles/components/task-plan/homework/exercise-summary.less
+++ b/resources/styles/components/task-plan/homework/exercise-summary.less
@@ -63,7 +63,7 @@
   }
 
   .tutor-added-later {
-    color: #999999;
+    color: @tutor-neutral-lite;
     width: 232px;
     line-height: 14px;
     font-style: italic;

--- a/resources/styles/variables/colors.less
+++ b/resources/styles/variables/colors.less
@@ -19,7 +19,8 @@
 @tutor-neutral-lightest: rgb(249, 249, 249); // nearly white
 @tutor-neutral-bright: rgb(245, 245, 245); // bright gray
 @tutor-neutral-lighter: rgb(241, 241, 241); // light gray
-@tutor-neutral-light: rgb(229, 229, 229); // light gray
+@tutor-neutral-light:  rgb(229, 229, 229); // light gray
+@tutor-neutral-lite: rgb(153, 153, 153); // a gray that's not quite as light as the "light"
 @tutor-neutral: rgb(129, 129, 129); // gray
 @tutor-neutral-dark: rgb(95, 97, 99); // dark gray
 @tutor-neutral-darker: rgb(66, 66, 66); // very dark gray

--- a/resources/styles/variables/tutor-bootstrap.less
+++ b/resources/styles/variables/tutor-bootstrap.less
@@ -272,7 +272,7 @@
 // @zindex-navbar:            1000;
 // @zindex-dropdown:          1000;
 // @zindex-popover:           1060;
-// @zindex-tooltip:           1070;
+@zindex-tooltip:           1020; // set to below fixed navbar
 // @zindex-navbar-fixed:      1030;
 // @zindex-modal-background:  1040;
 // @zindex-modal:             1050;

--- a/src/components/icon.cjsx
+++ b/src/components/icon.cjsx
@@ -9,7 +9,9 @@ module.exports = React.createClass
     type: React.PropTypes.string.isRequired
     spin: React.PropTypes.bool
     className: React.PropTypes.string
-    tooltip: React.PropTypes.string
+    tooltip: React.PropTypes.oneOf([
+      React.PropTypes.string, React.PropTypes.element
+    ])
     tooltipProps: React.PropTypes.object
 
   componentWillMount: ->

--- a/src/components/questions/dashboard.cjsx
+++ b/src/components/questions/dashboard.cjsx
@@ -8,8 +8,6 @@ classnames = require 'classnames'
 SectionsChooser = require './sections-chooser'
 ExercisesDisplay = require './exercises-display'
 
-Help = require './help'
-
 Icon = require '../icon'
 LoadingDisplay = require './loading-display'
 
@@ -41,7 +39,6 @@ QuestionsDashboard = React.createClass
         onSelectionsChange={@onSelectionsChange} />
 
       <ExercisesDisplay
-        helpTooltip={Help.forCourseId(@props.courseId).primary}
         {...@props}
         showingDetails={@state.showingDetails}
         onShowCardViewClick={@onShowCardViewClick}

--- a/src/components/questions/exercises-display.cjsx
+++ b/src/components/questions/exercises-display.cjsx
@@ -4,6 +4,7 @@ BS = require 'react-bootstrap'
 {PinnedHeaderFooterCard} = require 'openstax-react-components'
 {ExerciseStore, ExerciseActions} = require '../../flux/exercise'
 
+Help = require './help'
 Icon = require '../icon'
 ExerciseControls = require './exercise-controls'
 ExerciseDetails  = require '../exercises/details'
@@ -15,13 +16,13 @@ ExerciseHelpers  = require '../../helpers/exercise'
 Dialog           = require '../tutor-dialog'
 CourseGroupingLabel = require '../course-grouping-label'
 
+
 ExercisesDisplay = React.createClass
 
   propTypes:
     courseId:    React.PropTypes.string.isRequired
     sectionIds:  React.PropTypes.array
     ecosystemId: React.PropTypes.string.isRequired
-    helpTooltip: React.PropTypes.string.isRequired
 
   getInitialState: -> {
     filter: ''
@@ -169,6 +170,7 @@ ExercisesDisplay = React.createClass
     ExerciseStore.isExerciseExcluded(exercise.id)
 
   renderExercises: (exercises) ->
+
     return <NoExercisesFound /> unless exercises.count
 
     sharedProps =
@@ -177,6 +179,7 @@ ExercisesDisplay = React.createClass
         getExerciseActions: @getExerciseActions
         getExerciseIsSelected: @getExerciseIsSelected
         ecosystemId: @props.ecosystemId
+        topScrollOffset: 190
 
     if @props.showingDetails
       <ExerciseDetails
@@ -199,15 +202,7 @@ ExercisesDisplay = React.createClass
     return null if ExerciseStore.isLoading() or _.isEmpty(@props.sectionIds)
 
     exercises = ExerciseStore.groupBySectionsAndTypes(@props.ecosystemId, @props.sectionIds, withExcluded: true)
-
     <div className="exercises-display">
-      <div className="instructions">
-        <div className="wrapper">
-          Click each question that you would like to exclude from
-          all aspects of your students’ Tutor experience.
-          <Icon type='info-circle' tooltip={@props.helpTooltip} />
-        </div>
-      </div>
 
       <PinnedHeaderFooterCard
         ref='controls'
@@ -215,6 +210,12 @@ ExercisesDisplay = React.createClass
         header={@renderControls(exercises)}
         cardType='sections-questions'
       >
+
+      <div className="instructions">
+        <div className="wrapper">
+          {Help.forCourseId(@props.courseId).second.bar}
+        </div>
+      </div>
 
       {@renderExercises(
         if @state.filter then exercises[@state.filter] else exercises.all

--- a/src/components/questions/help.cjsx
+++ b/src/components/questions/help.cjsx
@@ -1,36 +1,78 @@
 React = require 'react'
 
 {CourseStore} = require '../../flux/course'
+Icon = require '../icon'
 
-CC_HELP = '''
-By default, Concept Coach will use all questions in the Library
-to deliver practice questions to your students.
-The Library gives you the option to exclude questions from your
-students' experiences. However, please note that you will
-not be able to exclude questions from assignments or
-scores once your students start using Concept Coach.
-'''
+TUT_TT1 =
+  <span>
+    Tutor uses these questions for your assignments, spaced practice, personalization,
+    and Performance Forecast practice.
+  </span>
 
-TUTOR_HELP = '''
-    Tutor uses these questions for your assignments,
-    spaced practice, personalization, and Performance Forecast practice.
-'''
-
-
-CC_SECONDARY_HELP = <div className="secondary-help">
-  <b>Best Practice:</b>
-  Exclude questions <u>before</u> giving students access to Concept Coach.
-</div>
+TUT_TT2 =
+  <span>
+    If you want to exclude any questions from a particular section,
+    be sure to do so before you assign those sections for reading or homework.
+  </span>
 
 
+TUTOR_HELP =
+  first:
+    bar:
+      <span>
+        Select the sections you plan to assign below to review all possible
+        questions. <Icon tooltip={TUT_TT1} type="info-circle" />
+      </span>
+    addon:
+      <span>
+        You can skip any sections you won’t be covering in your
+        course.  Students will never see questions from sections you don’t
+        assign. <Icon tooltip={TUT_TT2} type="info-circle" />
+      </span>
+
+  second:
+    bar:
+      <span>
+        If you want to exclude any questions, be sure to do so before
+        you assign those sections for reading or homework.
+      </span>
+
+CC_TT1 =
+  <span>
+    Concept Coach uses these questions to give students practice.
+    After reading a section, students will get questions
+    reinforcing that section and <i>and</i> review questions
+    reinforcing previously read sections.
+  </span>
+
+CC_TT2 =
+  <span>
+   If you want to exclude any questions, be sure to do so before your students start reading those sections.
+  </span>
+
+CC_HELP =
+  first:
+    bar:
+      <span>
+        Select the sections you plan to assign below to review all possible questions.
+        <Icon tooltip={CC_TT1} type="info-circle" />
+      </span>
+    addon:
+      <span>
+        You can skip any sections you won’t be covering in your course.
+        Students will only see questions from sections they work on in Concept Coach.
+      </span>
+  second:
+    bar:
+      <span>
+        If you want to exclude any questions, be sure to do so before your
+        students start reading those sections.
+      </span>
 
 Help =
 
   forCourseId: (courseId) ->
     course = CourseStore.get(courseId)
-    primary = if course.is_concept_coach then CC_HELP else TUTOR_HELP
-    secondary = if course.is_concept_coach then CC_SECONDARY_HELP else null
-
-    {primary, secondary}
+    if course.is_concept_coach then CC_HELP else TUTOR_HELP
 
 module.exports = Help

--- a/src/components/questions/sections-chooser.cjsx
+++ b/src/components/questions/sections-chooser.cjsx
@@ -33,7 +33,7 @@ QLSectionsChooser = React.createClass
   onSectionChange: (sectionIds) -> @setState({sectionIds})
 
   render: ->
-    help = Help.forCourseId(@props.courseId)
+    helpText = Help.forCourseId(@props.courseId).first
 
     <div className="sections-chooser panel">
 
@@ -48,12 +48,12 @@ QLSectionsChooser = React.createClass
 
       <div className="instructions">
         <div className="wrapper">
-          Select sections below to review and exclude questions from your
-           students’ experience.
-          <Icon type='info-circle' tooltip={help.primary} />
+          {helpText.bar}
         </div>
       </div>
-      {help.secondary}
+
+     <div className='instructions-addon'>{helpText.addon}</div>
+
       <div className="sections-list">
         <Chooser
           onSelectionChange={@onSectionChange}


### PR DESCRIPTION
Tutor top bar  (spacing is shown as-is directly after section choice):
![screen shot 2016-07-26 at 4 16 06 pm](https://cloud.githubusercontent.com/assets/79566/17155932/d14737be-534c-11e6-99ec-1db386efabd9.png)



Tutor second bar:
![screen shot 2016-07-26 at 4 16 34 pm](https://cloud.githubusercontent.com/assets/79566/17155933/d15d704c-534c-11e6-95c0-8291951044ef.png)



CC top bar:
![screen shot 2016-07-26 at 4 16 45 pm](https://cloud.githubusercontent.com/assets/79566/17155935/d15dd654-534c-11e6-8e5f-e83fd8ef78ca.png)



CC bottom bar:
![screen shot 2016-07-26 at 4 17 52 pm](https://cloud.githubusercontent.com/assets/79566/17155934/d15d5d14-534c-11e6-9c62-23f43df43934.png)
