### PR TITLE
Don't warn about students working when deleting unopened assignments

### DIFF
--- a/tutor/src/components/task-plan/event/index.cjsx
+++ b/tutor/src/components/task-plan/event/index.cjsx
@@ -26,6 +26,7 @@ EventPlan = React.createClass
       onPublish={@publish}
       onSave={@save}
       onCancel={@cancel}
+      isVisibleToStudents={@state.isVisibleToStudents}
       getBackToCalendarParams={@getBackToCalendarParams}
       goBackToCalendar={@goBackToCalendar}/>
 

--- a/tutor/src/components/task-plan/external/index.cjsx
+++ b/tutor/src/components/task-plan/external/index.cjsx
@@ -40,6 +40,7 @@ ExternalPlan = React.createClass
       onPublish={@publish}
       onSave={@save}
       onCancel={@cancel}
+      isVisibleToStudents={@state.isVisibleToStudents}
       getBackToCalendarParams={@getBackToCalendarParams}
       goBackToCalendar={@goBackToCalendar}/>
 
@@ -75,7 +76,7 @@ ExternalPlan = React.createClass
                 onChange={@setUrl} />
             </BS.Col>
           </BS.Row>
-          
+
         </BS.Grid>
       </BS.Panel>
     </div>

--- a/tutor/src/components/task-plan/footer/back-button.cjsx
+++ b/tutor/src/components/task-plan/footer/back-button.cjsx
@@ -1,0 +1,21 @@
+React = require 'react'
+Router = require 'react-router'
+
+BackButton = React.createClass
+
+  propTypes:
+    isEditable: React.PropTypes.bool.isRequired
+    getBackToCalendarParams: React.PropTypes.func.isRequired
+
+  render: ->
+    return null if @props.isEditable
+
+    backToCalendarParams = @props.getBackToCalendarParams()
+
+    <Router.Link {...backToCalendarParams} className='btn btn-default'>
+      Back to Calendar
+    </Router.Link>
+
+
+
+module.exports = BackButton

--- a/tutor/src/components/task-plan/footer/cancel-button.cjsx
+++ b/tutor/src/components/task-plan/footer/cancel-button.cjsx
@@ -1,0 +1,18 @@
+React = require 'react'
+BS = require 'react-bootstrap'
+
+
+CancelButton = React.createClass
+
+  propTypes:
+    onClick:    React.PropTypes.func.isRequired
+    isWaiting:  React.PropTypes.bool.isRequired
+    isEditable: React.PropTypes.bool.isRequired
+
+  render: ->
+    return null unless @props.isEditable
+
+    <BS.Button aria-role='close' disabled={@props.isWaiting} onClick={@props.onClick}>Cancel</BS.Button>
+
+
+module.exports = CancelButton

--- a/tutor/src/components/task-plan/footer/delete-link.cjsx
+++ b/tutor/src/components/task-plan/footer/delete-link.cjsx
@@ -9,15 +9,16 @@ DeleteLink = React.createClass
     isWaiting:   React.PropTypes.bool.isRequired
     isFailed:    React.PropTypes.bool.isRequired
     isNew:       React.PropTypes.bool.isRequired
+    isOpened:    React.PropTypes.bool.isRequired
     isPublished: React.PropTypes.bool.isRequired
 
   render: ->
     return null if @props.isNew and not @props.isWaiting
 
-    message = if @props.isPublished
-      message = 'Some students may have started work on this assignment. Are you sure you want to delete?'
-    else
-      message = 'Are you sure you want to delete this draft?'
+    message = 'Are you sure you want to delete this assignment?'
+
+    if @props.isPublished and @props.isOpened
+      message = "Some students may have started work on this assignment. #{message}"
 
     <SuretyGuard
       onConfirm={@props.onClick}
@@ -33,6 +34,7 @@ DeleteLink = React.createClass
       >
         <Icon type="trash" /> Delete Assignment
       </AsyncButton>
+
     </SuretyGuard>
 
 

--- a/tutor/src/components/task-plan/footer/delete-link.cjsx
+++ b/tutor/src/components/task-plan/footer/delete-link.cjsx
@@ -1,0 +1,39 @@
+React = require 'react'
+{AsyncButton, SuretyGuard} = require 'shared'
+Icon = require '../../icon'
+
+DeleteLink = React.createClass
+
+  propTypes:
+    onClick:     React.PropTypes.func.isRequired
+    isWaiting:   React.PropTypes.bool.isRequired
+    isFailed:    React.PropTypes.bool.isRequired
+    isNew:       React.PropTypes.bool.isRequired
+    isPublished: React.PropTypes.bool.isRequired
+
+  render: ->
+    return null if @props.isNew and not @props.isWaiting
+
+    message = if @props.isPublished
+      message = 'Some students may have started work on this assignment. Are you sure you want to delete?'
+    else
+      message = 'Are you sure you want to delete this draft?'
+
+    <SuretyGuard
+      onConfirm={@props.onClick}
+      okButtonLabel='Yes'
+      placement='top'
+      message={message}
+    >
+      <AsyncButton
+        className='delete-link pull-right'
+        isWaiting={@props.isWaiting}
+        isFailed={@props.isFailed}
+        waitingText='Deleting…'
+      >
+        <Icon type="trash" /> Delete Assignment
+      </AsyncButton>
+    </SuretyGuard>
+
+
+module.exports = DeleteLink

