### PR TITLE
listen for logout.received when opening from a coach view route.

### DIFF
--- a/coach/src/concept-coach/index.cjsx
+++ b/coach/src/concept-coach/index.cjsx
@@ -123,13 +123,16 @@ class ConceptCoachAPI extends EventEmitter2
       componentModel.channel.emit('close.clicked')
 
     @close = props.close
+
+    # Needs to be added on initialize since opening from a coach path calls
+    # initialize, and not open.  On will handle multiple logging in and out.
+    # 
+    # Wait until our logout request has been received and the close
+    User.channel.on('logout.received', @close)
+
     @component = coachWrapped.render(mountNode, props)
 
   open: (props) ->
-    # wait until our logout request has been received and the close
-    User.channel.once 'logout.received', =>
-      @close()
-
     openProps = _.extend({}, props, open: true)
     openProps.triggeredFrom = _.pick(props, 'moduleUUID', 'collectionUUID')
 


### PR DESCRIPTION
Fixes [logging out from coach does not close coach](https://trello.com/c/OJkEmiFh/22-concept-coach-bug-log-out-doesn-t-work).

Specifically, as @nathanstitt found, this happened whenever the webview was loaded with a coach route suffix.  When this happens, the `cc.open` function where we were adding the listeners for `logout.received` does not get called.  This PR moves adding the listeners on `cc.initialized`, which will always get called, regardless of webview loading with or without coach route suffix.