### PR TITLE
follow up to #1286, handling no personalized questions

### DIFF
--- a/shared/index.cjsx
+++ b/shared/index.cjsx
@@ -1,5 +1,6 @@
 {PinnedHeader, CardBody, PinnableFooter} = require './src/components/pinned-header-footer-card/sections'
 {Exercise, ExerciseWithScroll} = require './src/components/exercise'
+{ExControlButtons} = require './src/components/exercise/controls'
 
 require './src/helpers/polyfills'
 
@@ -15,6 +16,7 @@ module.exports = {
   CloseButton:            require './src/components/buttons/close-button'
 
   Exercise,
+  ExControlButtons,
   ExerciseGroup:          require './src/components/exercise/group'
   ExerciseIdentifierLink: require './src/components/exercise-identifier-link'
   ExerciseHelpers:        require './src/model/exercise'

--- a/shared/src/model/ui-settings.coffee
+++ b/shared/src/model/ui-settings.coffee
@@ -19,7 +19,7 @@ saveSettings = _.debounce( ->
 UiSettings = {
 
   initialize: (settings) ->
-    SETTINGS = _.clone(settings)
+    SETTINGS = _.clone(settings) or {}
 
   get: (key) ->
     SETTINGS[key]

--- a/tutor/api/courses/1/practice/POST.json
+++ b/tutor/api/courses/1/practice/POST.json
@@ -1,0 +1,95 @@
+{ "id": "Practice-Course-1",
+  "HACK_LOCAL_STEP_COMPLETION": true,
+  "title": "Chapter 5 and Chapter 6 Practice",
+  "opens_at": "2015-03-20T00:45:20.967Z",
+  "type": "practice",
+  "steps": [
+    { "id": "step-id-4-1",
+      "type": "exercise",
+      "feedback_html": "Two apples and then <span data-math='2'>2</span> more apples is <strong>four</strong>",
+      "content": {
+        "stimulus_html": "Addition is fun",
+        "questions":[
+          {
+            "id": "987",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"What is <span data-math='2+2'>2+2</span>?",
+            "answers":[
+              {"id":"id1","content_html":"22"},
+              {"id":"id2","content_html":"4"}
+            ]
+          }
+        ]
+      }
+    },
+    { "id": "step-id-4-2",
+      "type": "exercise",
+      "content": {
+        "stimulus_html": "Stimulus for Second Exercise",
+        "questions":[
+          {
+            "id": "876",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"Is the glass half full or half empty?",
+            "answers":[
+              {"id":"id3","content_html":"Half Full"},
+              {"id":"id4","content_html":"Half Empty"}
+            ]
+          }
+        ]
+      }
+    },
+    { "id": "step-id-4-5",
+      "type": "exercise",
+      "content": {
+        "questions":[
+          {
+            "id": "234",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"<p>The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s</p><p>What is the force if it slams into a wall?</p>",
+            "answers":[
+              {"id":"id1","content_html":"10 N"},
+              {"id":"id2","content_html":"1 N"}
+            ]
+          }
+        ]
+      }
+    },
+    { "id": "step-id-practice-4",
+      "type": "exercise",
+      "content": {
+        "questions":[
+          {
+            "id": "235",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"<p>The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s</p><p>What is the force if it slams into a wall?</p>",
+            "answers":[
+              {"id":"id1","content_html":"20 N"},
+              {"id":"id2","content_html":"2 N"},
+              {"id":"id3","content_html":"25 N"},
+              {"id":"id4","content_html":"10 N"}
+            ]
+          }
+        ]
+      }
+    },
+    { "id": "step-id-practice-5",
+      "type": "exercise",
+      "content": {
+        "stimulus_html": "Stimulus for another Exercise",
+        "questions":[
+          {
+            "id": "880",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"Is the glass half full or half empty?",
+            "answers":[
+              {"id":"id3","content_html":"Half Full"},
+              {"id":"id4","content_html":"Half Empty"}
+            ]
+          }
+        ]
+      }
+    }
+  ]
+
+}

--- a/tutor/api/courses/2/practice/POST.json
+++ b/tutor/api/courses/2/practice/POST.json
@@ -1,0 +1,95 @@
+{ "id": "Practice-Course-1",
+  "HACK_LOCAL_STEP_COMPLETION": true,
+  "title": "Chapter 5 and Chapter 6 Practice",
+  "opens_at": "2015-03-20T00:45:20.967Z",
+  "type": "practice",
+  "steps": [
+    { "id": "step-id-4-1",
+      "type": "exercise",
+      "feedback_html": "Two apples and then <span data-math='2'>2</span> more apples is <strong>four</strong>",
+      "content": {
+        "stimulus_html": "Addition is fun",
+        "questions":[
+          {
+            "id": "987",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"What is <span data-math='2+2'>2+2</span>?",
+            "answers":[
+              {"id":"id1","content_html":"22"},
+              {"id":"id2","content_html":"4"}
+            ]
+          }
+        ]
+      }
+    },
+    { "id": "step-id-4-2",
+      "type": "exercise",
+      "content": {
+        "stimulus_html": "Stimulus for Second Exercise",
+        "questions":[
+          {
+            "id": "876",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"Is the glass half full or half empty?",
+            "answers":[
+              {"id":"id3","content_html":"Half Full"},
+              {"id":"id4","content_html":"Half Empty"}
+            ]
+          }
+        ]
+      }
+    },
+    { "id": "step-id-4-5",
+      "type": "exercise",
+      "content": {
+        "questions":[
+          {
+            "id": "234",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"<p>The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s</p><p>What is the force if it slams into a wall?</p>",
+            "answers":[
+              {"id":"id1","content_html":"10 N"},
+              {"id":"id2","content_html":"1 N"}
+            ]
+          }
+        ]
+      }
+    },
+    { "id": "step-id-practice-4",
+      "type": "exercise",
+      "content": {
+        "questions":[
+          {
+            "id": "235",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"<p>The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s</p><p>What is the force if it slams into a wall?</p>",
+            "answers":[
+              {"id":"id1","content_html":"20 N"},
+              {"id":"id2","content_html":"2 N"},
+              {"id":"id3","content_html":"25 N"},
+              {"id":"id4","content_html":"10 N"}
+            ]
+          }
+        ]
+      }
+    },
+    { "id": "step-id-practice-5",
+      "type": "exercise",
+      "content": {
+        "stimulus_html": "Stimulus for another Exercise",
+        "questions":[
+          {
+            "id": "880",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"Is the glass half full or half empty?",
+            "answers":[
+              {"id":"id3","content_html":"Half Full"},
+              {"id":"id4","content_html":"Half Empty"}
+            ]
+          }
+        ]
+      }
+    }
+  ]
+
+}

--- a/tutor/api/steps/step-id-6-4.json
+++ b/tutor/api/steps/step-id-6-4.json
@@ -5,5 +5,6 @@
   "related_content": [{
       "title": "Physics is cool, yo",
       "chapter_section": "5.6"
-  }]
+  },
+  "exists": false]
 }