--- a/tutor/src/components/task-plan/footer/delete-link.cjsx
+++ b/tutor/src/components/task-plan/footer/delete-link.cjsx
@@ -9,15 +9,14 @@ DeleteLink = React.createClass
     isWaiting:   React.PropTypes.bool.isRequired
     isFailed:    React.PropTypes.bool.isRequired
     isNew:       React.PropTypes.bool.isRequired
-    isOpened:    React.PropTypes.bool.isRequired
-    isPublished: React.PropTypes.bool.isRequired
+    isVisibleToStudents: React.PropTypes.bool.isRequired
 
   render: ->
     return null if @props.isNew and not @props.isWaiting
 
     message = 'Are you sure you want to delete this assignment?'
 
-    if @props.isPublished and @props.isOpened
+    if @props.isVisibleToStudents
       message = "Some students may have started work on this assignment. #{message}"
 
     <SuretyGuard

--- a/tutor/src/components/task-plan/footer/help-tooltip.cjsx
+++ b/tutor/src/components/task-plan/footer/help-tooltip.cjsx
@@ -1,0 +1,35 @@
+React = require 'react'
+BS = require 'react-bootstrap'
+{TaskPlanStore} = require '../../../flux/task-plan'
+
+Tooltip =
+  <BS.Popover id='plan-footer-popover'>
+    <p>
+      <strong>Publish</strong> will make the assignment visible to students on the open date.
+      If open date is today, it will be available immediately.
+    </p>
+    <p>
+      <strong>Cancel</strong> will discard all changes and return to the calendar.
+    </p>
+    <p>
+      <strong>Save as draft</strong> will add the assignment to the teacher calendar only.
+      It will not be visible to students, even if the open date has passed.
+    </p>
+  </BS.Popover>
+
+HelpTooltip = React.createClass
+
+  propTypes:
+    isEditable: React.PropTypes.bool.isRequired
+
+  render: ->
+    return null unless @props.isEditable and TaskPlanStore.isPublished(id)
+
+    <BS.OverlayTrigger trigger='click' placement='top' overlay={tips} rootClose={true}>
+      <BS.Button className="footer-instructions" bsStyle="link">
+        <i className="fa fa-info-circle"></i>
+      </BS.Button>
+    </BS.OverlayTrigger>
+
+
+module.exports = HelpTooltip

--- a/tutor/src/components/task-plan/footer/help-tooltip.cjsx
+++ b/tutor/src/components/task-plan/footer/help-tooltip.cjsx
@@ -23,9 +23,9 @@ HelpTooltip = React.createClass
     isEditable: React.PropTypes.bool.isRequired
 
   render: ->
-    return null unless @props.isEditable and TaskPlanStore.isPublished(id)
+    return null unless @props.isEditable and @props.isPublished
 
-    <BS.OverlayTrigger trigger='click' placement='top' overlay={tips} rootClose={true}>
+    <BS.OverlayTrigger trigger='click' placement='top' overlay={Tooltip} rootClose={true}>
       <BS.Button className="footer-instructions" bsStyle="link">
         <i className="fa fa-info-circle"></i>
       </BS.Button>

--- a/tutor/src/components/task-plan/footer/index.cjsx
+++ b/tutor/src/components/task-plan/footer/index.cjsx
@@ -9,7 +9,7 @@ HelpTooltip  = require './help-tooltip'
 SaveButton   = require './save-button'
 CancelButton = require './cancel-button'
 BackButton   = require './back-button'
-SaveLink     = require './save-link'
+DraftButton  = require './save-as-draft'
 DeleteLink   = require './delete-link'
 
 PlanFooter = React.createClass
@@ -71,7 +71,7 @@ PlanFooter = React.createClass
   render: ->
     {id} = @props
 
-    saveable    = not (TaskPlanStore.isPublished(id) or TaskPlanStore.isPublishing(id))
+    isSaveable  = not (TaskPlanStore.isPublished(id) or TaskPlanStore.isPublishing(id))
     isWaiting   = TaskPlanStore.isSaving(id) or TaskPlanStore.isPublishing(id) or TaskPlanStore.isDeleteRequested(id)
     isFailed    = TaskPlanStore.isFailed(id)
     isPublished = TaskPlanStore.isPublished(id)
@@ -95,7 +95,8 @@ PlanFooter = React.createClass
         isEditable={@state.isEditable}
         getBackToCalendarParams={@props.getBackToCalendarParams}
       />
-      <SaveLink
+      <DraftButton
+        isSavable={isSaveable}
         onClick={@onSave}
         isWaiting={isWaiting and @state.saving}
         isFailed={isFailed}

