### PR TITLE
Fix for withdrawn external assignments

### DIFF
--- a/tutor/src/components/task-step/all-steps.cjsx
+++ b/tutor/src/components/task-step/all-steps.cjsx
@@ -66,8 +66,9 @@ ExternalUrl = React.createClass
   mixins: [StepMixin, StepFooterMixin]
   hideContinueButton: -> true
   onContinue: ->
-    {id, onStepCompleted} = @props
-    onStepCompleted() if StepPanel.canContinue(id)
+    {id, taskId, onStepCompleted} = @props
+    onStepCompleted() if StepPanel.canContinue(id) and not TaskStore.isDeleted(taskId)
+
   getUrl: ->
     {id} = @props
     {external_url} = TaskStepStore.get(id)


### PR DESCRIPTION
Pivotal ticket: https://www.pivotaltracker.com/story/show/127913061

Fixes clicking on withdrawn external assignments by removing the backend call when they click on the link.