### PR TITLE
fix missing section titles

### DIFF
--- a/tutor/resources/styles/book-content/ap-bio/variables.less
+++ b/tutor/resources/styles/book-content/ap-bio/variables.less
@@ -1,5 +1,6 @@
 @tutor-book-ap-bio-primary:  @openstax-book-biology-bg; // green
 @tutor-book-ap-bio-secondary:   @openstax-book-biology-fg; // dark gray
+@tutor-book-ap-bio-accent:   @openstax-book-biology-accent; // dark gray
 @tutor-book-ap-bio-tertiary: rgb(35, 48, 102); // dark blue
 @tutor-book-ap-bio-quaternary: rgb(244, 208, 25); // yellow
 @tutor-book-ap-bio-highlight: rgb(255, 255, 187); // pale yellow

--- a/tutor/resources/styles/book-content/hs-physics/variables.less
+++ b/tutor/resources/styles/book-content/hs-physics/variables.less
@@ -1,5 +1,6 @@
 @tutor-book-hs-physics-primary:  @openstax-book-hs_physics-bg; // blue
 @tutor-book-hs-physics-secondary:   @openstax-book-hs_physics-fg; // green
+@tutor-book-hs-physics-accent:   @openstax-book-hs_physics-accent; // light-green
 @tutor-book-hs-physics-tertiary:   rgb(119, 175, 65); // green
 @tutor-book-hs-physics-quaternary: rgb(244, 208, 25); // yellow
 @tutor-book-hs-physics-highlight: rgb(255, 255, 187); // pale yellow

--- a/tutor/resources/styles/book-content/index.less
+++ b/tutor/resources/styles/book-content/index.less
@@ -17,6 +17,7 @@
   @import './base';
   @import './typography';
   @import './learning-objectives';
+  @import './related-content';
   @import './splash-image';
   @import (reference) './note';
   @import './target';
@@ -31,6 +32,7 @@
   .tutor-book-theme-first-letter();
   .tutor-book-theme-typography();
   .tutor-book-theme-learning-objectives();
+  .tutor-book-theme-related-content();
   .tutor-book-theme-splash-image();
   .tutor-book-theme-note();
 }
@@ -42,7 +44,8 @@
 
   .tutor-book-theme-first-letter(@tutor-book-hs-physics-secondary);
   .tutor-book-theme-typography(@tutor-book-hs-physics-primary);
-  .tutor-book-theme-learning-objectives(@tutor-book-hs-physics-primary; rgba(255,255,255,.8));
+  .tutor-book-theme-learning-objectives(@tutor-book-hs-physics-accent; rgba(255,255,255,.8));
+  .tutor-book-theme-related-content(@tutor-book-hs-physics-primary);
   .tutor-book-theme-splash-image(@tutor-book-hs-physics-primary);
   .tutor-book-theme-note(@tutor-book-hs-physics-primary; @tutor-book-hs-physics-secondary);
   .tutor-book-theme-note-borders(@tutor-book-hs-physics-secondary);
@@ -57,7 +60,8 @@
 
   .tutor-book-theme-first-letter(@tutor-book-ap-bio-secondary);
   .tutor-book-theme-typography(@tutor-book-ap-bio-primary);
-  .tutor-book-theme-learning-objectives(@tutor-book-ap-bio-primary);
+  .tutor-book-theme-learning-objectives(@tutor-book-ap-bio-accent);
+  .tutor-book-theme-related-content(@tutor-book-ap-bio-primary);
   .tutor-book-theme-splash-image(@tutor-book-ap-bio-primary);
   .tutor-book-theme-note(@tutor-book-ap-bio-primary; @tutor-book-text-on-dark-labels);
   .tutor-book-theme-note-borders(@tutor-book-text-on-dark-labels);
@@ -72,7 +76,8 @@
 
   .tutor-book-theme-first-letter(@tutor-book-intro-sociology-primary);
   .tutor-book-theme-typography(@tutor-book-intro-sociology-secondary);