--- a/tutor/src/components/task-plan/footer/index.cjsx
+++ b/tutor/src/components/task-plan/footer/index.cjsx
@@ -1,16 +1,18 @@
 React = require 'react'
 BS = require 'react-bootstrap'
-Router = require 'react-router'
+
+
 {TaskPlanStore, TaskPlanActions} = require '../../../flux/task-plan'
 {PlanPublishStore, PlanPublishActions} = require '../../../flux/plan-publish'
 PlanHelper = require '../../../helpers/plan'
 {AsyncButton, SuretyGuard} = require 'shared'
 TutorDialog = require '../../tutor-dialog'
-BackButton = require '../../buttons/back-button'
 
-HelpTooltip = require './help-tooltip'
-SaveButton  = require './save-button'
-CancelButton  = require './cancel-button'
+
+HelpTooltip  = require './help-tooltip'
+SaveButton   = require './save-button'
+CancelButton = require './cancel-button'
+BackButton   = require './back-button'
 
 PlanFooter = React.createClass
   displayName: 'PlanFooter'
@@ -70,7 +72,7 @@ PlanFooter = React.createClass
     @context.router.transitionTo('viewStats', {courseId, id})
 
   render: ->
-    {id, courseId, clickedSelectProblem, onPublish, getBackToCalendarParams} = @props
+    {id, courseId, clickedSelectProblem, onPublish} = @props
     {isEditable} = @state
 
     plan = TaskPlanStore.get(id)
@@ -79,15 +81,6 @@ PlanFooter = React.createClass
     isWaiting = TaskPlanStore.isSaving(id) or TaskPlanStore.isPublishing(id) or TaskPlanStore.isDeleteRequested(id)
     deleteable = not TaskPlanStore.isNew(id) and not isWaiting
     isFailed = TaskPlanStore.isFailed(id)
-
-    unless isEditable
-      backToCalendarParams = getBackToCalendarParams()
-      backButton = <Router.Link
-        {...backToCalendarParams}
-        className='btn btn-default'>
-          Back to Calendar
-      </Router.Link>
-
 
     if deleteable
       if TaskPlanStore.isPublished(id)
@@ -141,7 +134,8 @@ PlanFooter = React.createClass
         onClick={@props.onCancel}
         isEditable={@state.isEditable}
       />
-      {backButton}
+      <BackButton getBackToCalendarParams={@props.getBackToCalendarParams} />
+
       {saveLink}
       <HelpTooltip isEditable={@state.isEditable} isPublished={TaskPlanStore.isPublished(id)} />
       {deleteLink}

--- a/tutor/src/components/task-plan/footer/index.cjsx
+++ b/tutor/src/components/task-plan/footer/index.cjsx
@@ -1,12 +1,12 @@
 React = require 'react'
 BS = require 'react-bootstrap'
 Router = require 'react-router'
