### PR TITLE
Fix/practice async

### DIFF
--- a/shared/src/components/buttons/async-button.cjsx
+++ b/shared/src/components/buttons/async-button.cjsx
@@ -12,8 +12,7 @@ module.exports = React.createClass
     isDone: React.PropTypes.bool
     isFailed: React.PropTypes.bool
     waitingText: React.PropTypes.node # TODO: This should be a Component or array
-    failedState: React.PropTypes.func
-    failedProps: React.PropTypes.object
+    failedState: React.PropTypes.element
     doneText: React.PropTypes.node
     isJob: React.PropTypes.bool
     timeoutLength: React.PropTypes.number
@@ -48,25 +47,21 @@ module.exports = React.createClass
     isDone: false
     isFailed: false
     waitingText: 'Loading…'
-    failedState: RefreshButton
-    failedProps:
-      beforeText: 'There was a problem.  '
+    failedState: <RefreshButton beforeText='There was a problem.  '/>
     doneText: ''
     isJob: false
 
   render: ->
     {className, disabled} = @props
     {isWaiting, isDone, isFailed} = @props
-    {children, waitingText, failedProps, doneText} = @props
+    {children, waitingText, failedState, doneText} = @props
     {isTimedout} = @state
-    # needs to be capitalized so JSX will transpile as a variable, not element
-    FailedState = @props.failedState
 
     buttonTypeClass = 'async-button'
 
     if isFailed or isTimedout
       stateClass = 'is-failed'
-      return <FailedState {...failedProps} />
+      return failedState
     else if isWaiting
       stateClass = 'is-waiting'
       text = waitingText

--- a/tutor/resources/styles/components/performance-forecast/section-mixin.less
+++ b/tutor/resources/styles/components/performance-forecast/section-mixin.less
@@ -32,6 +32,33 @@
   .progress-bar-button {
     margin-top: 0px;
     width: 100%;
+
+    &.is-waiting {
+      .fa-spinner, .practice-waiting-text {
+        position: absolute;
+      }
+
+      .fa-spinner {
+        top: 0.25em;
+        left: calc(~"50% - 2.5em");
+      }
+
+      .practice-waiting-text {
+        left: calc(~"50% - 1em");
+        top: 0;
+      }
+    }
+
+    &[disabled] {
+      &::before {
+        position: absolute;
+        content: 'No problems available for practice.';
+        right: 1em;
+        top: 0.5em;
+        font-size: 0.75em;
+      }
+    }
+
   }
   .amount-worked {
     .flex-display();

--- a/tutor/resources/styles/components/performance-forecast/section-mixin.less
+++ b/tutor/resources/styles/components/performance-forecast/section-mixin.less
@@ -49,7 +49,7 @@
       }
     }
 
