### PR TITLE
Fix email confirmation URL

### DIFF
--- a/shared/src/model/user.coffee
+++ b/shared/src/model/user.coffee
@@ -1,5 +1,5 @@
 _ = require 'underscore'
-axios = require 'axios'
+Networking = require './networking'
 URLs = require './urls'
 EventEmitter2 = require 'eventemitter2'
 
@@ -39,7 +39,7 @@ class Email extends EventEmitter2
       @requestInProgress = false
       @emit('change')
       resp
-    axios(
+    Networking.perform(
       method: 'PUT',
       url: URLs.construct('accounts_api', "contact_infos", @id, "#{type}.json")
       withCredentials: true

--- a/shared/src/model/user.coffee
+++ b/shared/src/model/user.coffee
@@ -41,7 +41,7 @@ class Email extends EventEmitter2
       resp
     axios(
       method: 'PUT',
-      url: URLs.construct('accounts_api', "contact_infos", @id, "{type}.json")
+      url: URLs.construct('accounts_api', "contact_infos", @id, "#{type}.json")
       withCredentials: true
       data: data
     ).catch(afterRequest).then(afterRequest)

--- a/shared/test/model/user.spec.coffee
+++ b/shared/test/model/user.spec.coffee
@@ -1,0 +1,36 @@
+{Testing, expect, sinon, _} = require 'test/helpers'
+
+URLs = require 'model/urls'
+User = require 'model/user'
+UiSettings = require 'model/ui-settings'
+Networking = require 'model/networking'
+
+describe 'User mode', ->
+
+  beforeEach ->
+    sinon.spy(Networking, 'perform')
+    URLs.update(accounts_api_url: 'http://localhost:2999/api')
+    @user = new User(contact_infos: [
+      {id: 1234, is_verified: false}
+    ])
+
+  afterEach ->
+    UiSettings._reset()
+    Networking.perform.restore()
+
+  it 'can request email confirmation', ->
+    email = _.first @user.unVerfiedEmails()
+    expect(email).to.exist
+    email.sendConfirmation()
+    expect(Networking.perform).to.have.been.calledWith({
+      method: 'PUT', url: 'http://localhost:2999/api/contact_infos/1234/resend_confirmation.json',
+      withCredentials: true, data: {send_pin: true}
+    })
+
+  it 'can send an email confirmation', ->
+    email = _.first @user.unVerfiedEmails()
+    email.sendVerification("1234")
+    expect(Networking.perform).to.have.been.calledWith({
+      method: 'PUT', url: 'http://localhost:2999/api/contact_infos/1234/confirm_by_pin.json',
+      withCredentials: true, data: { pin: "1234" }
+    })


### PR DESCRIPTION
So, looks like I messed this up and broke resending email confirmation

Fixes:
![screen shot 2016-08-30 at 6 23 40 pm](https://cloud.githubusercontent.com/assets/79566/18110653/e5fb2e9c-6ede-11e6-94a7-8b0cacffda22.png)
