### PR TITLE
Remove focus outline from CC user menu

### DIFF
--- a/coach/resources/styles/components/navigation/index.less
+++ b/coach/resources/styles/components/navigation/index.less
@@ -31,6 +31,9 @@
   .navbar .dropdown-menu > li > a {
     text-decoration: none;
   }
-
+  .concept-coach-user {
+    &:focus { outline: none; }
+    .dropdown-menu:focus { outline: none; }
+  }
 
 }


### PR DESCRIPTION
Would only appear when tabbing to the menu

Before:
![screen shot 2016-09-08 at 12 20 19 pm](https://cloud.githubusercontent.com/assets/79566/18359277/d05f26e2-75be-11e6-859d-c24268578e5c.png)



After:
![screen shot 2016-09-08 at 12 20 38 pm](https://cloud.githubusercontent.com/assets/79566/18359276/d04c0f9e-75be-11e6-8f27-7088779b9840.png)
