### PR TITLE
Removing sections from readings

### DIFF
--- a/tutor/src/flux/task-plan.coffee
+++ b/tutor/src/flux/task-plan.coffee
@@ -148,10 +148,11 @@ TaskPlanConfig =
     @_change(id, {is_feedback_immediate})
 
   removeTopic: (id, topicId) ->
-    {page_ids, exercise_ids} = @_getClonedSettings(id, 'page_ids', 'exercise_ids')
+    {page_ids, type, exercise_ids} = @_getClonedSettings(id, 'page_ids', 'exercise_ids')
     index = page_ids?.indexOf(topicId)
     page_ids?.splice(index, 1)
-    exercise_ids = ExerciseStore.removeTopicExercises(exercise_ids, topicId)
+    if (type is PLAN_TYPES.HOMEWORK)
+      exercise_ids = ExerciseStore.removeTopicExercises(exercise_ids, topicId)
     @_changeSettings(id, {page_ids, exercise_ids })
 
   updateTopics: (id, page_ids) ->


### PR DESCRIPTION
PIvotal: https://www.pivotaltracker.com/story/show/127926577

There was a javascript error when removing sections from readings, this fixes that.

![remove-reading](https://cloud.githubusercontent.com/assets/6434717/17812208/9ef0d79c-6658-11e6-90a0-f28e00324faf.gif)
