### PR TITLE
Escape css selectors 

### DIFF
--- a/tutor/src/components/book-content-mixin.cjsx
+++ b/tutor/src/components/book-content-mixin.cjsx
@@ -61,7 +61,7 @@ LinkContentMixin =
 
   getMedia: (mediaId) ->
     root = @getDOMNode()
-    root.querySelector("##{mediaId}")
+    root.querySelector("##{dom.escapeSelector(mediaId)}")
 
   cleanUpLinks: ->
     root = @getDOMNode()

--- a/tutor/src/helpers/dom.coffee
+++ b/tutor/src/helpers/dom.coffee
@@ -18,4 +18,7 @@ module.exports = {
     else
       {}
 
+  escapeSelector: (selector) ->
+    selector.replace( /(:|\.|\[|\]|,|\/)/g, "\\$1" )
+
 }

--- a/tutor/test/dom-helpers.spec.coffee
+++ b/tutor/test/dom-helpers.spec.coffee
@@ -42,3 +42,6 @@ describe 'DOM Helpers', ->
 
   it 'can read bootstrap data', ->
     expect(DOM.readBootstrapData(@root)).to.deep.equal({"user":{"name":"Atticus Finch"}})
+
+  it 'escapes css selectors', ->
+    expect(DOM.escapeSelector("/foo.bar,k12phys-ch11-ex064")).to.equal('\\/foo\\.bar\\,k12phys-ch11-ex064')


### PR DESCRIPTION
The mediaId may have slashes in it. Physics 11.3 has id's like: `ost/api/ex/k12phys-ch11-ex051`