### PR TITLE
Readings: Course name and assignment name overlap in a reading assignment on tablet

### DIFF
--- a/tutor/resources/styles/global/navbar.less
+++ b/tutor/resources/styles/global/navbar.less
@@ -159,6 +159,9 @@
     display: flex;
     font-size: 1.8rem;
     font-weight: bold;
+    background: @tutor-white;
+    z-index: 1;
+    box-shadow: 0 0 5px 10px @tutor-white;
 
     .fa {
         color: #888;


### PR DESCRIPTION
regarding: https://www.pivotaltracker.com/story/show/127732387

There is an edge case when a reading name is long but the header has not switched to compact mode for certain tablet resolutions/orientations.  In this case the course title and reading title may overlap. 

![screenshot from 2016-09-01 11 45 52](https://cloud.githubusercontent.com/assets/954569/18174292/0a16a966-703b-11e6-9f65-fd836e63fb12.png)

![screenshot from 2016-09-01 11 45 47](https://cloud.githubusercontent.com/assets/954569/18174302/0f23b818-703b-11e6-9385-3f25b9f6b037.png)

text ellipsis way w/ tooltip:

![screenshot from 2016-09-02 10 55 40](https://cloud.githubusercontent.com/assets/954569/18208139/36db5002-70fc-11e6-9ae6-0103cd70d24f.png)

