### PR TITLE
Fix scores overall cell displaying NaN 

### DIFF
--- a/tutor/resources/styles/components/scores/table.less
+++ b/tutor/resources/styles/components/scores/table.less
@@ -203,9 +203,13 @@
       font-weight: 400;
     }
 
+    border-top:    @table-outer-border-width solid @table-outer-border-color;
     .average-label {
-      border-left: @table-outer-border-width solid @table-outer-border-color;
+      border-left:   @table-outer-border-width solid @table-outer-border-color;
       text-align: center;
+      .student-header {
+        border-bottom: @table-outer-border-width solid @table-outer-border-color;
+      }
 
       .help {
         font-style: italic;

--- a/tutor/src/components/scores/table.cjsx
+++ b/tutor/src/components/scores/table.cjsx
@@ -83,8 +83,8 @@ module.exports = React.createClass
     </div>
 
   OverallCell: (props) ->
-    avg = (props.data[props.rowIndex].average_score * 100).toFixed(0)
-    <Cell className="overall-cell">{avg}%</Cell>
+    avg = props.data[props.rowIndex].average_score or 0
+    <Cell className="overall-cell">{(avg * 100).toFixed(0)}%</Cell>
 
 
   NameCell: (props) ->


### PR DESCRIPTION
Avoid multiply by undefined, default average to 0.  Also adds missing border to top of names column

Before:
![screen shot 2016-11-07 at 2 53 35 pm](https://cloud.githubusercontent.com/assets/79566/20075504/05810db2-a4fa-11e6-88e5-5c927b30a44e.png)


After:

![screen shot 2016-11-07 at 2 53 01 pm](https://cloud.githubusercontent.com/assets/79566/20075505/05966d92-a4fa-11e6-8014-31ab44f7e9ec.png)

