### PR TITLE
Follow Up reading content styling details

### DIFF
--- a/shared/resources/styles/components/question.less
+++ b/shared/resources/styles/components/question.less
@@ -22,10 +22,13 @@
 @feedback-vertical-spacing: @feedback-horizontal-spacing;
 @feedback-horizontal-buffer: 2 * @feedback-horizontal-spacing;
 
-.openstax-bubble(@diameter, @border-size){
+@openstax-bubble: {
+  @diameter: @answer-bubble-size;
+  @border-size: 2px;
+
   width: @diameter;
   height: @diameter;
-  border-radius: 2 * @diameter;
+  border-radius: @diameter / 2;
   border-width: @border-size;
   border-style: solid;
 
@@ -38,23 +41,23 @@
     text-align: center;
     display: inline-block;
   }
-}
+};
 
-.answer-fa-icon(){
+@answer-fa-icon: {
   .fa-icon();
   // em used here for line-height for compatibility with IE
   // http://caniuse.com/#feat=rem -- rem ignored in pseudo elements
   line-height: 1.6em;
   font-size: 2.5rem;
-}
+};
 
-.answer-bubble(){
-  .openstax-bubble(@answer-bubble-size, 2px);
+@answer-bubble: {
+  @openstax-bubble();
   border-color: lighten(@answer-label-color, 15%);
   color: @answer-label-color-hover;
 
   .transition(~'color @{answer-transition}, border-color @{answer-transition}, background-color @{answer-transition}');
-}
+};
 
 .answer-bubble(hover){
   border-color: @answer-label-color-selected;
@@ -72,7 +75,7 @@
   color: @openstax-white;
 
   &::after {
-    .answer-fa-icon();
+    @answer-fa-icon();
     content: @fa-var-close;
   }
 }
@@ -83,7 +86,7 @@
   color: @openstax-white;
 
   &::after {
-    .answer-fa-icon();
+    @answer-fa-icon();
     content: @fa-var-check;
   }
 }
@@ -101,7 +104,7 @@
 .answer(){
   color: @answer-label-color;
   .answer-letter {
-    .answer-bubble();
+    @answer-bubble();
   }
 }
 

--- a/tutor/resources/styles/book-content/base.less
+++ b/tutor/resources/styles/book-content/base.less
@@ -80,33 +80,6 @@ figure {
   img { width: 100%; }
 }
 
