### PR TITLE
Homework builder's info icon only shows in the right context

### DIFF
--- a/src/components/task-plan/footer.cjsx
+++ b/src/components/task-plan/footer.cjsx
@@ -176,7 +176,7 @@ PlanFooter = React.createClass
       {cancelButton}
       {backButton}
       {saveLink}
-      {helpInfo}
+      {helpInfo unless TaskPlanStore.isPublished(id)}
       {deleteLink}
     </div>
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1156756/stories/121533153

<img width="1247" alt="screen shot 2016-08-01 at 2 02 58 pm" src="https://cloud.githubusercontent.com/assets/7595652/17308812/ae881fa6-57f0-11e6-9b83-9e6f950d8394.png">
