### PR TITLE
Fix/handle no personalized

### DIFF
--- a/tutor/src/api.coffee
+++ b/tutor/src/api.coffee
@@ -185,6 +185,12 @@ start = (bootstrapData) ->
     throw new Error('BUG: Wrong type') unless typeof id is 'string' or typeof id is 'number'
     url: "/api/steps/#{id}"
 
+  # Loading personalized step should fail without should server error modal.
+  apiHelper TaskStepActions, TaskStepActions.loadPersonalized, TaskStepActions.loaded, 'GET', (id) ->
+    throw new Error('BUG: Wrong type') unless typeof id is 'string' or typeof id is 'number'
+    url: "/api/steps/#{id}"
+  , displayError: false, handleError: TaskStepActions.loadedNoPersonalized
+
   # # Go from complete to load so we fetch the new JSON
   # apiHelper TaskStepActions, TaskStepActions.complete, TaskStepActions.loaded, 'PUT', (id) ->
   #   url: "/api/steps/#{id}/completed"

--- a/tutor/src/components/breadcrumb/index.cjsx
+++ b/tutor/src/components/breadcrumb/index.cjsx
@@ -87,7 +87,7 @@ BreadcrumbTaskDynamic = React.createClass
   checkPlaceholder: ->
     {task_id, id} = @props.crumb.data
     unless TaskStore.hasIncompleteCoreStepsIndexes(task_id)
-      TaskStepActions.load(id)
+      TaskStepActions.loadPersonalized(id)
 
   update: (id) ->
     {crumb} = @props

--- a/tutor/src/components/task-step/all-steps.cjsx
+++ b/tutor/src/components/task-step/all-steps.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+classnames = require 'classnames'
 
 {TaskStepStore} = require '../../flux/task-step'
 {TaskStore} = require '../../flux/task'
@@ -58,8 +59,21 @@ Placeholder = React.createClass
   onContinue: ->
     @props.onNextStep()
   renderBody: ->
-    <p>This is a personalized question that will become available
-      to you after you answer more homework problems in this assignment.</p>
+    {id, taskId} = @props
+
+    step = TaskStepStore.get(id)
+    {type} = TaskStore.get(taskId)
+
+    message = if step.exists is false
+      "Looks like we don't have a personalized question this time. If you've answered all the other questions, you're done!"
+    else
+      "Unlock this personalized question by answering more #{type} problems for this assignment."
+
+    classes = classnames 'task-step-personalized',
+      'task-step-personalized-missing': step.exists is false
+
+    <p className={classes}>{message}</p>
+
 
 ExternalUrl = React.createClass
   displayName: 'ExternalUrl'

--- a/tutor/src/components/task-step/all-steps.cjsx
+++ b/tutor/src/components/task-step/all-steps.cjsx
@@ -60,17 +60,16 @@ Placeholder = React.createClass
     @props.onNextStep()
   renderBody: ->
     {id, taskId} = @props
-
-    step = TaskStepStore.get(id)
     {type} = TaskStore.get(taskId)
+    exists = TaskStepStore.shouldExist(id)
 
-    message = if step.exists is false
-      "Looks like we don't have a personalized question this time. If you've answered all the other questions, you're done!"
-    else
+    message = if exists
       "Unlock this personalized question by answering more #{type} problems for this assignment."
+    else
+      "Looks like we don't have a personalized question this time. If you've answered all the other questions, you're done!"
 
     classes = classnames 'task-step-personalized',
-      'task-step-personalized-missing': step.exists is false
+      'task-step-personalized-missing': not exists
 
     <p className={classes}>{message}</p>
 

--- a/tutor/src/components/task-step/index.cjsx
+++ b/tutor/src/components/task-step/index.cjsx
@@ -63,10 +63,12 @@ module.exports = React.createClass
 
   render: ->
     {id} = @props
-
-    <LoadableItem
-      id={id}
-      store={TaskStepStore}
-      actions={TaskStepActions}
-      renderItem={=> <TaskStepLoaded {...@props} onStepCompleted={@onStepCompleted}/>}
-    />
+    unless TaskStepStore.isPlaceholder(id) and not TaskStepStore.shouldExist(id)
+      <LoadableItem
+        id={id}
+        store={TaskStepStore}
+        actions={TaskStepActions}
+        renderItem={=> <TaskStepLoaded {...@props} onStepCompleted={@onStepCompleted}/>}
+      />
+    else
+      <TaskStepLoaded {...@props} onStepCompleted={@onStepCompleted}/>

--- a/tutor/src/flux/app.coffee
+++ b/tutor/src/flux/app.coffee
@@ -67,7 +67,7 @@ AppConfig =
 
   setServerError: (statusCode, message, requestDetails) ->
     status = @updateForResponse statusCode, message, requestDetails
-    return unless requestDetails
+    return unless requestDetails.displayError
     @_currentServerError = status
     unless _.isObject(message)
       try

--- a/tutor/src/flux/helpers.coffee
+++ b/tutor/src/flux/helpers.coffee
@@ -8,6 +8,14 @@ SAVING  = 'saving'
 DELETING = 'deleting'
 DELETED = 'deleted'
 
