### PR TITLE
tutor-icon followup

### DIFF
--- a/tutor/resources/styles/components/cc-dashboard/index.less
+++ b/tutor/resources/styles/components/cc-dashboard/index.less
@@ -13,10 +13,7 @@
         color: @tutor-neutral-darker;
       }
     }
-    button {
-      border: 0;
-      background-color: transparent;
-    }
+
     .tutor-icon {
       margin-left: 0.5rem;
     }

--- a/tutor/resources/styles/components/icon.less
+++ b/tutor/resources/styles/components/icon.less
@@ -4,4 +4,10 @@
   &:focus {
     box-shadow: 0 0 8px @link-color;
   }
+
+  button& {
+    border: 0;
+    background-color: transparent;
+  }
+
 }

--- a/tutor/src/components/icon.cjsx
+++ b/tutor/src/components/icon.cjsx
@@ -34,7 +34,7 @@ module.exports = React.createClass
       return <i {...@props} className={classNames} />
 
     icon = <button {...@props} className={classNames} />
-    classNames =
+
     tooltip = <BS.Tooltip id={@state.uniqueId}
       className={classnames({'on-navbar': @props.onNavbar})}
       >{@props.tooltip}</BS.Tooltip>


### PR DESCRIPTION
remove hanging classNames assignment, move button de-styling to icon.less so that buttons tutor-icons not in dashboard will revert to original style

## Before

![screen shot 2016-09-07 at 6 14 57 pm](https://cloud.githubusercontent.com/assets/2483873/18331775/0919c9a8-7527-11e6-9108-cfaa703afe8c.png)


## After

![screen shot 2016-09-07 at 6 14 27 pm](https://cloud.githubusercontent.com/assets/2483873/18331773/07b67156-7527-11e6-83a1-035ee5c98a4d.png)