--- a/tutor/api/tasks/6.json
+++ b/tutor/api/tasks/6.json
@@ -68,7 +68,8 @@
       "related_content": [{
           "title": "Physics is cool, yo",
           "chapter_section": "6.4"
-      }]
+      }],
+      "exists": false
     }
   ]
 }

--- a/tutor/api/tasks/Practice-Course-1.json
+++ b/tutor/api/tasks/Practice-Course-1.json
@@ -1,0 +1,95 @@
+{ "id": "Practice-Course-1",
+  "HACK_LOCAL_STEP_COMPLETION": true,
+  "title": "Chapter 5 and Chapter 6 Practice",
+  "opens_at": "2015-03-20T00:45:20.967Z",
+  "type": "practice",
+  "steps": [
+    { "id": "step-id-4-1",
+      "type": "exercise",
+      "feedback_html": "Two apples and then <span data-math='2'>2</span> more apples is <strong>four</strong>",
+      "content": {
+        "stimulus_html": "Addition is fun",
+        "questions":[
+          {
+            "id": "987",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"What is <span data-math='2+2'>2+2</span>?",
+            "answers":[
+              {"id":"id1","content_html":"22"},
+              {"id":"id2","content_html":"4"}
+            ]
+          }
+        ]
+      }
+    },
+    { "id": "step-id-4-2",
+      "type": "exercise",
+      "content": {
+        "stimulus_html": "Stimulus for Second Exercise",
+        "questions":[
+          {
+            "id": "876",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"Is the glass half full or half empty?",
+            "answers":[
+              {"id":"id3","content_html":"Half Full"},
+              {"id":"id4","content_html":"Half Empty"}
+            ]
+          }
+        ]
+      }
+    },
+    { "id": "step-id-4-5",
+      "type": "exercise",
+      "content": {
+        "questions":[
+          {
+            "id": "234",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"<p>The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s</p><p>What is the force if it slams into a wall?</p>",
+            "answers":[
+              {"id":"id1","content_html":"10 N"},
+              {"id":"id2","content_html":"1 N"}
+            ]
+          }
+        ]
+      }
+    },
+    { "id": "step-id-practice-4",
+      "type": "exercise",
+      "content": {
+        "questions":[
+          {
+            "id": "235",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"<p>The spaceship moves at <span data-math='\\dfrac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}'></span> 1 m/s</p><p>What is the force if it slams into a wall?</p>",
+            "answers":[
+              {"id":"id1","content_html":"20 N"},
+              {"id":"id2","content_html":"2 N"},
+              {"id":"id3","content_html":"25 N"},
+              {"id":"id4","content_html":"10 N"}
+            ]
+          }
+        ]
+      }
+    },
+    { "id": "step-id-practice-5",
+      "type": "exercise",
+      "content": {
+        "stimulus_html": "Stimulus for another Exercise",
+        "questions":[
+          {
+            "id": "880",
+            "formats": ["multiple-choice", "free-response"],
+            "stem_html":"Is the glass half full or half empty?",
+            "answers":[
+              {"id":"id3","content_html":"Half Full"},
+              {"id":"id4","content_html":"Half Empty"}
+            ]
+          }
+        ]
+      }
+    }
+  ]
+
+}