-  .tutor-book-theme-learning-objectives(@tutor-book-intro-sociology-primary; @tutor-book-intro-sociology-secondary);
+  .tutor-book-theme-learning-objectives(@tutor-book-intro-sociology-accent; @tutor-book-intro-sociology-secondary);
+  .tutor-book-theme-related-content(@tutor-book-intro-sociology-primary; @tutor-book-intro-sociology-secondary);
   .tutor-book-theme-splash-image(@tutor-book-intro-sociology-primary; @tutor-book-intro-sociology-secondary);
   .tutor-book-theme-note(@tutor-book-intro-sociology-primary; @tutor-book-intro-sociology-secondary);
   .tutor-book-theme-note-borders(@tutor-book-text-on-dark-labels);

--- a/tutor/resources/styles/book-content/index.less
+++ b/tutor/resources/styles/book-content/index.less
@@ -44,7 +44,7 @@
 
   .tutor-book-theme-first-letter(@tutor-book-hs-physics-secondary);
   .tutor-book-theme-typography(@tutor-book-hs-physics-primary);
-  .tutor-book-theme-learning-objectives(@tutor-book-hs-physics-accent; rgba(255,255,255,.8));
+  .tutor-book-theme-learning-objectives(@tutor-book-hs-physics-primary; @tutor-book-hs-physics-accent; rgba(255,255,255,.8));
   .tutor-book-theme-related-content(@tutor-book-hs-physics-primary);
   .tutor-book-theme-splash-image(@tutor-book-hs-physics-primary);
   .tutor-book-theme-note(@tutor-book-hs-physics-primary; @tutor-book-hs-physics-secondary);
@@ -60,7 +60,7 @@
 
   .tutor-book-theme-first-letter(@tutor-book-ap-bio-secondary);
   .tutor-book-theme-typography(@tutor-book-ap-bio-primary);
-  .tutor-book-theme-learning-objectives(@tutor-book-ap-bio-accent);
+  .tutor-book-theme-learning-objectives(@tutor-book-ap-bio-primary; @tutor-book-ap-bio-accent);
   .tutor-book-theme-related-content(@tutor-book-ap-bio-primary);
   .tutor-book-theme-splash-image(@tutor-book-ap-bio-primary);
   .tutor-book-theme-note(@tutor-book-ap-bio-primary; @tutor-book-text-on-dark-labels);
@@ -76,7 +76,7 @@
 
   .tutor-book-theme-first-letter(@tutor-book-intro-sociology-primary);
   .tutor-book-theme-typography(@tutor-book-intro-sociology-secondary);
-  .tutor-book-theme-learning-objectives(@tutor-book-intro-sociology-accent; @tutor-book-intro-sociology-secondary);
+  .tutor-book-theme-learning-objectives(@tutor-book-intro-sociology-primary; @tutor-book-intro-sociology-accent; @tutor-book-intro-sociology-secondary);
   .tutor-book-theme-related-content(@tutor-book-intro-sociology-primary; @tutor-book-intro-sociology-secondary);
   .tutor-book-theme-splash-image(@tutor-book-intro-sociology-primary; @tutor-book-intro-sociology-secondary);
   .tutor-book-theme-note(@tutor-book-intro-sociology-primary; @tutor-book-intro-sociology-secondary);

--- a/tutor/resources/styles/book-content/intro-sociology/variables.less
+++ b/tutor/resources/styles/book-content/intro-sociology/variables.less
@@ -1,5 +1,6 @@
 @tutor-book-intro-sociology-primary:  @openstax-book-intro_sociology-bg; // blue
 @tutor-book-intro-sociology-secondary:   @openstax-book-intro_sociology-fg; // green
+@tutor-book-intro-sociology-accent:   @openstax-book-intro_sociology-accent; // light-green
 @tutor-book-intro-sociology-tertiary:   rgb(119, 175, 65); // green
 @tutor-book-intro-sociology-quaternary: rgb(244, 208, 25); // yellow
 @tutor-book-intro-sociology-highlight: rgb(255, 255, 187); // pale yellow

--- a/tutor/resources/styles/book-content/learning-objectives.less
+++ b/tutor/resources/styles/book-content/learning-objectives.less
@@ -13,7 +13,7 @@
   .book-content-full-width();
   .flex-display(inline-flex);
   margin-top: -@tutor-card-body-padding-vertical;
