### PR TITLE
Only examine current sections for min-exclusions

### DIFF
--- a/shared/src/components/exercise-preview/index.cjsx
+++ b/shared/src/components/exercise-preview/index.cjsx
@@ -115,10 +115,10 @@ ExercisePreview = React.createClass
       header={@props.header}
       footer={@renderFooter() if @props.children}
     >
+      {<div className='selected-mask' /> if @props.isSelected}
+
       <ControlsOverlay exercise={@props.exercise}
         actions={@props.overlayActions} onClick={@props.onOverlayClick} />
-
-      {<div className='selected-mask' /> if @props.isSelected}
 
       <div className="exercise-body">
 

--- a/shared/src/components/exercise-preview/index.cjsx
+++ b/shared/src/components/exercise-preview/index.cjsx
@@ -118,8 +118,9 @@ ExercisePreview = React.createClass
       <ControlsOverlay exercise={@props.exercise}
         actions={@props.overlayActions} onClick={@props.onOverlayClick} />
 
+      {<div className='selected-mask' /> if @props.isSelected}
+
       <div className="exercise-body">
-        {<div className='selected-mask' /> if @props.isSelected}
 
         <ExerciseBadges exercise={@props.exercise} />
 

--- a/tutor/src/components/questions/exercises-display.cjsx
+++ b/tutor/src/components/questions/exercises-display.cjsx
@@ -88,17 +88,16 @@ ExercisesDisplay = React.createClass
     @props.onShowCardViewClick(ev, exercise)
 
   renderMinimumExclusionWarning: (minExerciseCount) ->
-    section = <CourseGroupingLabel courseId={@props.courseId} lowercase />
     [
       <Icon key="icon" type="exclamation" />
       <div key="message" className="message">
         <p>
-          Tutor needs at least {minExerciseCount} questions for this {section} to be
+          Tutor needs at least {minExerciseCount} questions for this section to be
           included in spaced practice and personalized learning.
         </p>
         <p>
           If you exclude too many, your students will not get
-          to practice on topics in this {section}.
+          to practice on topics in this section.
         </p>
       </div>
     ]

--- a/tutor/src/components/questions/exercises-display.cjsx
+++ b/tutor/src/components/questions/exercises-display.cjsx
@@ -3,6 +3,7 @@ BS = require 'react-bootstrap'
 
 {PinnedHeaderFooterCard} = require 'shared'
 {ExerciseStore, ExerciseActions} = require '../../flux/exercise'
+{TocStore} = require '../../flux/toc'
 
 Help = require './help'
 Icon = require '../icon'
@@ -104,7 +105,9 @@ ExercisesDisplay = React.createClass
 
   onExerciseToggle: (ev, exercise) ->
     isSelected = not ExerciseStore.isExerciseExcluded(exercise.id)
-    minExerciseCount = ExerciseStore.excludedAtMinimum(exercise)
+    if isSelected
+      validUids = _.pluck(_.map(@props.sectionIds, TocStore.getSectionInfo), 'uuid')
+      minExerciseCount = ExerciseStore.excludedAtMinimum(exercise, validUids)
     if isSelected and minExerciseCount isnt false
       Dialog.show(
         className: 'question-library-min-exercise-exclusions'

--- a/tutor/src/flux/exercise.coffee
+++ b/tutor/src/flux/exercise.coffee
@@ -133,9 +133,9 @@ ExerciseConfig =
       @_exercises[pageIds.toString()] or throw new Error('BUG: Invalid page ids')
 
     # returns the available count if at minimum or `false` if not at minimum amount
-    excludedAtMinimum: (exercise) ->
+    excludedAtMinimum: (exercise, validCnxUuids) ->
       isExcluded = _.bind(@.exports.isExerciseExcluded, @)
-      for uuid in getExerciseCnxModUuids(exercise)
+      for uuid in getExerciseCnxModUuids(exercise) when _.include(validCnxUuids, uuid)
         exercises = @exports.forCnxModuleUuid.call(@, uuid)
         excluded = _.filter(_.pluck(exercises, 'id'), isExcluded)
         availableCount = exercises.length - excluded.length

--- a/tutor/test/flux/exercise.spec.coffee
+++ b/tutor/test/flux/exercise.spec.coffee
@@ -12,6 +12,7 @@ EXERCISE  = _.first(EXERCISES.items)
 COURSE_ID = 1
 PAGE_IDS  = [1, 2]
 ECOSYSTEM_ID = 1
+VALID_UUIDS = ['0e58aa87-2e09-40a7-8bf3-269b2fa16509']
 
 findTagByType = (exercise, tagType) -> _.findWhere(exercise.tags, {type: tagType})
 
@@ -63,13 +64,13 @@ describe 'exercises store', ->
     expect(teksTag.name.indexOf(teks)).to.not.equal(-1)
 
   it 'calulates exclusion minimum threshold', ->
-    exercises = ExerciseStore.forCnxModuleUuid('0e58aa87-2e09-40a7-8bf3-269b2fa16509')
+    exercises = ExerciseStore.forCnxModuleUuid(VALID_UUIDS[0])
     exercise = exercises[0]
     expect(exercises).to.have.lengthOf(5)
-    expect(ExerciseStore.excludedAtMinimum(exercise)).to.equal(5)
+    expect(ExerciseStore.excludedAtMinimum(exercise, VALID_UUIDS)).to.equal(5)
     ExerciseActions.updateExercises([_.extend({}, exercise, is_excluded: true)])
     # it should not warn when the count is below minimum
-    expect(ExerciseStore.excludedAtMinimum(exercise)).to.be.false
+    expect(ExerciseStore.excludedAtMinimum(exercise, VALID_UUIDS)).to.be.false
 
   it 'warns immediatly if exercise count is less than 5', ->
     ExerciseActions.reset()
@@ -78,10 +79,10 @@ describe 'exercises store', ->
       {total_count: 2, items: exercises},
       COURSE_ID, PAGE_IDS
     )
-    exercises = ExerciseStore.forCnxModuleUuid('0e58aa87-2e09-40a7-8bf3-269b2fa16509')
+    exercises = ExerciseStore.forCnxModuleUuid(VALID_UUIDS[0])
     expect(exercises).to.have.lengthOf(3)
     exercise = exercises[0]
-    expect(ExerciseStore.excludedAtMinimum(exercise)).to.equal(3)
+    expect(ExerciseStore.excludedAtMinimum(exercise, VALID_UUIDS)).to.equal(3)
     ExerciseActions.updateExercises([_.extend({}, exercise, is_excluded: true)])
     # now that there is exclusions, it shouldn't warn
-    expect(ExerciseStore.excludedAtMinimum(exercise)).to.be.false
+    expect(ExerciseStore.excludedAtMinimum(exercise, VALID_UUIDS)).to.be.false


### PR DESCRIPTION
Before the exercise exclusion code would examine all the sections an exercise was in.  This changes it to only examine certain modules (the one's displayed) when it decides whether to display the warning message or not.

I also found a CSS bug with how the layout mask was displayed, and moved it so it fills the entire card now.