### PR TITLE
problem was with isContinue return true for tasks without steps

### DIFF
--- a/coach/src/task/index.cjsx
+++ b/coach/src/task/index.cjsx
@@ -41,7 +41,7 @@ TaskBase = React.createClass
 
   setupSteps: (task) ->
     steps = _.keys(task?.steps)
-    steps.push('continue')
+    steps.push('continue') unless _.isEmpty(steps)
 
     steps
 


### PR DESCRIPTION
Coach will no long close for when the page has no exercises

![screen shot 2016-09-28 at 10 27 07 am](https://cloud.githubusercontent.com/assets/2483873/18920152/2713647e-8566-11e6-8da6-648229376d45.png)
