### PR TITLE
Fix reading scrolling on MPQ

### DIFF
--- a/shared/src/components/exercise/part-card.cjsx
+++ b/shared/src/components/exercise/part-card.cjsx
@@ -82,7 +82,7 @@ ExerciseStepCard = React.createClass
     {id} = @props
 
     @setState {freeResponse}
-    @props.onFreeResponseChange?(id, freeResponse)
+    @props.onFreeResponseChange?(id, freeResponse, @props.stepPartIndex)
 
   onChangeAnswerAttempt: (answer) ->
     {id} = @props

--- a/shared/src/components/exercise/part.cjsx
+++ b/shared/src/components/exercise/part.cjsx
@@ -82,7 +82,7 @@ ExercisePart = React.createClass
 
   onMultipleChoiceAnswerChanged: (answer) ->
     {id} = @props
-    @props.setAnswerId(id, answer.id)
+    @props.setAnswerId(id, answer.id, @props.stepPartIndex)
 
   getReviewProps: ->
     reviewProps = _.omit(@props, NOT_REVIEW_PROPS)

--- a/tutor/src/components/task-step/exercise.cjsx
+++ b/tutor/src/components/task-step/exercise.cjsx
@@ -123,27 +123,21 @@ module.exports = React.createClass
     @setCurrentStep(current)
 
   setCurrentStep: (currentStep) ->
-    return unless currentStep isnt @state.currentStep
-
+    return if currentStep is @state.currentStep
     @setState({currentStep})
     @props.goToStep(currentStep)
 
-  setCurrentStepByStepId: (id) ->
-    {taskId} = @props
-    stepNavIndex = TaskStore.getStepNavIndex(taskId, id)
-    @setCurrentStep(stepNavIndex)
-
-  onFreeResponseChange: (id, tempFreeResponse) ->
+  onFreeResponseChange: (id, tempFreeResponse, stepIndex) ->
     TaskStepActions.updateTempFreeResponse(id, tempFreeResponse)
 
     # set part to be active if part of multipart
-    @setCurrentStepByStepId(id) unless @isSinglePart(@state.parts)
+    @setCurrentStep(stepIndex) unless @isSinglePart(@state.parts)
 
-  onChoiceChange: (id, answerId) ->
+  onChoiceChange: (id, answerId, stepIndex) ->
     TaskStepActions.setAnswerId(id, answerId)
 
     # set part to be active if part of multipart
-    @setCurrentStepByStepId(id) unless @isSinglePart(@state.parts)
+    @setCurrentStep(stepIndex) unless @isSinglePart(@state.parts)
 
   isAnyCompletedPartSaving: ->
     {parts} = @state

--- a/tutor/src/flux/task.coffee
+++ b/tutor/src/flux/task.coffee
@@ -274,23 +274,6 @@ TaskConfig =
       _.findIndex(@_steps[taskId], id: stepId)
 
 
-    # like getStepIndex, but takes into consideration CC spacer step
-    #
-    # TODO clean up by moving this, and stuff within crumb-mixin to a
-    # helper or flux of it's own.
-    getStepNavIndex: (taskId, stepId) ->
-      coachStart = _.findIndex @_steps[taskId], (step) ->
-        not TaskStepStore.isCore(step.id)
-
-      stepIndex = @exports.getStepIndex.call(@, taskId, stepId)
-
-      navIndex = stepIndex
-
-      if coachStart > -1 and stepIndex >= coachStart
-        navIndex = stepIndex + 1
-
-      navIndex
-
     getStepLateness: (taskId, stepId) ->
       result =
         late: false


### PR DESCRIPTION
https://trello.com/c/28Do07p1/110-mpq-in-reading-scrolls-back-and-forth-between-parts-when-typing-in-free-response-box

While readings shouldn't have MPQ, occasionally one will sneak through.  For an example view the link on the card above.


