### PR TITLE
Scroll to current exercise when returning from details view

### DIFF
--- a/shared/src/components/exercise-preview/index.cjsx
+++ b/shared/src/components/exercise-preview/index.cjsx
@@ -120,7 +120,7 @@ ExercisePreview = React.createClass
       <ControlsOverlay exercise={@props.exercise}
         actions={@props.overlayActions} onClick={@props.onOverlayClick} />
 
-      <div className="exercise-body">
+      <div className="exercise-body" data-exercise-id={@props.exercise.id}>
 
         <ExerciseBadges exercise={@props.exercise} />
 

--- a/shared/src/components/exercise-preview/index.cjsx
+++ b/shared/src/components/exercise-preview/index.cjsx
@@ -113,6 +113,8 @@ ExercisePreview = React.createClass
       className={classes}
       bsStyle={@props.panelStyle}
       header={@props.header}
+      data-exercise-id={@props.exercise.id}
+      tabIndex=-1
       footer={@renderFooter() if @props.children}
     >
       {<div className='selected-mask' /> if @props.isSelected}
@@ -120,7 +122,7 @@ ExercisePreview = React.createClass
       <ControlsOverlay exercise={@props.exercise}
         actions={@props.overlayActions} onClick={@props.onOverlayClick} />
 
-      <div className="exercise-body" data-exercise-id={@props.exercise.id}>
+      <div className="exercise-body" >
 
         <ExerciseBadges exercise={@props.exercise} />
 

--- a/shared/src/components/scroll-to-mixin.cjsx
+++ b/shared/src/components/scroll-to-mixin.cjsx
@@ -85,6 +85,7 @@ ScrollToMixin =
 
     if options.immediate is true
       win.scroll(0, endPos)
+      @_onAfterScroll(el, options)
       return
 
     startPos  = win.pageYOffset

--- a/shared/test/helpers/fake-window.coffee
+++ b/shared/test/helpers/fake-window.coffee
@@ -8,6 +8,13 @@ class FakeWindow
   setInterval: -> Math.random()
   document:
     hidden: false
+  pageYOffset: 0
+  pageXOffset: 0
+  scroll: (x, y) ->
+    @pageXOffset = x
+    @pageYOffset = y
+  requestAnimationFrame: (cb) -> _.defer cb
+  querySelector: (sb) -> null
 
   constructor: ->
     for method in _.functions(@)
@@ -15,5 +22,8 @@ class FakeWindow
     @localStorage =
       getItem: sinon.stub().returns('[]')
       setItem: sinon.stub()
+    @history =
+      pushState: sinon.spy()
+
 
 module.exports = FakeWindow

--- a/tutor/resources/styles/components/exercises.less
+++ b/tutor/resources/styles/components/exercises.less
@@ -166,3 +166,11 @@
     justify-content: space-around;
   }
 }
+
+.exercise-cards {
+  .exercise-card {
+    &:focus {
+      .tab-focus();
+    }
+  }
+}

--- a/tutor/src/components/exercises/cards.cjsx
+++ b/tutor/src/components/exercises/cards.cjsx
@@ -68,8 +68,10 @@ ExerciseCards = React.createClass
     not _.isEqual(nextProps, @props)
 
   componentDidMount:   ->
-    selector = if @props.focusedExerciseId then "[data-exercise-id='#{@props.focusedExerciseId}']" else '.exercise-sections'
-    @scrollToSelector(selector)
+    if @props.focusedExerciseId
+      @scrollToSelector("[data-exercise-id='#{@props.focusedExerciseId}']", immediate: true)
+    else
+      @scrollToSelector('.exercise-sections')
 
   onAfterScroll: (el) ->
     el.focus() if @props.focusedExerciseId

--- a/tutor/src/components/exercises/cards.cjsx
+++ b/tutor/src/components/exercises/cards.cjsx
@@ -24,6 +24,8 @@ SectionsExercises = React.createClass
     onExerciseToggle:       React.PropTypes.func.isRequired
     getExerciseIsSelected:  React.PropTypes.func.isRequired
     getExerciseActions:     React.PropTypes.func.isRequired
+    watchStore:             React.PropTypes.object.isRequired
+    watchEvent:             React.PropTypes.string.isRequired
 
   render: ->
     title = TocStore.findChapterSection(@props.ecosystemId, @props.chapter_section)?.title
@@ -52,6 +54,8 @@ ExerciseCards = React.createClass
     onShowDetailsViewClick: React.PropTypes.func.isRequired
     focusedExerciseId:      React.PropTypes.string
     topScrollOffset:        React.PropTypes.number
+    watchStore:             React.PropTypes.object.isRequired
+    watchEvent:             React.PropTypes.string.isRequired
 
   mixins: [ScrollToMixin]
 

--- a/tutor/src/components/exercises/cards.cjsx
+++ b/tutor/src/components/exercises/cards.cjsx
@@ -71,6 +71,9 @@ ExerciseCards = React.createClass
     selector = if @props.focusedExerciseId then "[data-exercise-id='#{@props.focusedExerciseId}']" else '.exercise-sections'
     @scrollToSelector(selector)
 
