### PR TITLE
fix weird milestone snippets

### DIFF
--- a/tutor/src/components/task/progress/milestones.cjsx
+++ b/tutor/src/components/task/progress/milestones.cjsx
@@ -44,7 +44,13 @@ Milestone = React.createClass
 
     previewText =
       if crumb.id?
-        StepTitleStore.get(crumb.id)
+        title = StepTitleStore.get(crumb.id)
+        if not title and
+          crumb.type is 'reading' and
+          crumb.related_content?[0]?.title?
+            crumb.related_content?[0]?.title
+        else
+          title
       else
         switch crumb.type
           when 'end'

--- a/tutor/src/flux/step-title.coffee
+++ b/tutor/src/flux/step-title.coffee
@@ -6,10 +6,28 @@ TEXT_LENGTH_CHECK = 110
 TEXT_LENGTH = 125
 TEXT_CHECK_RANGE = TEXT_LENGTH - TEXT_LENGTH_CHECK
 
+isLearningObjective = (element) ->
+  element?.attribs?['class']? and element.attribs['class'].search(/learning-objectives/) > -1
+
+isNote = (element) ->
+  return unless element?.attribs?['class']? or element.attribs['data-element-type']?
+
+  classes = element.attribs['class'].split(' ')
+  not _.isEmpty(_.intersection(classes, ['note', 'example', 'grasp-check'])) or
+    element.attribs['data-element-type'] is 'check-understanding'
+
+isTyped = (element) ->
+  element?.attribs?['data-element-type']?
+
 isLabel = (element) ->
   element.attribs['data-has-label'] is 'true'
 isTitle = (element) ->
-  element.attribs['data-type'] is 'title'
+  element.attribs['data-type'] is 'title' and
+    not isTyped(element.parent) and
+    not isLearningObjective(element.parent)
+isDocumentTitle = (element) ->
+  element.attribs['data-type'] is 'document-title'
+
 grabLabel = (element) ->
   element.attribs['data-label']?.trim?()
 grabTitle = (element) ->
@@ -50,8 +68,6 @@ StepTitleConfig =
     else
       label = htmlparser.DomUtils.findOne(isLabel, dom, false)
       text = grabLabel(label) if label?
-
-    text ?= grabTruncatedText(htmlparser.DomUtils.getText(dom))
 
     actions.loaded(id, text)
 


### PR DESCRIPTION
noticed some weird milestone snippets, this makes them generally make more sense

## Befores

![screen shot 2016-09-22 at 6 17 49 pm](https://cloud.githubusercontent.com/assets/2483873/18769223/fc29ccfe-80f0-11e6-8825-23de19670b0f.png)
![screen shot 2016-09-22 at 6 15 36 pm](https://cloud.githubusercontent.com/assets/2483873/18769222/fc265dc6-80f0-11e6-9d07-137bb8178407.png)
![screen shot 2016-09-22 at 6 15 25 pm](https://cloud.githubusercontent.com/assets/2483873/18769221/fc249ea0-80f0-11e6-8c66-486cc1dfd0cb.png)


## Afters

![screen shot 2016-09-22 at 6 18 05 pm](https://cloud.githubusercontent.com/assets/2483873/18769227/01d1f460-80f1-11e6-8731-522db07f36da.png)
![screen shot 2016-09-22 at 6 16 04 pm](https://cloud.githubusercontent.com/assets/2483873/18769229/01d45160-80f1-11e6-8f59-93a016c7c72d.png)
![screen shot 2016-09-22 at 6 15 50 pm](https://cloud.githubusercontent.com/assets/2483873/18769228/01d3f35a-80f1-11e6-901c-5f26d22fecbd.png)
