### PR TITLE
Fix: Reading progress does not match up when accepting late score

### DIFF
--- a/src/helpers/task.coffee
+++ b/src/helpers/task.coffee
@@ -38,9 +38,12 @@ module.exports = {
     "#{progress}%"
 
   getHumanProgressWithLateWork: (task) ->
-    progress = Math.round((
-      task.completed_exercise_count / task.exercise_count
-      ) * 100 )
+    percent =
+      if task.type is 'homework'
+        task.completed_exercise_count / task.exercise_count
+      else
+        task.completed_step_count / task.step_count
+    progress = Math.round(percent * 100)
     "#{progress}%"
 
   getCompletedSteps: (task) ->


### PR DESCRIPTION
Made it so the late-work progress for reading assignments is calculated with the steps instead of exercises to be consistent with non-late work.

https://www.pivotaltracker.com/n/projects/1156756/stories/125233391/comments/145060321

Before:
<img width="526" alt="screen shot 2016-07-28 at 12 55 55 pm" src="https://cloud.githubusercontent.com/assets/7595652/17227960/c610e708-54c5-11e6-8768-c073a25ea93d.png">

After:
<img width="548" alt="screen shot 2016-07-28 at 1 17 49 pm" src="https://cloud.githubusercontent.com/assets/7595652/17227963/ccb21f50-54c5-11e6-8e68-55514b3522fb.png">
