### PR TITLE
Fix breadcrumb end has title (popover) with "undefined"

### DIFF
--- a/shared/src/components/breadcrumb/index.cjsx
+++ b/shared/src/components/breadcrumb/index.cjsx
@@ -63,7 +63,7 @@ Breadcrumb = React.createClass
       status = <i className='icon-lg icon-incorrect'></i>
 
     if isEnd
-      title = "#{step.title} Completion"
+      title = "#{step.task?.title} Completion"
 
     classes = classnames 'openstax-breadcrumbs-step', 'icon-stack', 'icon-lg', step.group, "breadcrumb-#{crumbType}", className,
       current: isCurrent

--- a/shared/test/components/breadcrumb/index.spec.coffee
+++ b/shared/test/components/breadcrumb/index.spec.coffee
@@ -7,7 +7,9 @@ describe 'Breadcrumb Component', ->
   beforeEach ->
     @props =
       goToStep: sinon.spy()
-      step: {type: 'reading', is_completed: true, title: 'My Assignment', correct_answer_id: 1}
+      step:
+        type: 'reading', is_completed: true, correct_answer_id: 1
+        task: {title: 'My Assignment'}
       canReview: true
       currentStep: 1
       stepIndex: 2


### PR DESCRIPTION
Fixes:
<img width="421" alt="screen shot 2016-09-30 at 12 58 55 pm" src="https://cloud.githubusercontent.com/assets/79566/19014910/0fce297e-87bf-11e6-8939-5b33624bb752.png">


Now is:
<img width="374" alt="screen shot 2016-09-30 at 12 59 40 pm" src="https://cloud.githubusercontent.com/assets/79566/19014912/12475d9c-87bf-11e6-92a5-9cad4d7d3f06.png">
