### PR TITLE
handle sim width in 3 cases -- base, skinny, and wide, and note vs non-note

### DIFF
--- a/tutor/resources/styles/book-content/index.less
+++ b/tutor/resources/styles/book-content/index.less
@@ -5,12 +5,16 @@
 
 .tutor-book-content() {
 
-  padding: 0 @tutor-book-padding-horizontal @tutor-book-padding-vertical @tutor-book-padding-horizontal;
-  @media screen and ( max-width: @book-content-collapse-breakpoint ){
-    padding-left:  @book-content-narrow-horizontal-padding;
-    padding-right: @book-content-narrow-horizontal-padding;
-  }
   display: block;
+  padding-left:  @book-content-narrow-horizontal-padding;
+  padding-right: @book-content-narrow-horizontal-padding;
+  width: 100%;
+
+  @media screen and ( min-width: @book-content-collapse-breakpoint ){
+    padding: 0 @tutor-book-padding-horizontal @tutor-book-padding-vertical @tutor-book-padding-horizontal;
+    width: @reference-book-page-width;
+  }
+
 
   @import './base';
   @import './typography';

--- a/tutor/resources/styles/book-content/index.less
+++ b/tutor/resources/styles/book-content/index.less
@@ -12,9 +12,7 @@
 
   @media screen and ( min-width: @book-content-collapse-breakpoint ){
     padding: 0 @tutor-book-padding-horizontal @tutor-book-padding-vertical @tutor-book-padding-horizontal;
-    width: @reference-book-page-width;
   }
-
 
   @import './base';
   @import './typography';

--- a/tutor/resources/styles/book-content/index.less
+++ b/tutor/resources/styles/book-content/index.less
@@ -2,7 +2,6 @@
 @import './variables';
 @import './mixins';
 @import './theming-mixins';
-@import './context-mixins';
 
 .tutor-book-content() {
 

--- a/tutor/resources/styles/book-content/interactive.less
+++ b/tutor/resources/styles/book-content/interactive.less
@@ -3,7 +3,7 @@
 
 .book-content-interactives(
   @base-rules: {
-    // when < then sim width, go responsive.
+    // when < than sim width, go responsive.
     // this is a temporary solution for sims on small devices.
     width: 100%;
     height: @tutor-interactive-iframe-height;

--- a/tutor/resources/styles/book-content/interactive.less
+++ b/tutor/resources/styles/book-content/interactive.less
@@ -14,10 +14,6 @@
   @tight-width-rules: {
     // for any screen with > than sim width, be sim width
     width: @tutor-interactive-iframe-width;
-  };
-  @full-width-rules: {
-    // even wider screens will have crazy padding.  pull left of padding so that
-    // the sim, which is wider than the rest of the content, centers.
-    margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset);
+    margin-left: calc(~"50% - " @tutor-interactive-iframe-width / 2);
   };
 );

--- a/tutor/resources/styles/book-content/interactive.less
+++ b/tutor/resources/styles/book-content/interactive.less
@@ -1,16 +1,23 @@
 // The number of pixels the iframe will be inset from the task in the end
 @desired-iframe-inset: (@reference-book-page-width - @tutor-interactive-iframe-width) / 2;
 
-iframe.interactive {
-  // The rest of the card has a lot of padding, and it won't fit unless we shift it over so it's centered
-  margin: 20px auto;
-  margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset);
-  border: none;
-}
-
-@media (max-width: 1020px) {
-  .phet-explorations-embedded iframe.interactive {
+.book-content-interactives(
+  @base-rules: {
+    // when < then sim width, go responsive.
+    // this is a temporary solution for sims on small devices.
     width: 100%;
-    margin-left: 0px;
-  }
-}
+    height: @tutor-interactive-iframe-height;
+
+    margin: 20px auto;
+    border: none;
+  };
+  @tight-width-rules: {
+    // for any screen with > than sim width, be sim width
+    width: @tutor-interactive-iframe-width;
+  };
+  @full-width-rules: {
+    // even wider screens will have crazy padding.  pull left of padding so that
+    // the sim, which is wider than the rest of the content, centers.
+    margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset);
+  };
+);