-    &[disabled] {
+    &[disabled]:not(.is-waiting) {
       &::before {
         position: absolute;
         content: 'No problems available for practice.';

--- a/tutor/src/api.coffee
+++ b/tutor/src/api.coffee
@@ -121,6 +121,11 @@ start = (bootstrapData) ->
     url: "/api/courses/#{courseId}/practice"
     payload: params
 
+  apiHelper CoursePracticeActions, CoursePracticeActions.createSilent, CoursePracticeActions.created, 'POST', (courseId, params) ->
+    url: "/api/courses/#{courseId}/practice"
+    payload: params
+  , displayError: false
+
   apiHelper CoursePracticeActions, CoursePracticeActions.load, CoursePracticeActions.loaded, 'GET', (courseId) ->
     url: "/api/courses/#{courseId}/practice"
 

--- a/tutor/src/components/buttons/button-with-tip.cjsx
+++ b/tutor/src/components/buttons/button-with-tip.cjsx
@@ -2,6 +2,8 @@ React = require 'react'
 BS = require 'react-bootstrap'
 _ = require 'underscore'
 
+{AsyncButton} = require 'shared'
+
 module.exports = React.createClass
   displayName: 'ButtonWithTip'
 
@@ -21,15 +23,16 @@ module.exports = React.createClass
     {isDisabled, onClick, id, placement, children, className, getTip, disabledState} = @props
 
     tip = getTip(@props)
+    asyncPropKeys = _.keys(AsyncButton.propTypes)
 
-    buttonProps = _.pick(@props, 'className', 'bsStyle', 'block')
+    buttonProps = _.pick(@props, 'className', 'bsStyle', 'block', asyncPropKeys...)
     buttonProps.disabled = isDisabled
     buttonProps.onClick = onClick unless isDisabled
 
     if disabledState? and isDisabled
       button = disabledState
     else
-      button = <BS.Button {...buttonProps}>{children}</BS.Button>
+      button = <AsyncButton {...buttonProps}>{children}</AsyncButton>
 
     if tip
       tooltip = <BS.Tooltip id={id}>{tip}</BS.Tooltip>

--- a/tutor/src/components/index.cjsx
+++ b/tutor/src/components/index.cjsx
@@ -46,7 +46,11 @@ SinglePractice = React.createClass
 
   createPractice: (courseId) ->
     query = @context?.router?.getCurrentQuery()
-    CoursePracticeActions.create(courseId, query)
+    if query.taskId? and query.taskId is CoursePracticeStore.getTaskId(courseId)
+      @update()
+    else
+      practiceQuery = _.omit(query, 'taskId')
+      CoursePracticeActions.create(courseId, practiceQuery)
 
   getInitialState: ->
     # force a new practice each time

--- a/tutor/src/components/performance-forecast/practice-button.cjsx
+++ b/tutor/src/components/performance-forecast/practice-button.cjsx
@@ -34,6 +34,6 @@ module.exports = React.createClass
       courseId={courseId}
       page_ids={page_ids}>
       <ButtonWithTip id={id} className={classes} getTip={@getTip} placement='top'>
-        {@props.title}<i />
+        {@props.title}
       </ButtonWithTip>
     </Practice>

--- a/tutor/src/components/performance-forecast/practice.cjsx
+++ b/tutor/src/components/performance-forecast/practice.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 _ = require 'underscore'
 classnames = require 'classnames'
 
-{CoursePracticeStore} = require '../../flux/practice'
+{CoursePracticeStore, CoursePracticeActions} = require '../../flux/practice'
 
 module.exports = React.createClass
   displayName: 'PracticeButton'
@@ -15,16 +15,54 @@ module.exports = React.createClass
   contextTypes:
     router: React.PropTypes.func
 
+  getInitialState: ->
+    isWaiting: false
+    isDone: false
+    isFailed: false
+    isDisabled: false
+
   onClick: ->
     {courseId, page_ids} = @props
-    @context.router.transitionTo('viewPractice', {courseId}, {page_ids})
+    CoursePracticeActions.createSilent(courseId, {page_ids})
+    CoursePracticeStore.on('change', @updateState)
+    @setState(isWaiting: true)
+
+  componentWillUnmount: ->
+    CoursePracticeStore.off('change', @updateState)
+
+  isMatch: (courseId, params, props) ->
+    props ?= @props
+    props.courseId is courseId and _.isEqual(_.pick(props, 'page_ids'), params)
+
+  updateState: (courseId, params) ->
+    return unless @isMatch(courseId, params)
+
+    CoursePracticeStore.off('change', @updateState)
+
+    if CoursePracticeStore.isFailed(courseId)
+      @setState(isWaiting: false, isDisabled: true, isFailed: true)
+    else if CoursePracticeStore.isLoaded(courseId)
+      taskId = CoursePracticeStore.getTaskId(courseId, params)
+      @context.router.transitionTo('viewPractice', {courseId}, _.extend({taskId}, params))
+      @setState(isWaiting: false, isDone: true)
 
   isDisabled: ->
     {page_ids, courseId} = @props
-    _.isEmpty(page_ids) or CoursePracticeStore.isDisabled(courseId, {page_ids})
+    _.isEmpty(page_ids) or
+      CoursePracticeStore.isDisabled(courseId, {page_ids}) or
+      @state.isDisabled
 
   render: ->
     isDisabled = @isDisabled()
-    props = {isDisabled, onClick: @onClick}
+    {isWaiting, isDone, isFailed} = @state
+
+    props = {isDisabled, isWaiting, isDone, isFailed, onClick: @onClick}
+
+    disabledProps =
+      isDisabled: true
+      isWaiting: false
+    disabledPractice = React.addons.cloneWithProps(@props.children, disabledProps)
+    props.waitingText = disabledPractice
+    props.failedState = disabledPractice
 
     React.addons.cloneWithProps(@props.children, props)

--- a/tutor/src/components/performance-forecast/practice.cjsx
+++ b/tutor/src/components/performance-forecast/practice.cjsx
@@ -62,7 +62,10 @@ module.exports = React.createClass
       isDisabled: true
       isWaiting: false
     disabledPractice = React.addons.cloneWithProps(@props.children, disabledProps)
-    props.waitingText = disabledPractice
+    props.waitingText = <div>
+      <span className='practice-waiting-text'>Loading</span>
+      {@props.children.props.children}
+    </div>
     props.failedState = disabledPractice
 
     React.addons.cloneWithProps(@props.children, props)

--- a/tutor/src/components/performance-forecast/progress-bar.cjsx
+++ b/tutor/src/components/performance-forecast/progress-bar.cjsx
@@ -40,7 +40,7 @@ module.exports = React.createClass
       <Practice
         courseId={courseId}
         page_ids={page_ids}>
-        <ButtonWithTip id={id} block getTip={@getTip}>
+        <ButtonWithTip className='progress-bar-button' id={id} block getTip={@getTip}>
           {bar}
         </ButtonWithTip>
       </Practice>

--- a/tutor/src/flux/practice.coffee
+++ b/tutor/src/flux/practice.coffee
@@ -41,10 +41,14 @@ CoursePractice =
 
   _failed: (result, courseId, topicParams) ->
     @_cacheError(result, courseId, topicParams)
+    @emit('change', courseId, topicParams)
 
   create: (courseId, topicParams) ->
     @_local[courseId] = {} unless @dontReload(courseId)
     @_asyncStatus[courseId] = STATES.LOADED
+
+  createSilent: (courseId, topicParams) ->
+    @create(courseId, topicParams)
 
   created: (result, courseId, topicParams) ->
     # this will use the base config's loaded, which will
@@ -52,7 +56,7 @@ CoursePractice =
     @loaded(result, courseId, topicParams)
 
   _loaded: (result, courseId, topicParams = {}) ->
-    @emit("#{STATES.LOADED}.#{courseId}", courseId)
+    @emit('change', courseId, topicParams)
     TaskActions.loaded(result, result.id)
 
     @_recordTopics(result.id, courseId, topicParams)


### PR DESCRIPTION
to be considered after #1292 gets merged.  Not tested, tests not yet updated, and styling is not yet polished (for example, a failed/disabled button should have some explanation) but this is the basic idear, where the first one is a practice that cannot be created, and the second can be, and will complete creating before going to the task page:
## Before

![practice-before](https://cloud.githubusercontent.com/assets/2483873/18062843/2609b4f0-6dee-11e6-84c5-8cb71ec53d33.gif)
## After

![practice-async](https://cloud.githubusercontent.com/assets/2483873/18061804/c800fbce-6de9-11e6-8530-60df81821bcd.gif)
