### PR TITLE
Question Library -  details view filter bar height/placement

### DIFF
--- a/tutor/resources/styles/components/questions-dashboard.less
+++ b/tutor/resources/styles/components/questions-dashboard.less
@@ -42,7 +42,7 @@
   .exercises-display {
     max-width: @tutor-max-panel-width;
     margin: 0 auto;
-    .instructions { margin-top: @padding; }
+    .instructions { margin-bottom: @padding; }
   }
 
   .instructions-addon {

--- a/tutor/src/components/questions/exercises-display.cjsx
+++ b/tutor/src/components/questions/exercises-display.cjsx
@@ -207,18 +207,18 @@ ExercisesDisplay = React.createClass
     exercises = ExerciseStore.groupBySectionsAndTypes(@props.ecosystemId, @props.sectionIds, withExcluded: true)
     <div className="exercises-display">
 
+      <div className="instructions">
+        <div className="wrapper">
+          {Help.forCourseId(@props.courseId).second.bar}
+        </div>
+      </div>
+
       <PinnedHeaderFooterCard
         ref='controls'
         containerBuffer={50}
         header={@renderControls(exercises)}
         cardType='sections-questions'
       >
-
-      <div className="instructions">
-        <div className="wrapper">
-          {Help.forCourseId(@props.courseId).second.bar}
-        </div>
-      </div>
 
       {@renderExercises(
         if @state.filter then exercises[@state.filter] else exercises.all


### PR DESCRIPTION
regarding: https://trello.com/c/ijsIXHqp/43-bug-ql-details-view-actions-are-mis-placed-height-is-incorrect

in testing, filter placement on scroll is working correctly.
moved green info bar above filter bar as requested.

![screenshot from 2016-09-08 11 13 48](https://cloud.githubusercontent.com/assets/954569/18354983/aa101716-75b5-11e6-8d11-9e163c9a2b50.png)
