### PR TITLE
Switch mathjax back to using it's default font

### DIFF
--- a/resources/styles/global/maths.less
+++ b/resources/styles/global/maths.less
@@ -1,7 +1,5 @@
-// Override the inline style on mathjax text elements to match the tutor default of lato
-.MathJax .mtext { font-family: lato !important; }
 // a more specific style to override those for .exercise.card img to make sure that
-// MathJax's render images 
+// MathJax's render images
 .exercise.card {
   .MathJax img {
     margin: 0;


### PR DESCRIPTION
Remove the `lato` specification