### PR TITLE
Fix duplicated choice letter displayed on exercise preview

### DIFF
--- a/shared/resources/styles/components/exercise-preview/index.less
+++ b/shared/resources/styles/components/exercise-preview/index.less
@@ -168,14 +168,12 @@
     }
 
     .answers-table {
-      counter-reset: answer;
       font-size: 1.4rem;
       line-height: 1.4em;
       margin-bottom: 2rem;
 
       .answers-answer {
         padding-left: 15px;
-        counter-increment: answer;
         display: table;
 
         &.answer-correct {
@@ -200,7 +198,7 @@
           padding-right: 1rem;
           display: table-cell;
           &:after {
-            content: counter(answer, lower-latin) ')';
+            content: ')';
           }
         }
 

--- a/shared/src/components/exercise-identifier-link.cjsx
+++ b/shared/src/components/exercise-identifier-link.cjsx
@@ -16,7 +16,7 @@ ExerciseIdentifierLink = React.createClass
     url = Exercise.troubleUrl(@props)
     <div>
       <span className='exercise-identifier-link'>
-        ID&pound; {@props.exerciseId} | <a
+        ID# {@props.exerciseId} | <a
           target="_blank" tabIndex={-1} href={url}
         >Report an error</a>
       </span>

--- a/shared/test/components/exercise-preview/index.spec.coffee
+++ b/shared/test/components/exercise-preview/index.spec.coffee
@@ -72,3 +72,12 @@ describe 'Exercise Preview Component', ->
     _.extend(@props.exercise, context: '')
     Testing.renderComponent( ExercisePreview, props: @props ).then ({dom}) ->
       expect(dom.querySelector('div.context')).not.to.exist
+
+  it 'renders answer choices', ->
+    Testing.renderComponent( ExercisePreview, props: @props ).then ({dom}) ->
+      answers = _.pluck dom.querySelectorAll('.openstax-answer .answer-label'), 'textContent'
+      expect(answers).to.deep.equal([
+        "aa sequence of DNA", "ba sequence of rRNA",
+        "ca sequence of mRNA.", "da sequence of tRNA.",
+        "aYES", "bNO"
+      ])


### PR DESCRIPTION
from: 

<img width="471" alt="screen shot 2016-09-29 at 4 05 01 pm" src="https://cloud.githubusercontent.com/assets/79566/18972383/945412e2-865e-11e6-90f0-0649f36c4c2b.png">



To:

<img width="473" alt="screen shot 2016-09-29 at 3 59 01 pm" src="https://cloud.githubusercontent.com/assets/79566/18972380/8d763fcc-865e-11e6-81ca-cc6fa857b8a9.png">
