### PR TITLE
start up a mock server based on the API blueprint

### DIFF
--- a/api/tutor.apib
+++ b/api/tutor.apib
@@ -192,13 +192,36 @@ _TODO:_ Figure out what this is
 + tags: `book:stax-apbio`, `filter-type:import:hs` (array[string])
 + uid: `30@1` (string, required)
 + version: `1` (number, required)
++ collaborator_solutions (array[Exercise Solution], required)
++ community_solutions (array[Exercise Solution], required)
++ hints (array, required)
++ formats: `free-response`, `multiple-choice` (array[enum], required)
++ combo_choices (array, required)
+
+### Exercise Solution (object)
++ attachments (array)
++ solution_type: `detailed` (enum, required)
++ content_html: `A hypothesis is a proposed explanation for an occurance or event based on previous observations that can be tested.` (string, required)
+
+
 
 ### Exercise User (object)
 + name: `OpenStax` (string, required)
 + user_id': `1` (string, required)
 
 ### Exercise Question (object)
-_TODO:_ Fill in the JSON schema for a question
++ id: `26945` (number, required)
++ is_answer_order_important: `true` (boolean, required)
++ stimulus_html (string)
++ stem_html: `What is a suggested and testable explanation for an event called?` (string, required)
++ answers (array[Exercise Question Answer], required)
+
+### Exercise Question Answer (object)
++ id: `107149` (number, required)
++ content_html: `discovery` (string, required)
++ correctness: `0.0` (string, required) - But it's a float. _TODO:_ make this a number again
++ feedback_html: `A hypothesis is a suggested and testable explanation for an event.` (string, required)
+
 
 
 ## Current User (object)
@@ -257,8 +280,35 @@ Placeholder for the time format `00:00`
 + deidentifier: `d34db33f` (string, required)
 + is_active: `true` (boolean, required)
 
+## Exercise List (object)
++ total_count: `1` (number, required)
++ items (array[Tutor Exercise], required)
 
-# Teacher Course Routes [/api/courses/{courseId}]
+### Tutor Exercise (object)
++ id: `3` (string, required)
++ url: `https://exercises.openstax.org/exercises/3@2` (URL, required)
++ content (Task Step Exercise Content, required)
++ tags (array[Tutor Exercise Tag], required)
+
+### Tutor Exercise Tag (object)
++ id: `apbio-ch01-s01-lo02` (string, required)
++ type: `lo`, `generic`, `cnxmod` (enum, required)
++ is_visible: `true` (boolean, required)
++ description: `What are the steps of the scientific method?` (string, required)
++ chapter_section (Chapter Section, required)
+
+
+# Get Teacher Plan [/api/plans/{planId}]
+
+## Get the Teacher Plan [GET /api/plans/{planId}]
++ Parameters
+    + planId: `69` (number, required)
+
++ Response 200 (application/json)
+    + Attributes (Teacher Plan)
+
+
+# Teacher Plan Statistics [/api/plans/{planId}/stats]
 
 ## Get Teacher Assignment Statistics [GET /api/plans/{planId}/stats]
 
@@ -324,3 +374,15 @@ Placeholder for the time format `00:00`
 
 + Response 200 (application/json)
   + Attributes (array[My Course List Item])
+
+
+# Available Exercises [/api/courses/1/exercises/homework_core{?page_ids%5B%5D,ecosystem_id}]
+
+# Get Available Exercises [GET /api/courses/1/exercises/homework_core{?page_ids%5B%5D,ecosystem_id}]
+
++ Parameters
+    + page_ids%5B%5D: `314` (number, required) - This actually needs to have square brackets at then end `...ids[]`
+    + ecosystem_id: `4` (number, required)
+
++ Response 200 (application/json)
+  + Attributes (Exercise List)

