### PR TITLE
info icon should appear until plan is published

### DIFF
--- a/tutor/src/components/task-plan/footer/help-tooltip.cjsx
+++ b/tutor/src/components/task-plan/footer/help-tooltip.cjsx
@@ -20,10 +20,10 @@ Tooltip =
 HelpTooltip = React.createClass
 
   propTypes:
-    isEditable: React.PropTypes.bool.isRequired
+    isPublished: React.PropTypes.bool.isRequired
 
   render: ->
-    return null unless @props.isEditable and @props.isPublished
+    return null if @props.isPublished
 
     <BS.OverlayTrigger trigger='click' placement='top' overlay={Tooltip} rootClose={true}>
       <BS.Button className="footer-instructions" bsStyle="link">

--- a/tutor/src/components/task-plan/footer/index.cjsx
+++ b/tutor/src/components/task-plan/footer/index.cjsx
@@ -103,8 +103,7 @@ PlanFooter = React.createClass
         isFailed={isFailed}
       />
       <HelpTooltip
-        isEditable={@state.isEditable}
-        isPublished={TaskPlanStore.isPublished(id)}
+        isPublished={isPublished}
       />
       <DeleteLink
         isNew={TaskPlanStore.isNew(id)}


### PR DESCRIPTION
Somehow we got the logic slightly wrong and were looking at isEditable as well.

The previous logic looked only at isPublished https://github.com/openstax/tutor-js/blob/8138187dd23103b3c7e6bee81b9e79a357c80127/tutor/src/components/task-plan/footer.cjsx#L178
