### PR TITLE
IE11 Mathjax - use classNames instead of classList

### DIFF
--- a/shared/src/helpers/mathjax.coffee
+++ b/shared/src/helpers/mathjax.coffee
@@ -30,8 +30,9 @@ typesetDocument = (windowImpl) ->
 
   windowImpl.MathJax.Hub.Queue ->
     # Queue a call to mark the found nodes as rendered so are ignored if typesetting is called repeatedly
+    # uses className += instead of classList because IE
     for node in latexNodes.concat(mathMLNodes)
-      node.classList.add(MATH_RENDERED_CLASS)
+      node.className += " #{MATH_RENDERED_CLASS}"
 
 # Install a debounce around typesetting function so that it will only run once
 # every Xms even if called multiple times in that period


### PR DESCRIPTION
IE11 is buggy with / does not have support for classList.

http://caniuse.com/#feat=classlist
http://stackoverflow.com/questions/8098406/code-with-classlist-does-not-work-in-ie

rendering now, though still has some alignment issues.

![mathjax-workin](https://cloud.githubusercontent.com/assets/954569/17784120/471d406a-6549-11e6-827e-f4e42021e89d.PNG)
