### PR TITLE
Hide QR codes globally, except on QA view

### DIFF
--- a/tutor/resources/styles/book-content/index.less
+++ b/tutor/resources/styles/book-content/index.less
@@ -17,7 +17,6 @@
   @import './typography';
   @import './learning-objectives';
   @import './splash-image';
-  @import './link-to-learning';
   @import './note';
   @import './target';
   @import './os-teacher';

--- a/tutor/resources/styles/global/misc.less
+++ b/tutor/resources/styles/global/misc.less
@@ -1,0 +1,4 @@
+// This file is part of the book-content mixin and should not be included directly
+[data-alt='QR Code representing a URL'] {
+  display: none;
+}

--- a/tutor/resources/styles/qa.less
+++ b/tutor/resources/styles/qa.less
@@ -99,4 +99,8 @@
     }
 
   }
+  // QR codes are hidden elsewhere, but QA view should see the all content as-is
+  [data-alt='QR Code representing a URL'] {
+    display: unset;
+  }
 }

--- a/tutor/resources/styles/tutor.less
+++ b/tutor/resources/styles/tutor.less
@@ -26,6 +26,7 @@
 @import './global/popover';
 @import './global/tooltip';
 @import './global/menus';
+@import './global/misc';
 
 // qa view
 @import './qa.less';


### PR DESCRIPTION
We were only hiding them on book content before, which was reference view and reading steps, not on exercises, or exercises with book context.