-section {
-  // counter-reset: exerciseCount;
-  [data-type="exercise"] {
-    [data-type="problem"],
-    [data-type="solution"] {
-      p:first-of-type {
-        // counter-increment: exerciseCount;
-        // &::before {
-        //   content: counter(exerciseCount) ". ";
-        //   font-weight: bold;
-        //   font-size: 2.5rem;
-        // }
-      }
-      ol {
-        counter-reset: lowerAlpha;
-        list-style: none;
-      }
-      ol li {
-        counter-increment: lowerAlpha;
-      }
-      ol li::before {
-        content: counter(lowerAlpha, lower-alpha) ") ";
-      }
-    }
-  }
-}
-
 [data-type="footnote-refs"] {
   ol {
     padding-left: 0;

--- a/tutor/resources/styles/book-content/base.less
+++ b/tutor/resources/styles/book-content/base.less
@@ -1,5 +1,22 @@
 
 
+// This file is part of the book-content mixin and should not be included directly
+// Hide titles, abstracts and CNX Processing instructions
+
+// Default font for text content
+p,
+ul,
+ol,
+div {
+  #fonts > .serif(1.75rem, 190%);
+}
+
+p,
+ul,
+ol {
+  margin: 0 0 2.4rem 0;
+}
+
 [data-type=term]{
   font-weight: bold;
   font-style: italic;
@@ -10,14 +27,6 @@
 div[data-type="document-title"],
 cnx-pi{
   display: none;
-}
-
-// Default font for text content
-p,
-ul,
-ol {
-  #fonts > .serif(1.75rem, 190%);
-  margin: 0 0 2.4rem 0;
 }
 
 ul {
@@ -78,17 +87,17 @@ figure {
 }
 
 section {
-  counter-reset: exerciseCount;
+  // counter-reset: exerciseCount;
   [data-type="exercise"] {
     [data-type="problem"],
     [data-type="solution"] {
       p:first-of-type {
-        counter-increment: exerciseCount;
-        &::before {
-          content: counter(exerciseCount) ". ";
-          font-weight: bold;
-          font-size: 2.5rem;
-        }
+        // counter-increment: exerciseCount;
+        // &::before {
+        //   content: counter(exerciseCount) ". ";
+        //   font-weight: bold;
+        //   font-size: 2.5rem;
+        // }
       }
       ol {
         counter-reset: lowerAlpha;

--- a/tutor/resources/styles/book-content/base.less
+++ b/tutor/resources/styles/book-content/base.less
@@ -6,14 +6,8 @@
 // Default font for text content
 p,
 ul,
-ol,
-div {
-  #fonts > .serif(1.75rem, 190%);
-}
-
-p,
-ul,
 ol {
+  #fonts > .serif(1.75rem, 190%);
   margin: 0 0 2.4rem 0;
 }
 

--- a/tutor/resources/styles/book-content/index.less
+++ b/tutor/resources/styles/book-content/index.less
@@ -71,7 +71,7 @@
 
   .tutor-book-theme-first-letter(@tutor-book-intro-sociology-primary);
   .tutor-book-theme-typography(@tutor-book-intro-sociology-secondary);
-  .tutor-book-theme-learning-objectives(@tutor-book-intro-sociology-primary);
+  .tutor-book-theme-learning-objectives(@tutor-book-intro-sociology-primary; @tutor-book-intro-sociology-secondary);
   .tutor-book-theme-splash-image(@tutor-book-intro-sociology-primary; @tutor-book-intro-sociology-secondary);
   .tutor-book-theme-note(@tutor-book-intro-sociology-primary; @tutor-book-intro-sociology-secondary);
   .tutor-book-theme-note-borders(@tutor-book-text-on-dark-labels);

--- a/tutor/resources/styles/book-content/learning-objectives.less
+++ b/tutor/resources/styles/book-content/learning-objectives.less
@@ -40,6 +40,10 @@
     content: attr(data-preamble);
   }
 
+  &[data-is-intro=false] {
+    margin-bottom: 3rem;
+  }
+
 
   ul {
     text-transform: none;

--- a/tutor/resources/styles/book-content/learning-objectives.less
+++ b/tutor/resources/styles/book-content/learning-objectives.less
@@ -1,8 +1,13 @@
 .learning-objectives,
-[data-type=abstract]
-{
-  &.note:before {display: none;}
-  #fonts > .sans(1.8rem, 1.8rem);
+[data-type=abstract] {
+
+  // hide the "Section learning Objectives" phrase
+  > div[data-type=title],
+  &:empty,
+  p {
+    display: none;
+  }
+
   width: 100%;
   min-height: 100px;
   .book-content-full-width();
@@ -10,23 +15,34 @@
   margin-top: -@tutor-card-body-padding-vertical;
   padding: 10px 20px;
   border: none;
-  &:empty { display: none; }
-  // hide the "Section learning Objectives" phrase
-  > div[data-type=title] {
-    display: none;
-  }
-  p {
+
+  &::before {
     #fonts > .sans(1.4rem, 1.8em);
-    width: 220px; // keep line length consistent
     text-transform: uppercase;
     text-align: right;
-    margin: 0 20px 0 0;
     .flex-display();
     .flex-direction(column);
     .justify-content(center);
+    margin: 0 20px 0 0;
   }
 
+  &[data-is-intro=true]::before {
+    content: 'In this chapter you will learn about:';
+  }
+
+  &[data-is-intro=false]::before {
+    width: 220px; // keep line length consistent
+
+    content: 'By the end of this section, you will be able to:';
+  }
+
+  &[data-preamble]::before {
+    content: attr(data-preamble);
+  }
+
+
   ul {
+    text-transform: none;
     list-style: disc;
     margin: 0 0;
     padding: 0 20px;
@@ -35,37 +51,24 @@
     .flex-direction(column);
     .flex(1);
     .justify-content(center);
-    border-left-style: solid;
     border-left-width: 1px;
+    border-left-style: solid;
+
     li {
       #fonts > .sans(1.5rem, 1.4em);
       .justify-content(center);
       margin-left: 20px;
       padding-bottom: 5px;
       font-weight: 300;
-      &:before {
+
+      &::before {
         content: none;
+        display: none;
       }
       .MathJax {
         margin-left: 2rem;
       }
     }
   }
-  .printer-safe(inline-flex, inherit, inherit, 10px)
-}
-
-
-
-[data-type=abstract] {
-  align-items: center;
-  #fonts > .sans(1.4rem, 1.8em);
-  text-transform: uppercase;
-  text-align: right;
-  ul {
-    text-transform: initial;
-    text-align: left;
-    margin-left: 20px;
-    border-left: 0;
-  }
-  li:before{ display: none; } // disable the custom li bullets
+  .printer-safe(inline-flex, inherit, inherit, 10px);
 }

--- a/tutor/resources/styles/book-content/note.less
+++ b/tutor/resources/styles/book-content/note.less
@@ -94,6 +94,14 @@
   }
 }
 
+.tutor-style-note(
+  @note-rules: @tutor-empty-rules;
+  @title-rules: @tutor-empty-rules;
+) {
+  @note-rules();
+  .tutor-style-note-title-variants(@title-rules);
+}
+
 .tutor-style-note-variants(
   @all-note-rules: @tutor-empty-rules;
   @title-rules: @tutor-empty-rules;
@@ -111,14 +119,10 @@
 
   > .example,
   section > .example {
-    @all-note-rules();
-
-    .tutor-style-note-title-variants(@title-rules);
+    .tutor-style-note(@all-note-rules; @title-rules);
 
     &:not(.os-teacher) {
-      @except-teacher-rules();
-
-      .tutor-style-note-title-variants(@except-teacher-title-rules);
+      .tutor-style-note(@except-teacher-rules; @except-teacher-title-rules);
     }
   }
 }
@@ -180,26 +184,33 @@
   // the non-`[data-label]`led notes will also be affected like a fully featured note.
 }
 
+@tutor-note-plain-style: {
+  @desired-iframe-inset: (@reference-book-page-width - @tutor-interactive-iframe-width) / 2;
+
+  background: none;
+  padding: 20px 0;
+  .embed-responsive {
+    iframe {
+      width: 100%;
+    }
+  }
+
+  iframe.interactive {
+    margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset);
+  }
+};
+
+@tutor-note-plain-title-style: {
+  margin: @book-content-note-without-background-margin;
+};
+
 .tutor-book-step-note() {
+  .tutor-style-note(@tutor-note-plain-style; @tutor-note-plain-title-style);
+}
+
+.tutor-book-step-notes() {
   // tutor-book-step specific modifications
-  .tutor-style-note-variants(@all-note-rules: {
-    @desired-iframe-inset: (@reference-book-page-width - @tutor-interactive-iframe-width) / 2;
-
-    background: none;
-    padding: 20px 0;
-    .embed-responsive {
-      iframe {
-        width: 100%;
-      }
-    }
-
-    iframe.interactive {
-      margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset);
-    }
-
-  }, @title-rules: {
-    margin: @book-content-note-without-background-margin;
-  });
+  .tutor-style-note-variants(@tutor-note-plain-style; @tutor-note-plain-title-style);
 }
 
 .tutor-book-reading-titles(){

--- a/tutor/resources/styles/book-content/note.less
+++ b/tutor/resources/styles/book-content/note.less
@@ -137,6 +137,11 @@
         margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset + @tutor-note-margin-horizontal);
       }
 
+      .exercise[data-type=exercise] .solution {
+        // undo general hiding of solutions
+        display: block;
+      }
+
       .tutor-book-note-style();
     };
     @title-rules: @tutor-book-label-style;
@@ -175,9 +180,10 @@
   // the non-`[data-label]`led notes will also be affected like a fully featured note.
 }
 
-.tutor-book-reading-note() {
-  // tutor-book-reading specific modifications
+.tutor-book-step-note() {
+  // tutor-book-step specific modifications
   .tutor-style-note-variants(@all-note-rules: {
+    @desired-iframe-inset: (@reference-book-page-width - @tutor-interactive-iframe-width) / 2;
 
     background: none;
     padding: 20px 0;

--- a/tutor/resources/styles/book-content/note.less
+++ b/tutor/resources/styles/book-content/note.less
@@ -136,6 +136,7 @@
       border-bottom: solid 8px @tutor-neutral-lighter;
       padding: @tutor-note-padding;
       width: 100%;
+      position: relative;
 
       iframe.interactive {
         margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset + @tutor-note-margin-horizontal);

--- a/tutor/resources/styles/book-content/questions.less
+++ b/tutor/resources/styles/book-content/questions.less
@@ -2,6 +2,20 @@ section {
   counter-reset: question;
 }
 
+.exercise[data-type=exercise] {
+  >[data-type=problem] {
+    > p[id^='import-auto-'] {
+      &::before {
+        counter-increment: question;
+        content: counter(question) ". ";
+        display: block;
+        float: left;
+        width: 4%;
+      }
+    }
+  }
+}
+
 .openstax-question {
   .tutor-tables(@tutor-white, @tutor-white);
 

--- a/tutor/resources/styles/book-content/questions.less
+++ b/tutor/resources/styles/book-content/questions.less
@@ -1,18 +1,49 @@
+@import (reference) '~shared/resources/styles/components/question';
+
 section {
   counter-reset: question;
 }
 
+@question-number: {
+  counter-increment: question;
+  content: counter(question) ". ";
+  display: block;
+  float: left;
+  width: 4%;
+};
+
 .exercise[data-type=exercise] {
   >[data-type=problem] {
-    > p[id^='import-auto-'] {
+    > p {
+      margin: 0;
+
       &::before {
-        counter-increment: question;
-        content: counter(question) ". ";
-        display: block;
-        float: left;
-        width: 4%;
+        @question-number();
       }
     }
+
+    // make fully imported questions imitate embedded exercises
+    ol {
+      counter-reset: lowerAlpha;
+      list-style: none;
+      padding-left: 3rem;
+
+      li {
+        counter-increment: lowerAlpha;
+        padding-top: 1.5rem;
+        color: @answer-label-color;
+
+        &::before {
+          content: counter(lowerAlpha, lower-alpha);
+          @answer-bubble();
+          line-height: 4rem;
+          display: inline-block;
+          text-align: center;
+          margin-right: 1rem;
+        }
+      }
+    }
+
   }
 }
 
@@ -20,12 +51,9 @@ section {
   .tutor-tables(@tutor-white, @tutor-white);
 
   &::before {
-    counter-increment: question;
-    content: counter(question) ". ";
-    display: block;
-    float: left;
-    width: 4%;
+    @question-number();
   }
+
   .question-stem {
     float: left;
     width: 96%;

--- a/tutor/resources/styles/book-content/questions.less
+++ b/tutor/resources/styles/book-content/questions.less
@@ -12,7 +12,7 @@ section {
   width: 4%;
 };
 
-.exercise[data-type=exercise] {
+.exercise[data-type=exercise]:not(.unnumbered) {
   >[data-type=problem] {
     > p {
       margin: 0;

--- a/tutor/resources/styles/book-content/theming-mixins.less
+++ b/tutor/resources/styles/book-content/theming-mixins.less
@@ -1,8 +1,10 @@
 .tutor-book-theme-learning-objectives(@theme-primary: @tutor-book-primary; @text-color: @tutor-book-text-on-dark-labels) {
-  .learning-objectives {
+  .learning-objectives,
+  [data-type=abstract] {
     background: @theme-primary;
     color: @text-color;
-    p {
+
+    &::before {
       color: fade(@text-color, 75%);
     }
 
@@ -11,14 +13,6 @@
     }
   }
 
-  [data-type=abstract] {
-    background: @theme-primary;
-    color: fade(@text-color, 75%);
-    ul {
-      color: @text-color;
-      border-left-color: fade(@text-color, 40%);
-    }
-  }
 }
 
 .tutor-book-theme-note(@label-background: @tutor-book-primary; @label-text: @tutor-book-text-on-dark-labels) {

--- a/tutor/resources/styles/components/reference-book/exercise.less
+++ b/tutor/resources/styles/components/reference-book/exercise.less
@@ -4,9 +4,9 @@
     .openstax-question {
       padding: 0;
     }
-		.solution {
-			display: none;
-		}
+    .solution {
+      display: none;
+    }
   }
 
   .reference-book-missing-exercise {

--- a/tutor/resources/styles/components/reference-book/exercise.less
+++ b/tutor/resources/styles/components/reference-book/exercise.less
@@ -2,6 +2,7 @@
   .exercise[data-type=exercise] {
     margin-bottom: 40px;
     .openstax-question {
+      #fonts > .serif(1.75rem, 190%);
       padding: 0;
     }
     .solution {

--- a/tutor/resources/styles/components/reference-book/page.less
+++ b/tutor/resources/styles/components/reference-book/page.less
@@ -96,11 +96,11 @@
 
       &::after {
         left: 0;
-        top: -8px;
+        top: -20px;
       }
     }
 
-    &.page-loading {
+    .page-loading {
       .refresh-button {
         position: absolute;
         left: 50%;

--- a/tutor/resources/styles/components/task-step/all-steps.less
+++ b/tutor/resources/styles/components/task-step/all-steps.less
@@ -33,7 +33,13 @@
 
   .video-content,
   .interactive-content {
-    .tutor-book-step-note();
+    .tutor-book-step-notes();
+  }
+
+  .reading-content {
+    > .note:first-child {
+      .tutor-book-step-note();
+    }
   }
 
   .task-step-personalized {

--- a/tutor/resources/styles/components/task-step/all-steps.less
+++ b/tutor/resources/styles/components/task-step/all-steps.less
@@ -2,24 +2,14 @@
 @import (reference) '../../book-content/note';
 
 .task {
-  iframe {
-    width: @tutor-interactive-iframe-width;
-    height: 500px;
-    border: none;
-    margin: 0 auto;
-  }
-  .embed-responsive > iframe {
-    width: 100%;
-    height: 100%;
-  }
   .spacer-step {
     padding: @tutor-card-body-padding;
   }
+
   .video-content,
   .interactive-content,
   .reading-content {
     .tutor-book-content();
-    .tutor-book-reading-note();
     .tutor-book-reading-titles();
 
     &[data-appearance=hs_physics],
@@ -41,20 +31,9 @@
     }
   }
 
-  .task-step {
-    // The number of pixels the iframe will be inset from the task in the end
-    @desired-iframe-inset: (@tutor-task-width - @tutor-interactive-iframe-width) / 2;
-
-    iframe.interactive {
-      margin: 20px auto;
-    }
-
-    :not(.interactive-step) {
-      iframe.interactive {
-        // The rest of the card has a lot of padding, and it won't fit unless we shift it over so it's centered
-        margin-left: -(@tutor-card-body-padding-horizontal - @desired-iframe-inset);
-      }
-    }
+  .video-content,
+  .interactive-content {
+    .tutor-book-step-note();
   }
 
   .task-step-personalized {

--- a/tutor/resources/styles/components/task-step/reading/interactive.less
+++ b/tutor/resources/styles/components/task-step/reading/interactive.less
@@ -3,7 +3,6 @@
     iframe {
       width: @tutor-interactive-iframe-width;
       height: 560px;
-      margin-left: -(@tutor-card-body-padding-horizontal - 20px);
     }
   }
 }

--- a/tutor/src/components/book-content-mixin.cjsx
+++ b/tutor/src/components/book-content-mixin.cjsx
@@ -183,14 +183,14 @@ ReadingContentMixin =
       # leave the list alone -- this is the main content
       continue if not abstractChild? or abstractChild.tagName is 'UL'
 
-      text = abstractChild.textContent.trim()
+      text = (abstractChild.textContent or '').trim()
 
       # grab text if relevant and set as preamble
       if abstractChild.dataset?.type isnt 'title' and text
         abstract.dataset.preamble = text
 
       # remove all non-lists children to prevent extra text in preamble
-      abstractChild.remove()
+      abstractChild.remove?()
 
     abstract.dataset.isIntro = root.querySelector(IS_INTRO_SELECTORS)?
 

--- a/tutor/src/components/book-content-mixin.cjsx
+++ b/tutor/src/components/book-content-mixin.cjsx
@@ -17,6 +17,10 @@ EXERCISE_LINK_SELECTOR = [
   '.ost-exercise > [data-type="problem"] > p > a[href]'
 ].join(', ')
 
+
+LEARNING_OBJECTIVE_SELECTORS = '.learning-objectives, [data-type=abstract]'
+IS_INTRO_SELECTORS = '.splash img, [data-type="cnx.flag.introduction"]'
+
 LinkContentMixin =
   componentDidMount:  ->
     @processLinks()
@@ -142,12 +146,14 @@ ReadingContentMixin =
   componentDidMount:  ->
     @insertOverlays()
     @detectImgAspectRatio()
+    @cleanUpAbstracts()
     @processLinks()
 
 
   componentDidUpdate: ->
     @insertOverlays()
     @detectImgAspectRatio()
+    @cleanUpAbstracts()
     @processLinks()
 
   contextTypes:
@@ -166,6 +172,27 @@ ReadingContentMixin =
       overlay.className = 'tutor-ui-overlay'
       overlay.innerHTML = title
       img.parentElement.appendChild(overlay)
+
+  cleanUpAbstracts: ->
+    root = @getDOMNode()
+    abstract = root.querySelector(LEARNING_OBJECTIVE_SELECTORS)
+    # dont clean up if abstract does not exist or if it has already been cleaned up
+    return if not abstract? or abstract.dataset.isIntro?
+
+    for abstractChild in abstract.childNodes
+      # leave the list alone -- this is the main content
+      continue if not abstractChild? or abstractChild.tagName is 'UL'
+
+      text = abstractChild.textContent.trim()
+
+      # grab text if relevant and set as preamble
+      if abstractChild.dataset?.type isnt 'title' and text
+        abstract.dataset.preamble = text
+
+      # remove all non-lists children to prevent extra text in preamble
+      abstractChild.remove()
+
+    abstract.dataset.isIntro = root.querySelector(IS_INTRO_SELECTORS)?
 
   detectImgAspectRatio: ->
     root = @getDOMNode()


### PR DESCRIPTION
follow up to #1331

## Show worked example solutions

Also, get rid of extraneous exercise numbers

### Before
![screen shot 2016-09-07 at 5 15 01 pm](https://cloud.githubusercontent.com/assets/2483873/18330712/c0230aea-751f-11e6-8ccd-4bc7be4a5e56.png)


### After
![screen shot 2016-09-07 at 5 22 16 pm](https://cloud.githubusercontent.com/assets/2483873/18330708/bb3791ae-751f-11e6-9d16-2a22d59bdb54.png)


## Fix imported exercise rendering

Make styled (almost) the same as embedded exercises, fix numbering

### Before
![screen shot 2016-09-07 at 5 14 43 pm](https://cloud.githubusercontent.com/assets/2483873/18330735/ef54515c-751f-11e6-80b9-e505217ab800.png)

### After
![screen shot 2016-09-07 at 5 08 18 pm](https://cloud.githubusercontent.com/assets/2483873/18330744/f9bbb3a6-751f-11e6-9434-7fc2bc0534fd.png)

### Embedded exercises before
![screen shot 2016-09-07 at 5 15 35 pm](https://cloud.githubusercontent.com/assets/2483873/18330759/117149fc-7520-11e6-9cd2-d0259f20e0c7.png)

## Single stepped notes have clear background

![screen shot 2016-09-07 at 5 26 33 pm](https://cloud.githubusercontent.com/assets/2483873/18330795/3fe9fdec-7520-11e6-81ee-5a3796119503.png)

## Abstract labeling

### Before
![screen shot 2016-09-07 at 5 14 30 pm](https://cloud.githubusercontent.com/assets/2483873/18330809/5460c012-7520-11e6-8528-87970290477c.png)

### After
![screen shot 2016-09-07 at 5 08 07 pm](https://cloud.githubusercontent.com/assets/2483873/18330817/60d3851e-7520-11e6-9a3c-57fc5ba221bd.png)

## Fixes page loading status



