### PR TITLE
Add tooltip to HW builder course timezone change

### DIFF
--- a/src/components/task-plan/builder/time-zone-settings-link.cjsx
+++ b/src/components/task-plan/builder/time-zone-settings-link.cjsx
@@ -1,5 +1,6 @@
-React = require 'react'
+React  = require 'react'
 Router = require 'react-router'
+BS     = require 'react-bootstrap'
 
 {CourseStore} = require '../../../flux/course'
 
@@ -12,12 +13,18 @@ TimeZoneSettingsLink = React.createClass
     router: React.PropTypes.func
 
   render: ->
+    tooltip =
+      <BS.Tooltip id='change-course-time'>
+        Click to change course time zone
+      </BS.Tooltip>
     <Router.Link
       className='course-time-zone'
       to='courseSettings'
       params={courseId: @props.courseId}
     >
-      {CourseStore.getTimezone(@props.courseId)}
+      <BS.OverlayTrigger placement='top' overlay={tooltip}>
+        <span>{CourseStore.getTimezone(@props.courseId)}</span>
+      </BS.OverlayTrigger>
     </Router.Link>
 
 


### PR DESCRIPTION
This was missed when the link was added.

![screen shot 2016-07-27 at 2 04 46 pm](https://cloud.githubusercontent.com/assets/79566/17188557/323a71f6-5403-11e6-80df-7ea332fdd790.png)
