### PR TITLE
Allow clicks to pass through navbar-overlay

### DIFF
--- a/tutor/resources/styles/global/navbar.less
+++ b/tutor/resources/styles/global/navbar.less
@@ -154,6 +154,7 @@
     position: absolute;
     top: 0;
     width: 100%;
+    pointer-events: none;
   }
   .center-control {
     align-items: baseline;
@@ -163,6 +164,7 @@
     background: @tutor-white;
     z-index: 1;
     box-shadow: 0 0 5px 10px @tutor-white;
+    pointer-events: auto;
 
     .fa-stack {
       height: 1.3em;

--- a/tutor/src/components/navbar/index.cjsx
+++ b/tutor/src/components/navbar/index.cjsx
@@ -58,15 +58,13 @@ module.exports = React.createClass
     params = Router.currentParams()
     {courseId} = params
 
-    brand = <TutorLink to='listing' className='navbar-brand'>
-              <i className='ui-brand-logo'></i>
-            </TutorLink>
-
     <BS.Navbar fixedTop fluid ref="navBar">
-      <CenterControls params={params} />
       <BS.Navbar.Brand>
-        {brand}
+        <TutorLink to='listing' className='navbar-brand'>
+          <i className='ui-brand-logo'></i>
+        </TutorLink>
       </BS.Navbar.Brand>
+      <CenterControls params={params} />
       <BS.Navbar.Collapse>
         <BS.Nav>
           <CourseName course={course}/>


### PR DESCRIPTION
Since it's 100% width it was intercepting clicks for the logo and course title.