### PR TITLE
Downgrade lodash to 3.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "interpolate": "0.1.0",
     "jquery": "2.1.4",
     "keymaster": "1.6.2",
-    "lodash": "4.14.1",
+    "lodash": "3.10.1",
     "markdown-it": "4.4.0",
     "mime-types": "2.1.7",
     "moment": "2.13.0",


### PR DESCRIPTION
NOTE: this also happened in https://github.com/openstax/tutor-js/pull/1027 (insert witty comment about frailty of memory here)

Upgrading to version 4.x breaks the calendar.  It's getEventHandlers
uses _.pick with a funtion on props to select the valid props.

Lodash 4.x has removed the ability to use a function with _.pick, and
requires the use of _.pickBy for that.

Because of this, the onClick prop isn't passed to the Day component and
days cannot be clicked.