### PR TITLE
Remove duplicate api from accounts URL

### DIFF
--- a/shared/src/model/notifications.coffee
+++ b/shared/src/model/notifications.coffee
@@ -23,7 +23,7 @@ Notifications = {
 
   startPolling: (@windowImpl = window) ->
     @_startPolling(
-      'accounts', URLs.construct('accounts_api', 'api', 'user')
+      'accounts', URLs.construct('accounts_api', 'user')
     ) if URLs.get('accounts_api')
 
     @_startPolling(

--- a/shared/test/model/notifications.spec.coffee
+++ b/shared/test/model/notifications.spec.coffee
@@ -18,11 +18,11 @@ describe 'Notifications', ->
     URLs.reset()
 
   it 'polls when URL is set', ->
-    URLs.update(accounts_api_url: 'http://localhost:2999')
+    URLs.update(accounts_api_url: 'http://localhost:2999/api')
     Notifications.startPolling(@windowImpl)
     expect(Poller::poll).to.have.callCount(1)
     expect(Poller::setUrl.lastCall.args).to.deep.equal(['http://localhost:2999/api/user'])
-    URLs.update(tutor_api_url: 'http://localhost:3001/api/notifications')
+    URLs.update(tutor_api_url: 'http://localhost:3001/api')
     Notifications.startPolling(@windowImpl)
     expect(Poller::poll).to.have.callCount(2)
 


### PR DESCRIPTION
accounts_api setting already includes "api" path

fixes:
![screen shot 2016-08-12 at 4 01 51 pm](https://cloud.githubusercontent.com/assets/79566/17636958/1ef92826-60a6-11e6-90d7-40a76dbf26e6.png)
