### PR TITLE
Use college specific icons

### DIFF
--- a/src/components/app.cjsx
+++ b/src/components/app.cjsx
@@ -1,11 +1,12 @@
 React = require 'react'
+classnames = require 'classnames'
 
 {HistoryLocation, History, RouteHandler} = require 'react-router'
 
 Navbar = require './navbar'
 Analytics = require '../helpers/analytics'
 {SpyMode} = require 'openstax-react-components'
-
+{CourseStore} = require '../flux/course'
 {TransitionActions, TransitionStore} = require '../flux/transition'
 
 module.exports = React.createClass
@@ -29,7 +30,12 @@ module.exports = React.createClass
     TransitionActions.load(locationChangeEvent, @context.router)
 
   render: ->
-    <div className='tutor-app openstax-wrapper'>
+    {courseId} = @context.router.getCurrentParams()
+    classNames = classnames('tutor-app', 'openstax-wrapper', {
+      'is-college':     courseId? and CourseStore.isCollege(courseId)
+      'is-high-school': courseId? and CourseStore.isHighSchool(courseId)
+    })
+    <div className={classNames}>
       <SpyMode.Wrapper>
         <Navbar />
         <RouteHandler/>

--- a/src/components/breadcrumb/index.cjsx
+++ b/src/components/breadcrumb/index.cjsx
@@ -8,6 +8,15 @@ React = require 'react'
 
 BreadcrumbStatic = React.createClass
   displayName: 'BreadcrumbStatic'
+  propTypes:
+    crumb: React.PropTypes.shape(
+      type: React.PropTypes.string.isRequired
+      data: React.PropTypes.shape(
+        id: React.PropTypes.string.isRequired
+        task_id: React.PropTypes.string.isRequired
+      ).isRequired
+    ).isRequired
+
   componentWillMount: ->
     @setStep(@props)
 
@@ -30,6 +39,16 @@ BreadcrumbStatic = React.createClass
       step={step}/>
 
 BreadcrumbTaskDynamic = React.createClass
+  propTypes:
+    crumb: React.PropTypes.shape(
+      type: React.PropTypes.string.isRequired
+      data: React.PropTypes.shape(
+        id: React.PropTypes.number.isRequired
+        task_id: React.PropTypes.number.isRequired
+      ).isRequired
+    ).isRequired
+    onMount: React.PropTypes.func
+
   displayName: 'BreadcrumbTaskDynamic'
   componentWillMount: ->
     {crumb} = @props

--- a/src/flux/course.coffee
+++ b/src/flux/course.coffee
@@ -78,6 +78,7 @@ CourseConfig =
 
     isConceptCoach: (courseId) -> !! @_local[courseId]?.is_concept_coach
     isCollege: (courseId) -> !! @_local[courseId]?.is_college
+    isHighSchool: (courseId) -> not @_local[courseId]?.is_college
 
     isGuideLoading: (courseId) -> @_asyncStatusGuides[courseId] is 'loading'
     isGuideLoaded: (courseId) -> !! @_guides[courseId]


### PR DESCRIPTION
Depends on https://github.com/openstax/react-components/pull/102

Adds the 'is-college' and 'is-high-school' classes on root element for switching icons and styles
is no longer based off production


![screen shot 2016-07-27 at 10 54 48 am](https://cloud.githubusercontent.com/assets/79566/17182310/ac2de6a2-53e8-11e6-9532-6d3eb25fbcde.png)

![screen shot 2016-07-27 at 12 17 39 pm](https://cloud.githubusercontent.com/assets/79566/17184878/2494e824-53f4-11e6-99a4-132754788410.png)