### PR TITLE
Fix/some tests

### DIFF
--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -1,7 +1,10 @@
 # Somehow this pulls in a test that crashes phantomjs, which in turn causes karma to exit with status 1
 # testsContext = require.context("../tutor/test", true, /\.spec\.(cjsx|coffee)$/)
 # testsContext.keys().forEach(testsContext)
-  try
-    require 'test/some-tests'
-  catch e
+fs = require 'fs'
+
+fs.access 'test/some-tests', (err) ->
+  if err?
     require 'test/all-tests'
+  else
+    require 'test/some-tests'

--- a/test/all-tests.coffee
+++ b/test/all-tests.coffee
@@ -1,10 +1,11 @@
 # Somehow this pulls in a test that crashes phantomjs, which in turn causes karma to exit with status 1
 # testsContext = require.context("../tutor/test", true, /\.spec\.(cjsx|coffee)$/)
 # testsContext.keys().forEach(testsContext)
-fs = require 'fs'
-
-fs.access 'test/some-tests', (err) ->
-  if err?
+try
+  require 'test/some-tests'
+catch e
+  # I know, this is gross, but it seems to be the way to
+  # catch specifically if 'some-tests' does not exist,
+  # as opposed to another module we might be requiring within some-tests.
+  if e.message is 'Cannot find module "test/some-tests"'
     require 'test/all-tests'
-  else
-    require 'test/some-tests'


### PR DESCRIPTION
follow up to #1307, `all-tests` would get required if something within `some-tests` threw an uncaught exception unrelated to whether `some-tests` exists.  require `all-tests` only if `some-tests` does not exist.