--- a/tutor/resources/styles/book-content/mixins.less
+++ b/tutor/resources/styles/book-content/mixins.less
@@ -1,6 +1,7 @@
 // Mixins used internally by the book-content mixin
 
 // TODO: refactor internally to replace the "tutor-reading-" prefix with "book-content-"
+@tutor-empty-rules: {};
 
 .tutor-reading-step-banner-icon(@img){
   background: @tutor-tertiary url(@img);
@@ -59,5 +60,23 @@
   @media screen and ( max-width: @book-content-collapse-breakpoint ){
     margin-left: -@book-content-narrow-horizontal-padding;
     width: calc(~"100% + "@book-content-narrow-horizontal-padding*2);
+  }
+}
+
+.book-content-interactives(
+  @base-rules: @tutor-empty-rules;
+  @tight-width-rules: @tutor-empty-rules;
+  @full-width-rules: @tutor-empty-rules;
+){
+  iframe.interactive {
+    @base-rules();
+
+    @media (min-width: @tutor-interactive-iframe-width) {
+      @tight-width-rules();
+    }
+
+    @media (min-width: @book-content-collapse-breakpoint) {
+      @full-width-rules();
+    }
   }
 }

--- a/tutor/resources/styles/book-content/mixins.less
+++ b/tutor/resources/styles/book-content/mixins.less
@@ -63,6 +63,16 @@
   }
 }
 
+.book-paged-content(){
+  .paged-content {
+    width: 100%;
+
+    @media screen and ( min-width: @book-content-collapse-breakpoint ){
+      width: @reference-book-page-width;
+    }
+  }
+}
+
 .book-content-interactives(
   @base-rules: @tutor-empty-rules;
   @tight-width-rules: @tutor-empty-rules;

--- a/tutor/resources/styles/book-content/note.less
+++ b/tutor/resources/styles/book-content/note.less
@@ -69,8 +69,6 @@
   }
 }
 
