### PR TITLE
Fix bug with displaying dialog more than once

### DIFF
--- a/shared/src/components/buttons/close-button.cjsx
+++ b/shared/src/components/buttons/close-button.cjsx
@@ -3,7 +3,12 @@ classnames = require 'classnames'
 
 OXLink = require '../../factories/link'
 
-module.exports = React.createClass
+CloseButton = (props) ->
   render: ->
-    classNames = classnames 'openstax-close-x', 'close', @props.className
-    <button {...OXLink.filterProps(@props)} className={classNames} aria-role='close'></button>
+    classNames = classnames 'openstax-close-x', 'close', props.className
+    <button
+      {...OXLink.filterProps(props)}
+      className={classNames} aria-role='close'
+    ></button>
+
+module.exports = CloseButton

--- a/tutor/specs/components/tutor-dialog.spec.cjsx
+++ b/tutor/specs/components/tutor-dialog.spec.cjsx
@@ -1,0 +1,23 @@
+{React, Testing} = require './helpers/component-testing'
+{Promise} = require 'es6-promise'
+
+TutorDialog = require '../../src/components/tutor-dialog'
+
+describe 'TutorDialog', ->
+
+  it 'can be shown multiple times', ->
+    promises = for i in [1..3]
+      new Promise( (resolve) ->
+        title = "dialog title #{i}"
+        body  = "dialog body #{i}"
+        TutorDialog.show({title, body}).then( ->
+          resolve()
+        )
+        dialogs = document.body.querySelectorAll(".tutor-dialog")
+        expect(dialogs).to.have.length(1)
+        el = document.body.querySelector(".tutor-dialog")
+        expect(el.querySelector('.modal-title').textContent).to.equal(title)
+        expect(el.querySelector('.modal-body').textContent).to.equal(body)
+        Testing.actions.click(document.body.querySelector('.tutor-dialog button.ok'))
+      )
+    Promise.all promises

--- a/tutor/src/components/tutor-dialog.cjsx
+++ b/tutor/src/components/tutor-dialog.cjsx
@@ -92,13 +92,14 @@ module.exports = TutorDialog = React.createClass
         props = _.extend(_.clone(props), {
           onOk, onCancel, show: true
         })
-        if @dialog
-          @dialog.replaceProps(props)
+        div = if @dialog
+          document.body.querySelector('.-tutor-dialog-parent')
         else
           div = document.body.appendChild( document.createElement('div') )
           div.className = '-tutor-dialog-parent'
-          @dialog = ReactDOM.render(React.createElement(DetachedTutorDialog, props), div)
+          div
 
+        @dialog = ReactDOM.render(React.createElement(DetachedTutorDialog, props), div)
         @dialog
 
     hide: ->


### PR DESCRIPTION
Believe this is the root cause of the various "task builder can't exit" bugs.  It was trying to display the "unsaved data" warning but was failing.