### PR TITLE
A preview mode for exercises

### DIFF
--- a/configs/test/jest.setup.coffee
+++ b/configs/test/jest.setup.coffee
@@ -4,6 +4,11 @@ sinonChai = require('sinon-chai')
 chai.use(sinonChai)
 isFunction = require('lodash/isFunction')
 
+global.enzyme = require 'enzyme'
+chaiEnzyme = require('chai-enzyme')
+chai.use(chaiEnzyme())
+
+
 # https://github.com/facebook/jest/issues/1730
 
 # Make sure chai and jasmine ".not" play nice together
@@ -28,7 +33,8 @@ global.expect = (actual) ->
 global.chia = chai
 global.sinon = sinon
 global.jasmineExpect = global.expect
-
+global.shallow = enzyme.shallow
+global.mount   = enzyme.mount
 global.expect = (actual) ->
   originalMatchers = global.jasmineExpect(actual)
   chaiMatchers = chai.expect(actual)

--- a/exercises/README.md
+++ b/exercises/README.md
@@ -3,25 +3,18 @@
 # Development Instructions
 
 ```sh
-npm install -g gulp
 npm install
-bower install
+npm run tdd
 ```
 
 To build a dist file:
 
 ```sh
-gulp dist
+npm run build exercises
 ```
 
 To run tests:
 
 ```sh
-npm test  # Or gulp test
-```
-
-To continuously run tests:
-
-```sh
-gulp tdd
+npm run test  # Or tdd command above
 ```

--- a/exercises/api/exercises/1.json
+++ b/exercises/api/exercises/1.json
@@ -48,9 +48,10 @@
         "lo:22-22-4",
         "filter-type:ap-test-prep"
     ],
-    "uid": "1@2",
-    "number": 1,
+    "uid": "2@2",
+    "number": 2,
     "version": 2,
