### PR TITLE
Fix calendar events escaping the week they should be in

### DIFF
--- a/tutor/src/components/course-calendar/duration.cjsx
+++ b/tutor/src/components/course-calendar/duration.cjsx
@@ -108,7 +108,7 @@ CourseDuration = React.createClass
 
         _.chain(plans)
           .sortBy((plan) ->
-            -1 * plan.rangeDuration.start.valueOf()
+            plan.rangeDuration.count('days')
           )
           .each(@setPlanOrder({current, existingOrdered, weekTopOffset, maxPlansOnDay}))
           .value()

--- a/tutor/src/components/course-calendar/duration.cjsx
+++ b/tutor/src/components/course-calendar/duration.cjsx
@@ -109,15 +109,16 @@ CourseDuration = React.createClass
 
   # set plan order, makes sure that order is not already taken on this day
   setPlanOrder: ({current, existingOrdered, weekTopOffset, maxPlansOnDay}) ->
-    (plan, order) =>
-      unless plan.order?
+    (duration, order) =>
+      unless duration.order?
         current.order = order
         @_calcOrder({existingOrdered, current, maxPlansOnDay})
-        plan.order = current.order
-        plan.weekTopOffset = weekTopOffset
+        duration.order = current.order
+        duration.weekTopOffset = weekTopOffset
 
   _calcOrder: ({existingOrdered, current, maxPlansOnDay}) ->
     # find an order that is not already occupied by any overlapping plans
+
     while existingOrdered.indexOf(maxPlansOnDay - (current.order + current.adder)) > -1
       current.adder = current.adder + 1
 

--- a/tutor/src/components/course-calendar/duration.cjsx
+++ b/tutor/src/components/course-calendar/duration.cjsx
@@ -77,15 +77,7 @@ CourseDuration = React.createClass
     groupedDurations = _.chain(groupingDurations)
       .map(@groupByRanges(durationsInView))
       .tap(@calcTopOffset)
-      .each(@setWeeksHeight)
       .value()
-
-  setWeeksHeight: (range) ->
-    height = 1 + _.reduce(range.plansByDays, (maxOrder, plansOnDay) ->
-      durationMax = _.max(plansOnDay, (plan) -> plan.order + 1 ).order or 0
-      Math.max(durationMax, maxOrder)
-    , 0)
-    range.dayHeight = Math.max(@_calcDayHeight(height), range.dayHeight)
 
   calcTopOffset: (ranges) ->
     dayHeights = _.pluck(ranges, 'dayHeight')


### PR DESCRIPTION
There were different edge cases that would cause problems seen [here](https://www.pivotaltracker.com/story/show/127275267) and [here](https://www.pivotaltracker.com/story/show/127915967).

Specifically, when multiple plans overlap on common day, kinda transitively, like this:

Plan 1 - Sunday, **Monday**, **Tuesday**
Plan 2 - **Monday**, **Tuesday**, _Wednesday_
Plan 3 - _Wednesday_, Thursday

the calendar was not accounting for when groups of plans like this amounted to more than 5 rows and needed more space on the calendars.
 
## Before
![screen shot 2016-08-11 at 1 26 11 am](https://cloud.githubusercontent.com/assets/2483873/17580236/adf28af8-5f62-11e6-97b5-7745581ac9dc.png)
![screen shot 2016-08-11 at 1 25 57 am](https://cloud.githubusercontent.com/assets/2483873/17580237/adf316f8-5f62-11e6-9761-50bf34805b51.png)


## After

![screen shot 2016-08-11 at 1 21 37 am](https://cloud.githubusercontent.com/assets/2483873/17580211/77abc9be-5f62-11e6-8527-43b4e04fac89.png)
![screen shot 2016-08-11 at 1 24 02 am](https://cloud.githubusercontent.com/assets/2483873/17580212/77ade5f0-5f62-11e6-81aa-3601d22bd2a9.png)