+  onAfterScroll: (el) ->
+    el.focus() if @props.focusedExerciseId
+
   getScrollTopOffset: ->
     # no idea why scrollspeed makes the difference, sorry :(
     if @props.scrollFast then @props.topScrollOffset else @props.topScrollOffset + 40

--- a/tutor/src/components/exercises/cards.cjsx
+++ b/tutor/src/components/exercises/cards.cjsx
@@ -50,6 +50,7 @@ ExerciseCards = React.createClass
     getExerciseIsSelected:  React.PropTypes.func.isRequired
     getExerciseActions:     React.PropTypes.func.isRequired
     onShowDetailsViewClick: React.PropTypes.func.isRequired
+    focusedExerciseId:      React.PropTypes.string
     topScrollOffset:        React.PropTypes.number
 
   mixins: [ScrollToMixin]
@@ -63,7 +64,8 @@ ExerciseCards = React.createClass
     not _.isEqual(nextProps, @props)
 
   componentDidMount:   ->
-    @scrollToSelector('.exercise-sections')
+    selector = if @props.focusedExerciseId then "[data-exercise-id='#{@props.focusedExerciseId}']" else '.exercise-sections'
+    @scrollToSelector(selector)
 
   getScrollTopOffset: ->
     # no idea why scrollspeed makes the difference, sorry :(

--- a/tutor/src/components/exercises/details.cjsx
+++ b/tutor/src/components/exercises/details.cjsx
@@ -34,7 +34,7 @@ ExerciseDetails = React.createClass
 
   getInitialState: -> {}
 
-  componentDidMount:   ->
+  componentDidMount: ->
     @scrollToSelector('.exercise-controls-bar')
 
   componentWillMount: ->
@@ -87,7 +87,6 @@ ExerciseDetails = React.createClass
     next: @state.currentIndex isnt @state.exercises.length - 1
 
   render: ->
-
     exercise = @state.exercises[@state.currentIndex] or _.first(@state.exercises)
     unless exercise
       return <NoExercisesFound />
@@ -99,7 +98,7 @@ ExerciseDetails = React.createClass
     <div className="exercise-details">
 
       <div className="controls">
-        <a className="show-cards" onClick={@props.onShowCardViewClick}>
+        <a className="show-cards" onClick={_.partial(@props.onShowCardViewClick, _, exercise)}>
           <Icon type="th-large" /> Back to Card View
         </a>
       </div>

--- a/tutor/src/components/icons/arrow.cjsx
+++ b/tutor/src/components/icons/arrow.cjsx
@@ -11,7 +11,7 @@ class Arrow extends React.Component
 
   shouldComponentUpdate: (nextProps) -> nextProps.direction isnt @props.direction
 
-  propTypes:
+  @propTypes:
     direction: React.PropTypes.oneOf(['left', 'right', 'up', 'down'])
 
   render: ->

--- a/tutor/src/components/questions/exercises-display.cjsx
+++ b/tutor/src/components/questions/exercises-display.cjsx
@@ -28,7 +28,6 @@ ExercisesDisplay = React.createClass
 
   getInitialState: -> {
     filter: ''
-    currentView: 'cards'
     showingCardsFromDetailsView: false
   }
   componentWillMount:   -> ExerciseStore.on('change',  @update)
@@ -51,7 +50,7 @@ ExercisesDisplay = React.createClass
     <ExerciseControls
       filter={@state.filter}
       courseId={@props.courseId}
-      currentView={@state.currentView}
+      showingDetails={@props.showingDetails}
       onFilterChange={@onFilterChange}
       onSectionSelect={@scrollToSection}
       onShowCardViewClick={@onShowCardViewClick}
@@ -76,7 +75,6 @@ ExercisesDisplay = React.createClass
     exercise ||= _.first ExerciseStore.get(@props.sectionIds)
     @setState(
       selectedExercise: exercise,
-      currentView: 'details'
       currentSection: ExerciseStore.getChapterSectionOfExercise(@props.ecosystemId, exercise)
     )
     @props.onShowDetailsViewClick(ev, exercise)
@@ -85,7 +83,7 @@ ExercisesDisplay = React.createClass
     # The pinned header doesn't notice when the elements above it are unhidden
     # and will never unstick by itself.
     @refs.controls.unPin()
-    @setState({currentView: 'cards', showingCardsFromDetailsView: true})
+    @setState({fromDetailsExercise: exercise})
     @props.onShowCardViewClick(ev, exercise)
 
   renderMinimumExclusionWarning: (minExerciseCount) ->
@@ -137,7 +135,7 @@ ExercisesDisplay = React.createClass
       actions.exclude =
         message: 'Exclude question'
         handler: @onExerciseToggle
-    if @state.currentView is 'details'
+    if @props.showingDetails
       @addDetailsActions(actions, exercise)
     else
       @addCardActions(actions, exercise)
