### PR TITLE
change for intro two step message

### DIFF
--- a/shared/resources/styles/components/exercise/intro.less
+++ b/shared/resources/styles/components/exercise/intro.less
@@ -17,9 +17,14 @@
     padding: 60px 140px;
   }
 
+  h1, h2, h3, h4, h5, h6 {
+    font-weight: 900;
+  }
+
   p {
     font-size: 18px;
     line-height: 24px;
+    margin-bottom: 2.4rem;
   }
 
   button:not(.btn-link):not(.btn-flat):not(.btn-fab).btn-default {

--- a/shared/src/helpers/step-helps.cjsx
+++ b/shared/src/helpers/step-helps.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 _ = require 'underscore'
+capitalize = require 'lodash/capitalize'
 
 PERSONALIZED_GROUP = 'personalized'
 SPACED_PRACTICE_GROUP = 'spaced practice'
@@ -68,17 +69,15 @@ getIntroText[SPACED_PRACTICE_GROUP] = (project, locate = true) ->
 
 getIntroText[TWO_STEP_ALIAS] = (project) ->
   [
-    <p>Research shows quizzing yourself is a great way to boost learning.</p>
-    <h4>Step 1: Free response</h4>
+    <p>Research shows a great way to boost learning is to try recalling what you have learned.</p>
+    <h4>Step 1: Free response for longer lasting learning</h4>
     <p>
-      Read the question, then construct an answer in the
-      free response box. Recalling knowledge from memory (rather than looking up
-      the answer or recognizing it in a list) helps your learning last longer.
+      Help your learning last longer by constructing an answer in the free response box from memory.
+      For greatest benefit, try not to refer to notes or text.
     </p>
-    <h4>Step 2: Multiple choice</h4>
+    <h4>Step 2: {capitalize(getProject(project).feedbackType)} with multiple choice</h4>
     <p>
-      Then select the best multiple choice answer so
-      {getProject(project).name} can give you {getProject(project).feedbackType}.
+      Receive {getProject(project).feedbackType} by selecting the best multiple-choice option.
     </p>
     <p>
       Both you and your instructor can review your answers later.

--- a/shared/src/helpers/step-helps.cjsx
+++ b/shared/src/helpers/step-helps.cjsx
@@ -67,14 +67,23 @@ getIntroText[SPACED_PRACTICE_GROUP] = (project, locate = true) ->
   ]
 
 getIntroText[TWO_STEP_ALIAS] = (project) ->
-  <p>
-    Research shows that a great way to boost your learning is to quiz
-    yourself.  For maximum benefit, read the text and then answer the
-    free response question in your own words.  Then, select the best
-    multiple choice answer so {getProject(project).name} can give
-    you {getProject(project).feedbackType}.  Both you and your instructor
-    can review your answers later.
-  </p>
+  [
+    <p>Research shows quizzing yourself is a great way to boost learning.</p>
+    <h4>Step 1: Free response</h4>
+    <p>
+      Read the question, then construct an answer in the
+      free response box. Recalling knowledge from memory (rather than looking up
+      the answer or recognizing it in a list) helps your learning last longer.
+    </p>
+    <h4>Step 2: Multiple choice</h4>
+    <p>
+      Then select the best multiple choice answer so
+      {getProject(project).name} can give you {getProject(project).feedbackType}.
+    </p>
+    <p>
+      Both you and your instructor can review your answers later.
+    </p>
+  ]
 
 getHelpText = _.mapObject(getIntroText, (getIntro) ->
   _.partial(getIntro, _, false)


### PR DESCRIPTION
As defined here: https://trello.com/c/7VIdD1Y3/166-update-the-wording-in-the-first-time-two-step-card-in-tutor-readings-and-homeworks and [here for coach](https://trello.com/c/tCSxdOJh/168-update-the-wording-in-the-first-time-two-step-card-in-concept-coach-readings)

## Tutor
![screen shot 2016-09-29 at 1 49 37 am](https://cloud.githubusercontent.com/assets/2483873/18943757/3a7b5e0a-85e7-11e6-8998-5820add752da.png)

## Coach
![screen shot 2016-09-29 at 1 50 23 am](https://cloud.githubusercontent.com/assets/2483873/18943761/3ec691d2-85e7-11e6-965b-ebcfe22ef4fc.png)
