### PR TITLE
When building, copy asset files when making them MD5ified

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -23,7 +23,7 @@ if [ "$2" = "archive" ]; then
     fi
     echo -n '  "'$F'": "'$MD5'"' >> ./rev-manifest.json
     LAST_FILE=$F
-    mv $F $MD5
+    cp $F $MD5
   done
   echo "}" >> ./rev-manifest.json
   cd ..


### PR DESCRIPTION
This keeps the original files around so they can be loaded by webpack if
they're built to dynamically load