--- a/api/tutor.apib
+++ b/api/tutor.apib
@@ -1,0 +1,326 @@
+FORMAT: 1A
+HOST: https://tutor-dev.openstax.org/
+
+# tutor
+
+_TODO:_
+- Use `title` or `name` more consistently
+
+# Data Structures
+
+## URL (string)
+A fully qualified URL
+
+## Date (string)
+An ISO date (no time or timezone information)
+
+## Timestamp (Date)
+An ISO date with time and timezone information
+
+## Href (string)
+Marker for a partial URL
+
+## Chapter Section (array[number, number])
+Array of `[chapter, section]`
+
+## Teacher Plan Page Stats (object)
++ id: `314` (string, required)
++ title: `Themes and Concepts of Biology` (string, required)
++ is_trouble: `false` (boolean, required)
++ correct_count: `2` (number, required)
++ incorrect_count: `2` (number, required)
++ student_count: `1` (number, required)
++ chapter_section (Chapter Section, required)
+
+## Teacher Plan Period Stats (object)
++ name: `2nd Period` (string, required)
++ period_id: `2` (string, required)
++ is_trouble: `false` (boolean, required)
++ mean_grade_percent: `50` (number, required)
++ current_pages (array[Teacher Plan Page Stats], required)
++ spaced_pages (array[Teacher Plan Page Stats], required)
++ complete_count: `1` (number, required)
++ partially_complete_count: `1` (number, required)
++ total_count: `10` (number, required)
+
+## Teacher Plan Stats (object)
++ id: `69` (string, required)
++ type: homework, reading, event (enum, required)
++ title: `3 part MPQ` (string, required)
++ stats (array[Teacher Plan Period Stats], required)
++ shareable_url: `/@/kEyX0d/3-part-mpq` (Href, required)
+
+## Teacher Plan Homework Settings (object)
++ page_ids: `314` (array[string], required)
++ exercise_ids: `2994` (array[string], required)
++ exercises_count_dynamic: `3` (number, required)
+
+## Tasking Plan (object)
+- target_id: `1` (string, required)
+- target_type: period (enum, required)
+- opens_at: `2016-07-06T05:01:00.000Z` (Timestamp, required)
+- due_at: `2016-07-15T12:00:00.000Z` (Timestamp, required)
+
+
+## Teacher Plan (object)
++ id: `69` (string, required)
++ title: `3 part MPQ` (string, required)
++ type: homework, reading, event (enum, required)
++ ecosystem_id: `4` (string, required)
++ is_feedback_immediate: `false` (boolean, required)
++ is_draft: `false` (boolean, required)
++ is_publishing: `false` (boolean, required)
++ is_published: `true` (boolean, required)
++ is_trouble: `false` (boolean, required)
++ first_published_at: `2016-07-06T19:30:59.515Z` (Timestamp, required)
++ last_published_at: `2016-07-06T19:30:59.515Z` (Timestamp, required)
++ publish_last_requested_at: `2016-07-06T19:30:58.399Z` (Timestamp, required)
++ publish_job_url: `/api/jobs/af8f9add-cb30-4973-be4c-42295287bd60` (Href, required)
++ settings (Teacher Plan Homework Settings, required)
++ tasking_plans' (array[Tasking Plan], required)
+
+
+## Tutor User (object)
++ id: `1` (string, required)
++ role_id: `1` (string, required)
++ first_name: `Charles` (string, required)
++ last_name: `Morris` (string, required)
+
+## User Role (object)
++ id: `1` (string, required)
++ type: teacher, student (enum, required)
+
+## Course Blurb (object)
++ name: `Biology I` (string, required)
++ teachers (array[Tutor User], required)
+
+## Teacher Dashboard (object)
++ plans (array[Teacher Plan], required)
++ tasks (array, required)
++ role (User Role, required)
++ course (Course Blurb, required)
+
+## Teacher Student Scores Period Data Heading (object)
++ title: `3 part MPQ` (string, required)
++ plan_id: `69` (number, required)
++ type: homework, reading (enum, required)
++ due_at: `2016-07-15T12:00:00.000Z` (Timestamp, required)
++ average_score': `0.0277777777777778` (number, required)
+
+## Teacher Student Scores User Data (object)
++ type: `homework` (string, required)
++ id: `1362` (number, required)
++ status: `not_started` (string, required)
++ step_count: `4` (number, required)
++ completed_step_count: `0` (number, required)
++ completed_on_time_step_count: `0` (number, required)
++ completed_accepted_late_step_count: `0` (number, required)
++ exercise_count: `4` (number, required)
++ completed_exercise_count: `0` (number, required)
++ completed_on_time_exercise_count: `0` (number, required)
++ completed_accepted_late_exercise_count: `0` (number, required)
++ correct_exercise_count: `0` (number, required)
++ correct_on_time_exercise_count: `0` (number, required)
++ correct_accepted_late_exercise_count: `0` (number, required)
++ score: `0.9` (number, required)
++ recovered_exercise_count: `0` (number, required)
++ due_at: `2016-07-15T12:00:00.000Z` (Timestamp, required)
++ is_late_work_accepted: `false` (boolean, required)
++ is_included_in_averages: `true` (boolean, required)
+
+
+## Teacher Student Scores User (object)
++ name: `Rabbit Angstrom` (string, required)
++ first_name: `Rabbit` (string, required)
++ last_name: `Angstrom` (string, required)
++ role: 9 (number, required) - _TODO:_ Use `role_id` and make it a string
++ student_identifier: `JQMVOWU2PA` (string, required)
++ average_score: `0.9` (number, required)
++ data (array[Teacher Student Scores User Data], required) - This has to match the length of the Data Headings
+
+
+## Teacher Student Scores Period (object)
++ period_id: `1` (string, required)
++ overall_average_score: `0.0222` (number, required)
++ data_headings (array[Teacher Student Scores Period Data Heading], required)
++ students (array[Teacher Student Scores User], required)
+
+
+## Assignment Task (object)
++ id: `2014` (string, required)
++ is_feedback_available: `true` (boolean, required)
++ is_shared: `false` (boolean, required)
++ spy (Task Spy Data, required)
++ steps (array[Assignment Task Step], required)
++ title: `Practice` (string, required)
++ type: `page_practice` (string, required)
+
+### Task Spy Data (object)
+_TODO:_ Unknown what this contains
+
+### Assignment Task Step (object)
++ id: `11322` (string, required)
++ type: exercise (enum, required)
++ group: default (enum, required)
++ task_id: `2014` (string, required)
++ has_recovery: `false` (boolean, required)
++ is_completed: `false` (boolean, required)
++ is_in_multipart: `false` (boolean, required)
++ labels (array[Task Step Label], required)
++ question_id: `30` (string, required)
++ related_content' (array[Page Details], required)
++ content (Task Step Exercise Content, required)
++ content_url: `https://exercises-dev.openstax.org/exercises/30@1` (URL, required)
+
+### Page Details (object)
++ title: `The Science of Biology` (string, required)
++ chapter_section (Chapter Section, required)
+
+### Task Step Label (object)
+_TODO:_ Figure out what this is
+
+### Task Step Exercise Content (object)
++ authors (array[Exercise User], required)
++ copyright_holders (array[Exercise User], required)
++ derived_from (array) - _TODO_ Not sure what the format of this is. Also, should it be an Array or a nullable field?
++ editors (array[Exercise User], required)
++ is_vocab: `false` (boolean, required)
++ number: `30` (number, required) - _TODO_ should this be `count`? It is unclear what the number is
++ published_at: `2015-09-16T20:13:33.142Z` (Timestamp, required)
++ questions (array[Exercise Question], required)
++ stimulus_html: `To answer the following questions you need to know the formula for Force` (string, required)
++ tags: `book:stax-apbio`, `filter-type:import:hs` (array[string])
++ uid: `30@1` (string, required)
++ version: `1` (number, required)
+
+### Exercise User (object)
++ name: `OpenStax` (string, required)
++ user_id': `1` (string, required)
+
+### Exercise Question (object)
+_TODO:_ Fill in the JSON schema for a question
+
+
+## Current User (object)
++ id: `2` (number, required) - _TODO_ Should probably be a string
++ username: `student1234` (string, required)
++ first_name: `Bob` (string, required)
++ last_name: `Smith` (string, required)
++ full_name: `Robert Smith` (string, required)
++ title: `Mr.` (string)
++ contact_infos (array[User Contact Info], required)
+
+### User Contact Info (object)
++ id: `147` (number, required)
++ type: EmailAddress (enum, required)
++ value: `email@example.com` (enum, required)
++ is_verified: `false` (boolean, required)
++ num_pin_verification_attempts_remaining: `5` (number) - This is only available when `is_verified` is `false`
+
+## My Course List Item (object)
++ id: `1` (string, required)
++ name: `Biology for AP Courses` (string, required)
++ time_zone: `Eastern Time (US & Canada)` (string, required) - Actually, it is an enum
++ default_open_time: `00:01` (Time, required)
++ default_due_time: `07:00` (Time, required)
++ salesforce_book_name: `AP Bio` (enum, required) - Actually, it is an enum
++ appearance_code: `biology` (enum, required)
++ ecosystem_id: `1` (string, required)
++ book_pdf_url: `https://archive-staging-tutor.cnx.org/exports/d52e93f4-8653-4273-86da-3850001c0786.pdf` (URL, required)
++ webview_url: `https://staging-tutor.cnx.org/contents/d52e93f4-8653-4273-86da-3850001c0786` (URL, required)
++ is_concept_coach: `false` (boolean, required)
++ is_college: `false` (boolean, required)
++ roles (array[User Role], required)
++ periods (array[Course Period], required)
+
+### Time (string)
+Placeholder for the time format `00:00`
+
+### Course Period (object)
++ id: `1` (string, required)
++ name: `1st` (string, required)
++ enrollment_code: `123456` (string, required)
++ enrollment_url: `https://tutor-qa.openstax.org/enroll/123456` (string, required)
++ default_open_time: `00:01` (Time, required)
++ default_due_time: `07:00` (Time, required)
++ is_archived: `false` (boolean, required)
++ students (array[Course Student], required)
+
+### Course Student (object)
++ id: `466` (string, required)
++ period_id: `6` (string, required)
++ role_id: `123` (string, required)
++ first_name: `Johnny` (string, required)
++ last_name: `Smith` (string, required)
++ name: `John Smith` (string, required) - _TODO_ rename to `full_name`
++ student_identifier: `123` (string, required)
++ deidentifier: `d34db33f` (string, required)
++ is_active: `true` (boolean, required)
+
+
+# Teacher Course Routes [/api/courses/{courseId}]
+
+## Get Teacher Assignment Statistics [GET /api/plans/{planId}/stats]
+
++ Parameters
+    + planId: `69` (number, required)
+
++ Response 200 (application/json)
+    + Attributes (Teacher Plan Stats)
+
+
+# Teacher Course Dashboard [/api/courses/{courseId}/dashboard]
+
+## Get Events for a date range [GET /api/courses/{courseId}/dashboard{?start_at,end_at}]
+
++ Parameters
+    + courseId: `1` (number, required)
+    + start_at: `2016-06-30` (Date)
+    + end_at: `2016-08-01` (Date)
+
++ Response 200 (application/json)
+  + Attributes (Teacher Dashboard)
+
+
+## Get Matrix of Student Scores [GET /api/courses/{courseId}/performance]
+
++ Parameters
+    + courseId: `1` (number, required)
+
++ Response 200 (application/json)
+  + Attributes (array[Teacher Student Scores Period])
+
+
+# Task Routes [/tasks/{taskId}]
+
+## Get a single Task [GET /api/tasks/{taskId}]
+
++ Parameters
+    + taskId: `2014` (number, required)
+
++ Response 200 (application/json)
+  + Attributes (Assignment Task)
+
+
+## Get a single Task Step [GET /api/steps/{stepId}]
+
++ Parameters
+    + stepId: `11322` (number, required)
+
++ Response 200 (application/json)
+  + Attributes (Assignment Task Step)
+
+# User Route [/api/user]
+
+## Get the Current User [GET /api/user]
+
++ Response 200 (application/json)
+  + Attributes (Current User)
+
+
+# User Courses Route [/api/user/courses]
+
+## List the courses available to the Current User [GET /api/user/courses]
+
++ Response 200 (application/json)
+  + Attributes (array[My Course List Item])

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint-cjsx": "./scripts/lint-cjsx-files.sh",
     "validate": "node ./scripts/validate-package-json.js",
     "prestart": "npm run validate",
