### PR TITLE
avoid milestone text from references or ap-connections, captions, etc…

### DIFF
--- a/tutor/src/components/task/progress/milestones.cjsx
+++ b/tutor/src/components/task/progress/milestones.cjsx
@@ -39,9 +39,10 @@ Milestone = React.createClass
 
     title = StepTitleStore.get(crumb.id)
 
-    if not title and
-      crumb.type is 'reading' and
-      crumb.related_content?[0]?.title?
+    if crumb.type is 'reading' and crumb.related_content?[0]?.title?
+      if title is 'Summary'
+        title = "#{title} of #{crumb.related_content?[0]?.title}"
+      else if not title
         title = crumb.related_content?[0]?.title
 
     title

--- a/tutor/src/components/task/progress/milestones.cjsx
+++ b/tutor/src/components/task/progress/milestones.cjsx
@@ -34,6 +34,38 @@ Milestone = React.createClass
       @props.goToStep(crumbKey)
       keyEvent.preventDefault()
 
+  getStepTitle: (crumb) ->
+    {goToStep, crumb, currentStep, stepIndex} = @props
+
+    title = StepTitleStore.get(crumb.id)
+
+    if not title and
+      crumb.type is 'reading' and
+      crumb.related_content?[0]?.title?
+        title = crumb.related_content?[0]?.title
+
+    title
+
+  getPreviewText: (crumb) ->
+    if crumb.id?
+      @getStepTitle(crumb)
+    else
+      switch crumb.type
+        when 'end'
+          "#{crumb.task.title} Completed"
+
+        when 'coach'
+          TITLES[SPACED_PRACTICE_GROUP]
+
+        when INTRO_ALIASES[SPACED_PRACTICE_GROUP]
+          TITLES[SPACED_PRACTICE_GROUP]
+
+        when INTRO_ALIASES[PERSONALIZED_GROUP]
+          TITLES[PERSONALIZED_GROUP]
+
+        when INTRO_ALIASES[TWO_STEP_ALIAS]
+          TITLES[TWO_STEP_ALIAS]
+
   render: ->
     {goToStep, crumb, currentStep, stepIndex} = @props
 
@@ -42,31 +74,7 @@ Milestone = React.createClass
     classes = classnames 'milestone', "milestone-#{crumb.type}",
       'active': isCurrent
 
-    previewText =
-      if crumb.id?
-        title = StepTitleStore.get(crumb.id)
-        if not title and
-          crumb.type is 'reading' and
-          crumb.related_content?[0]?.title?
-            crumb.related_content?[0]?.title
-        else
-          title
-      else
-        switch crumb.type
-          when 'end'
-            "#{crumb.task.title} Completed"
-
-          when 'coach'
-            TITLES[SPACED_PRACTICE_GROUP]
-
-          when INTRO_ALIASES[SPACED_PRACTICE_GROUP]
-            TITLES[SPACED_PRACTICE_GROUP]
-
-          when INTRO_ALIASES[PERSONALIZED_GROUP]
-            TITLES[PERSONALIZED_GROUP]
-
-          when INTRO_ALIASES[TWO_STEP_ALIAS]
-            TITLES[TWO_STEP_ALIAS]
+    previewText = @getPreviewText(crumb)
 
     if crumb.type is 'exercise'
       preview = <ArbitraryHtmlAndMath


### PR DESCRIPTION
… for milestone texts that make more sense

From trying to investigate this: https://trello.com/c/qd29BT5E/140-bug-section-title-does-not-show-anywhere-in-the-reading-content

## References

### Before
![screen shot 2016-10-05 at 1 46 47 pm](https://cloud.githubusercontent.com/assets/2483873/19126910/6c56f342-8b02-11e6-8ba5-48b8d94792ec.png)

### After
![screen shot 2016-10-05 at 1 47 46 pm](https://cloud.githubusercontent.com/assets/2483873/19126909/6c56afe0-8b02-11e6-8c94-ccf489c6e27b.png)


## AP Connection

### Before
![screen shot 2016-10-05 at 1 49 38 pm](https://cloud.githubusercontent.com/assets/2483873/19126966/ac46984a-8b02-11e6-9efc-7b212f40e339.png)

### After
![screen shot 2016-10-05 at 1 49 49 pm](https://cloud.githubusercontent.com/assets/2483873/19126975/b46efce2-8b02-11e6-85b3-623338e89c8d.png)

## HTML Escape

### Before
![screen shot 2016-10-05 at 1 56 56 pm](https://cloud.githubusercontent.com/assets/2483873/19127245/d1789c8e-8b03-11e6-91d1-2467e0f0a03b.png)

### After
![screen shot 2016-10-05 at 1 57 45 pm](https://cloud.githubusercontent.com/assets/2483873/19127241/d160c05a-8b03-11e6-9502-a209adad08f7.png)

## Tips for Success

### Before
![screen shot 2016-10-05 at 1 57 23 pm](https://cloud.githubusercontent.com/assets/2483873/19127243/d1618f1c-8b03-11e6-84e4-027a9b6af36d.png)

### After
![screen shot 2016-10-05 at 1 58 16 pm](https://cloud.githubusercontent.com/assets/2483873/19127240/d1606056-8b03-11e6-804c-3788f2f07cf5.png)

## Captions

### Before
![screen shot 2016-10-05 at 1 57 10 pm](https://cloud.githubusercontent.com/assets/2483873/19127244/d165d946-8b03-11e6-983d-f9729052d428.png)

### After
![screen shot 2016-10-05 at 1 57 52 pm](https://cloud.githubusercontent.com/assets/2483873/19127242/d160f66a-8b03-11e6-89de-6ef01766edcd.png)

## Summary
### After
![screen shot 2016-10-05 at 1 55 51 pm](https://cloud.githubusercontent.com/assets/2483873/19127246/d17c05e0-8b03-11e6-8529-a91dfef2465d.png)


