### PR TITLE
Don't mark tasks as not late when work is preformed

### DIFF
--- a/tutor/src/components/student-dashboard/event-info-icon.cjsx
+++ b/tutor/src/components/student-dashboard/event-info-icon.cjsx
@@ -3,6 +3,7 @@ BS       = require 'react-bootstrap'
 S = require '../../helpers/string'
 {TimeStore} = require '../../flux/time'
 moment   = require 'moment'
+TH = require '../../helpers/task'
 
 module.exports = React.createClass
   displayName: 'EventInfoIcon'
@@ -14,9 +15,7 @@ module.exports = React.createClass
     due = moment(@props.event.due_at)
     now = TimeStore.getNow()
 
-    return null if @props.event.type isnt 'homework' or
-      @props.event.complete_exercise_count is @props.event.exercise_count or
-      due.isAfter(now, 'd')
+    return null if due.isAfter(now, 'd') and TH.hasLateWork(@props.event)
 
     # use 'day' granularity for checking if the due date is today or after today
     status = if due.isSame(now, 'd') then 'incomplete' else 'late'

--- a/tutor/src/components/student-dashboard/event-info-icon.cjsx
+++ b/tutor/src/components/student-dashboard/event-info-icon.cjsx
@@ -3,7 +3,6 @@ BS       = require 'react-bootstrap'
 S = require '../../helpers/string'
 {TimeStore} = require '../../flux/time'
 moment   = require 'moment'
-TH = require '../../helpers/task'
 
 module.exports = React.createClass
   displayName: 'EventInfoIcon'
@@ -12,17 +11,22 @@ module.exports = React.createClass
     event: React.PropTypes.object.isRequired
 
   render: ->
-    due = moment(@props.event.due_at)
-    now = TimeStore.getNow()
+    {event} = @props
 
-    return null if due.isAfter(now, 'd') and TH.hasLateWork(@props.event)
+    now   = TimeStore.getNow()
+    dueAt = moment(event.due_at)
+    isIncomplete = event.complete_exercise_count isnt event.exercise_count
+    pastDue      = event.type is 'homework' and dueAt.isBefore(now, 'd')
+    workedLate   = moment(event.last_worked_at).isAfter(dueAt)
+
+    return null unless workedLate or (pastDue and isIncomplete)
 
     # use 'day' granularity for checking if the due date is today or after today
-    status = if due.isSame(now, 'd') then 'incomplete' else 'late'
+    status = if dueAt.isSame(now, 'd') then 'incomplete' else 'late'
 
     tooltip =
       <BS.Tooltip
-        id="event-info-icon-#{@props.event.id}">
+        id="event-info-icon-#{event.id}">
         <b>{S.capitalize(status)}</b>
       </BS.Tooltip>
 


### PR DESCRIPTION
Uses the task helper for determining lateness.

The earlier check was marking exercises as non-late as soon as any work was performed