### PR TITLE
Fix js error when course has no periods 

### DIFF
--- a/tutor/src/components/course-calendar/add-menu-mixin.cjsx
+++ b/tutor/src/components/course-calendar/add-menu-mixin.cjsx
@@ -89,6 +89,7 @@ CourseAddMenuMixin =
         text: linkText
         to: "/course/#{courseId}/settings"
         type: 'none'
+        query: {}
       }]
 
     renderLink = @renderMenuLink or @menuMixinRenderMenuLink

--- a/tutor/src/components/course-settings/no-archive-help.cjsx
+++ b/tutor/src/components/course-settings/no-archive-help.cjsx
@@ -18,7 +18,9 @@ NoArchiveHelp = React.createClass
       <h1>Hep</h1>
     </BS.Popover>
 
-  open:  -> @setState({showModal: true})
+  open:  (ev) ->
+    ev.preventDefault()
+    @setState({showModal: true})
   close: -> @setState({showModal: false})
 
   HelpModal: ->


### PR DESCRIPTION
Otherwise it causes an error when it attempts to dereference query

Also fixed bug where they help modal wouldn't display for the "Why Can't I Archive periods?" link.  