-    "start": "gulp dev",
+    "start": "parallelshell --verbose 'gulp dev' 'drakov -f ./api/tutor.apib --autoOptions'",
+    "mock": "drakov -f ./api/tutor.apib --autoOptions --watch",
     "test-docs": "csdoc --template dependency <test-integration/helpers/ui/test-element.coffee >docs-dependency.json; csdoc --template html --dep ../../../docs-dependency test-integration/helpers/ui/"
   },
   "repository": {
@@ -88,6 +89,7 @@
     "csdoc": "0.1.4",
     "css-loader": "0.22.0",
     "del": "1.1.1",
+    "drakov": "1.0.1",
     "eslint": "1.10.3",
     "extract-text-webpack-plugin": "0.8.2",
     "file-exists": "0.1.1",

--- a/src/helpers/api.coffee
+++ b/src/helpers/api.coffee
@@ -29,13 +29,8 @@ makeLocalRequest = (requestConfig) ->
   {url} = requestConfig
 
   [uri, params] = url.split('?')
-  if requestConfig.method is 'GET'
-    url_parts = ["#{uri}.json", params]
-  else
-    url_parts = ["#{uri}/#{requestConfig.method}.json", params]
-    requestConfig.mockMethod = requestConfig.method
-    requestConfig.method = 'GET'
-
+  uri = "http://localhost:3000#{uri}" # TODO: Pass this in as an ENV setting
+  url_parts = [uri, params]
 
   requestConfig.url = _.compact(url_parts).join('?')
 
@@ -136,10 +131,13 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker, option
       opts =
         method: httpMethod or httpMethodOverride
         dataType: 'json'
-        headers:
+        displayError: true
+
+      # drakov (the API mock server) does not seem to like these headers. CORS complains
+      unless IS_LOCAL
+        opts.headers =
           'X-CSRF-Token': CurrentUserStore.getCSRFToken(),
           token: CurrentUserStore.getToken()
-        displayError: true
 
       if payload?
         opts.data = JSON.stringify(payload)


### PR DESCRIPTION
This starts up a mock server instead of relying on the API JSON files. Why?
1. the API is documented and kept up to date
2. allows for conditional requests (based on headers) which are useful for Selenium tests
3. response headers that contain the server time
4. properly supporting non-GET requests
5. Running Selenium tests in Travis without having to start up `tutor-server`

To see it in action, run `npm start` which starts up the mock server and runs `gulp dev`, and then go to http://localhost:8000 (or http://localhost:3000/api/user)
