### PR TITLE
Performance Forecast tooltip on tablet

### DIFF
--- a/tutor/resources/styles/components/performance-forecast/heading.less
+++ b/tutor/resources/styles/components/performance-forecast/heading.less
@@ -23,15 +23,9 @@
       .flex-flow(space-between);
       .flex-wrap(wrap);
       .align-items(baseline);
-    } 
+    }
   }
 
-  .info-link:after {
-    padding-left: 10px;
-    .fa-icon();
-    content: @fa-var-info-circle;
-    color: @tutor-neutral-dark;
-  }
   .guide-group-key {
     &.teacher .guide-key { margin-top: 15px; }
     min-width: 300px;

--- a/tutor/resources/styles/components/performance-forecast/heading.less
+++ b/tutor/resources/styles/components/performance-forecast/heading.less
@@ -26,10 +26,6 @@
     } 
   }
 
-  .info-link {
-    border: 0;
-    background: transparent;
-  }
   .info-link:after {
     padding-left: 10px;
     .fa-icon();

--- a/tutor/resources/styles/components/performance-forecast/heading.less
+++ b/tutor/resources/styles/components/performance-forecast/heading.less
@@ -26,6 +26,10 @@
     }
   }
 
+  .tutor-icon:before {
+    color: @tutor-neutral-dark;
+  }
+
   .guide-group-key {
     &.teacher .guide-key { margin-top: 15px; }
     min-width: 300px;

--- a/tutor/resources/styles/components/performance-forecast/heading.less
+++ b/tutor/resources/styles/components/performance-forecast/heading.less
@@ -26,6 +26,10 @@
     } 
   }
 
+  .info-link {
+    border: 0;
+    background: transparent;
+  }
   .info-link:after {
     padding-left: 10px;
     .fa-icon();

--- a/tutor/resources/styles/components/performance-forecast/index.less
+++ b/tutor/resources/styles/components/performance-forecast/index.less
@@ -5,13 +5,6 @@
 @import "./teacher";
 @import "./teacher-student";
 
-.info-link-tooltip .tooltip-inner {
-  // tooltip appends itself before closing body tag
-  max-width: 350px;
-  width: 350px;
-  text-align: left;
-}
-
 .performance-forecast {
 
   .tutor-tabs {

--- a/tutor/src/components/performance-forecast/info-link.cjsx
+++ b/tutor/src/components/performance-forecast/info-link.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 BS = require 'react-bootstrap'
+Icon = require '../icon'
 
 MESSAGES = {
   student: [
@@ -31,11 +32,9 @@ module.exports = React.createClass
   type: React.PropTypes.oneOf(['student', 'teacher', 'teacher_student']).isRequired
 
   render: ->
-    tooltip =
-    <BS.Tooltip id='info-link-tooltip' className='info-link-tooltip' html='true'>
-      {MESSAGES[@props.type]}
-    </BS.Tooltip>
+    <Icon
+      className="info-link"
+      tooltipProps={placement: 'right', className: "info-link"}
+      tooltip={MESSAGES[@props.type]}
+    />
 
-    <BS.OverlayTrigger placement='right' overlay={tooltip}>
-      <button className='info-link'></button>
-    </BS.OverlayTrigger>

--- a/tutor/src/components/performance-forecast/info-link.cjsx
+++ b/tutor/src/components/performance-forecast/info-link.cjsx
@@ -34,7 +34,7 @@ module.exports = React.createClass
   render: ->
     <Icon
       className="info-link"
-      tooltipProps={placement: 'right', className: "info-link"}
+      tooltipProps={placement: 'right'}
       tooltip={MESSAGES[@props.type]}
     />
 

--- a/tutor/src/components/performance-forecast/info-link.cjsx
+++ b/tutor/src/components/performance-forecast/info-link.cjsx
@@ -37,5 +37,5 @@ module.exports = React.createClass
     </BS.Tooltip>
 
     <BS.OverlayTrigger placement='right' overlay={tooltip}>
-      <span className='info-link'></span>
+      <button className='info-link'></button>
     </BS.OverlayTrigger>

--- a/tutor/src/components/performance-forecast/info-link.cjsx
+++ b/tutor/src/components/performance-forecast/info-link.cjsx
@@ -34,7 +34,7 @@ module.exports = React.createClass
   render: ->
     <Icon
       className="info-link"
+      type="info-circle"
       tooltipProps={placement: 'right'}
       tooltip={MESSAGES[@props.type]}
     />
-


### PR DESCRIPTION
Fixes performance forecast tooltip not showing up on tablets

Pivotal: https://www.pivotaltracker.com/story/show/128026799
![performance-forecast-tablet](https://cloud.githubusercontent.com/assets/6434717/18319469/db0d03d2-74f3-11e6-86f2-3b312b4e3393.gif)
