### PR TITLE
Fix: Offset sim inside note

### DIFF
--- a/resources/styles/components/task-step/all-steps.less
+++ b/resources/styles/components/task-step/all-steps.less
@@ -44,13 +44,6 @@
         margin-left: -(@tutor-card-body-padding-horizontal - @desired-iframe-inset);
       }
     }
-
-    .interactive-content > .note {
-      iframe.interactive {
-        // The rest of the card has a lot of padding, and it won't fit unless we shift it over so it's centered
-        margin-left: -(@tutor-card-body-padding-horizontal + @tutor-note-padding-horizontal - @desired-iframe-inset);
-      }
-    }
   }
 
   .openstax-exercise-card {


### PR DESCRIPTION
Removes the special offset for sims that are inside `.note` elements because there is no longer any special styling for notes.

https://www.pivotaltracker.com/n/projects/1156756/stories/110780416/comments/145290063

<img width="1115" alt="screen shot 2016-07-29 at 1 46 26 pm" src="https://cloud.githubusercontent.com/assets/7595652/17262942/2bc27a12-5593-11e6-87ac-beba61b8cc1c.png">
