### PR TITLE
Replace bare "All Periods" on course builder with switcher for Sections

### DIFF
--- a/tutor/src/components/task-plan/builder/index.cjsx
+++ b/tutor/src/components/task-plan/builder/index.cjsx
@@ -247,7 +247,9 @@ TaskPlanBuilder = React.createClass
     <BS.Row className="common tutor-date-input">
       <BS.Col sm=4 md=3>
         {radio}
-        <label className="period" htmlFor='hide-periods-radio'>All Periods</label>
+        <label className="period" htmlFor='hide-periods-radio'>
+          All <CourseGroupingLabel courseId={@props.courseId} plural />
+        </label>
       </BS.Col>
       {@renderTaskPlanRow()}
     </BS.Row>


### PR DESCRIPTION
Can't believe no-ones noticed this before.  Guess we all just got so used to seeing it say "All Periods"

![screen shot 2016-08-25 at 3 28 51 pm](https://cloud.githubusercontent.com/assets/79566/17984852/bdd94106-6ad8-11e6-9752-e3beb2538594.png)