+    "versions": [ 1, 2, 3, 4, 5 ],
     "editors": [],
     "authors": [
         {

--- a/exercises/resources/styles/app.less
+++ b/exercises/resources/styles/app.less
@@ -33,6 +33,7 @@
 @import "./exercise/preview";
 @import "./vocabulary";
 @import './tags';
+@import './preview';
 
 .editor-app {
   padding: 10px;

--- a/exercises/resources/styles/preview.less
+++ b/exercises/resources/styles/preview.less
@@ -1,0 +1,20 @@
+.preview-screen {
+
+  padding: 40px;
+}
+
+.preview-navbar-controls {
+  justify-content: center;
+
+  .paging-controls {
+    display: flex;
+    align-items: center;
+    span {
+      border-top: 1px solid;
+      border-bottom: 1px solid;
+      border-color: @btn-default-border;
+      padding: 6px 12px;
+
+    }
+  }
+}

--- a/exercises/specs/components/preview/controls.spec.cjsx
+++ b/exercises/specs/components/preview/controls.spec.cjsx
@@ -1,0 +1,54 @@
+{React, _} = require 'shared/specs/helpers'
+Location = require '../../../src/stores/location'
+
+
+EXERCISE = require '../../../api/exercises/1.json'
+{ExerciseActions} = require 'stores/exercise'
+
+PreviewControls = require '../../../src/components/preview/controls'
+
+describe 'Exercises component', ->
+
+  beforeEach ->
+    @props =
+      id: '1'
+      location: new Location
+    sinon.stub(@props.location, 'visitPreview')
+    ExerciseActions.loaded(EXERCISE, @props.id)
+
+  it 'renders', ->
+    wrapper = shallow(<PreviewControls {...@props} />)
+    expect(wrapper.find('span').text()).to.include('Viewing exercise 2@2')
+    undefined
+
+  it 'can move to next exercise', ->
+    wrapper = shallow(<PreviewControls {...@props} />)
+    next = wrapper.find('Button[title="Go to next exercise"]')
+    next.simulate('click')
+    expect(next).to.have.length(1)
+    expect(@props.location.visitPreview).to.have.been.calledWith('3')
+    undefined
+
+  it 'can move to prev exercise', ->
+    wrapper = shallow(<PreviewControls {...@props} />)
+    prev = wrapper.find('Button[title="Go to previous exercise"]')
+    expect(prev).to.have.length(1)
+    prev.simulate('click')
+    expect(@props.location.visitPreview).to.have.been.calledWith('1')
+    undefined
+
+  it 'can move to next version', ->
+    wrapper = shallow(<PreviewControls {...@props} />)
+    up = wrapper.find('Button[title="Go up a version"]')
+    expect(up).to.have.length(1)
+    up.simulate('click')
+    expect(@props.location.visitPreview).to.have.been.calledWith('2@3')
+    undefined
+
+  it 'can move to prev version', ->
+    wrapper = shallow(<PreviewControls {...@props} />)
+    down = wrapper.find('Button[title="Go down a version"]')
+    expect(down).to.have.length(1)
+    down.simulate('click')
+    expect(@props.location.visitPreview).to.have.been.calledWith('2@1')
+    undefined

--- a/exercises/src/components/app.cjsx
+++ b/exercises/src/components/app.cjsx
@@ -20,7 +20,7 @@ App = React.createClass
     location: new Location
 
   componentWillMount: ->
-    @props.location.startListening(@onHistoryChange)
+    @props.location.startListening(@onHistoryChange, @props.data.user)
     {view, id} = @props.location.getCurrentUrlParts()
     if id is 'new'
       @setState(newId: @createNewRecord(view))

--- a/exercises/src/components/app.cjsx
+++ b/exercises/src/components/app.cjsx
@@ -66,8 +66,7 @@ App = React.createClass
 
     return newId
 
-  onReset: (ev) ->
-    ev.preventDefault()
+  onSearch: ->
     @props.location.visitSearch()
 
   render: ->
@@ -80,8 +79,9 @@ App = React.createClass
     Body = NetworkActivity if store?.isLoading(id)
 
     guardProps =
-      onlyPromptIf: ->
+      onlyPromptIf: (ev) ->
         id and store?.isChanged(id)
+
       placement: 'right'
       message: "You will lose all unsaved changes"
 
@@ -100,10 +100,10 @@ App = React.createClass
             <BS.ButtonToolbar className="navbar-btn">
               {if view
                 <SuretyGuard
-                  onConfirm={@onReset}
+                  onConfirm={@onSearch}
                   {...guardProps}
                 >
-                  <a href="/exercises" className="btn btn-danger back">Back</a>
+                  <BS.Button className="btn btn-danger back">Search</BS.Button>
                 </SuretyGuard>}
 
               <SuretyGuard

--- a/exercises/src/components/exercise.cjsx
+++ b/exercises/src/components/exercise.cjsx
@@ -1,4 +1,3 @@
-# @csx React.DOM
 React = require 'react'
 _ = require 'underscore'
 BS = require 'react-bootstrap'

--- a/exercises/src/components/exercise/controls.cjsx
+++ b/exercises/src/components/exercise/controls.cjsx
@@ -36,6 +36,9 @@ ExerciseControls = React.createClass
    publishExercise: ->
      ExerciseActions.publish(@props.id)
 
+  onPreview: ->
+    @props.location.visitPreview(@props.id)
+
   render: ->
     {id} = @props
 
@@ -78,6 +81,7 @@ ExerciseControls = React.createClass
             </AsyncButton>
           </SuretyGuard>
         }
+        <BS.Button bsStyle='info' onClick={@onPreview}>Preview Only</BS.Button>
       </BS.ButtonToolbar>
       <div className="right-side">
         <MPQToggle exerciseId={@props.id} />

--- a/exercises/src/components/preview.cjsx
+++ b/exercises/src/components/preview.cjsx
@@ -1,0 +1,23 @@
+React = require 'react'
+_ = require 'underscore'
+BS = require 'react-bootstrap'
+
+ExercisePreview = require 'components/exercise/preview'
+{ExerciseActions, ExerciseStore} = require 'stores/exercise'
+
+
+Preview = React.createClass
+  propTypes:
+    id:   React.PropTypes.string
+    location: React.PropTypes.object
+
+  render: ->
+    exercise = ExerciseStore.get(@props.id)
+
+    <div className="preview-screen">
+
+      <ExercisePreview exerciseId={@props.id} />
+    </div>
+
+
+module.exports = Preview

--- a/exercises/src/components/preview/controls.cjsx
+++ b/exercises/src/components/preview/controls.cjsx
@@ -1,0 +1,46 @@
+React = require 'react'
+_ = require 'underscore'
+BS = require 'react-bootstrap'
+
+{ExerciseActions, ExerciseStore} = require 'stores/exercise'
+
+PreviewControls = React.createClass
+  propTypes:
+    id:   React.PropTypes.string
+    location: React.PropTypes.object
+
+  goToVersion: (version, ev) ->
+    ev.preventDefault()
+    exercise = ExerciseStore.get(@props.id)
+    @props.location.visitPreview("#{exercise.number}@#{version}")
+
+
+  render: ->
+    exercise = ExerciseStore.get(@props.id)
+    return null unless exercise?
+
+    versions = _.sortBy(exercise.versions, parseInt)
+    # find the first version that's less than current
+    nextVersion = _.find(versions, (version) -> version > exercise.version)
+    prevVersion = _.find(versions.reverse(), (version) -> version < exercise.version)
+    console.log prevVersion, nextVersion, versions
+
+    <div className="preview-navbar-controls">
+
+      <BS.ButtonGroup className="paging-controls">
+        <BS.Button href="#"
+          onClick={_.partial(@goToVersion, prevVersion)}
+          disabled={not prevVersion}
+        >⇦</BS.Button>
+
+        <span>Viewing exercise {exercise?.uid}</span>
+
+        <BS.Button href="#"
+          onClick={_.partial(@goToVersion, nextVersion)}
+          disabled={not nextVersion}
+        >⇨</BS.Button>
+      </BS.ButtonGroup>
+
+    </div>
+
+module.exports = PreviewControls

--- a/exercises/src/components/preview/controls.cjsx
+++ b/exercises/src/components/preview/controls.cjsx
@@ -20,10 +20,9 @@ PreviewControls = React.createClass
     return null unless exercise?
 
     versions = _.sortBy(exercise.versions, parseInt)
-    # find the first version that's less than current
+
     nextVersion = _.find(versions, (version) -> version > exercise.version)
     prevVersion = _.find(versions.reverse(), (version) -> version < exercise.version)
-    console.log prevVersion, nextVersion, versions
 
     <div className="preview-navbar-controls">
 

--- a/exercises/src/components/preview/controls.cjsx
+++ b/exercises/src/components/preview/controls.cjsx
@@ -30,14 +30,14 @@ PreviewControls = React.createClass
         <BS.Button href="#"
           onClick={_.partial(@goToVersion, prevVersion)}
           disabled={not prevVersion}
-        >⇦</BS.Button>
+        >{if prevVersion then '⇦' else 'X' }</BS.Button>
 
         <span>Viewing exercise {exercise?.uid}</span>
 
         <BS.Button href="#"
           onClick={_.partial(@goToVersion, nextVersion)}
           disabled={not nextVersion}
-        >⇨</BS.Button>
+        >{if nextVersion then '⇨' else 'X'}</BS.Button>
       </BS.ButtonGroup>
 
     </div>

--- a/exercises/src/components/preview/controls.cjsx
+++ b/exercises/src/components/preview/controls.cjsx
@@ -1,43 +1,98 @@
 React = require 'react'
 _ = require 'underscore'
 BS = require 'react-bootstrap'
+keymaster = require 'keymaster'
 
 {ExerciseActions, ExerciseStore} = require 'stores/exercise'
+
+KEYBINDING_SCOPE = 'ex-preview'
 
 PreviewControls = React.createClass
   propTypes:
     id:   React.PropTypes.string
     location: React.PropTypes.object
 
-  goToVersion: (version, ev) ->
-    ev.preventDefault()
-    exercise = ExerciseStore.get(@props.id)
-    @props.location.visitPreview("#{exercise.number}@#{version}")
+  componentDidMount: ->
+    # left/right to go between exercises, and up/down to go between versions.
+    keymaster('up',    KEYBINDING_SCOPE, @goNextVersion)
+    keymaster('down',  KEYBINDING_SCOPE, @goPrevVersion)
+    keymaster('left',  KEYBINDING_SCOPE, @goPrevExercise)
+    keymaster('right', KEYBINDING_SCOPE, @goNextExercise)
+    keymaster.setScope(KEYBINDING_SCOPE)
 
+  disableKeys: ->
+    keymaster.deleteScope(KEYBINDING_SCOPE)
+
+  goNextExercise: ->
+    exercise = ExerciseStore.get(@props.id)
+    @props.location.visitPreview("#{exercise.number+1}")
+
+  goPrevExercise: ->
+    exercise = ExerciseStore.get(@props.id)
+    @props.location.visitPreview("#{exercise.number-1}")
+
+  goNextVersion: ->
+    exercise = ExerciseStore.get(@props.id)
+    version = @findNextVersion()
+    @props.location.visitPreview("#{exercise.number}@#{version}") if version?
+
+  goPrevVersion: ->
+    exercise = ExerciseStore.get(@props.id)
+    version = @findPrevVersion()
+    @props.location.visitPreview("#{exercise.number}@#{version}") if version?
+
+  findNextVersion: ->
+    exercise = ExerciseStore.get(@props.id)
+    return null unless exercise
+    versions = _.sortBy(exercise.versions, _.partial(parseInt, _, 10))
+    _.find(versions, (version) -> version > exercise.version)
+
+  findPrevVersion: ->
+    exercise = ExerciseStore.get(@props.id)
+    return null unless exercise
+    versions = _.sortBy(exercise.versions, _.partial(parseInt, _, 10)).reverse()
+    _.find(versions, (version) -> version < exercise.version)
 
   render: ->
     exercise = ExerciseStore.get(@props.id)
     return null unless exercise?
 
-    versions = _.sortBy(exercise.versions, parseInt)
+    nextVersion = @findNextVersion()
+    prevVersion = @findPrevVersion()
 
-    nextVersion = _.find(versions, (version) -> version > exercise.version)
-    prevVersion = _.find(versions.reverse(), (version) -> version < exercise.version)
+    # left/right to go between exercises, and up/down to go between versions.
 
     <div className="preview-navbar-controls">
 
       <BS.ButtonGroup className="paging-controls">
+
         <BS.Button href="#"
-          onClick={_.partial(@goToVersion, prevVersion)}
+          onClick={@goPrevExercise}
+          title="Go to previous exercise"
+          disabled={exercise.number is 1}
+        >{if exercise.number is 1 then '◅' else '◀' }</BS.Button>
+
+        <BS.Button href="#"
+          onClick={@goPrevVersion}
           disabled={not prevVersion}
-        >{if prevVersion then '⇦' else 'X' }</BS.Button>
+          title="Go down a version"
+        >
+          {if prevVersion then '▼' else '▽' }
+        </BS.Button>
 
         <span>Viewing exercise {exercise?.uid}</span>
 
         <BS.Button href="#"
-          onClick={_.partial(@goToVersion, nextVersion)}
+          onClick={@goNextVersion}
           disabled={not nextVersion}
-        >{if nextVersion then '⇨' else 'X'}</BS.Button>
+          title="Go up a version"
+        >{if nextVersion then '▲' else '△'}</BS.Button>
+
+        <BS.Button href="#"
+          onClick={@goNextExercise}
+          title="Go to next exercise"
+        >►</BS.Button>
+
       </BS.ButtonGroup>
 
     </div>

--- a/exercises/src/components/search.cjsx
+++ b/exercises/src/components/search.cjsx
@@ -34,7 +34,6 @@ Search = React.createClass
     @updateLoading(exerciseId)
     ExerciseStore.once 'loaded', =>
       @props.location.onRecordLoad('exercises', exerciseId, ExerciseStore) if ExerciseStore.get(exerciseId)
-
     ExerciseActions.load(exerciseId)
 
   onFindExercise: ->
@@ -51,10 +50,23 @@ Search = React.createClass
       else
         @updateLoading(@refs.exerciseId.value)
 
+  clearError: ->
+    @setState(error: null)
+
+  Errors: ->
+    return null unless @state.error
+    <BS.Alert bsStyle="danger" onDismiss={@clearError}>
+      <p>{@state.error}</p>
+    </BS.Alert>
+
   render: ->
     <div className="search">
       {<NetworkActivity /> if ExerciseStore.isLoading(@state.loading) }
+<<<<<<< f35db2e2cf11c149bad08a15edd7b829c0d1d706
       {<h3>Search is empty, please type an exercise ID into the input.</h3> if @state.showEmptyWarning}
+=======
+      <@Errors />
+>>>>>>> display error message when exercise id is blank
       {<RecordNotFound
         recordType="Exercise" id={@state.loading}
         /> if ExerciseStore.isFailed(@state.loading)}

--- a/exercises/src/components/search.cjsx
+++ b/exercises/src/components/search.cjsx
@@ -62,11 +62,8 @@ Search = React.createClass
   render: ->
     <div className="search">
       {<NetworkActivity /> if ExerciseStore.isLoading(@state.loading) }
-<<<<<<< f35db2e2cf11c149bad08a15edd7b829c0d1d706
       {<h3>Search is empty, please type an exercise ID into the input.</h3> if @state.showEmptyWarning}
-=======
       <@Errors />
->>>>>>> display error message when exercise id is blank
       {<RecordNotFound
         recordType="Exercise" id={@state.loading}
         /> if ExerciseStore.isFailed(@state.loading)}

--- a/exercises/src/stores/exercise.coffee
+++ b/exercises/src/stores/exercise.coffee
@@ -1,4 +1,6 @@
 _ = require 'underscore'
+find = require 'lodash/find'
+map = require 'lodash/map'
 flux = require 'flux-react'
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
 {QuestionActions, QuestionStore} = require './question'
@@ -23,7 +25,7 @@ ExerciseConfig = {
   updateStimulus: (id, stimulus_html) -> @_change(id, {stimulus_html})
 
   sync: (id) ->
-    questions = _.map @_local[id].questions, (question) ->
+    questions = map @_local[id].questions, (question) ->
       QuestionActions.syncAnswers(question.id)
       QuestionStore.get(question.id)
     @_change(id, {questions})
@@ -167,6 +169,10 @@ ExerciseConfig = {
       tags: []
       stimulus_html:"",
       questions:[_.extend({}, QuestionStore.getTemplate(), {id: questionId})]
+
+    canEdit: (id, user) ->
+      exercise = @_get(id)
+      !!find( exercise.authors, user_id: user.id )
 
     validate: (id) ->
       return {valid: false, part: 'exercise'} unless @_local[id]

--- a/exercises/src/stores/vocabulary.coffee
+++ b/exercises/src/stores/vocabulary.coffee
@@ -86,6 +86,10 @@ VocabularyConfig = {
         not @exports.isPublishing.call(@, id) and
         not @_get(id)?.published_at
 
+    canEdit: (id, user) ->
+      exercise = @_get(id)
+      !!find( exercise.authors, user_id: user.id )
+
     validate: (id) ->
       return {valid: false, part: 'vocab'} unless @_get(id)
       valid: true

--- a/tutor/specs/components/course-calendar/add-assignment-menu.spec.cjsx
+++ b/tutor/specs/components/course-calendar/add-assignment-menu.spec.cjsx
@@ -1,4 +1,4 @@
-{React, shallow, sinon} = require '../helpers/component-testing'
+{React} = require '../helpers/component-testing'
 
 AddAssignmentMenu = require '../../../src/components/course-calendar/add-assignment-menu'
 

--- a/tutor/specs/components/course-calendar/header.spec.cjsx
+++ b/tutor/specs/components/course-calendar/header.spec.cjsx
@@ -1,4 +1,4 @@
-{React, shallow, sinon} = require '../helpers/component-testing'
+{React} = require '../helpers/component-testing'
 
 Header = require '../../../src/components/course-calendar/header'
 moment = require 'moment'

--- a/tutor/specs/components/course_settings/roster.spec.coffee
+++ b/tutor/specs/components/course_settings/roster.spec.coffee
@@ -1,4 +1,4 @@
-{Testing, expect, sinon, _, ReactTestUtils} = require '../helpers/component-testing'
+{Testing, sinon, _, ReactTestUtils} = require '../helpers/component-testing'
 ld = require 'lodash'
 Roster = require '../../../src/components/course-settings/roster'
 

--- a/tutor/specs/components/course_settings/undrop-student.spec.coffee
+++ b/tutor/specs/components/course_settings/undrop-student.spec.coffee
@@ -1,4 +1,4 @@
-{Testing, expect, sinon, _, ReactTestUtils} = require '../helpers/component-testing'
+{Testing, sinon, _, ReactTestUtils} = require '../helpers/component-testing'
 {Promise}      = require 'es6-promise'
 ld = require 'lodash'
 

--- a/tutor/specs/components/helpers/component-testing.coffee
+++ b/tutor/specs/components/helpers/component-testing.coffee
@@ -5,9 +5,6 @@ React = require 'react'
 ReactDOM = require 'react-dom'
 ReactTestUtils  = require 'react-addons-test-utils'
 { spyOnComponentMethod, stubComponentMethod } = require 'sinon-spy-react'
-enzyme = require 'enzyme'
-chaiEnzyme = require('chai-enzyme')
-chai.use(chaiEnzyme())
 
 # No longer exists, needs further investigation if we're using it
 # ReactContext   = require('react/lib/ReactContext')
@@ -18,7 +15,6 @@ chai.use(chaiEnzyme())
 {commonActions} = require './utilities'
 sandbox = null
 Sinon = {}
-
 
 ROUTER = null
 CURRENT_ROUTER_PARAMS = null
@@ -105,8 +101,7 @@ pause = (scope) ->
 
 
 module.exports = {
-  Testing, expect, sinon, React, _, ReactTestUtils,
+  Testing, sinon, React, _, ReactTestUtils,
   spyOnComponentMethod, stubComponentMethod,
-  shallow: enzyme.shallow, mount: enzyme.mount,
   pause
 }

--- a/tutor/specs/components/icon.spec.cjsx
+++ b/tutor/specs/components/icon.spec.cjsx
@@ -1,4 +1,4 @@
-{Testing, expect, sinon, _, ReactTestUtils} = require './helpers/component-testing'
+{Testing, sinon, _, ReactTestUtils} = require './helpers/component-testing'
 React = require 'react'
 Icon = require '../../src/components/icon'
 

--- a/tutor/specs/components/name.spec.coffee
+++ b/tutor/specs/components/name.spec.coffee
@@ -1,4 +1,4 @@
-{Testing, expect, _} = require './helpers/component-testing'
+{Testing, _} = require './helpers/component-testing'
 
 Name = require '../../src/components/name'
 

--- a/tutor/specs/components/navbar/account_link.spec.coffee
+++ b/tutor/specs/components/navbar/account_link.spec.coffee
@@ -1,4 +1,4 @@
-{Testing, expect, sinon, _} = require '../helpers/component-testing'
+{Testing, sinon, _} = require '../helpers/component-testing'
 
 Link = require '../../../src/components/navbar/account-link'
 USER = require '../../../api/user.json'

--- a/tutor/specs/components/navbar/user_actions_menu.spec.cjsx
+++ b/tutor/specs/components/navbar/user_actions_menu.spec.cjsx
@@ -1,4 +1,4 @@
-{React, Testing, expect, sinon, _} = require '../helpers/component-testing'
+{React, Testing, sinon, _} = require '../helpers/component-testing'
 
 { shallow } = require 'enzyme'
 

--- a/tutor/specs/components/new-course/build-course.spec.cjsx
+++ b/tutor/specs/components/new-course/build-course.spec.cjsx
@@ -1,4 +1,4 @@
-{React, sinon, pause, shallow} = require '../helpers/component-testing'
+{React, sinon, pause} = require '../helpers/component-testing'
 
 BuildCourse = require '../../../src/components/new-course/build-course'
 

--- a/tutor/specs/components/new-course/copy-ql.spec.cjsx
+++ b/tutor/specs/components/new-course/copy-ql.spec.cjsx
@@ -1,4 +1,4 @@
-{React, shallow} = require '../helpers/component-testing'
+{React} = require '../helpers/component-testing'
 
 CopyQL = require '../../../src/components/new-course/copy-ql'
 

--- a/tutor/specs/components/new-course/course-details.spec.cjsx
+++ b/tutor/specs/components/new-course/course-details.spec.cjsx
@@ -1,4 +1,4 @@
-{React, pause, mount} = require '../helpers/component-testing'
+{React, pause} = require '../helpers/component-testing'
 
 CourseDetails = require '../../../src/components/new-course/course-details'
 {CourseListingActions, CourseListingStore} = require '../../../src/flux/course-listing'

--- a/tutor/specs/components/new-course/index.spec.cjsx
+++ b/tutor/specs/components/new-course/index.spec.cjsx
@@ -1,4 +1,4 @@
-{React, _, sinon, shallow} = require '../helpers/component-testing'
+{React} = require '../helpers/component-testing'
 
 NewCourse = require '../../../src/components/new-course'
 

--- a/tutor/specs/components/new-course/select-course.spec.cjsx
+++ b/tutor/specs/components/new-course/select-course.spec.cjsx
@@ -1,4 +1,4 @@
-{React, sinon, shallow} = require '../helpers/component-testing'
+{React} = require '../helpers/component-testing'
 
 SelectCourse = require '../../../src/components/new-course/select-course'
 OFFERINGS = require '../../../api/offerings'

--- a/tutor/specs/components/new-course/select-dates.spec.cjsx
+++ b/tutor/specs/components/new-course/select-dates.spec.cjsx
@@ -1,4 +1,4 @@
-{React, sinon, shallow} = require '../helpers/component-testing'
+{React} = require '../helpers/component-testing'
 
 SelectDates = require '../../../src/components/new-course/select-dates'
 OFFERINGS = require '../../../api/offerings'

--- a/tutor/specs/components/new-course/select-type.spec.cjsx
+++ b/tutor/specs/components/new-course/select-type.spec.cjsx
@@ -1,4 +1,4 @@
-{React, spyOnComponentMethod, mount, pause} = require '../helpers/component-testing'
+{React, spyOnComponentMethod, pause} = require '../helpers/component-testing'
 
 SelectType = require '../../../src/components/new-course/select-type'
 {NewCourseStore} = require '../../../src/flux/new-course'

--- a/tutor/specs/components/new-course/wizard.spec.cjsx
+++ b/tutor/specs/components/new-course/wizard.spec.cjsx
@@ -1,9 +1,8 @@
-{React, Testing, expect, sinon, _, pause, spyOnComponentMethod} = require '../helpers/component-testing'
+{React, spyOnComponentMethod, pause} = require '../helpers/component-testing'
 
 Wizard = require '../../../src/components/new-course/wizard'
 SelectType = require '../../../src/components/new-course/select-type'
 SelectCourse = require '../../../src/components/new-course/select-course'
-{ mount } = require 'enzyme'
 
 # SnapShot = require 'react-test-renderer'
 

--- a/tutor/specs/components/scores/homework-cell.spec.coffee
+++ b/tutor/specs/components/scores/homework-cell.spec.coffee
@@ -1,4 +1,4 @@
-{Testing, expect, _} = require '../helpers/component-testing'
+{Testing, _} = require '../helpers/component-testing'
 
 {TimeActions, TimeStore} = require '../../../src/flux/time'
 

--- a/tutor/specs/components/scores/late-work.spec.coffee
+++ b/tutor/specs/components/scores/late-work.spec.coffee
@@ -1,4 +1,4 @@
-{Testing, expect, _} = require '../helpers/component-testing'
+{Testing, _} = require '../helpers/component-testing'
 
 {LateWorkPopover} = require '../../../src/components/scores/late-work'
 {ScoresStore, ScoresActions} = require '../../../src/flux/scores'

--- a/tutor/specs/components/scores/name-cell.spec.coffee
+++ b/tutor/specs/components/scores/name-cell.spec.coffee
@@ -1,4 +1,4 @@
-{Testing, expect, _} = require '../helpers/component-testing'
+{Testing, _} = require '../helpers/component-testing'
 
 {TimeActions, TimeStore} = require '../../../src/flux/time'
 

--- a/tutor/specs/components/scores/reading-cell.spec.coffee
+++ b/tutor/specs/components/scores/reading-cell.spec.coffee
@@ -1,4 +1,4 @@
-{Testing, expect, _} = require '../helpers/component-testing'
+{Testing, _} = require '../helpers/component-testing'
 
 {TimeActions, TimeStore} = require '../../../src/flux/time'
 

--- a/tutor/specs/components/scores/student-data-sorter.spec.coffee
+++ b/tutor/specs/components/scores/student-data-sorter.spec.coffee
@@ -1,4 +1,4 @@
-{Testing, expect, _} = require '../helpers/component-testing'
+{Testing, _} = require '../helpers/component-testing'
 
 StudentDataSorter = require '../../../src/components/scores/student-data-sorter'
 

--- a/tutor/specs/components/task-plan/builder/index.spec.coffee
+++ b/tutor/specs/components/task-plan/builder/index.spec.coffee
@@ -5,7 +5,7 @@ Builder = require '../../../../src/components/task-plan/builder'
 PlanMixin = require '../../../../src/components/task-plan/plan-mixin'
 {TaskPlanActions, TaskPlanStore} = require '../../../../src/flux/task-plan'
 {TaskingActions, TaskingStore} = require '../../../../src/flux/tasking'
-{Testing, sinon, expect, _, React} = require '../../helpers/component-testing'
+{Testing, sinon, _, React} = require '../../helpers/component-testing'
 {commonActions} = require '../../helpers/utilities'
 {ExtendBasePlan, PlanRenderHelper} = require '../../helpers/task-plan'
 

--- a/tutor/specs/components/task-plan/external-plan.spec.coffee
+++ b/tutor/specs/components/task-plan/external-plan.spec.coffee
@@ -9,7 +9,7 @@ TimeHelper = require '../../../src/helpers/time'
 
 {ExternalPlan} = require '../../../src/components/task-plan/external'
 
-{Testing, sinon, expect, _, React, ReactTestUtils} = require '../helpers/component-testing'
+{Testing, sinon, _, React, ReactTestUtils} = require '../helpers/component-testing'
 {ExtendBasePlan, PlanRenderHelper} = require '../helpers/task-plan'
 
 yesterday = moment(TimeStore.getNow()).subtract(1, 'day').format(TimeHelper.ISO_DATE_FORMAT)

--- a/tutor/specs/components/task-plan/footer.spec.coffee
+++ b/tutor/specs/components/task-plan/footer.spec.coffee
@@ -5,7 +5,7 @@ moment = require 'moment'
 {TimeActions, TimeStore} = require '../../../src/flux/time'
 
 PlanFooter = require '../../../src/components/task-plan/footer'
-{Testing, sinon, expect, _, React} = require '../helpers/component-testing'
+{Testing, sinon, _, React} = require '../helpers/component-testing'
 {ExtendBasePlan, PlanRenderHelper} = require '../helpers/task-plan'
 
 ISO_DATE_FORMAT = 'YYYY-MM-DD'

--- a/tutor/specs/components/task-plan/homework-plan.spec.coffee
+++ b/tutor/specs/components/task-plan/homework-plan.spec.coffee
@@ -9,7 +9,7 @@ TimeHelper = require '../../../src/helpers/time'
 
 {HomeworkPlan} = require '../../../src/components/task-plan/homework'
 
-{Testing, sinon, expect, _, React, ReactTestUtils} = require '../helpers/component-testing'
+{Testing, sinon, _, React, ReactTestUtils} = require '../helpers/component-testing'
 {ExtendBasePlan, PlanRenderHelper} = require '../helpers/task-plan'
 
 yesterday = moment(TimeStore.getNow()).subtract(1, 'day').format(TimeHelper.ISO_DATE_FORMAT)

--- a/tutor/specs/components/task-plan/homework/choose-exercises.spec.coffee
+++ b/tutor/specs/components/task-plan/homework/choose-exercises.spec.coffee
@@ -1,4 +1,4 @@
-{Testing, sinon, expect, _, React} = require '../../helpers/component-testing'
+{Testing, sinon, _, React} = require '../../helpers/component-testing'
 _ = require 'underscore'
 moment = require 'moment-timezone'
 

--- a/tutor/specs/components/task-plan/lms-info.spec.coffee
+++ b/tutor/specs/components/task-plan/lms-info.spec.coffee
@@ -1,4 +1,4 @@
-{Testing, expect, sinon, _, ReactTestUtils} = require '../helpers/component-testing'
+{Testing, sinon, _, ReactTestUtils} = require '../helpers/component-testing'
 
 
 LmsInfo = require '../../../src/components/task-plan/lms-info'

--- a/tutor/specs/components/task-plan/mini-editor/editor.spec.cjsx
+++ b/tutor/specs/components/task-plan/mini-editor/editor.spec.cjsx
@@ -1,4 +1,4 @@
-{React, _, sinon, shallow, mount} = require '../../helpers/component-testing'
+{React, _} = require '../../helpers/component-testing'
 
 MiniEditor = require '../../../../src/components/task-plan/mini-editor/editor'
 {CourseActions} = require '../../../../src/flux/course'

--- a/tutor/specs/components/task-plan/mini-editor/index.spec.cjsx
+++ b/tutor/specs/components/task-plan/mini-editor/index.spec.cjsx
@@ -1,4 +1,4 @@
-{React, _, sinon, shallow} = require '../../helpers/component-testing'
+{React, _} = require '../../helpers/component-testing'
 
 MiniEditor = require '../../../../src/components/task-plan/mini-editor'
 {CourseActions} = require '../../../../src/flux/course'

--- a/tutor/specs/components/task-plan/reading-plan.spec.coffee
+++ b/tutor/specs/components/task-plan/reading-plan.spec.coffee
@@ -9,7 +9,7 @@ TimeHelper = require '../../../src/helpers/time'
 
 {ReadingPlan} = require '../../../src/components/task-plan/reading'
 
-{Testing, sinon, expect, _, React} = require '../helpers/component-testing'
+{Testing, sinon, _, React} = require '../helpers/component-testing'
 {ExtendBasePlan, PlanRenderHelper} = require '../helpers/task-plan'
 
 yesterday = moment(TimeStore.getNow()).subtract(1, 'day').format(TimeHelper.ISO_DATE_FORMAT)

--- a/tutor/specs/components/unsaved-state.spec.coffee
+++ b/tutor/specs/components/unsaved-state.spec.coffee
@@ -1,4 +1,4 @@
-{Testing, sinon, expect, _, React} = require './helpers/component-testing'
+{Testing, sinon, _, React} = require './helpers/component-testing'
 
 {UnsavedStateMixin, TransitionAssistant} = require '../../src/components/unsaved-state'
 


### PR DESCRIPTION
This updates exercises to:
- Renames the "Back" button to "Search" 
- Adds a "view" screen with paging controls to switch between versions
- If an exercise is loaded by a user who is not the owner, the editor switches to "view" mode
- Adds a "preview" button to the editor for manually switching to "view" mode.

![screen shot 2016-11-03 at 1 07 57 pm](https://cloud.githubusercontent.com/assets/79566/19980227/3f03309c-a1cb-11e6-80b9-6525cd84ea12.png)