-  padding: 10px 20px;
+  padding: @tutor-book-padding-vertical;
   border: none;
 
   &::before {
@@ -42,6 +42,7 @@
 
   &[data-is-intro=false] {
     margin-bottom: 3rem;
+    margin-top: -1rem;
   }
 
 

--- a/tutor/resources/styles/book-content/note.less
+++ b/tutor/resources/styles/book-content/note.less
@@ -106,16 +106,16 @@
   @except-teacher-rules: @tutor-empty-rules;
   @except-teacher-title-rules: @tutor-empty-rules
 ) {
-  > .note,
+  .book-content > .note,
   section > section > .note,
-  > section > .note:not(.learning-objectives),
+  .book-content > section > .note:not(.learning-objectives),
 
   .grasp-check,
 
-  > [data-element-type="check-understanding"],
+  .book-content > [data-element-type="check-understanding"],
   section > [data-element-type="check-understanding"],
 
-  > .example,
+  .book-content > .example,
   section > .example {
     .tutor-style-note(@all-note-rules; @title-rules);
 
@@ -162,7 +162,7 @@
   }
 
   // .example, check-understanding content currently lacks a data-label attribute
-  > .example,
+  .book-content > .example,
   section > .example {
     .tutor-book-before-manual-label("Worked Example");
   }

--- a/tutor/resources/styles/book-content/questions.less
+++ b/tutor/resources/styles/book-content/questions.less
@@ -13,7 +13,7 @@ section {
 };
 
 .exercise[data-type=exercise]:not(.unnumbered) {
-  >[data-type=problem] {
+  > [data-type=problem] {
     > p {
       margin: 0;
 
@@ -46,6 +46,12 @@ section {
       }
     }
 
+  }
+
+  &[data-element-type$=quiz] {
+    > [data-type=problem] + [data-type=solution] {
+      display: none;
+    }    
   }
 }
 

--- a/tutor/resources/styles/book-content/related-content.less
+++ b/tutor/resources/styles/book-content/related-content.less
@@ -1,0 +1,13 @@
+.related-content {
+  font-weight: bold;
+  padding: 2rem 0;
+  .printer-safe(inline-flex, inherit, inherit, 10px);
+
+  &[data-has-learning-objectives=true] {
+    .book-content-full-width();
+    .flex-display(inline-flex);
+    margin-top: -@tutor-card-body-padding-vertical;
+    padding: 3rem;
+    font-size: 2.4rem;
+  }
+}

--- a/tutor/resources/styles/book-content/theming-mixins.less
+++ b/tutor/resources/styles/book-content/theming-mixins.less
@@ -1,4 +1,4 @@
-.tutor-book-theme-learning-objectives(@theme-primary: @tutor-book-primary; @text-color: @tutor-book-text-on-dark-labels) {
+.tutor-book-theme-learning-objectives(@theme-primary: @tutor-book-accent; @text-color: @tutor-book-text-on-dark-labels) {
   .learning-objectives,
   [data-type=abstract] {
     background: @theme-primary;
@@ -12,7 +12,13 @@
       border-left-color: fade(@text-color, 40%);
     }
   }
+}
 
+.tutor-book-theme-related-content(@theme-primary: @tutor-book-primary; @text-color: @tutor-book-text-on-dark-labels) {
+  .related-content[data-has-learning-objectives=true] {
+    background: @theme-primary;
+    color: @text-color;
+  }
 }
 
 .tutor-book-theme-note(@label-background: @tutor-book-primary; @label-text: @tutor-book-text-on-dark-labels) {

--- a/tutor/resources/styles/book-content/theming-mixins.less
+++ b/tutor/resources/styles/book-content/theming-mixins.less
@@ -1,4 +1,4 @@
-.tutor-book-theme-learning-objectives(@theme-primary: @tutor-book-accent; @text-color: @tutor-book-text-on-dark-labels) {
+.tutor-book-theme-learning-objectives(@theme-primary: @tutor-book-primary; @theme-accent: @tutor-book-accent; @text-color: @tutor-book-text-on-dark-labels) {
   .learning-objectives,
   [data-type=abstract] {
     background: @theme-primary;
@@ -10,6 +10,13 @@
 
     ul {
       border-left-color: fade(@text-color, 40%);
+    }
+  }
+
+  .related-content[data-has-learning-objectives=true] + .book-content {
+    .learning-objectives,
+    [data-type=abstract] {
+      background: @theme-accent;
     }
   }
 }

--- a/tutor/resources/styles/book-content/variables.less
+++ b/tutor/resources/styles/book-content/variables.less
@@ -7,6 +7,7 @@
 @tutor-book-tertiary: @tutor-tertiary;  // dark blue
 @tutor-book-quaternary: @tutor-quaternary;  // yellow
 @tutor-book-highlight: @tutor-highlight;  // pale yellow
+@tutor-book-accent: lighten(@tutor-primary, 5%);  // orange
 
 // @tutor-book-white: @tutor-white;
 // @tutor-book-neutral-lightest: @tutor-neutral-lightest;

--- a/tutor/resources/styles/components/task/index.less
+++ b/tutor/resources/styles/components/task/index.less
@@ -7,7 +7,6 @@
 
   max-width: @tutor-task-width;
   margin: 0 auto;
-  position: relative;
 
   &.task-reading {
     max-width: inherit;

--- a/tutor/resources/styles/components/task/teacher-review-controls.less
+++ b/tutor/resources/styles/components/task/teacher-review-controls.less
@@ -1,7 +1,7 @@
 .task-teacher-review-controls {
-  position: absolute;
-  top: -2.5rem;
-  right: 0;
+  text-align: right;
+  margin-bottom: -3rem;
+  margin-top: -2rem;
 
   > * {
     display: inline-block;

--- a/tutor/resources/styles/variables/colors.less
+++ b/tutor/resources/styles/variables/colors.less
@@ -52,7 +52,7 @@
 
 @openstax-book-blue-accent: rgb(40, 55, 124);
 @openstax-book-green-accent: lighten(@openstax-book-green, 5%);
-@openstax-book-yellow-accent: lighten(@openstax-book-yellow, 5%);
+@openstax-book-yellow-accent: lighten(@openstax-book-yellow, 12%);
 @openstax-book-orange-accent: lighten(@openstax-book-orange, 5%);
 @openstax-book-gray-accent: lighten(@openstax-book-gray, 5%);
 @openstax-book-brighter-green-accent: lighten(@openstax-book-brighter-green, 5%);

--- a/tutor/resources/styles/variables/colors.less
+++ b/tutor/resources/styles/variables/colors.less
@@ -50,44 +50,63 @@
 @openstax-book-orange: @tutor-primary;
 @openstax-book-warmer-blue: rgb(0, 36, 106);
 
+@openstax-book-blue-accent: rgb(40, 55, 124);
+@openstax-book-green-accent: lighten(@openstax-book-green, 5%);
+@openstax-book-yellow-accent: lighten(@openstax-book-yellow, 5%);
+@openstax-book-orange-accent: lighten(@openstax-book-orange, 5%);
+@openstax-book-gray-accent: lighten(@openstax-book-gray, 5%);
+@openstax-book-brighter-green-accent: lighten(@openstax-book-brighter-green, 5%);
 
 @openstax-book-default-fg: @openstax-book-brighter-green;
 @openstax-book-default-bg: @openstax-book-gray;
+@openstax-book-default-accent: @openstax-book-gray-accent;
 
 // Physics
 @openstax-book-physics-fg: @openstax-book-green;
 @openstax-book-physics-bg: @openstax-book-blue;
+@openstax-book-physics-accent: @openstax-book-blue-accent;
 @openstax-book-hs_physics-fg: @openstax-book-green;
 @openstax-book-hs_physics-bg: @openstax-book-blue;
+@openstax-book-hs_physics-accent: @openstax-book-blue-accent;
 @openstax-book-college_physics-fg: @openstax-book-green;
 @openstax-book-college_physics-bg: @openstax-book-blue;
+@openstax-book-college_physics-accent: @openstax-book-blue-accent;
 
 // Biology
 @openstax-book-biology-fg: @openstax-book-gray;
 @openstax-book-biology-bg: @openstax-book-brighter-green;
+@openstax-book-biology-accent: @openstax-book-brighter-green-accent;
 @openstax-book-ap_biology-fg: @openstax-book-gray;
 @openstax-book-ap_biology-bg: @openstax-book-brighter-green;
+@openstax-book-ap_biology-accent: @openstax-book-brighter-green-accent;
 @openstax-book-college_biology-fg: @openstax-book-gray;
 @openstax-book-college_biology-bg: @openstax-book-brighter-green;
+@openstax-book-college_biology-accent: @openstax-book-brighter-green-accent;
 
 @openstax-book-concepts_biology-fg: @openstax-book-yellow;
 @openstax-book-concepts_biology-bg: @openstax-book-orange;
+@openstax-book-concepts_biology-accent: @openstax-book-orange-accent;
 
 // Social Sciences
 @openstax-book-principles_economics-fg: @openstax-book-gray;
 @openstax-book-principles_economics-bg: @openstax-book-white;
+@openstax-book-principles_economics-accent: @openstax-book-white;
 
 @openstax-book-macro_economics-fg: @openstax-book-brighter-green;
 @openstax-book-macro_economics-bg: @openstax-book-gray;
+@openstax-book-macro_economics-accent: @openstax-book-gray-accent;
 
 @openstax-book-micro_economics-fg: @openstax-book-yellow;
 @openstax-book-micro_economics-bg: @openstax-book-gray;
+@openstax-book-micro_economics-accent: @openstax-book-gray-accent;
 
 @openstax-book-intro_sociology-fg: @openstax-book-warmer-blue;
 @openstax-book-intro_sociology-bg: @openstax-book-yellow;
+@openstax-book-intro_sociology-accent: @openstax-book-yellow-accent;
 
 @openstax-book-anatomy_physiology-fg: @openstax-book-orange;
 @openstax-book-anatomy_physiology-bg: @openstax-book-gray;
+@openstax-book-anatomy_physiology-accent: @openstax-book-gray-accent;
 
 // NOTE: Make borders and input background colors one of the above grays with a high opacity so it works on
 //       multiple backgrounds.

--- a/tutor/src/components/reference-book/page.cjsx
+++ b/tutor/src/components/reference-book/page.cjsx
@@ -8,6 +8,7 @@ classnames = require 'classnames'
 {ArbitraryHtmlAndMath, GetPositionMixin} = require 'shared'
 
 {ReferenceBookExerciseShell} = require './exercise'
+RelatedContent = require '../related-content'
 
 {ReferenceBookPageStore} = require '../../flux/reference-book-page'
 {ReferenceBookStore} = require '../../flux/reference-book'
@@ -64,10 +65,17 @@ module.exports = React.createClass
       .replace(/^[\s\S]*<body[\s\S]*?>/, '')
       .replace(/<\/body>[\s\S]*$/, '')
 
+    related =
+      chapter_section: @props.section
+      title: @getSplashTitle()
+
     <div className={classnames('page-wrapper', @props.className)}>
       {@props.children}
+      <div className='page center-panel'>
+        <RelatedContent contentId={cnxId} {...related} />
 
-      <ArbitraryHtmlAndMath className='page center-panel' block html={html} />
+        <ArbitraryHtmlAndMath className='book-content' block html={html} />
+      </div>
 
       <SpyMode.Content className="ecosystem-info">
         PageId: {@props.cnxId}, Ecosystem: {page?.spy}

--- a/tutor/src/components/related-content.cjsx
+++ b/tutor/src/components/related-content.cjsx
@@ -1,0 +1,40 @@
+React    = require 'react'
+_ = require 'underscore'
+
+{ChapterSectionMixin} = require 'shared'
+
+{StepTitleStore} = require '../flux/step-title'
+
+RelatedContent = React.createClass
+
+  propTypes:
+    contentId: React.PropTypes.string.isRequired
+    title: React.PropTypes.string.isRequired
+    chapter_section: React.PropTypes.array.isRequired
+
+  mixins: [ChapterSectionMixin]
+
+  isIntro: ->
+    (_.isArray(@props.chapter_section) and
+      (@props.chapter_section.length is 1 or
+      @props.chapter_section[1] is 0)) or
+      (_.isString(@props.chapter_section) and 
+      @props.chapter_section.indexOf('.') is -1)
+
+  render: ->
+    {title, contentId, chapter_section} = @props
+
+    return null if _.isEmpty(title) or @isIntro()
+
+    section = @sectionFormat(chapter_section)
+
+    <h4
+      className='related-content'
+      data-has-learning-objectives={StepTitleStore.hasLearningObjectives(contentId)}>
+      <span className="part">
+        <span className="section">{section} </span>
+        <span className="title">{title}</span>
+      </span>
+    </h4>
+
+module.exports = RelatedContent

--- a/tutor/src/components/related-content.cjsx
+++ b/tutor/src/components/related-content.cjsx
@@ -10,7 +10,10 @@ RelatedContent = React.createClass
   propTypes:
     contentId: React.PropTypes.string.isRequired
     title: React.PropTypes.string.isRequired
-    chapter_section: React.PropTypes.array.isRequired
+    chapter_section: React.PropTypes.oneOfType([
+      React.PropTypes.array
+      React.PropTypes.string
+    ]).isRequired
 
   mixins: [ChapterSectionMixin]
 
@@ -30,7 +33,8 @@ RelatedContent = React.createClass
 
     <h4
       className='related-content'
-      data-has-learning-objectives={StepTitleStore.hasLearningObjectives(contentId)}>
+      data-has-learning-objectives={StepTitleStore.hasLearningObjectives(contentId)}
+    >
       <span className="part">
         <span className="section">{section} </span>
         <span className="title">{title}</span>

--- a/tutor/src/components/task-step/step-with-reading-content.cjsx
+++ b/tutor/src/components/task-step/step-with-reading-content.cjsx
@@ -3,7 +3,7 @@ React = require 'react'
 {TaskStepStore} = require '../../flux/task-step'
 {ArbitraryHtmlAndMath, ChapterSectionMixin} = require 'shared'
 {BookContentMixin, LinkContentMixin} = require '../book-content-mixin'
-RelatedContentLink = require '../related-content-link'
+RelatedContent = require '../related-content'
 
 # TODO: will combine with below, after BookContentMixin clean up
 ReadingStepContent = React.createClass
@@ -27,16 +27,20 @@ ReadingStepContent = React.createClass
   shouldOpenNewTab: -> true
   render: ->
     {id, courseDataProps, stepType} = @props
+
     {content_html, related_content} = TaskStepStore.get(id)
     {courseId} = @context.router.getCurrentParams()
 
     <div className="#{stepType}-step">
-      <ArbitraryHtmlAndMath
-        {...courseDataProps}
+      <div
         className="#{stepType}-content"
-        shouldExcludeFrame={@shouldExcludeFrame}
-        html={content_html} />
-      <RelatedContentLink courseId={courseId} content={related_content} />
+        {...courseDataProps}>
+        <RelatedContent contentId={id} {...related_content?[0]} />
+        <ArbitraryHtmlAndMath
+          className='book-content'
+          shouldExcludeFrame={@shouldExcludeFrame}
+          html={content_html} />
+      </div>
     </div>
 
 StepContent = React.createClass

--- a/tutor/src/components/task-step/step-with-reading-content.cjsx
+++ b/tutor/src/components/task-step/step-with-reading-content.cjsx
@@ -39,7 +39,8 @@ ReadingStepContent = React.createClass
         <ArbitraryHtmlAndMath
           className='book-content'
           shouldExcludeFrame={@shouldExcludeFrame}
-          html={content_html} />
+          html={content_html}
+        />
       </div>
     </div>
 
@@ -62,7 +63,8 @@ StepContent = React.createClass
       <ArbitraryHtmlAndMath
         className={"#{stepType}-content"}
         html={content_html}
-        shouldExcludeFrame={@shouldExcludeFrame} />
+        shouldExcludeFrame={@shouldExcludeFrame}
+      />
     </div>
 
 

--- a/tutor/src/components/task/progress/milestones.cjsx
+++ b/tutor/src/components/task/progress/milestones.cjsx
@@ -40,10 +40,12 @@ Milestone = React.createClass
     title = StepTitleStore.get(crumb.id)
 
     if crumb.type is 'reading' and crumb.related_content?[0]?.title?
+      relatedTitle = crumb.related_content[0].title
+
       if title is 'Summary'
-        title = "#{title} of #{crumb.related_content?[0]?.title}"
+        title = "#{title} of #{relatedTitle}"
       else if not title
-        title = crumb.related_content?[0]?.title
+        title = relatedTitle
 
     title
 
@@ -161,6 +163,7 @@ MilestonesWrapper = React.createClass
 
   render: ->
     {crumbs, currentStep} = @state
+    console.info(crumbs)
 
     stepButtons = _.map crumbs, (crumb, crumbIndex) =>
       <Milestone

--- a/tutor/src/components/task/progress/milestones.cjsx
+++ b/tutor/src/components/task/progress/milestones.cjsx
@@ -96,7 +96,8 @@ Milestone = React.createClass
         role='button'
         aria-label={previewText}
         onClick={goToStepForCrumb}
-        onKeyUp={_.partial(@handleKeyUp, stepIndex)}>
+        onKeyUp={_.partial(@handleKeyUp, stepIndex)}
+      >
         <BreadcrumbStatic
           crumb={crumb}
           data-label={crumb.label}
@@ -104,7 +105,8 @@ Milestone = React.createClass
           goToStep={goToStepForCrumb}
           stepIndex={stepIndex}
           key="breadcrumb-#{crumb.type}-#{stepIndex}"
-          ref="breadcrumb-#{crumb.type}-#{stepIndex}"/>
+          ref="breadcrumb-#{crumb.type}-#{stepIndex}"
+        />
         {preview}
       </div>
     </BS.Col>
@@ -163,7 +165,6 @@ MilestonesWrapper = React.createClass
 
   render: ->
     {crumbs, currentStep} = @state
-    console.info(crumbs)
 
     stepButtons = _.map crumbs, (crumb, crumbIndex) =>
       <Milestone
@@ -171,7 +172,8 @@ MilestonesWrapper = React.createClass
         crumb={crumb}
         goToStep={@goToStep}
         stepIndex={crumbIndex}
-        currentStep={currentStep}/>
+        currentStep={currentStep}
+      />
 
     classes = 'task-breadcrumbs'
 
@@ -196,7 +198,8 @@ Milestones = React.createClass
     <ReactCSSTransitionGroup
       transitionName='task-with-milestones'
       transitionAppearTimeout={0}
-      transitionAppear={true}>
+      transitionAppear={true}
+    >
       {milestones}
     </ReactCSSTransitionGroup>
 

--- a/tutor/src/flux/reference-book-page.coffee
+++ b/tutor/src/flux/reference-book-page.coffee
@@ -2,11 +2,13 @@
 _ = require 'underscore'
 
 {MediaActions} = require './media'
+{StepTitleActions} = require './step-title'
 
 ReferenceBookPageConfig = {
 
   _loaded: (obj, id) ->
     MediaActions.parse(obj.content_html)
+    StepTitleActions.parseMetaOnly(id, obj.content_html)
     obj
 
   loadSilent: (id) ->

--- a/tutor/src/flux/step-title.coffee
+++ b/tutor/src/flux/step-title.coffee
@@ -7,6 +7,11 @@ TEXT_LENGTH_CHECK = 110
 TEXT_LENGTH = 125
 TEXT_CHECK_RANGE = TEXT_LENGTH - TEXT_LENGTH_CHECK
 
+isLearningObjectives = (element) ->
+  (element?.attribs?['class']? and
+    element.attribs['class'].search(/learning-objectives/) > -1) or
+    element.attribs['data-type'] is 'abstract'
+
 isTypedClass = (element) ->
   element?.attribs?['class']? and
     element.attribs['class'].search(/learning-objectives|references|ap-connection/) > -1
@@ -67,13 +72,29 @@ getLengthFromTextOrMaths = (element) ->
 StepTitleConfig =
 
   _local: {}
+  _meta: {}
 
   loaded: (id, title) ->
     @_local[id] = title
     @emit("loaded.#{id}", title)
 
+  loadedMetaData: (contentId, metaData = {}) ->
+    metaData = _.extend({
+      hasLearningObjectives: false
+    }, metaData)
+
+    @_meta[contentId] = metaData
+
+  _parseMeta: (actions, contentId, error, dom) ->
+    learningObjectives = htmlparser.DomUtils.findOne(isLearningObjectives, dom, false)
+    meta =
+      hasLearningObjectives: learningObjectives?
+
+    actions.loadedMetaData(contentId, meta)
+
   _parseReading: (actions, id, error, dom) ->
     title = htmlparser.DomUtils.findOne(isTitle, dom, false)
+    meta = actions._parseMeta(actions, id, error, dom)
 
     if title?
       text = grabTitle(title)
@@ -112,6 +133,7 @@ StepTitleConfig =
       text = htmlparser.DomUtils.getOuterHTML(truncatedExercise)
 
     actions.loaded(id, text)
+    actions.loadedMetaData(id)
 
   parseReading: (id, htmlString) ->
     unless @_get(id)?
@@ -134,15 +156,25 @@ StepTitleConfig =
   parseSteps: (steps) ->
     _.each steps, @parseStep, @
 
+  parseMetaOnly: (contentId, htmlString) ->
+    unless @_meta[contentId]?
+      parseHandler = new htmlparser.DomHandler _.partial(@_parseMeta, @, contentId)
+      metaParser = new htmlparser.Parser(parseHandler)
+      metaParser.parseComplete(htmlString)
+
   _get: (id) ->
     @_local[id]
 
   reset: ->
     @_local = {}
+    @_meta = {}
 
   exports:
     get: (id) -> @_get(id)
     isLoaded: (id) -> @_get(id)?
+
+    hasLearningObjectives: (contentId) -> @_meta[contentId]?.hasLearningObjectives
+
 
 {actions, store} = makeSimpleStore(StepTitleConfig)
 module.exports = {StepTitleActions:actions, StepTitleStore:store}

--- a/tutor/src/flux/step-title.coffee
+++ b/tutor/src/flux/step-title.coffee
@@ -14,7 +14,7 @@ isLearningObjectives = (element) ->
 
 isTypedClass = (element) ->
   element?.attribs?['class']? and
-    element.attribs['class'].search(/learning-objectives|references|ap-connection/) > -1
+    element.attribs['class'].search(/learning-objectives|references|ap-connection|solution/) > -1
 
 isTipsForSuccess = (element) ->
   element?.attribs?['class']? and element.attribs['class'].search(/tips-for-success/) > -1

--- a/tutor/test/components/reference-book.spec.coffee
+++ b/tutor/test/components/reference-book.spec.coffee
@@ -73,7 +73,7 @@ describe 'Reference Book Component', ->
       .to.match(/1\.1/)
 
   it 'renders page html', ->
-    expect(@state.div.querySelector('.page').textContent)
+    expect(@state.div.querySelector('.book-content').textContent)
       .to.equal('A bunch of html')
 
   it 'toggles menu when navbar control is clicked', ->

--- a/tutor/test/components/related-content-link.spec.coffee
+++ b/tutor/test/components/related-content-link.spec.coffee
@@ -2,7 +2,7 @@
 React = require 'react/addons'
 RelatedContentLink = require '../../src/components/related-content-link'
 
-describe 'Relalated Content Link Component', ->
+describe 'Related Content Link Component', ->
 
   beforeEach ->
     @props =


### PR DESCRIPTION
https://trello.com/c/qd29BT5E/140-bug-section-title-does-not-show-anywhere-in-the-reading-content

# In Readings

![screen shot 2016-10-20 at 3 59 48 am](https://cloud.githubusercontent.com/assets/2483873/19553437/e8b69ec4-9679-11e6-90aa-d247b8866fc8.png)
![screen shot 2016-10-20 at 3 59 55 am](https://cloud.githubusercontent.com/assets/2483873/19553442/ea9d5c28-9679-11e6-96d0-40ba1bb38ec6.png)

# In reference view

![screen shot 2016-10-20 at 4 00 25 am](https://cloud.githubusercontent.com/assets/2483873/19553448/ee2a2d12-9679-11e6-987d-fa7b35ef4777.png)


# In other books

![screen shot 2016-10-20 at 2 19 43 pm](https://cloud.githubusercontent.com/assets/2483873/19574505/51f396ac-96d0-11e6-9875-271f3d0cc5d1.png)

![screen shot 2016-10-20 at 4 02 33 am](https://cloud.githubusercontent.com/assets/2483873/19553487/11248dd0-967a-11e6-8a92-d6ed0f409542.png)
