### PR TITLE
prevent server errors from guide from messing with loaded course data

### DIFF
--- a/tutor/src/api.coffee
+++ b/tutor/src/api.coffee
@@ -11,6 +11,7 @@ TimeHelper = require './helpers/time'
 {CurrentUserActions, CurrentUserStore} = require './flux/current-user'
 {CourseActions} = require './flux/course'
 {CoursePracticeActions} = require './flux/practice'
+{CourseGuideActions} = require './flux/guide'
 {JobActions} = require './flux/job'
 {EcosystemsActions} = require './flux/ecosystems'
 PerformanceForecast = require './flux/performance-forecast'
@@ -105,7 +106,7 @@ start = (bootstrapData) ->
   apiHelper TocActions, TocActions.load, TocActions.loaded, 'GET', (ecosystemId) ->
     url: "/api/ecosystems/#{ecosystemId}/readings"
 
-  apiHelper CourseActions, CourseActions.loadGuide, CourseActions.loadedGuide, 'GET', (courseId) ->
+  apiHelper CourseGuideActions, CourseGuideActions.load, CourseGuideActions.loaded, 'GET', (courseId) ->
     url: "/api/courses/#{courseId}/guide"
 
   apiHelper CourseActions, CourseActions.save, CourseActions.saved, 'PATCH', (courseId, params) ->

--- a/tutor/src/components/task-plan/guide.cjsx
+++ b/tutor/src/components/task-plan/guide.cjsx
@@ -3,7 +3,7 @@ _ = require 'underscore'
 BS = require 'react-bootstrap'
 Router = require 'react-router'
 
-{CourseStore, CourseActions} = require '../../flux/course'
+{CourseGuideStore, CourseGuideActions} = require '../../flux/guide'
 LoadableItem = require '../loadable-item'
 PracticeButton = require '../buttons/practice-button'
 
@@ -31,7 +31,7 @@ Guide = React.createClass
   render: ->
     {id} = @props
 
-    guide = CourseStore.getGuide(id)
+    guide = CourseGuideStore.get(id)
     table = _.map(guide.fields, @renderCrudeTable)
 
     <BS.Panel className='-course-guide-container'>
@@ -68,11 +68,8 @@ GuideShell = React.createClass
     {courseId} = @context.router.getCurrentParams()
 
     <LoadableItem
-      store={CourseStore}
-      actions={CourseActions}
-      load={CourseActions.loadGuide}
-      isLoaded={CourseStore.isGuideLoaded}
-      isLoading={CourseStore.isGuideLoading}
+      store={CourseGuideStore}
+      actions={CourseGuideActions}
       id={courseId}
       renderItem={-> <Guide key={courseId} id={courseId} />}
     />

--- a/tutor/src/flux/course.coffee
+++ b/tutor/src/flux/course.coffee
@@ -11,25 +11,8 @@ DEFAULT_TIME_ZONE = 'Central Time (US & Canada)'
 
 CourseConfig =
 
-  _guides: {}
-  _asyncStatusGuides: {}
-
-  loadGuide: (courseId) ->
-    delete @_guides[courseId]
-    @_asyncStatusGuides[courseId] = 'loading'
-    @emitChange()
-
-  loadedGuide: (obj, courseId) ->
-    @_guides[courseId] = obj
-    @_asyncStatusGuides[courseId] = 'loaded'
-    @emitChange()
-
   _loaded: (obj, id) ->
     @emit('course.loaded', obj.id)
-
-  _reset: ->
-    @_guides = {}
-    @_asyncStatusGuides = {}
 
   _saved: (result, id) ->
     @emit('saved')
@@ -42,15 +25,9 @@ CourseConfig =
       {appearance_code} = @_local[courseId]
       AppearanceCodes[appearance_code]
 
-    getGuide: (courseId) ->
-      @_guides[courseId] or throw new Error('BUG: Not loaded yet')
-
     isConceptCoach: (courseId) -> !! @_local[courseId]?.is_concept_coach
     isCollege: (courseId) -> !! @_local[courseId]?.is_college
     isHighSchool: (courseId) -> not @_local[courseId]?.is_college
-
-    isGuideLoading: (courseId) -> @_asyncStatusGuides[courseId] is 'loading'
-    isGuideLoaded: (courseId) -> !! @_guides[courseId]
 
     validateCourseName: (name, courses, active) ->
       for course in courses

--- a/tutor/src/flux/guide.coffee
+++ b/tutor/src/flux/guide.coffee
@@ -1,0 +1,7 @@
+{CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
+
+CourseGuideConfig = {}
+
+extendConfig(CourseGuideConfig, new CrudConfig())
+{actions, store} = makeSimpleStore(CourseGuideConfig)
+module.exports = {CourseGuideActions:actions, CourseGuideStore:store}

--- a/tutor/test/components/course-listing.spec.coffee
+++ b/tutor/test/components/course-listing.spec.coffee
@@ -110,7 +110,7 @@ describe 'Course Listing Component', ->
 
   it 'renders a "no membership" page when not a member of any courses', ->
     # clear all course stores
-    CourseActions._reset()
+    CourseActions.reset()
     CourseListingActions.loaded([])
     renderListing().then (state) ->
       expect(state.div.textContent).to.include('We cannot find an OpenStax course associated with your account')


### PR DESCRIPTION
These fluxes should've been separate to begin with.  Server errors for guide was rare, so this was going undetected.