### PR TITLE
should fix mpq scrolling

### DIFF
--- a/tutor/src/components/task-step/exercise.cjsx
+++ b/tutor/src/components/task-step/exercise.cjsx
@@ -55,6 +55,13 @@ module.exports = React.createClass
     {id, taskId, courseId, onNextStep} = props
     parts = TaskStore.getStepParts(taskId, id)
 
+    parts = _.map(parts, (part) ->
+      stepIndex = TaskPanelStore.getStepIndex(taskId, {id: part.id})
+      questionNumber = TaskStore.getStepIndex(taskId, part.id) + 1
+
+      _.extend({}, part, {stepIndex, questionNumber})
+    )
+
     lastPartId = _.last(parts).id
     isSinglePartExercise = @isSinglePart(parts)
 

--- a/tutor/src/components/task/index.cjsx
+++ b/tutor/src/components/task/index.cjsx
@@ -108,7 +108,9 @@ module.exports = React.createClass
 
   _isSameStep: (nextProps, nextState) ->
     return false unless nextProps.id is @props.id
-    TaskStore.isSameStep(@props.id, @state.currentStep, nextState.currentStep)
+    step = @getStep(@state.currentStep)
+    nextStep = @getStep(nextState.currentStep)
+    TaskStore.isSameStep(@props.id, step.id, nextStep.id)
 
   # After a step is recovered, the task needs to load itself in order to store the new step
   # at the proper index.  prepareToRecover handles this.

--- a/tutor/src/components/task/index.cjsx
+++ b/tutor/src/components/task/index.cjsx
@@ -110,6 +110,7 @@ module.exports = React.createClass
     return false unless nextProps.id is @props.id
     step = @getStep(@state.currentStep)
     nextStep = @getStep(nextState.currentStep)
+    return false if _.isEmpty(step) or _.isEmpty(nextStep)
     TaskStore.isSameStep(@props.id, step.id, nextStep.id)
 
   # After a step is recovered, the task needs to load itself in order to store the new step

--- a/tutor/src/flux/task.coffee
+++ b/tutor/src/flux/task.coffee
@@ -283,11 +283,6 @@ TaskConfig =
 
       parts = getSteps(parts)
 
-      _.map parts, (part) =>
-        part.stepIndex = @exports.getStepIndex.call(@, taskId, part.id)
-        part.questionNumber = part.stepIndex + 1
-        part
-
     getStepByIndex: (taskId, stepIndex) ->
       @_steps[taskId][stepIndex]
 
@@ -299,10 +294,10 @@ TaskConfig =
       {is_deleted} = @_get(taskId)
       is_deleted
 
-    isSameStep: (taskId, stepIndices...) ->
-      contentUrls = _.chain(stepIndices)
-        .map (stepIndex) =>
-          step = @exports.getStepByIndex.call(@, taskId, stepIndex)
+    isSameStep: (taskId, stepIds...) ->
+      contentUrls = _.chain(stepIds)
+        .map (stepId) =>
+          step = @_getStep(taskId, stepId)
 
           if step?.is_in_multipart
             step.content_url


### PR DESCRIPTION
step indices were mismatched and confused, and so which step to scroll to was confused as well.  this more carefully matches the visual step indices with real steps on tasks, especially around things like whether steps are part of same multipart

TODO clean up.

hopefully addresses
* https://trello.com/c/28Do07p1
* https://trello.com/c/DBTgj8Ba
* https://trello.com/c/247ytbaE