-{TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
-{PlanPublishStore, PlanPublishActions} = require '../../flux/plan-publish'
-PlanHelper = require '../../helpers/plan'
+{TaskPlanStore, TaskPlanActions} = require '../../../flux/task-plan'
+{PlanPublishStore, PlanPublishActions} = require '../../../flux/plan-publish'
+PlanHelper = require '../../../helpers/plan'
 {AsyncButton, SuretyGuard} = require 'shared'
-TutorDialog = require '../tutor-dialog'
-BackButton = require '../buttons/back-button'
+TutorDialog = require '../../tutor-dialog'
+BackButton = require '../../buttons/back-button'
 
 PlanFooter = React.createClass
   displayName: 'PlanFooter'

--- a/tutor/src/components/task-plan/footer/index.cjsx
+++ b/tutor/src/components/task-plan/footer/index.cjsx
@@ -70,7 +70,7 @@ PlanFooter = React.createClass
 
   render: ->
     {id} = @props
-
+    plan = TaskPlanStore.get(id)
     isSaveable  = not (TaskPlanStore.isPublished(id) or TaskPlanStore.isPublishing(id))
     isWaiting   = TaskPlanStore.isSaving(id) or TaskPlanStore.isPublishing(id) or TaskPlanStore.isDeleteRequested(id)
     isFailed    = TaskPlanStore.isFailed(id)
@@ -109,6 +109,7 @@ PlanFooter = React.createClass
         isNew={TaskPlanStore.isNew(id)}
         onClick={@onDelete}
         isFailed={isFailed}
+        isOpened={PlanHelper.isPlanOpen(plan)}
         isWaiting={TaskPlanStore.isDeleting(id)}
         isPublished={isPublished}
       />

--- a/tutor/src/components/task-plan/footer/index.cjsx
+++ b/tutor/src/components/task-plan/footer/index.cjsx
@@ -20,6 +20,7 @@ PlanFooter = React.createClass
     id: React.PropTypes.string.isRequired
     courseId: React.PropTypes.string.isRequired
     goBackToCalendar: React.PropTypes.func
+    isVisibleToStudents: React.PropTypes.bool.isRequired
 
   getDefaultProps: ->
     goBackToCalendar: =>
@@ -109,7 +110,7 @@ PlanFooter = React.createClass
         isNew={TaskPlanStore.isNew(id)}
         onClick={@onDelete}
         isFailed={isFailed}
-        isOpened={PlanHelper.isPlanOpen(plan)}
+        isVisibleToStudents={@props.isVisibleToStudents}
         isWaiting={TaskPlanStore.isDeleting(id)}
         isPublished={isPublished}
       />

--- a/tutor/src/components/task-plan/footer/index.cjsx
+++ b/tutor/src/components/task-plan/footer/index.cjsx
@@ -1,12 +1,9 @@
 React = require 'react'
 BS = require 'react-bootstrap'
 
-
 {TaskPlanStore, TaskPlanActions} = require '../../../flux/task-plan'
-{PlanPublishStore, PlanPublishActions} = require '../../../flux/plan-publish'
+{PlanPublishStore} = require '../../../flux/plan-publish'
 PlanHelper = require '../../../helpers/plan'
-{AsyncButton, SuretyGuard} = require 'shared'
-TutorDialog = require '../../tutor-dialog'
 
 HelpTooltip  = require './help-tooltip'
 SaveButton   = require './save-button'
@@ -47,7 +44,6 @@ PlanFooter = React.createClass
   componentWillMount: ->
     plan = TaskPlanStore.get(@props.id)
     publishState = PlanHelper.subscribeToPublishing(plan, @checkPublishingStatus)
-
     @setState(publishing: publishState.isPublishing)
 
   saved: ->
@@ -73,20 +69,17 @@ PlanFooter = React.createClass
     @context.router.transitionTo('viewStats', {courseId, id})
 
   render: ->
-    {id, courseId, clickedSelectProblem, onPublish} = @props
-    {isEditable} = @state
+    {id} = @props
 
-    plan = TaskPlanStore.get(id)
-
-    saveable = not (TaskPlanStore.isPublished(id) or TaskPlanStore.isPublishing(id))
-    isWaiting = TaskPlanStore.isSaving(id) or TaskPlanStore.isPublishing(id) or TaskPlanStore.isDeleteRequested(id)
-    isFailed = TaskPlanStore.isFailed(id)
+    saveable    = not (TaskPlanStore.isPublished(id) or TaskPlanStore.isPublishing(id))
+    isWaiting   = TaskPlanStore.isSaving(id) or TaskPlanStore.isPublishing(id) or TaskPlanStore.isDeleteRequested(id)
+    isFailed    = TaskPlanStore.isFailed(id)
     isPublished = TaskPlanStore.isPublished(id)
 
     <div className='footer-buttons'>
       <SaveButton
         onSave={@onSave}
-        onPublish={@onPublish}
+        onPublish={@props.onPublish}
         isWaiting={isWaiting}
         isSaving={@state.saving}
         isEditable={@state.isEditable}

--- a/tutor/src/components/task-plan/footer/index.cjsx
+++ b/tutor/src/components/task-plan/footer/index.cjsx
@@ -8,6 +8,8 @@ PlanHelper = require '../../../helpers/plan'
 TutorDialog = require '../../tutor-dialog'
 BackButton = require '../../buttons/back-button'
 
+HelpTooltip = require './help-tooltip'
+
 PlanFooter = React.createClass
   displayName: 'PlanFooter'
   contextTypes:
@@ -76,20 +78,6 @@ PlanFooter = React.createClass
     deleteable = not TaskPlanStore.isNew(id) and not isWaiting
     isFailed = TaskPlanStore.isFailed(id)
 
-    tips = <BS.Popover id='plan-footer-popover'>
-      <p>
-        <strong>Publish</strong> will make the assignment visible to students on the open date.
-        If open date is today, it will be available immediately.
-      </p>
-      <p>
-        <strong>Cancel</strong> will discard all changes and return to the calendar.
-      </p>
-      <p>
-        <strong>Save as draft</strong> will add the assignment to the teacher calendar only.
-        It will not be visible to students, even if the open date has passed.
-      </p>
-    </BS.Popover>
-
     if isEditable
 
       publishButtonProps =
@@ -118,12 +106,6 @@ PlanFooter = React.createClass
       cancelButton =
         <BS.Button aria-role='close' disabled={isWaiting} onClick={onCancel}>Cancel</BS.Button>
 
-      helpInfo =
-        <BS.OverlayTrigger trigger='click' placement='top' overlay={tips} rootClose={true}>
-          <BS.Button className="footer-instructions" bsStyle="link">
-            <i className="fa fa-info-circle"></i>
-          </BS.Button>
-        </BS.OverlayTrigger>
     else
       backToCalendarParams = getBackToCalendarParams()
       backButton = <Router.Link
@@ -175,7 +157,7 @@ PlanFooter = React.createClass
       {cancelButton}
       {backButton}
       {saveLink}
-      {helpInfo unless TaskPlanStore.isPublished(id)}
+      <HelpTooltip isEditable={@state.isEditable} />
       {deleteLink}
     </div>
 

--- a/tutor/src/components/task-plan/footer/index.cjsx
+++ b/tutor/src/components/task-plan/footer/index.cjsx
@@ -13,6 +13,7 @@ HelpTooltip  = require './help-tooltip'
 SaveButton   = require './save-button'
 CancelButton = require './cancel-button'
 BackButton   = require './back-button'
+SaveLink     = require './save-link'
 
 PlanFooter = React.createClass
   displayName: 'PlanFooter'
@@ -105,26 +106,12 @@ PlanFooter = React.createClass
           </AsyncButton>
         </SuretyGuard>
 
-    if saveable
-      saveLink =
-          <AsyncButton
-            className='-save'
-            onClick={@onSave}
-            isWaiting={isWaiting and @state.saving}
-            isFailed={isFailed}
-            waitingText='Saving…'
-            disabled={isWaiting}
-            >
-            {'Save as Draft'}
-          </AsyncButton>
-
     <div className='footer-buttons'>
       <SaveButton
         onSave={@onSave}
         onPublish={@onPublish}
         isWaiting={isWaiting}
         isSaving={@state.saving}
-        isSaving={@state.isSaving}
         isEditable={@state.isEditable}
         isPublishing={@state.publishing}
         isPublished={TaskPlanStore.isPublished(id)}
@@ -134,10 +121,19 @@ PlanFooter = React.createClass
         onClick={@props.onCancel}
         isEditable={@state.isEditable}
       />
-      <BackButton getBackToCalendarParams={@props.getBackToCalendarParams} />
-
-      {saveLink}
-      <HelpTooltip isEditable={@state.isEditable} isPublished={TaskPlanStore.isPublished(id)} />
+      <BackButton
+        isEditable={@state.isEditable}
+        getBackToCalendarParams={@props.getBackToCalendarParams}
+      />
+      <SaveLink
+        onClick={@onSave}
+        isWaiting={isWaiting and @state.saving}
+        isFailed={isFailed}
+      />
+      <HelpTooltip
+        isEditable={@state.isEditable}
+        isPublished={TaskPlanStore.isPublished(id)}
+      />
       {deleteLink}
     </div>
 

--- a/tutor/src/components/task-plan/footer/index.cjsx
+++ b/tutor/src/components/task-plan/footer/index.cjsx
@@ -9,6 +9,7 @@ TutorDialog = require '../../tutor-dialog'
 BackButton = require '../../buttons/back-button'
 
 HelpTooltip = require './help-tooltip'
+SaveButton  = require './save-button'
 
 PlanFooter = React.createClass
   displayName: 'PlanFooter'
@@ -80,29 +81,6 @@ PlanFooter = React.createClass
 
     if isEditable
 
-      publishButtonProps =
-        bsStyle:  'primary'
-        className:  '-publish'
-        isFailed: isFailed
-        disabled: isWaiting
-
-      if TaskPlanStore.isPublished(id)
-        saveButton = <AsyncButton {...publishButtonProps}
-          onClick={@onSave}
-          isJob={true}
-          isWaiting={isWaiting and (@state.saving or @state.publishing)}
-          waitingText='Saving…'>
-          Save
-        </AsyncButton>
-      else
-        publishButton = <AsyncButton {...publishButtonProps}
-          onClick={@onPublish}
-          isWaiting={isWaiting and @state.publishing}
-          waitingText='Publishing…'
-          isJob={true}>
-          Publish
-        </AsyncButton>
-
       cancelButton =
         <BS.Button aria-role='close' disabled={isWaiting} onClick={onCancel}>Cancel</BS.Button>
 
@@ -152,12 +130,18 @@ PlanFooter = React.createClass
           </AsyncButton>
 
     <div className='footer-buttons'>
-      {saveButton}
-      {publishButton}
+      <SaveButton
+        isSaving={@state.isSaving}
+        isWaiting={isWaiting}
+        isEditable={@state.isEditable}
+        isPublished={TaskPlanStore.isPublished(id)}
+        isPublishing={@state.publishing}
+        onSave={@onSave}
+      />
       {cancelButton}
       {backButton}
       {saveLink}
-      <HelpTooltip isEditable={@state.isEditable} />
+      <HelpTooltip isEditable={@state.isEditable} isPublished={TaskPlanStore.isPublished(id)} />
       {deleteLink}
     </div>
 

--- a/tutor/src/components/task-plan/footer/index.cjsx
+++ b/tutor/src/components/task-plan/footer/index.cjsx
@@ -8,12 +8,12 @@ PlanHelper = require '../../../helpers/plan'
 {AsyncButton, SuretyGuard} = require 'shared'
 TutorDialog = require '../../tutor-dialog'
 
-
 HelpTooltip  = require './help-tooltip'
 SaveButton   = require './save-button'
 CancelButton = require './cancel-button'
 BackButton   = require './back-button'
 SaveLink     = require './save-link'
+DeleteLink   = require './delete-link'
 
 PlanFooter = React.createClass
   displayName: 'PlanFooter'
@@ -80,31 +80,8 @@ PlanFooter = React.createClass
 
     saveable = not (TaskPlanStore.isPublished(id) or TaskPlanStore.isPublishing(id))
     isWaiting = TaskPlanStore.isSaving(id) or TaskPlanStore.isPublishing(id) or TaskPlanStore.isDeleteRequested(id)
-    deleteable = not TaskPlanStore.isNew(id) and not isWaiting
     isFailed = TaskPlanStore.isFailed(id)
-
-    if deleteable
-      if TaskPlanStore.isPublished(id)
-        message = 'Some students may have started work on this assignment. Are you sure you want to delete?'
-      else
-        message = 'Are you sure you want to delete this draft?'
-
-      deleteLink =
-        <SuretyGuard
-          onConfirm={@onDelete}
-          okButtonLabel='Yes'
-          placement='top'
-          message={message}
-        >
-          <AsyncButton
-            className='delete-link pull-right'
-            isWaiting={TaskPlanStore.isDeleting(id)}
-            isFailed={isFailed}
-            waitingText='Deleting…'
-          >
-            <i className="fa fa-trash"></i> Delete Assignment
-          </AsyncButton>
-        </SuretyGuard>
+    isPublished = TaskPlanStore.isPublished(id)
 
     <div className='footer-buttons'>
       <SaveButton
@@ -114,7 +91,7 @@ PlanFooter = React.createClass
         isSaving={@state.saving}
         isEditable={@state.isEditable}
         isPublishing={@state.publishing}
-        isPublished={TaskPlanStore.isPublished(id)}
+        isPublished={isPublished}
       />
       <CancelButton
         isWaiting={isWaiting}
@@ -134,7 +111,13 @@ PlanFooter = React.createClass
         isEditable={@state.isEditable}
         isPublished={TaskPlanStore.isPublished(id)}
       />
-      {deleteLink}
+      <DeleteLink
+        isNew={TaskPlanStore.isNew(id)}
+        onClick={@onDelete}
+        isFailed={isFailed}
+        isWaiting={TaskPlanStore.isDeleting(id)}
+        isPublished={isPublished}
+      />
     </div>
 
 module.exports = PlanFooter

--- a/tutor/src/components/task-plan/footer/index.cjsx
+++ b/tutor/src/components/task-plan/footer/index.cjsx
@@ -10,6 +10,7 @@ BackButton = require '../../buttons/back-button'
 
 HelpTooltip = require './help-tooltip'
 SaveButton  = require './save-button'
+CancelButton  = require './cancel-button'
 
 PlanFooter = React.createClass
   displayName: 'PlanFooter'
@@ -69,7 +70,7 @@ PlanFooter = React.createClass
     @context.router.transitionTo('viewStats', {courseId, id})
 
   render: ->
-    {id, courseId, clickedSelectProblem, onPublish, onSave, onCancel, getBackToCalendarParams} = @props
+    {id, courseId, clickedSelectProblem, onPublish, getBackToCalendarParams} = @props
     {isEditable} = @state
 
     plan = TaskPlanStore.get(id)
@@ -79,12 +80,7 @@ PlanFooter = React.createClass
     deleteable = not TaskPlanStore.isNew(id) and not isWaiting
     isFailed = TaskPlanStore.isFailed(id)
 
-    if isEditable
-
-      cancelButton =
-        <BS.Button aria-role='close' disabled={isWaiting} onClick={onCancel}>Cancel</BS.Button>
-
-    else
+    unless isEditable
       backToCalendarParams = getBackToCalendarParams()
       backButton = <Router.Link
         {...backToCalendarParams}
@@ -131,14 +127,20 @@ PlanFooter = React.createClass
 
     <div className='footer-buttons'>
       <SaveButton
-        isSaving={@state.isSaving}
-        isWaiting={isWaiting}
-        isEditable={@state.isEditable}
-        isPublished={TaskPlanStore.isPublished(id)}
-        isPublishing={@state.publishing}
         onSave={@onSave}
+        onPublish={@onPublish}
+        isWaiting={isWaiting}
+        isSaving={@state.saving}
+        isSaving={@state.isSaving}
+        isEditable={@state.isEditable}
+        isPublishing={@state.publishing}
+        isPublished={TaskPlanStore.isPublished(id)}
       />
-      {cancelButton}
+      <CancelButton
+        isWaiting={isWaiting}
+        onClick={@props.onCancel}
+        isEditable={@state.isEditable}
+      />
       {backButton}
       {saveLink}
       <HelpTooltip isEditable={@state.isEditable} isPublished={TaskPlanStore.isPublished(id)} />

--- a/tutor/src/components/task-plan/footer/save-as-draft.cjsx
+++ b/tutor/src/components/task-plan/footer/save-as-draft.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 {AsyncButton} = require 'shared'
 
-SaveLink = React.createClass
+SaveAsDraft = React.createClass
 
   propTypes:
     onClick:   React.PropTypes.func.isRequired
@@ -19,8 +19,8 @@ SaveLink = React.createClass
       waitingText='Saving…'
       disabled={@props.isWaiting}
     >
-      'Save as Draft'
+      Save as Draft
     </AsyncButton>
 
 
-module.exports = SaveLink
+module.exports = SaveAsDraft

--- a/tutor/src/components/task-plan/footer/save-button.cjsx
+++ b/tutor/src/components/task-plan/footer/save-button.cjsx
@@ -17,6 +17,7 @@ TaskSaveButton = React.createClass
 
   propTypes:
     onSave: React.PropTypes.func.isRequired
+    onPublish: React.PropTypes.func.isRequired
     isEditable:   React.PropTypes.bool.isRequired
     isSaving:     React.PropTypes.bool.isRequired
     isWaiting:    React.PropTypes.bool.isRequired
@@ -36,15 +37,14 @@ TaskSaveButton = React.createClass
     Text = if isPublished then MESSAGES.save else MESSAGES.publish
 
     <AsyncButton
+        isJob={true}
         bsStyle='primary'
         className='-publish'
+        onClick={if isPublished then @props.onSave else @props.onPublish}
+        waitingText={Text.waiting}
         isFailed={@props.isFailed}
         disabled={@props.isWaiting}
-
-        onClick={@props.onSave}
-        isJob={true}
         isWaiting={@props.isWaiting}
-        waitingText={Text.waiting}
       >
           {Text.action}
     </AsyncButton>

--- a/tutor/src/components/task-plan/footer/save-button.cjsx
+++ b/tutor/src/components/task-plan/footer/save-button.cjsx
@@ -1,0 +1,53 @@
+React = require 'react'
+BS = require 'react-bootstrap'
+{AsyncButton} = require 'shared'
+
+MESSAGES =
+
+  publish:
+    action: 'Publish'
+    waiting: 'Publishing…'
+
+  save:
+    action: 'Save'
+    waiting: 'Saving…'
+
+
+TaskSaveButton = React.createClass
+
+  propTypes:
+    onSave: React.PropTypes.func.isRequired
+    isEditable:   React.PropTypes.bool.isRequired
+    isSaving:     React.PropTypes.bool.isRequired
+    isWaiting:    React.PropTypes.bool.isRequired
+    isPublished:  React.PropTypes.bool.isRequired
+    isPublishing: React.PropTypes.bool.isRequired
+
+  render: ->
+    return null unless @props.isEditable
+
+    {isPublished} = @props
+
+    isBusy = if isPublished
+      @props.isWaiting and (@props.isSaving or @props.isPublishing)
+    else
+      @props.isWaiting and @props.isPublishing
+
+    Text = if isPublished then MESSAGES.save else MESSAGES.publish
+
+    <AsyncButton
+        bsStyle='primary'
+        className='-publish'
+        isFailed={@props.isFailed}
+        disabled={@props.isWaiting}
+
+        onClick={@props.onSave}
+        isJob={true}
+        isWaiting={@props.isWaiting}
+        waitingText={Text.waiting}
+      >
+          {Text.action}
+    </AsyncButton>
+
+
+module.exports = TaskSaveButton

--- a/tutor/src/components/task-plan/footer/save-link.cjsx
+++ b/tutor/src/components/task-plan/footer/save-link.cjsx
@@ -1,0 +1,26 @@
+React = require 'react'
+{AsyncButton} = require 'shared'
+
+SaveLink = React.createClass
+
+  propTypes:
+    onClick:   React.PropTypes.func.isRequired
+    isWaiting: React.PropTypes.bool.isRequired
+    isFailed:  React.PropTypes.bool.isRequired
+
+  render: ->
+    return null unless @props.isSavable
+
+    <AsyncButton
+      className='-save'
+      onClick={@props.onClick}
+      isWaiting={@props.isWaiting}
+      isFailed={@props.isFailed}
+      waitingText='Saving…'
+      disabled={@props.isWaiting}
+    >
+      'Save as Draft'
+    </AsyncButton>
+
+
+module.exports = SaveLink

--- a/tutor/src/components/task-plan/homework.cjsx
+++ b/tutor/src/components/task-plan/homework.cjsx
@@ -39,11 +39,11 @@ HomeworkPlan = React.createClass
         header={@builderHeader('homework')}
         className={formClasses}
         footer={<PlanFooter id={id}
-          isVisibleToStudents={@state.isVisibleToStudents}
           courseId={courseId}
           onPublish={@publish}
           onSave={@save}
           onCancel={@cancel}
+          isVisibleToStudents={@state.isVisibleToStudents}
           getBackToCalendarParams={@getBackToCalendarParams}
           goBackToCalendar={@goBackToCalendar}
         />}

--- a/tutor/src/components/task-plan/homework.cjsx
+++ b/tutor/src/components/task-plan/homework.cjsx
@@ -39,6 +39,7 @@ HomeworkPlan = React.createClass
         header={@builderHeader('homework')}
         className={formClasses}
         footer={<PlanFooter id={id}
+          isVisibleToStudents={@state.isVisibleToStudents}
           courseId={courseId}
           onPublish={@publish}
           onSave={@save}

--- a/tutor/src/components/task-plan/reading.cjsx
+++ b/tutor/src/components/task-plan/reading.cjsx
@@ -132,6 +132,7 @@ ReadingPlan = React.createClass
 
     footer = <PlanFooter
       id={id}
+      isVisibleToStudents={@state.isVisibleToStudents}
       courseId={courseId}
       onPublish={@publish}
       onSave={@save}

--- a/tutor/src/components/task-plan/reading.cjsx
+++ b/tutor/src/components/task-plan/reading.cjsx
@@ -132,11 +132,11 @@ ReadingPlan = React.createClass
 
     footer = <PlanFooter
       id={id}
-      isVisibleToStudents={@state.isVisibleToStudents}
       courseId={courseId}
       onPublish={@publish}
       onSave={@save}
       onCancel={@cancel}
+      isVisibleToStudents={@state.isVisibleToStudents}
       getBackToCalendarParams={@getBackToCalendarParams}
       goBackToCalendar={@goBackToCalendar}/>
     header = @builderHeader('reading')

--- a/tutor/src/helpers/plan.coffee
+++ b/tutor/src/helpers/plan.coffee
@@ -2,7 +2,7 @@ moment = require 'moment'
 _ = require 'underscore'
 
 {PlanPublishStore, PlanPublishActions} = require '../flux/plan-publish'
-{TimeStore, TimeActions} = require '../flux/time'
+{TimeStore} = require '../flux/time'
 
 PlanHelper =
   isPublishing: (plan) ->
@@ -25,6 +25,14 @@ PlanHelper =
       PlanPublishStore.on("progress.#{id}.*", callback) if callback? and _.isFunction(callback)
 
     {isPublishing, publishStatus}
+
+
+  isPlanOpen: (plan) ->
+    now = moment(TimeStore.getNow())
+    for tasking in plan.tasking_plans
+      if moment(tasking.opens_at).isBefore(now)
+        return true # at least one tasking is opened
+    false
 
 
 module.exports = PlanHelper

--- a/tutor/src/helpers/plan.coffee
+++ b/tutor/src/helpers/plan.coffee
@@ -29,10 +29,7 @@ PlanHelper =
 
   isPlanOpen: (plan) ->
     now = moment(TimeStore.getNow())
-    for tasking in plan.tasking_plans
-      if moment(tasking.opens_at).isBefore(now)
-        return true # at least one tasking is opened
-    false
+    !! _.find plan?.tasking_plans, (tasking) -> moment(tasking.opens_at).isBefore(now)
 
 
 module.exports = PlanHelper

--- a/tutor/src/helpers/plan.coffee
+++ b/tutor/src/helpers/plan.coffee
@@ -27,9 +27,4 @@ PlanHelper =
     {isPublishing, publishStatus}
 
 
-  isPlanOpen: (plan) ->
-    now = moment(TimeStore.getNow())
-    !! _.find plan?.tasking_plans, (tasking) -> moment(tasking.opens_at).isBefore(now)
-
-
 module.exports = PlanHelper

--- a/tutor/test/components/task-plan/footer.spec.coffee
+++ b/tutor/test/components/task-plan/footer.spec.coffee
@@ -47,7 +47,8 @@ getBackToCalendarParams = ->
   params:
     date: moment(TimeStore.getNow()).format('YYYY-MM-DD')
 
-helper = (model) -> PlanRenderHelper(model, PlanFooter, {getBackToCalendarParams})
+
+helper = (model) -> PlanRenderHelper(model, PlanFooter, {getBackToCalendarParams, onCancel: sinon.spy(), onPublish: sinon.spy()})
 
 describe 'Task Plan Footer', ->
   beforeEach ->
@@ -58,6 +59,7 @@ describe 'Task Plan Footer', ->
       expect(dom.querySelector('.delete-link')).to.be.null
       expect(dom.querySelector('.-save')).to.not.be.null
       expect(dom.querySelector('.-publish')).to.not.be.null
+      expect(dom.querySelector('.-publish').textContent).to.equal('Publish')
 
   it 'should have correct buttons when reading is unpublished', ->
     helper(UNPUBLISHED_READING).then ({dom}) ->
@@ -70,6 +72,7 @@ describe 'Task Plan Footer', ->
       expect(dom.querySelector('.delete-link')).to.not.be.null
       expect(dom.querySelector('.-save')).to.be.null
       expect(dom.querySelector('.-publish')).to.not.be.null
+      expect(dom.querySelector('.-publish').textContent).to.equal('Save')
 
   it 'should have correct buttons when reading is visible', ->
     helper(VISIBLE_READING).then ({dom}) ->


### PR DESCRIPTION
Work was done via the the "get the code to a place where you can make the easy change, then make it" philosophy.

Also, I'm surprised we don't have a "isPlanOpened" helper somewhere.  Maybe I just missed it though?

![screen shot 2016-09-06 at 4 44 14 pm](https://cloud.githubusercontent.com/assets/79566/18292186/832b4464-7451-11e6-843b-019f192ae1f9.png)