### PR TITLE
Fix/plan spacing

### DIFF
--- a/coach/src/api/loader.coffee
+++ b/coach/src/api/loader.coffee
@@ -1,5 +1,5 @@
 _ = require 'underscore'
-deepMerge = require 'lodash.merge'
+deepMerge = require 'lodash/merge'
 $ = require 'jquery'
 interpolate = require 'interpolate'
 

--- a/tutor/resources/styles/components/course-calendar/month.less
+++ b/tutor/resources/styles/components/course-calendar/month.less
@@ -36,18 +36,19 @@
     padding-bottom: @tutor-card-body-padding-vertical;
   }
 
-  .calendar-body {
-    [class^="col-"] {
-      overflow-x: hidden;
-      overflow-y: visible;
-      padding-bottom: 20px;
-    }
+  .calendar-body [class^="col-"] {
+    overflow-x: hidden;
+    overflow-y: visible;
+    padding-bottom: 20px;
+
+    .tutor-subtle-load(will-load; 'Loading ' attr(data-duration-name) '...');
   }
 
   .calendar-loading {
-    .rc-Month {
+    .calendar-body [class^="col-"] {
       .tutor-subtle-load(loading);
     }
+
     .plan {
       opacity: 0.1;
     }
@@ -67,7 +68,6 @@
       display: inline-block;
       vertical-align: top;
       position: relative;
-      .tutor-subtle-load(will-load; 'Loading Calendar...');
 
       &-weekdays {
         width: 100%;

--- a/tutor/src/components/course-calendar/duration.cjsx
+++ b/tutor/src/components/course-calendar/duration.cjsx
@@ -63,14 +63,13 @@ CourseDuration = React.createClass
       # TODO these parts actually seem like they should be in flux
       .each(@setDuration(viewingDuration))
       .filter(@isInDuration(viewingDuration))
-      .sortBy((plan) ->
-        moment(plan.published_at).valueOf()
-      )
-      .sortBy((plan) ->
-        plan.duration.end().valueOf()
-      )
-      .sortBy((plan) ->
-        plan.duration.start().valueOf()
+      .sortBy((plan) =>
+        [
+          plan.duration.start().valueOf()
+          plan.duration.end().valueOf()
+          @_getEarliestOpensAt(plan).valueOf()
+          moment(plan.last_published_at).valueOf()
+        ].join()
       )
       .value()
 

--- a/tutor/src/components/course-calendar/month.cjsx
+++ b/tutor/src/components/course-calendar/month.cjsx
@@ -93,6 +93,9 @@ CourseMonth = React.createClass
       activeAddDate: null
     })
 
+  getFullMonthName: ->
+    @props.date?.format?('MMMM')
+
 
   # render days based on whether they are past or upcoming
   # past days do not allow adding of plans
@@ -164,7 +167,7 @@ CourseMonth = React.createClass
         ref='calendarHeader'/>
 
       <BS.Row className='calendar-body'>
-        <BS.Col xs={12}>
+        <BS.Col xs={12} data-duration-name={@getFullMonthName()}>
 
           <Month date={date} monthNames={false} weekdayFormat='ddd' ref='calendar'>
             {days}

--- a/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -15,6 +15,15 @@ PH = require '../../helpers/period'
 CourseCalendar = require '../course-calendar'
 CourseDataMixin = require '../course-data-mixin'
 
+getDisplayBounds =
+  month: (date) ->
+    startAt: TimeHelper.toISO(
+      date.clone().startOf('month').startOf('week').subtract(1, 'day')
+    )
+    endAt: TimeHelper.toISO(
+      date.clone().endOf('month').endOf('week').add(1, 'day')
+    )
+
 TeacherTaskPlans = React.createClass
 
   contextTypes:
@@ -78,10 +87,7 @@ TeacherTaskPlanListing = React.createClass
 
     {displayAs} = state
 
-    startAt = TimeHelper.toISO(date.clone().startOf(displayAs).subtract(1, 'day'))
-    endAt = TimeHelper.toISO(date.clone().endOf(displayAs).add(1, 'day'))
-
-    {startAt, endAt}
+    getDisplayBounds[displayAs](date)
 
   mixins: [CourseDataMixin]
 


### PR DESCRIPTION
Preserves fixes from #1232 while deleting code (-7 lines difference!) and using previous logic that can prevent those problems, while fixing extra spacing caveat from #1232 fix.

## Fix: queries full month bounds
Also queries the full week for the month bounds as opposed to just the day before and after month bounds.

## Before, extra spacing from #1232 
![screen shot 2016-08-15 at 5 25 48 pm](https://cloud.githubusercontent.com/assets/2483873/17682970/f96b90fa-6314-11e6-9c29-35a9a0151df4.png)

## Now
![screen shot 2016-08-15 at 5 25 26 pm](https://cloud.githubusercontent.com/assets/2483873/17682972/001cb4ce-6315-11e6-9678-29769e59e601.png)

Also, a nice little modification for changing "Loading Calendar..." to:

![screen shot 2016-08-15 at 6 39 20 pm](https://cloud.githubusercontent.com/assets/2483873/17683330/9f5a5c10-6317-11e6-85ba-6f8e1a8a8040.png)