-@tutor-empty-rules: {};
-
 .tutor-style-note-title-variants(@tutor-title-rules: @tutor-empty-rules){
 
   &@{has-data-label-selector},
@@ -138,9 +136,16 @@
       width: 100%;
       position: relative;
 
-      iframe.interactive {
-        margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset + @tutor-note-margin-horizontal);
-      }
+      .book-content-interactives(
+        @tight-width-rules: {
+          // move left of note padding to get more room for sim
+          margin-left: -@tutor-note-padding-horizontal;
+        };
+        @full-width-rules: {
+          // padding pushes the sim over, compensate for the padding by pulling sim left
+          margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset + @tutor-note-margin-horizontal);
+        };
+      );
 
       .exercise[data-type=exercise] .solution {
         // undo general hiding of solutions
@@ -190,15 +195,20 @@
 
   background: none;
   padding: 20px 0;
-  .embed-responsive {
-    iframe {
-      width: 100%;
-    }
-  }
+  border-bottom: none;
 
-  iframe.interactive {
-    margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset);
-  }
+  .book-content-interactives(
+    @tight-width-rules: {
+      // undo note padding finnagling -- theses notes have no left padding,
+      // so the margin here can be auto
+      margin-left: auto;
+    };
+    @full-width-rules: {
+      // compensate for regular padding and offset, omit calculating with note padding.
+      margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset);
+    };
+  );
+
 };
 
 @tutor-note-plain-title-style: {

--- a/tutor/resources/styles/book-content/note.less
+++ b/tutor/resources/styles/book-content/note.less
@@ -140,6 +140,7 @@
         @tight-width-rules: {
           // move left of note padding to get more room for sim
           margin-left: -@tutor-note-padding-horizontal;
+          margin-left: calc(~"50% - " @tutor-interactive-iframe-width / 2);
         };
         @full-width-rules: {
           // padding pushes the sim over, compensate for the padding by pulling sim left

--- a/tutor/resources/styles/book-content/note.less
+++ b/tutor/resources/styles/book-content/note.less
@@ -136,18 +136,6 @@
       width: 100%;
       position: relative;
 
-      .book-content-interactives(
-        @tight-width-rules: {
-          // move left of note padding to get more room for sim
-          margin-left: -@tutor-note-padding-horizontal;
-          margin-left: calc(~"50% - " @tutor-interactive-iframe-width / 2);
-        };
-        @full-width-rules: {
-          // padding pushes the sim over, compensate for the padding by pulling sim left
-          margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset + @tutor-note-margin-horizontal);
-        };
-      );
-
       .exercise[data-type=exercise] .solution {
         // undo general hiding of solutions
         display: block;
@@ -197,18 +185,6 @@
   background: none;
   padding: 20px 0;
   border-bottom: none;
-
-  .book-content-interactives(
-    @tight-width-rules: {
-      // undo note padding finnagling -- theses notes have no left padding,
-      // so the margin here can be auto
-      margin-left: auto;
-    };
-    @full-width-rules: {
-      // compensate for regular padding and offset, omit calculating with note padding.
-      margin-left: -(@tutor-book-padding-horizontal - @desired-iframe-inset);
-    };
-  );
 
 };
 

--- a/tutor/resources/styles/book-content/questions.less
+++ b/tutor/resources/styles/book-content/questions.less
@@ -23,7 +23,7 @@ section {
     }
 
     // make fully imported questions imitate embedded exercises
-    ol {
+    > ol:not(:first-child) {
       counter-reset: lowerAlpha;
       list-style: none;
       padding-left: 3rem;

--- a/tutor/resources/styles/book-content/questions.less
+++ b/tutor/resources/styles/book-content/questions.less
@@ -23,6 +23,8 @@ section {
     }
 
     // make fully imported questions imitate embedded exercises
+    // If the list follows something else in the problem,
+    // kinda assume it is most likely multiple-choices.
     > ol:not(:first-child) {
       counter-reset: lowerAlpha;
       list-style: none;

--- a/tutor/resources/styles/components/reference-book/page.less
+++ b/tutor/resources/styles/components/reference-book/page.less
@@ -5,7 +5,6 @@
     margin-right: -40px;
 
     .center-panel {
-      // width: @reference-book-page-width;
       margin: 0 auto;
 
       // always wrap around elements by extending bootstrap's clearfix

--- a/tutor/resources/styles/components/reference-book/page.less
+++ b/tutor/resources/styles/components/reference-book/page.less
@@ -5,11 +5,15 @@
     margin-right: -40px;
 
     .center-panel {
-      width: @reference-book-page-width;
+      // width: @reference-book-page-width;
       margin: 0 auto;
 
       // always wrap around elements by extending bootstrap's clearfix
       &:extend(.clearfix all);
+    }
+
+    .paged-content {
+      width: 100%;
     }
 
     .page {

--- a/tutor/resources/styles/components/reference-book/page.less
+++ b/tutor/resources/styles/components/reference-book/page.less
@@ -12,9 +12,7 @@
       &:extend(.clearfix all);
     }
 
-    .paged-content {
-      width: 100%;
-    }
+    .book-paged-content();
 
     .page {
       counter-reset: question;

--- a/tutor/resources/styles/components/reference-book/page.less
+++ b/tutor/resources/styles/components/reference-book/page.less
@@ -7,9 +7,7 @@
     .center-panel {
       width: @reference-book-page-width;
       margin: 0 auto;
-      @media screen and ( max-width: @book-content-collapse-breakpoint ){
-        width: @reference-book-collapse-width;
-      }
+
       // always wrap around elements by extending bootstrap's clearfix
       &:extend(.clearfix all);
     }

--- a/tutor/resources/styles/components/related-content-link.less
+++ b/tutor/resources/styles/components/related-content-link.less
@@ -7,6 +7,9 @@
 .interactive-step {
   .related-content-link {
     text-align: right;
-    margin: 0 @tutor-book-padding-horizontal;
+    margin: 0 20px;
+    @media (min-width: @book-content-collapse-breakpoint) {
+      margin: 0 @tutor-card-body-padding-horizontal;
+    }
   }
 }

--- a/tutor/resources/styles/components/task-step/all-steps.less
+++ b/tutor/resources/styles/components/task-step/all-steps.less
@@ -1,4 +1,5 @@
 @import '~shared/resources/styles/components/breadcrumbs/coach';
+@import (reference) '../../book-content/index';
 @import (reference) '../../book-content/note';
 
 .task {

--- a/tutor/resources/styles/components/task-step/all-steps.less
+++ b/tutor/resources/styles/components/task-step/all-steps.less
@@ -7,6 +7,8 @@
     padding: @tutor-card-body-padding;
   }
 
+  .book-paged-content();
+
   .video-content,
   .interactive-content,
   .reading-content {

--- a/tutor/resources/styles/components/task-step/reading.less
+++ b/tutor/resources/styles/components/task-step/reading.less
@@ -1,5 +1,3 @@
-@import '../../book-content/index';
-
 .task-step {
 
   .reading-step {
@@ -22,4 +20,3 @@
 }
 
 @import './reading/completed';
-@import './reading/interactive';

--- a/tutor/resources/styles/components/task-step/reading/interactive.less
+++ b/tutor/resources/styles/components/task-step/reading/interactive.less
@@ -1,8 +1,0 @@
-.task-reading {
-  .interactive-step {
-    iframe {
-      width: @tutor-interactive-iframe-width;
-      height: 560px;
-    }
-  }
-}

--- a/tutor/resources/styles/components/task/index.less
+++ b/tutor/resources/styles/components/task/index.less
@@ -13,7 +13,6 @@
     }
     // small screens
     @media screen and (max-width: (@tutor-task-width + 200px)){
-      .paged-content { width: @tutor-task-width - 200px; }
       .icon.arrow.left  { margin-left: -30px; }
       .icon.arrow.right { margin-left: 30px; }
     }

--- a/tutor/resources/styles/components/task/index.less
+++ b/tutor/resources/styles/components/task/index.less
@@ -8,9 +8,7 @@
   margin: 0 auto;
   &.task-reading {
     max-width: inherit;
-    .paged-content {
-      width: @tutor-task-width;
-    }
+
     // small screens
     @media screen and (max-width: (@tutor-task-width + 200px)){
       .icon.arrow.left  { margin-left: -30px; }

--- a/tutor/resources/styles/variables.less
+++ b/tutor/resources/styles/variables.less
@@ -30,6 +30,7 @@
 @tutor-video-iframe-width: 720px;
 @tutor-video-iframe-height: 405px;
 @tutor-interactive-iframe-width: 960px;
+@tutor-interactive-iframe-height: 630px;
 
 @tutor-note-padding-vertical: 20px;
 @tutor-note-padding-horizontal: 40px;

--- a/tutor/src/components/book-content-mixin.cjsx
+++ b/tutor/src/components/book-content-mixin.cjsx
@@ -208,7 +208,10 @@ sizeImage = ->
   figure = dom.closest(@, 'figure')
   return unless figure
 
-  if @naturalWidth > @naturalHeight or figure.parentNode.dataset.orient is 'horizontal'
+  aspectRatio = @naturalWidth / @naturalHeight
+
+  # let wide, square, and almost square figures be natural.
+  if aspectRatio > 0.9 or figure.parentNode.dataset.orient is 'horizontal'
     figure.classList.add('tutor-ui-horizontal-img')
     if @naturalWidth > 450 and figure.parentNode?.nodeName isnt 'FIGURE'
       figure.classList.add('full-width')


### PR DESCRIPTION
Sims will be
* `100%` of content width on small screens
* `960px`, centered, for sizes above `960px`
  * squishy margin for sizes below `1020px`
  * fixed margin, centered within content, bulging out of the content, for sizes above `1020px`

## After

### Ref View
![responsive-ref](https://cloud.githubusercontent.com/assets/2483873/18370146/7f736464-75f0-11e6-8b8e-3598ab5ce24e.gif)


### Task View
![responsive-task](https://cloud.githubusercontent.com/assets/2483873/18370144/7a9b3782-75f0-11e6-8aed-8ca5d3513cc3.gif)

Take note that this particular sim happens to be responsive.  Most of our sims are not.  They will center and size down as window size shrinks.  This is a temporary solution, as sims will not be workable below a certain width.