--- a/tutor/resources/styles/components/task-step/all-steps.less
+++ b/tutor/resources/styles/components/task-step/all-steps.less
@@ -46,6 +46,25 @@
     }
   }
 
+  .task-step-personalized {
+    .exercise-typography();
+    padding-top: @tutor-card-body-padding-horizontal/2;
+    padding-bottom: @tutor-card-body-padding-horizontal/2;
+
+    &:not(.task-step-personalized-missing) {
+      display: flex;
+      align-items: center;
+
+      &::before {
+        .fa-icon();
+        content: @fa-var-lock;
+        font-size: 6rem;
+        color: @tutor-neutral;
+        padding-right: 2rem;
+      }
+    }
+  }
+
   .openstax-exercise-card {
     padding: @tutor-panel-padding-vertical @tutor-card-body-padding-horizontal;
 

--- a/tutor/resources/styles/components/task-step/ends.less
+++ b/tutor/resources/styles/components/task-step/ends.less
@@ -90,9 +90,6 @@
 
 
 .task-step {
-  &.placeholder-step {
-    .size-exercise-card();
-  }
   .external-step {
     .size-exercise-card();
   }

--- a/tutor/src/api.coffee
+++ b/tutor/src/api.coffee
@@ -10,6 +10,7 @@ _ = require 'underscore'
 TimeHelper = require './helpers/time'
 {CurrentUserActions, CurrentUserStore} = require './flux/current-user'
 {CourseActions} = require './flux/course'
+{CoursePracticeActions} = require './flux/practice'
 {JobActions} = require './flux/job'
 {EcosystemsActions} = require './flux/ecosystems'
 PerformanceForecast = require './flux/performance-forecast'
@@ -104,9 +105,6 @@ start = (bootstrapData) ->
   apiHelper TocActions, TocActions.load, TocActions.loaded, 'GET', (ecosystemId) ->
     url: "/api/ecosystems/#{ecosystemId}/readings"
 
-  apiHelper CourseActions, CourseActions.loadPractice, CourseActions.loadedPractice, 'GET', (courseId) ->
-    url: "/api/courses/#{courseId}/practice"
-
   apiHelper CourseActions, CourseActions.loadGuide, CourseActions.loadedGuide, 'GET', (courseId) ->
     url: "/api/courses/#{courseId}/guide"
 
@@ -117,10 +115,12 @@ start = (bootstrapData) ->
   apiHelper CCDashboardActions, CCDashboardActions.load, CCDashboardActions.loaded, 'GET', (courseId) ->
     url: "/api/courses/#{courseId}/cc/dashboard"
 
-  createMethod = if IS_LOCAL then 'GET' else 'POST' # Hack to get back a full practice on create when on local
-  apiHelper CourseActions, CourseActions.createPractice, CourseActions.createdPractice, createMethod, (courseId, params) ->
+  apiHelper CoursePracticeActions, CoursePracticeActions.create, CoursePracticeActions.created, 'POST', (courseId, params) ->
     url: "/api/courses/#{courseId}/practice"
     payload: params
+
+  apiHelper CoursePracticeActions, CoursePracticeActions.load, CoursePracticeActions.loaded, 'GET', (courseId) ->
+    url: "/api/courses/#{courseId}/practice"
 
   apiHelper CourseActions, CourseActions.load, CourseActions.loaded, 'GET', (courseId) ->
     url: "/api/courses/#{courseId}"
@@ -167,12 +167,12 @@ start = (bootstrapData) ->
     url: "/api/students/#{id}", payload: params
   apiHelper RosterActions, RosterActions.undrop, RosterActions.undropped, 'PUT', (id) ->
     url: "/api/students/#{id}/undrop"
-  apiHelper RosterActions, RosterActions.create, RosterActions.created, createMethod, (courseId, params) ->
+  apiHelper RosterActions, RosterActions.create, RosterActions.created, 'POST', (courseId, params) ->
     url: "/api/courses/#{courseId}/roster", payload: params
   apiHelper RosterActions, RosterActions.load, RosterActions.loaded, 'GET', (id) ->
     url: "/api/courses/#{id}/roster"
 
-  apiHelper PeriodActions, PeriodActions.create, PeriodActions.created, createMethod, (courseId, params) ->
+  apiHelper PeriodActions, PeriodActions.create, PeriodActions.created, 'POST', (courseId, params) ->
     url: "/api/courses/#{courseId}/periods", payload: params
   apiHelper PeriodActions, PeriodActions.save, PeriodActions.saved, 'PATCH', (id, period, params) ->
     url: "/api/periods/#{period}", payload: params

--- a/tutor/src/components/index.cjsx
+++ b/tutor/src/components/index.cjsx
@@ -8,7 +8,7 @@ App = require './app'
 Task = require './task'
 LoadableItem = require './loadable-item'
 {TaskActions, TaskStore} = require '../flux/task'
-{CourseActions, CourseStore} = require '../flux/course'
+{CoursePracticeActions, CoursePracticeStore} = require '../flux/practice'
 {CurrentUserActions, CurrentUserStore} = require '../flux/current-user'
 
 
@@ -38,15 +38,15 @@ SinglePractice = React.createClass
     router: React.PropTypes.func
 
   componentWillMount: ->
+    CoursePracticeStore.on("loaded.#{@getId()}", @update)
     @createPractice(@getId())
-    CourseStore.on('practice.loaded', @update)
 
   componentWillUnmount: ->
-    CourseStore.off('practice.loaded', @update)
+    CoursePracticeStore.off("loaded.#{@getId()}", @update)
 
   createPractice: (courseId) ->
     query = @context?.router?.getCurrentQuery()
-    CourseActions.createPractice(courseId, query)
+    CoursePracticeActions.create(courseId, query)
 
   getInitialState: ->
     # force a new practice each time
@@ -58,7 +58,7 @@ SinglePractice = React.createClass
 
   update: ->
     @setState({
-      taskId:  CourseStore.getPracticeId(@getId())
+      taskId:  CoursePracticeStore.getTaskId(@getId())
     })
 
   render: ->

--- a/tutor/src/components/task-step/all-steps.cjsx
+++ b/tutor/src/components/task-step/all-steps.cjsx
@@ -5,6 +5,7 @@ classnames = require 'classnames'
 {TaskStore} = require '../../flux/task'
 {StepContent, ReadingStepContent} = require './step-with-reading-content'
 Exercise = require './exercise'
+Placeholder = require './placeholder'
 Markdown = require '../markdown'
 StepMixin = require './step-mixin'
 StepFooterMixin = require './step-footer-mixin'
@@ -47,32 +48,6 @@ Video = React.createClass
   renderBody: ->
     {id} = @props
     <StepContent id={id} stepType='video'/>
-
-Placeholder = React.createClass
-  displayName: 'Placeholder'
-  getDefaultProps: ->
-    className: 'placeholder-step'
-  mixins: [StepMixin, StepFooterMixin]
-  isContinueEnabled: ->
-    {review} = @props
-    not review?.length
-  onContinue: ->
-    @props.onNextStep()
-  renderBody: ->
-    {id, taskId} = @props
-    {type} = TaskStore.get(taskId)
-    exists = TaskStepStore.shouldExist(id)
-
-    message = if exists
-      "Unlock this personalized question by answering more #{type} problems for this assignment."
-    else
-      "Looks like we don't have a personalized question this time. If you've answered all the other questions, you're done!"
-
-    classes = classnames 'task-step-personalized',
-      'task-step-personalized-missing': not exists
-
-    <p className={classes}>{message}</p>
-
 
 ExternalUrl = React.createClass
   displayName: 'ExternalUrl'

--- a/tutor/src/components/task-step/ends.cjsx
+++ b/tutor/src/components/task-step/ends.cjsx
@@ -12,6 +12,7 @@ StepFooterMixin = require './step-footer-mixin'
 
 TaskStep = require './index'
 {CourseStore} = require '../../flux/course'
+{CoursePracticeStore} = require '../../flux/practice'
 {TaskStore} = require '../../flux/task'
 {TaskStepStore} = require '../../flux/task-step'
 {CardBody, PinnableFooter} = require 'shared'
@@ -41,7 +42,7 @@ PracticeEnd = React.createClass
     {courseId, taskId, reloadPractice} = @props
     {type} = TaskStore.get(taskId)
 
-    pageIds = CourseStore.getPracticePageIds(courseId)
+    pageIds = CoursePracticeStore.getCurrentTopics(courseId)
 
     fallbackLink =
       to: 'viewPerformanceForecast'

--- a/tutor/src/components/task-step/exercise.cjsx
+++ b/tutor/src/components/task-step/exercise.cjsx
@@ -8,10 +8,8 @@ _ = require 'underscore'
 
 BrowseTheBook = require '../buttons/browse-the-book'
 
-{ChapterSectionMixin, CardBody, ExerciseWithScroll} = require 'shared'
-{ExControlButtons} = require 'shared/src/components/exercise/controls'
+{ChapterSectionMixin, CardBody, ExerciseWithScroll, ExControlButtons} = require 'shared'
 
-ScrollSpy = require '../scroll-spy'
 StepFooter = require './step-footer'
 
 canOnlyContinue = (id) ->

--- a/tutor/src/components/task-step/placeholder.cjsx
+++ b/tutor/src/components/task-step/placeholder.cjsx
@@ -1,0 +1,63 @@
+React = require 'react'
+classnames = require 'classnames'
+
+{TaskStepStore} = require '../../flux/task-step'
+{TaskStore} = require '../../flux/task'
+
+Icon = require '../icon'
+{ChapterSectionMixin, CardBody, ExerciseGroup, ExControlButtons} = require 'shared'
+
+StepFooter = require './step-footer'
+
+Placeholder = React.createClass
+  displayName: 'Placeholder'
+  getDefaultProps: ->
+    className: 'placeholder-step'
+  isContinueEnabled: ->
+    {review} = @props
+    not review?.length
+  onContinue: ->
+    @props.onNextStep()
+  render: ->
+    {id, taskId, courseId} = @props
+    {type} = TaskStore.get(taskId)
+    step = TaskStepStore.get(id)
+    exists = TaskStepStore.shouldExist(id)
+    console.info(step)
+
+    message = if exists
+      "Unlock this personalized question by answering more #{type} problems for this assignment."
+    else
+      "Looks like we don't have a personalized question this time. If you've answered all the other questions, you're done!"
+
+    classes = classnames 'task-step-personalized',
+      'task-step-personalized-missing': not exists
+
+    controlButtons = <ExControlButtons
+      panel='review'
+      controlText={'Continue'}
+      onContinue={@onContinue}
+      isContinueEnabled={not exists}/>
+
+    footer = <StepFooter
+      id={id}
+      key='step-footer'
+      taskId={taskId}
+      courseId={courseId}
+      controlButtons={controlButtons}
+      onContinue={@onContinue}/>
+
+    group = <ExerciseGroup
+      key='step-exercise-group'
+      project='tutor'
+      group={step.group}
+      related_content={step.related_content}/>
+
+    <CardBody className='task-step openstax-exercise-card' pinned={true} footer={footer}>
+      {group}
+      <div className={classes}>
+        {message}
+      </div>
+    </CardBody>
+
+module.exports = Placeholder

--- a/tutor/src/components/task-step/placeholder.cjsx
+++ b/tutor/src/components/task-step/placeholder.cjsx
@@ -11,11 +11,11 @@ StepFooter = require './step-footer'
 
 Placeholder = React.createClass
   displayName: 'Placeholder'
-  getDefaultProps: ->
-    className: 'placeholder-step'
-  isContinueEnabled: ->
-    {review} = @props
-    not review?.length
+  propTypes:
+    id: React.PropTypes.string.isRequired
+    taskId: React.PropTypes.string.isRequired
+    courseId: React.PropTypes.string.isRequired
+    onNextStep: React.PropTypes.func.isRequired
   onContinue: ->
     @props.onNextStep()
   render: ->
@@ -23,7 +23,6 @@ Placeholder = React.createClass
     {type} = TaskStore.get(taskId)
     step = TaskStepStore.get(id)
     exists = TaskStepStore.shouldExist(id)
-    console.info(step)
 
     message = if exists
       "Unlock this personalized question by answering more #{type} problems for this assignment."

--- a/tutor/src/flux/course.coffee
+++ b/tutor/src/flux/course.coffee
@@ -11,21 +11,8 @@ DEFAULT_TIME_ZONE = 'Central Time (US & Canada)'
 
 CourseConfig =
 
-  _practices: {}
-  _asyncStatusPractices: {}
-
-  _isPractice: (obj) ->
-    # TODO check with backend about task.type = 'practice' since task.type for homework = 'homework'
-    obj.steps? # TODO: Find a more reliable way to determine if a practice is being loaded
-
-  createPractice: (courseId, params) -> # Used by API
-  createdPractice: (obj, courseId, params) ->
-    obj.created_for = params
-    @_loadedPractice(obj, courseId) # TODO: Maybe this should emit practice.created
-
   _guides: {}
   _asyncStatusGuides: {}
-
 
   loadGuide: (courseId) ->
     delete @_guides[courseId]
@@ -37,30 +24,12 @@ CourseConfig =
     @_asyncStatusGuides[courseId] = 'loaded'
     @emitChange()
 
-  loadPractice: (courseId) ->
-    delete @_practices[courseId]
-    @_asyncStatusPractices[courseId] = 'loading'
-    @emitChange()
-
-  loadedPractice: (obj, courseId) ->
-    @_loadedPractice(obj, courseId)
-    @_asyncStatusPractices[courseId] = 'loaded'
-    @emitChange()
-
-  _loadedPractice: (obj, courseId) ->
-    obj.type ?= 'practice' # Used to filter out the practice task from the student list
-    @_practices[courseId] = obj
-    TaskActions.loaded(obj, obj.id)
-    @emit('practice.loaded', obj.id)
-
   _loaded: (obj, id) ->
     @emit('course.loaded', obj.id)
 
   _reset: ->
     @_guides = {}
     @_asyncStatusGuides = {}
-    @_practices = {}
-    @_asyncStatusPractices = {}
 
   _saved: (result, id) ->
     @emit('saved')
@@ -82,24 +51,6 @@ CourseConfig =
 
     isGuideLoading: (courseId) -> @_asyncStatusGuides[courseId] is 'loading'
     isGuideLoaded: (courseId) -> !! @_guides[courseId]
-
-    isPracticeLoading: (courseId) -> @_asyncStatusPractices[courseId] is 'loading'
-    isPracticeLoaded: (courseId) -> !! @_practices[courseId]
-
-    getPracticeId: (courseId) ->
-      @_practices[courseId]?.id
-
-    getPracticePageIds: (courseId) ->
-      @_practices[courseId]?.created_for?.page_ids
-
-    hasPractice: (courseId) ->
-      @_practices[courseId]?
-
-    getPractice: (courseId) ->
-      if @_practices[courseId]?
-        {id} = @_practices[courseId]
-        task = TaskStore.get(id)
-      task
 
     validateCourseName: (name, courses, active) ->
       for course in courses

--- a/tutor/src/flux/helpers.coffee
+++ b/tutor/src/flux/helpers.coffee
@@ -44,6 +44,9 @@ CrudConfig = ->
       @_reset?()
       @emitChange()
 
+    dontReload: (id) ->
+      @_asyncStatus[id] is LOADED and @_HACK_DO_NOT_RELOAD
+
     FAILED: (status, msg, id) ->
       @_asyncStatus[id] = FAILED
       @_errors[id] = msg
@@ -54,7 +57,7 @@ CrudConfig = ->
 
     load: (id) ->
       # Add a shortcut for unit testing
-      return if @_asyncStatus[id] is LOADED and @_HACK_DO_NOT_RELOAD
+      return if @dontReload(id)
       @_reload[id] = false
       @_asyncStatus[id] = LOADING
       @emitChange()

--- a/tutor/src/flux/practice.coffee
+++ b/tutor/src/flux/practice.coffee
@@ -1,0 +1,54 @@
+_ = require 'underscore'
+{TaskActions, TaskStore} = require './task'
+{CrudConfig, makeSimpleStore, extendConfig, STATES} = require './helpers'
+
+CoursePractice =
+
+  _topics: {}
+
+  _reset: ->
+    @_topics = {}
+
+  recordTopics: (courseId, topicParams) ->
+    @_topics[courseId] ?= []
+    @_topics[courseId].push(topicParams)
+
+  create: (courseId, topicParams) ->
+    @_local[courseId] = {} unless @dontReload(courseId)
+    @_asyncStatus[courseId] = STATES.LOADED
+    @recordTopics(courseId, topicParams)
+
+  created: (result, courseId, topicParams) ->
+    # this will use the base config's loaded, which will
+    # run _loaded within.
+    @loaded(result, courseId)
+
+  _loaded: (result, courseId) ->
+    @emit("#{STATES.LOADED}.#{courseId}", courseId)
+    TaskActions.loaded(result, result.id)
+
+    result
+
+  exports:
+
+    getTaskId: (courseId) ->
+      @_get(courseId)?.id
+
+    getPageIds: (courseId) ->
+      @_get(courseId)?.created_for?.page_ids
+
+    has: (courseId) ->
+      @_get(courseId)?
+
+    get: (courseId) ->
+      return {} unless @exports.has.call(@, courseId)
+
+      taskId = @exports.getTaskId.call(@, courseId)
+      TaskStore.get(taskId)
+
+    getCurrentTopics: (courseId) ->
+      _.last(@_topics[courseId]) or {}
+
+extendConfig(CoursePractice, new CrudConfig())
+{actions, store} = makeSimpleStore(CoursePractice)
+module.exports = {CoursePracticeActions:actions, CoursePracticeStore:store}

--- a/tutor/src/flux/task-step.coffee
+++ b/tutor/src/flux/task-step.coffee
@@ -19,7 +19,7 @@ TaskStepConfig =
   _loaded: (obj, id) ->
     if not obj.task_id
       obj.task_id = @_local[id]?.task_id
-    @emit("step.loaded", id)
+    @emit('step.loaded', id)
     _.each(@_recoveryTarget, _.partial(@_updateRecoveredFor, id), @)
     StepTitleActions.parseStep(obj)
 
@@ -39,6 +39,7 @@ TaskStepConfig =
     if isMissingExercises(data) and @exports.isPlaceholder.call(@, id)
       @setNoPersonalized(id)
       @emitChange()
+      @emit('step.loaded', id)
     else
       @FAILED(status, statusMessage, id)
 
@@ -49,8 +50,9 @@ TaskStepConfig =
       placeholder_for: 'exercise'
       exists: false
       id: id
+      is_completed: true
 
-    @_local[id] = _.extend({}, fakeEmptyPersonalized, @_get(id))
+    @_local[id] = _.extend({}, @_get(id), fakeEmptyPersonalized)
 
   forceReload: (id) ->
     @_reload[id] = true

--- a/tutor/test/components/helpers/task/checks.coffee
+++ b/tutor/test/components/helpers/task/checks.coffee
@@ -253,7 +253,7 @@ checks._checkIsPendingStep = (stepIndex, {div, component, stepId, taskId, state,
   placeholderBreadcrumbDOM = placeholderBreadcrumb.getDOMNode()
 
   expect(placeholderBreadcrumbDOM.className).to.contain('placeholder')
-  expect(div.querySelector('.placeholder-step')).to.not.be.null
+  expect(div.querySelector('.task-step-personalized')).to.not.be.null
 
   {div, component, stepId, taskId, state, router, history}
 

--- a/tutor/test/components/practice.spec.coffee
+++ b/tutor/test/components/practice.spec.coffee
@@ -4,7 +4,7 @@ _ = require 'underscore'
 {taskActions, taskTests, taskChecks} = require './helpers/task'
 {routerStub} = require './helpers/utilities'
 {UiSettings} = require 'shared'
-{CourseActions, CourseStore} = require '../../src/flux/course'
+{CoursePracticeActions, CoursePracticeStore} = require '../../src/flux/practice'
 {TaskActions, TaskStore} = require '../../src/flux/task'
 {TaskStepActions, TaskStepStore} = require '../../src/flux/task-step'
 
@@ -19,10 +19,10 @@ describe 'Practice Widget', ->
     UiSettings.initialize({'has-viewed-two-step-help': true})
     TaskActions.HACK_DO_NOT_RELOAD(true)
     TaskStepActions.HACK_DO_NOT_RELOAD(true)
-    CourseActions.HACK_DO_NOT_RELOAD(true)
+    CoursePracticeActions.HACK_DO_NOT_RELOAD(true)
 
-    CourseActions.loadedPractice(VALID_MODEL, courseId)
-    taskId = CourseStore.getPracticeId(courseId)
+    CoursePracticeActions.loaded(VALID_MODEL, courseId)
+    taskId = CoursePracticeStore.getTaskId(courseId)
 
     taskTests
       .renderStep(taskId)
@@ -35,13 +35,13 @@ describe 'Practice Widget', ->
     UiSettings._reset()
     taskTests.unmount()
 
-    CourseActions.reset()
+    CoursePracticeActions.reset()
     TaskActions.reset()
     TaskStepActions.reset()
 
     TaskActions.HACK_DO_NOT_RELOAD(false)
     TaskStepActions.HACK_DO_NOT_RELOAD(false)
-    CourseActions.HACK_DO_NOT_RELOAD(false)
+    CoursePracticeActions.HACK_DO_NOT_RELOAD(false)
 
   it 'should render empty free response for unanswered exercise', (done) ->
     taskChecks
@@ -89,10 +89,10 @@ describe 'Practice Widget, through route', ->
     UiSettings.initialize({'has-viewed-two-step-help': true})
     TaskActions.HACK_DO_NOT_RELOAD(true)
     TaskStepActions.HACK_DO_NOT_RELOAD(true)
-    CourseActions.HACK_DO_NOT_RELOAD(true)
+    CoursePracticeActions.HACK_DO_NOT_RELOAD(true)
 
-    CourseActions.loadedPractice(VALID_MODEL, courseId)
-    taskId = CourseStore.getPracticeId(courseId)
+    CoursePracticeActions.loaded(VALID_MODEL, courseId)
+    taskId = CoursePracticeStore.getTaskId(courseId)
 
     taskTests
       .goToTask("/courses/#{courseId}/practice", taskId)
@@ -105,13 +105,13 @@ describe 'Practice Widget, through route', ->
     UiSettings._reset()
     taskTests.unmount()
 
-    CourseActions.reset()
+    CoursePracticeActions.reset()
     TaskActions.reset()
     TaskStepActions.reset()
 
     TaskActions.HACK_DO_NOT_RELOAD(false)
     TaskStepActions.HACK_DO_NOT_RELOAD(false)
-    CourseActions.HACK_DO_NOT_RELOAD(false)
+    CoursePracticeActions.HACK_DO_NOT_RELOAD(false)
 
   it 'should load expected practice at the practice url', ->
     tests = ({div}) ->


### PR DESCRIPTION
Follow up to #1286 

Also, there was a bug hiding all along --

## Broken

If practice returned a 404 for a course, that course would basically be removed from the client side -- see how it's missing from the course list? -- and the user would have to reload.

![practice-broken](https://cloud.githubusercontent.com/assets/2483873/17779740/56c217ae-652e-11e6-9e2b-aa0534fd1ba4.gif)


## Fixed

User gets redirected to dashboard if there are no practices

![practice-fixed](https://cloud.githubusercontent.com/assets/2483873/17779741/56c38d28-652e-11e6-8418-189b520a480a.gif)

Not ideal from a user experience perspective, but not broken.

I think ideally, clicking the practice button would have a async like "Creating Practice" animation before redirecting to the practice if available, or showing a message of being unable to create if not available