### PR TITLE
Display data-type=abstract elements in content

### DIFF
--- a/tutor/resources/styles/book-content/base.less
+++ b/tutor/resources/styles/book-content/base.less
@@ -121,21 +121,3 @@ section {
     }
   }
 }
-
-[data-type=abstract] {
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-  margin: 1rem 0;
-  ul {
-    margin: 0;
-    padding: 0;
-    li:before{ display: none; } // disable the custom li bullets setup above
-  }
-  background-color: @tutor-neutral-bright;
-  &:before {
-    content: "Abstract:";
-    .book-content-subtitle();
-    margin: 0 1rem;
-  }
-}

--- a/tutor/resources/styles/book-content/base.less
+++ b/tutor/resources/styles/book-content/base.less
@@ -1,9 +1,5 @@
-// This file is part of the book-content mixin and should not be included directly
-// Hide titles, abstracts and CNX Processing instructions
-.section-opener,
-.summary,
-[data-type=abstract] {
-}
+
+
 [data-type=term]{
   font-weight: bold;
   font-style: italic;
@@ -14,7 +10,6 @@
   .tutor-tables(@tutor-white, @tutor-white);
 }
 div[data-type="document-title"],
-div[data-type=abstract],
 cnx-pi{
   display: none;
 }
@@ -124,5 +119,19 @@ section {
         display:inline;
       }
     }
+  }
+}
+
+[data-type=abstract] {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  margin: 1rem 0;
+  ul { margin: 0; padding: 0; }
+  background-color: @tutor-neutral-bright;
+  &:before {
+    content: "Abstract:";
+    .book-content-subtitle();
+    margin: 0 1rem;
   }
 }

--- a/tutor/resources/styles/book-content/base.less
+++ b/tutor/resources/styles/book-content/base.less
@@ -127,7 +127,11 @@ section {
   align-items: center;
   justify-content: space-around;
   margin: 1rem 0;
-  ul { margin: 0; padding: 0; }
+  ul {
+    margin: 0;
+    padding: 0;
+    li:before{ display: none; } // disable the custom li bullets setup above
+  }
   background-color: @tutor-neutral-bright;
   &:before {
     content: "Abstract:";

--- a/tutor/resources/styles/book-content/learning-objectives.less
+++ b/tutor/resources/styles/book-content/learning-objectives.less
@@ -1,4 +1,6 @@
-.learning-objectives {
+.learning-objectives,
+[data-type=abstract]
+{
   &.note:before {display: none;}
   #fonts > .sans(1.8rem, 1.8rem);
   width: 100%;
@@ -9,6 +11,7 @@
   margin-top: -@tutor-card-body-padding-vertical;
   padding: 10px 20px;
   border: none;
+  &:empty { display: none; }
   // hide the "Section learning Objectives" phrase
   > div[data-type=title] {
     display: none;
@@ -23,17 +26,19 @@
     .flex-direction(column);
     .justify-content(center);
   }
+
   ul {
     list-style: disc;
     margin: 0 0;
     padding: 0 20px;
-    border-left-style: solid;
-    border-left-width: 1px;
+    #fonts > .sans(1.8rem, 1.8rem);
     .flex-display();
     .flex-direction(column);
     .flex(1);
     .justify-content(center);
-    .ost-learning-objective-def {
+    border-left-style: solid;
+    border-left-width: 1px;
+    li {
       #fonts > .sans(1.5rem, 1.4em);
       .justify-content(center);
       margin-left: 20px;
@@ -48,4 +53,19 @@
     }
   }
   .printer-safe(inline-flex, inherit, inherit, 10px)
+}
+
+
+[data-type=abstract] {
+  align-items: center;
+  #fonts > .sans(1.4rem, 1.8em);
+  text-transform: uppercase;
+  text-align: right;
+  ul {
+    text-transform: initial;
+    text-align: left;
+    margin-left: 20px;
+    border-left: 0;
+  }
+  li:before{ display: none; } // disable the custom li bullets
 }

--- a/tutor/resources/styles/book-content/learning-objectives.less
+++ b/tutor/resources/styles/book-content/learning-objectives.less
@@ -5,7 +5,6 @@
   #fonts > .sans(1.8rem, 1.8rem);
   width: 100%;
   min-height: 100px;
-  margin-bottom: 40px;
   .book-content-full-width();
   .flex-display(inline-flex);
   margin-top: -@tutor-card-body-padding-vertical;
@@ -16,8 +15,6 @@
   > div[data-type=title] {
     display: none;
   }
-  // move .splash elements up to fit directly under the heading
-  & + .splash { margin-top: -40px; }
   p {
     #fonts > .sans(1.4rem, 1.8em);
     width: 220px; // keep line length consistent

--- a/tutor/resources/styles/book-content/learning-objectives.less
+++ b/tutor/resources/styles/book-content/learning-objectives.less
@@ -16,6 +16,8 @@
   > div[data-type=title] {
     display: none;
   }
+  // move .splash elements up to fit directly under the heading
+  & + .splash { margin-top: -40px; }
   p {
     #fonts > .sans(1.4rem, 1.8em);
     width: 220px; // keep line length consistent
@@ -54,6 +56,7 @@
   }
   .printer-safe(inline-flex, inherit, inherit, 10px)
 }
+
 
 
 [data-type=abstract] {

--- a/tutor/resources/styles/book-content/mixins.less
+++ b/tutor/resources/styles/book-content/mixins.less
@@ -28,10 +28,18 @@
     font-weight: 600;
     color: @letter-color;
     margin: .1em .08em 0 -.06em; //best combination on line-height and margin to look good in chrome and ff
+
+
   }
-  // ensure that the p is heigh enough for the drop cap
-  // to fit beside it, otherwise it will overlay on top of the next element
-  min-height: 8rem;
+  // use clearfix hack to ensure the paragraph's first-leter does not flow into the following block
+  &:after {
+    content: " ";
+    display: table;
+  }
+  &:after {
+    clear: both;
+  }
+
 }
 
 .book-content-subtitle(@subtitle-color: @tutor-book-secondary) {

--- a/tutor/resources/styles/book-content/theming-mixins.less
+++ b/tutor/resources/styles/book-content/theming-mixins.less
@@ -2,12 +2,20 @@
   .learning-objectives {
     background: @theme-primary;
     color: @text-color;
-
     p {
       color: fade(@text-color, 75%);
     }
 
     ul {
+      border-left-color: fade(@text-color, 40%);
+    }
+  }
+
+  [data-type=abstract] {
+    background: @theme-primary;
+    color: fade(@text-color, 75%);
+    ul {
+      color: @text-color;
       border-left-color: fade(@text-color, 40%);
     }
   }


### PR DESCRIPTION
From https://trello.com/c/Asuv9A1Y/69-bug-abstracts-div-data-type-abstract-not-being-displayed-in-college-books-readings-or-reference-view

This styles abstracts like learning-objectives.  The only difference is that they do not have the separating line.  I had to disable that because all abstracts do not have a "In this chapter you will learn about" pre-amble.  Without that, the line looks weird because it doesn't separate anything.

HS Physics abstract with pre-amble:

![screen shot 2016-09-06 at 12 00 42 pm](https://cloud.githubusercontent.com/assets/79566/18283166/98cf7ed4-7429-11e6-924e-cb81e74f7fe1.png)



College physics without one:
![screen shot 2016-09-06 at 12 01 28 pm](https://cloud.githubusercontent.com/assets/79566/18283191/aaf2196e-7429-11e6-8d8e-2924b110bcee.png)

