### PR TITLE
Display tooltip w/due-date for past plans in sidebar 

### DIFF
--- a/tutor/src/components/course-calendar/past-assignments.cjsx
+++ b/tutor/src/components/course-calendar/past-assignments.cjsx
@@ -4,6 +4,8 @@ classnames = require 'classnames'
 
 {CloneAssignmentLink} = require './task-dnd'
 
+TaskPlanHelper = require '../../helpers/task-plan'
+TimeHelper = require '../../helpers/time'
 isEmpty = require 'lodash/isEmpty'
 partial = require 'lodash/partial'
 
@@ -24,20 +26,42 @@ PastAssignments = React.createClass
     courseId: React.PropTypes.string.isRequired
     cloningPlanId: React.PropTypes.string
 
+  getInitialState: ->
+    tooltipTarget: null
+
+  offTaskHover: ->
+    @setState(tooltipTarget: null, hoveredPlan: null)
+
+  onTaskHover: (plan, ev) ->
+    @setState(tooltipTarget: ev.currentTarget, hoveredPlan: plan)
+
   render: ->
     plans = PastTaskPlansStore.get(@props.courseId) or []
     return null if isEmpty(plans)
 
     <div className={classnames('past-assignments', @props.className)}>
       <div className="section-label">Copied</div>
+
       <div className="plans">
         {for plan in plans
           <CloneAssignmentLink
+            onHover={partial(@onTaskHover, plan)}
+            offHover={@offTaskHover}
             key={plan.id}
             plan={plan}
             isEditing={plan.id is @props.cloningPlanId}
           />}
       </div>
+      <BS.Overlay
+        show={!!@state.tooltipTarget}
+        target={@state.tooltipTarget}
+        placement="right"
+      >
+        <BS.Popover id="task-original-due-date">
+          Orig. due date {TimeHelper.toISO(TaskPlanHelper.earliestDueDate(@state.hoveredPlan))}
+        </BS.Popover>
+      </BS.Overlay>
+
     </div>
 
 PastAssignmentsShell = React.createClass

--- a/tutor/src/components/course-calendar/plan.cjsx
+++ b/tutor/src/components/course-calendar/plan.cjsx
@@ -11,8 +11,7 @@ CoursePlanDetails = require './plan-details'
 CoursePlanLabel = require './plan-label'
 
 { CoursePlanDisplayEdit,
-  CoursePlanDisplayQuickLook,
-  CoursePlanDisplayMiniEditor} = require './plan-display'
+  CoursePlanDisplayQuickLook} = require './plan-display'
 
 {PlanPublishStore, PlanPublishActions} = require '../../flux/plan-publish'
 PlanHelper = require '../../helpers/plan'
@@ -199,9 +198,7 @@ CoursePlan = React.createClass
     labelProps = {rangeDuration, plan, index, offset, offsetFromPlanStart}
     label = <CoursePlanLabel {...labelProps} ref="label#{index}"/>
 
-    DisplayComponent = if plan.is_draft
-      CoursePlanDisplayMiniEditor
-    else if hasQuickLook
+    DisplayComponent = if hasQuickLook
       CoursePlanDisplayQuickLook
     else
       CoursePlanDisplayEdit

--- a/tutor/src/components/course-calendar/task-dnd.cjsx
+++ b/tutor/src/components/course-calendar/task-dnd.cjsx
@@ -21,9 +21,10 @@ NewTaskDrag =
     )
 
 CloneTaskDrag =
-  beginDrag: ({plan}) ->
+  beginDrag: ({plan, offHover}) ->
     # start loading task plan details as soon as it starts to drag
     # hopefully the load will have completed by the time it's dropped
+    offHover()
     unless TaskPlanStore.isLoaded(plan.id) or TaskPlanStore.isLoading(plan.id)
       TaskPlanActions.load(plan.id)
     plan
@@ -67,6 +68,8 @@ AddAssignmentLink = (props) ->
 CloneAssignmentLink = (props) ->
   props.connectDragSource(
     <div
+      onMouseEnter={props.onHover}
+      onMouseLeave={props.offHover}
       data-assignment-type={props.plan.type}
       className={classnames('task-plan',
         'is-dragging': props.isDragging
@@ -90,6 +93,5 @@ module.exports = {
   ),
   CloneAssignmentLink: DragSource(ItemTypes.CloneTask, CloneTaskDrag, DragInjector)(
     CloneAssignmentLink
-  ),
-
+  )
 }

--- a/tutor/src/components/new-course/wizard.cjsx
+++ b/tutor/src/components/new-course/wizard.cjsx
@@ -68,7 +68,6 @@ NewCourseWizard = React.createClass
 
   BackButton: ->
     return null if @state.currentStage is @state.firstStage
-    console.log @state.currentStage
     <BS.Button onClick={@onBack} className="back">
       Back
     </BS.Button>

--- a/tutor/src/helpers/task-plan.coffee
+++ b/tutor/src/helpers/task-plan.coffee
@@ -26,4 +26,9 @@ module.exports = {
         memo[tp.target_id] = pickFn(tp)
         memo
       , {})
+
+
+  earliestDueDate: (plan) ->
+    dates = _.map(plan?.tasking_plans, 'due_at')
+    _.first(dates.sort()) or ''
 }


### PR DESCRIPTION
And stop using mini editor for draft plans

<img width="472" alt="screen shot 2016-11-21 at 8 53 59 pm" src="https://cloud.githubusercontent.com/assets/79566/20509203/a96ee7f4-b02c-11e6-9fb8-579a42dcae3c.png">
