### PR TITLE
builder states were not being updated on load

### DIFF
--- a/tutor/src/components/task-plan/plan-mixin.cjsx
+++ b/tutor/src/components/task-plan/plan-mixin.cjsx
@@ -37,12 +37,14 @@ PlanMixin =
     {id} = @props
 
     TaskPlanStore.on('publish-queued', @updateIsVisibleAndIsEditable)
+    TaskPlanStore.on("loaded.#{id}", @updateIsVisibleAndIsEditable)
     TaskingStore.on("taskings.#{id}.*.loaded", @updateIsVisibleAndIsEditable)
 
   componentWillUnmount: ->
     {id} = @props
 
     TaskPlanStore.off('publish-queued', @updateIsVisibleAndIsEditable)
+    TaskPlanStore.off("loaded.#{id}", @updateIsVisibleAndIsEditable)
     TaskingStore.off("taskings.#{id}.*.loaded", @updateIsVisibleAndIsEditable)
 
   showSectionTopics: ->

--- a/tutor/src/flux/task-plan.coffee
+++ b/tutor/src/flux/task-plan.coffee
@@ -71,7 +71,7 @@ TaskPlanConfig =
 
   _loaded: (obj, planId) ->
     @_server_copy[planId] = JSON.stringify(obj) if _.isObject(obj)
-
+    @emit("loaded.#{planId}")
     obj
 
   # Somewhere, the local copy gets taken apart and rebuilt.


### PR DESCRIPTION
fixes [ The message "Open times cannot be edited..." appears the second time you try to edit the assignment ](https://www.pivotaltracker.com/n/projects/1156756/stories/127671629).

the builder states were not being updated after load