### PR TITLE
Set promises globally to fix timeout issues

### DIFF
--- a/configs/test/jest.setup.coffee
+++ b/configs/test/jest.setup.coffee
@@ -8,6 +8,7 @@ global.enzyme = require 'enzyme'
 chaiEnzyme = require('chai-enzyme')
 chai.use(chaiEnzyme())
 
+global.Promise = require.requireActual('es6-promise')
 
 # https://github.com/facebook/jest/issues/1730
 

--- a/configs/test/jest.setup.coffee
+++ b/configs/test/jest.setup.coffee
@@ -25,6 +25,9 @@ Object.defineProperty chai.Assertion.prototype, 'not',
 # Combine both jest and chai matchers on expect
 originalExpect = global.expect
 
+# bump up timeout to 5 seconds
+global.jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000
+
 global.expect = (actual) ->
   originalMatchers = originalExpect(actual)
   chaiMatchers = chai.expect(actual)

--- a/tutor/specs/components/scores/homework-cell.spec.cjsx
+++ b/tutor/specs/components/scores/homework-cell.spec.cjsx
@@ -28,17 +28,6 @@ describe 'Student Scores Homework Cell', ->
         completed_accepted_late_exercise_count: 0
         correct_accepted_late_exercise_count: 0
 
-  it 'renders score cell', ->
-    @props.task.completed_exercise_count = @props.task.exercise_count - 1
-    now = new Date
-    TimeActions.reset()
-    @props.due_at = moment(now).subtract(10, 'day')
-    expect(TH.isDue(@props.task)).to.eq(false)
-    wrapper = mount(<Cell {...@props} />)
-    expect(wrapper.find('.score a').text()).to.equal('---')
-    expect(wrapper.find('.late-caret')).to.have.length(0)
-    undefined
-
   it 'renders as completed', ->
     completedProps = _.extend({}, @props)
     completedProps.task.completed_on_time_exercise_count = @props.task.exercise_count


### PR DESCRIPTION
Per
https://facebook.github.io/jest/docs/troubleshooting.html#unresolved-promises,
this is most likely the cause of the random spec timeout's we've been having