### PR TITLE
Fix exercise editor bug with old values persisting in fields

### DIFF
--- a/exercises/src/components/exercise/answer.cjsx
+++ b/exercises/src/components/exercise/answer.cjsx
@@ -8,7 +8,7 @@ module.exports = React.createClass
   getInitialState: -> {}
 
   propTypes:
-    id: React.PropTypes.number.isRequired
+    id: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]).isRequired
     sync: React.PropTypes.func.isRequired
 
   updateContent: (event) ->

--- a/exercises/src/components/exercise/question-format-type.cjsx
+++ b/exercises/src/components/exercise/question-format-type.cjsx
@@ -17,7 +17,7 @@ TYPES =
 QuestionFormatType = React.createClass
 
   propTypes:
-    questionId: React.PropTypes.number.isRequired
+    questionId: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]).isRequired
     sync: React.PropTypes.func.isRequired
 
   update: -> @forceUpdate()

--- a/exercises/src/components/exercise/question-format-type.cjsx
+++ b/exercises/src/components/exercise/question-format-type.cjsx
@@ -53,6 +53,7 @@ QuestionFormatType = React.createClass
           name={"#{@props.questionId}-formats"}
           label={name}
           value={id}
+          onChange={@update}
           onClick={@updateFormat}
           checked={@isFormatChecked(id)}
         />}

--- a/exercises/src/components/exercise/question.cjsx
+++ b/exercises/src/components/exercise/question.cjsx
@@ -22,7 +22,7 @@ module.exports = React.createClass
     QuestionStore.removeChangeListener(@update)
 
   propTypes:
-    id: React.PropTypes.number.isRequired
+    id: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]).isRequired
     sync: React.PropTypes.func.isRequired
 
   sync: ->

--- a/exercises/src/components/tags/requires-context.cjsx
+++ b/exercises/src/components/tags/requires-context.cjsx
@@ -17,7 +17,7 @@ RequiresContextTag = React.createClass
     @props.actions.setPrefixedTag(@props.id, prefix: PREFIX, tag: tag, replaceOthers:true)
 
   render: ->
-    tag = _.first @props.store.getTagsWithPrefix(@props.id, PREFIX)
+    tag = _.first(@props.store.getTagsWithPrefix(@props.id, PREFIX)) or 'false'
 
     <Wrapper label="Requires Context">
       <div className="tag">

--- a/exercises/src/components/tags/single-dropdown.cjsx
+++ b/exercises/src/components/tags/single-dropdown.cjsx
@@ -19,12 +19,13 @@ SingleDropdown = React.createClass
     )
 
   render: ->
-    tag = _.first @props.store.getTagsWithPrefix(@props.id, @props.prefix)
+    tag = _.first(@props.store.getTagsWithPrefix(@props.id, @props.prefix)) or ''
+
     <Wrapper label={@props.label} singleTag={true}>
       <div className="tag">
         <select className='form-control' onChange={@updateTag} value={tag}>
           {unless tag # a tag cannot be blank once it's set
-            <option key='blank' value={''}>{name}</option>}
+            <option key='blank' value=''>{name}</option>}
           {for tag, name of @props.choices
             <option key={tag} value={tag}>{name}</option>}
         </select>

--- a/exercises/src/stores/question.coffee
+++ b/exercises/src/stores/question.coffee
@@ -92,18 +92,18 @@ QuestionConfig = {
 
     getAnswers: (id) -> @_get(id)?.answers or []
 
-    getStem: (id) -> @_get(id)?.stem_html
+    getStem: (id) -> @_get(id)?.stem_html or ''
 
-    getStimulus: (id) -> @_get(id)?.stimulus_html
+    getStimulus: (id) -> @_get(id)?.stimulus_html or ''
 
     getSolution: (id) ->
-      _.first(@_get(id).collaborator_solutions)?.content_html
+      _.first(@_get(id).collaborator_solutions)?.content_html or ''
 
     getCorrectAnswer: (id) ->
       _.find @_get(id)?.answers, (answer) -> AnswerStore.isCorrect(answer.id)
 
     isOrderPreserved: (id) ->
-      @_get(id).is_answer_order_important
+      @_get(id).is_answer_order_important or false
 
     getTemplate: ->
       answerId = AnswerStore.freshLocalId()

--- a/exercises/src/stores/tagging-mixin.coffee
+++ b/exercises/src/stores/tagging-mixin.coffee
@@ -37,7 +37,7 @@ Store =
     getTagsWithPrefix: (id, prefix) ->
       prefix += ':'
       tags = _.select @_get(id).tags, (tag) -> 0 is tag.indexOf(prefix)
-      _.map( tags, (tag) -> tag.replace(prefix, '') ).sort()
+      _.map( tags, (tag) -> tag.replace(prefix, '') ).sort() or []
 
 
 Extend =


### PR DESCRIPTION
https://trello.com/c/bTWS6Rcy/111-bug-create-edit-first-try-in-exercises-has-trash-data-in-the-detailed-solution-and-causes-an-error-at-save

If an input's value is set to undefined, it doesn't clear it.  This was causing old record's values to be retained in the input field of a new record