### PR TITLE
fix layout bugs when calendar is narrow

### DIFF
--- a/tutor/resources/styles/components/course-calendar/header.less
+++ b/tutor/resources/styles/components/course-calendar/header.less
@@ -3,8 +3,10 @@
 .list-task-plans {
 
   .calendar-header {
-    margin: 20px 0;
+    margin-top: 20px;
     background-color: @tutor-neutral-lighter;
+    .clearfix();
+    > * { margin-bottom: 20px; }
 
     .btn-default {
       background-color: @tutor-neutral-lightest;
@@ -30,8 +32,7 @@
     }
 
     .no-periods-text {
-      display: inline-block;
-      margin: 16px 0;
+      display: block;
     }
 
     &-actions {


### PR DESCRIPTION
Before:

<img width="760" alt="screen shot 2016-11-18 at 6 31 21 pm" src="https://cloud.githubusercontent.com/assets/79566/20451293/38fe160a-adbd-11e6-8338-df17a2c42958.png">


Now:

<img width="761" alt="screen shot 2016-11-18 at 6 30 46 pm" src="https://cloud.githubusercontent.com/assets/79566/20451296/3dd04fae-adbd-11e6-9227-7ddea253f5c6.png">