+STATES =
+  LOADING : LOADING
+  LOADED  : LOADED
+  FAILED  : FAILED
+  SAVING  : SAVING
+  DELETING: DELETING
+  DELETED : DELETED
+
 idCounter = 0
 CREATE_KEY = -> "_CREATING_#{idCounter++}"
 
@@ -169,4 +177,4 @@ extendConfig = (newConfig, origConfig) ->
   newConfig
 
 
-module.exports = {CrudConfig, makeSimpleStore, extendConfig}
+module.exports = {CrudConfig, makeSimpleStore, extendConfig, STATES}

--- a/tutor/src/flux/task-step.coffee
+++ b/tutor/src/flux/task-step.coffee
@@ -113,6 +113,9 @@ TaskStepConfig =
       step = @_get(id)
       step?.type is 'placeholder'
 
+    shouldExist: (id) ->
+      @_get(id)?.exists isnt false
+
     getTaskId: (id) ->
       step = @_get(id)
       step.task_id

--- a/tutor/src/flux/task-step.coffee
+++ b/tutor/src/flux/task-step.coffee
@@ -7,7 +7,10 @@ Durations = require '../helpers/durations'
 
 RECOVERY = 'recovery'
 
-{CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
+{CrudConfig, makeSimpleStore, extendConfig, STATES} = require './helpers'
+
+isMissingExercises = (response) ->
+  response.errors? and _.findWhere(response.errors, {code: 'no_exercises'})
 
 TaskStepConfig =
   _asyncStatus: {}
@@ -25,6 +28,29 @@ TaskStepConfig =
   _saved: (obj, id) ->
     obj.task_id = @_local[id]?.task_id
     obj
+
+  loadPersonalized: (id) ->
+    @load(id)
+
+  loadedNoPersonalized: (obj, id) ->
+    {data, status, statusMessage} = obj
+    @_asyncStatus[id] = STATES.LOADED
+
+    if isMissingExercises(data) and @exports.isPlaceholder.call(@, id)
+      @setNoPersonalized(id)
+      @emitChange()
+    else
+      @FAILED(status, statusMessage, id)
+
+  setNoPersonalized: (id) ->
+    fakeEmptyPersonalized =
+      type: 'placeholder'
+      group: 'personalized'
+      placeholder_for: 'exercise'
+      exists: false
+      id: id
+
+    @_local[id] = _.extend({}, fakeEmptyPersonalized, @_get(id))
 
   forceReload: (id) ->
     @_reload[id] = true
@@ -85,7 +111,7 @@ TaskStepConfig =
 
     isPlaceholder: (id) ->
       step = @_get(id)
-      step.type is 'placeholder'
+      step?.type is 'placeholder'
 
     getTaskId: (id) ->
       step = @_get(id)

--- a/tutor/src/helpers/api.coffee
+++ b/tutor/src/helpers/api.coffee
@@ -62,6 +62,8 @@ interceptors =
     response
 
   handleError: (errorResponse) ->
+    {config} = errorResponse
+
     if _.isError(errorResponse)
       errorResponse =
         status: 1
@@ -69,7 +71,7 @@ interceptors =
     else if errorResponse.headers
       setNow(errorResponse.headers)
 
-    Promise.reject(_.extend({handled: false}, errorResponse))
+    Promise.reject(_.extend({handled: config.handleError?}, errorResponse))
 
   makeLocalResponse: (response) ->
     makeLocalResponse(response)
@@ -159,6 +161,7 @@ apiHelper = (Actions, listenAction, successAction, httpMethod, pathMaker, option
       rejected = (response) ->
         {status, statusText, statusMessage, handled} = response
         onRequestError(response, requestConfig)
+        requestConfig.handleError?(response, args...)
         return if handled
 
         Actions.FAILED(status, statusMessage, args...)

--- a/tutor/test/components/navbar/server-error-monitoring.spec.coffee
+++ b/tutor/test/components/navbar/server-error-monitoring.spec.coffee
@@ -34,3 +34,12 @@ describe 'Server Error Monitoring', ->
       '{"status":422,"errors":[{"code":"no_exercises","message":' +
       '"No exercises were found to build the Practice Widget.","data":null}]}'
       , {url: '/test', displayError: true})
+
+  it 'renders no error dialog when displayError is set to false', ->
+    AppActions.setServerError(500, 'an error happens',
+      {url: '/test', displayError: false})
+    Testing.renderComponent( ErrorMonitor ).then ->
+      expect(Dialog.show).to.have.not.been.calledWith(sinon.match(
+        title: 'Server Error'
+      ))
+


### PR DESCRIPTION
Address [FE needs to handle no personalized question error gracefully](https://www.pivotaltracker.com/n/projects/1156756/stories/128339225), as mocked up [here](http://mmwerz.axshare.com/#g=1&p=no_personalized_question_messaging&c=1)

- [x] No more error modal/stuck FE state when completing core steps
- [x] Update messaging on personalized placeholder

For another PR:
- [ ] ~~Update styling on personalized placeholder~~
- [ ] ~~Fake placeholder for homeworks that have deleted placeholders~~