### PR TITLE
redirect to dashboard when course is not found

### DIFF
--- a/tutor/src/components/student-dashboard/index.cjsx
+++ b/tutor/src/components/student-dashboard/index.cjsx
@@ -5,6 +5,7 @@ LoadableItem = require '../loadable-item'
 isStepComplete = (step) -> step.is_completed
 StudentDashboard = require './dashboard'
 WindowHelpers = require '../../helpers/window'
+{NotificationActions} = require 'shared'
 
 StudentDashboardShell = React.createClass
   displayName: 'StudentDashboardShell'
@@ -17,9 +18,14 @@ StudentDashboardShell = React.createClass
     # Will display the redirect screen if course is a concept coach one
     willTransitionTo: (transition, params, query, callback) ->
       {courseId} = params
-      {is_concept_coach, webview_url} = CourseStore.get(courseId)
-      if is_concept_coach and webview_url
-        transition.redirect('viewStudentCCRedirect', {courseId})
+      course = CourseStore.get(courseId)
+      if course
+        {is_concept_coach, webview_url} = course
+        if is_concept_coach and webview_url
+          transition.redirect('viewStudentCCRedirect', {courseId})
+      else
+        NotificationActions.display(message: 'That is not a valid course', icon: 'exclamation-circle')
+        transition.redirect('dashboard')
       callback()
 
   render: ->


### PR DESCRIPTION
Fixes the FE part of the bug that https://github.com/openstax/tutor-server/pull/1272 addresses.

This simply displays an error and redirects to the dashboard course listing if the given course id isn't found.  Before there would be a JS error when it attempted to get the `is_concept_coach` member of null, and only a blank page would be displayed.

![screen shot 2016-09-09 at 8 41 50 am](https://cloud.githubusercontent.com/assets/79566/18389015/776db746-7669-11e6-9b7c-8dc6e71d8bf6.png)