### PR TITLE
Fixes weird tabs in Performance Forecast and implements new design

### DIFF
--- a/tutor/resources/styles/components/course-settings.less
+++ b/tutor/resources/styles/components/course-settings.less
@@ -33,10 +33,6 @@
   .nav-tabs {
     .tutor-nav-tabs();
     span { max-width: 100px; }
-    li.active {
-      border: 1px solid @nav-tabs-border-color;
-      border-bottom: none;
-    }
   }
 
   .period-edit-controls {
@@ -96,21 +92,17 @@
       position: relative;
 
       .control {
-
-
         margin-left: 10px;
+
         .btn-link {
           color: @tutor-tertiary-light;
           padding: 0;
-
         }
 
         &.add-period, &.view-archived-periods {
           background-color: white;
-          margin-bottom: inherit;
-
-
         }
+
         &.view-archived-periods {
           position: absolute;
           right: 0;

--- a/tutor/resources/styles/components/performance-forecast/index.less
+++ b/tutor/resources/styles/components/performance-forecast/index.less
@@ -15,13 +15,8 @@
 .performance-forecast {
 
   .nav-tabs {
-    .tutor-nav-tabs();
+    .tutor-nav-tabs(@page-background);
     margin-bottom: 20px;
-
-    li.active {
-      border: 1px solid @nav-tabs-border-color;
-      border-bottom: none;
-    }
   }
 
   background: none;

--- a/tutor/resources/styles/components/scores/index.less
+++ b/tutor/resources/styles/components/scores/index.less
@@ -25,12 +25,8 @@
       clear: both;
 
       > li {
-        border-bottom: 1px solid @nav-tabs-border-color;
-
         &.active {
           position: relative;
-          border: 1px solid @nav-tabs-border-color;
-          border-bottom: none;
         }
 
         > a {
@@ -91,7 +87,7 @@
   &.panel {
     max-width: 100%;
   }
-  
+
   .course-scores-wrap {
     position: relative;
   }

--- a/tutor/resources/styles/components/student-dashboard/dashboard.less
+++ b/tutor/resources/styles/components/student-dashboard/dashboard.less
@@ -25,6 +25,19 @@
     li {
       #fonts .sans(2.4rem, 2.4rem);
       width: 210px;
+      background: @tutor-neutral-lighter;
+      border: none;
+      padding: 0;
+
+      &:hover {
+        background: @tutor-neutral-lightest;
+      }
+
+      &.active {
+        background: @tutor-white;
+        border: none;
+        padding: 0;
+      }
     }
   }
 

--- a/tutor/resources/styles/components/student-dashboard/dashboard.less
+++ b/tutor/resources/styles/components/student-dashboard/dashboard.less
@@ -31,6 +31,10 @@
 
       &:hover {
         background: @tutor-neutral-lightest;
+
+        a {
+          color: @tutor-neutral !important;
+        }
       }
 
       &.active {

--- a/tutor/resources/styles/components/task-plan/reading-stats.less
+++ b/tutor/resources/styles/components/task-plan/reading-stats.less
@@ -6,11 +6,6 @@
   .nav-tabs {
     .tutor-nav-tabs();
     margin-bottom: 20px;
-
-    li.active {
-      border: 1px solid @nav-tabs-border-color;
-      border-bottom: none;
-    }
   }
 
   section {

--- a/tutor/resources/styles/mixins.less
+++ b/tutor/resources/styles/mixins.less
@@ -74,14 +74,18 @@
   }
 }
 
-.tutor-nav-tabs() {
+.tutor-nav-tabs(@selected-background-color: @tutor-white) {
   background: none;
   display: flex;
   flex-wrap: wrap;
+
   li {
     text-align: center;
-    background: @tutor-neutral-lighter;
-
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid @nav-tabs-border-color;
+    padding: 1px;
+    padding-bottom: 0;
     .transition(background 0.2s);
 
     a {
@@ -103,7 +107,12 @@
     }
 
     &.active {
-      background: @tutor-white;
+      background: @selected-background-color;
+      border: 1px solid @nav-tabs-border-color;
+      border-bottom: none;
+      padding: 0;
+      padding-bottom: 1px;
+
       a {
         font-weight: 900;
         color: @tutor-neutral-darker !important;

--- a/tutor/resources/styles/mixins.less
+++ b/tutor/resources/styles/mixins.less
@@ -102,8 +102,8 @@
       }
     }
 
-    &:hover {
-      background: @tutor-neutral-lightest;
+    &:hover a {
+      color: lighten(@tutor-neutral, 14%) !important;
     }
 
     &.active {


### PR DESCRIPTION
Fixes the bug by implementing a slightly new tab design that should be consistent across all these kinds of tabs.

https://www.pivotaltracker.com/n/projects/1156756/stories/127656737

<img width="408" alt="screen shot 2016-08-03 at 4 04 36 pm" src="https://cloud.githubusercontent.com/assets/7595652/17385234/448a7bd8-5996-11e6-90f1-2d5fc43a023a.png">
<img width="376" alt="screen shot 2016-08-03 at 4 04 45 pm" src="https://cloud.githubusercontent.com/assets/7595652/17385237/448e74a4-5996-11e6-9130-08e8677a87a3.png">
<img width="566" alt="screen shot 2016-08-03 at 4 04 51 pm" src="https://cloud.githubusercontent.com/assets/7595652/17385236/448e4042-5996-11e6-9afb-7ecb401b7b6d.png">
<img width="879" alt="screen shot 2016-08-03 at 4 17 54 pm" src="https://cloud.githubusercontent.com/assets/7595652/17385235/448bcfba-5996-11e6-89d0-4a48f2a159c4.png">

Verify no change for:
<img width="920" alt="screen shot 2016-08-03 at 10 09 36 am" src="https://cloud.githubusercontent.com/assets/7595652/17385246/56cfd81a-5996-11e6-9603-c43cb42c227c.png">