@@ -199,6 +197,7 @@ ExercisesDisplay = React.createClass
         watchStore={ExerciseStore}
         watchEvent='change-exercise-'
         onExerciseToggle={@onExerciseToggle}
+        focusedExerciseId={@state.fromDetailsExercise?.id}
         onShowDetailsViewClick={@onShowDetailsViewClick} />
 
   render: ->

--- a/tutor/src/components/task-plan/homework/add-exercises.cjsx
+++ b/tutor/src/components/task-plan/homework/add-exercises.cjsx
@@ -24,8 +24,10 @@ AddExercises = React.createClass
 
   mixins: [ScrollToMixin, LoadingExercises]
 
-  onShowDetailsViewClick: -> @setState(currentView: 'details')
-  onShowCardViewClick:    -> @setState(currentView: 'cards')
+  onShowDetailsViewClick: ->
+    @setState(currentView: 'details')
+  onShowCardViewClick:    (ev, exercise) ->
+    @setState(currentView: 'cards', focusedExerciseId: exercise.id)
 
   onExerciseToggle: (ev, exercise) ->
     if @getExerciseIsSelected(exercise)
@@ -92,10 +94,11 @@ AddExercises = React.createClass
       ecosystemId, @props.sectionIds
     )
     sharedProps =
-        exercises: exercises.all
-        onExerciseToggle: @onExerciseToggle
-        getExerciseActions: @getExerciseActions
-        getExerciseIsSelected: @getExerciseIsSelected
+      ecosystemId: ecosystemId
+      exercises: exercises.all
+      onExerciseToggle: @onExerciseToggle
+      getExerciseActions: @getExerciseActions
+      getExerciseIsSelected: @getExerciseIsSelected
 
     body = switch @state.currentView
       when 'details'
@@ -115,6 +118,7 @@ AddExercises = React.createClass
           watchStore={TaskPlanStore}
           watchEvent='change-exercise-'
           topScrollOffset={110}
+          focusedExerciseId={@state.focusedExerciseId}
           onShowDetailsViewClick={@onShowDetailsViewClick}
         />
 

--- a/tutor/test/components/exercises/cards.spec.coffee
+++ b/tutor/test/components/exercises/cards.spec.coffee
@@ -1,0 +1,29 @@
+{Testing, expect, sinon, _, ReactTestUtils} = require '../helpers/component-testing'
+
+Cards = require '../../../src/components/exercises/cards'
+{ExerciseActions, ExerciseStore} = require '../../../src/flux/exercise'
+FakeWindow = require 'shared/test/helpers/fake-window'
+
+
+EXERCISES = require '../../../api/exercises'
+ECOSYSTEM_ID = '1'
+
+describe 'Exercise Cards Component', ->
+
+  beforeEach ->
+
+    @props =
+      ecosystemId: ECOSYSTEM_ID
+      exercises: {grouped: { '1.1': EXERCISES.items} }
+      onExerciseToggle:       sinon.spy()
+      getExerciseIsSelected:  sinon.stub().returns(false)
+      getExerciseActions:     sinon.stub().returns({})
+      onShowDetailsViewClick: sinon.spy()
+      windowImpl: new FakeWindow
+      watchStore: ExerciseStore
+      watchEvent: 'testing-'
+
+  it 'scrolls to exercse id on mount', ->
+    @props.focusedExerciseId = EXERCISES.items[0].id
+    Testing.renderComponent( Cards, props: @props ).then ({element}) =>
+      expect(@props.windowImpl.scroll).to.have.been.called

--- a/tutor/test/components/exercises/details.spec.coffee
+++ b/tutor/test/components/exercises/details.spec.coffee
@@ -1,0 +1,24 @@
+{Testing, expect, sinon, _, ReactTestUtils} = require '../helpers/component-testing'
+
+ExerciseDetails = require '../../../src/components/exercises/details'
+
+EXERCISES = require '../../../api/exercises'
+ECOSYSTEM_ID = '1'
+
+describe 'Exercise Details Component', ->
+
+
+  beforeEach ->
+    @props =
+      ecosystemId: ECOSYSTEM_ID
+      selectedExercise: EXERCISES.items[0]
+      exercises: {grouped: { '1.1': EXERCISES.items} }
+      onExerciseToggle:      sinon.spy()
+      onShowCardViewClick:   sinon.spy()
+      getExerciseActions:    sinon.stub().returns({})
+      getExerciseIsSelected: sinon.stub().returns(false)
+
+  it 'sends current exercise along when showing card view', ->
+    Testing.renderComponent( ExerciseDetails, props: @props ).then ({dom}) =>
+      Testing.actions.click(dom.querySelector('.show-cards'))
+      expect(@props.onShowCardViewClick).to.have.been.calledWith(sinon.match.any, @props.selectedExercise, sinon.match.any)


### PR DESCRIPTION
Applies to both QL and HW builder

The selected exercise is focused after it's returned to so it can be identified:
![screen shot 2016-10-04 at 4 12 45 pm](https://cloud.githubusercontent.com/assets/79566/19092693/6ab98438-8a4d-11e6-9ffc-81947d5810ac.png)
