### PR TITLE
Fix qa view menu; only redirect to first ecosystem if not present

### DIFF
--- a/tutor/src/components/qa/index.cjsx
+++ b/tutor/src/components/qa/index.cjsx
@@ -18,9 +18,10 @@ QADashboard = React.createClass
 
 
   componentWillMount: ->
-    unless EcosystemsStore.isLoading()
+    unless EcosystemsStore.isLoaded() or EcosystemsStore.isLoading()
       EcosystemsActions.load()
-      EcosystemsStore.once('loaded', @redirectToFirst)
+      unless @props.params?.ecosystemId?
+        EcosystemsStore.once('loaded', @redirectToFirst)
 
   redirectToFirst: ->
     ecosystemId = EcosystemsStore.first()?.id


### PR DESCRIPTION
Otherwise it'll just load the first section over and over