### PR TITLE
amendment to plan publish status fix, displays plan publishing status…

### DIFF
--- a/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -5,7 +5,7 @@ _ = require 'underscore'
 
 LoadableItem = require '../loadable-item'
 {TeacherTaskPlanStore, TeacherTaskPlanActions} = require '../../flux/teacher-task-plan'
-{TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
+{TaskPlanStore} = require '../../flux/task-plan'
 {CourseStore} = require '../../flux/course'
 {TimeStore} = require '../../flux/time'
 TimeHelper = require '../../helpers/time'
@@ -100,8 +100,15 @@ TeacherTaskPlanListing = React.createClass
     courseTimezone = CourseStore.getTimezone(courseId)
     TimeHelper.syncCourseTimezone(courseTimezone)
 
+    TaskPlanStore.on('publish-queued', @loadToListing)
+
   componentWillUnmount: ->
     TimeHelper.unsyncCourseTimezone()
+
+    TaskPlanStore.off('publish-queued', @loadToListing)
+
+  loadToListing: (plan) ->
+    TeacherTaskPlanActions.addPublishingPlan(plan, @props.params.courseId)
 
   getDateFromParams: ->
     {date} = @props.params

--- a/tutor/src/flux/plan-publish.coffee
+++ b/tutor/src/flux/plan-publish.coffee
@@ -1,9 +1,10 @@
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
-{JobListenerConfig} = require '../helpers/job'
+{JobListenerConfig, getJobIdFromJobUrl} = require '../helpers/job'
 
 getIds = (obj) ->
-  {publish_job, id} = obj
-  jobId = publish_job?.id or null
+  {publish_job, publish_job_url, id} = obj
+  jobId = publish_job?.id or (getJobIdFromJobUrl(publish_job_url) if publish_job_url?)
+
   {id, jobId}
 
 PlanPublishConfig =

--- a/tutor/src/flux/scores-export.coffee
+++ b/tutor/src/flux/scores-export.coffee
@@ -1,6 +1,6 @@
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
 {JobActions, JobStore} = require './job'
-{JobListenerConfig} = require '../helpers/job'
+{JobListenerConfig, getJobIdFromJobUrl} = require '../helpers/job'
 
 _ = require 'underscore'
 
@@ -8,15 +8,9 @@ ScoresExportConfig =
   _loaded: (obj, id) ->
     @emit('loaded', id)
 
-  getJobIdFromJobUrl: (jobUrl) ->
-    jobUrlSegments = jobUrl.split('/api/jobs/')
-    jobId = jobUrlSegments[1] if jobUrlSegments[1]?
-
-    jobId
-
   _getId: (obj, id) ->
     {job} = obj
-    jobId = @getJobIdFromJobUrl(job)
+    jobId = getJobIdFromJobUrl(job)
     {jobId, id}
 
   exports:

--- a/tutor/src/flux/task-plan.coffee
+++ b/tutor/src/flux/task-plan.coffee
@@ -229,7 +229,7 @@ TaskPlanConfig =
   _saved: (obj, id) ->
     if obj.is_publishing
       PlanPublishActions.queued(obj, id)
-      @emit('publish-queued', id)
+      @emit('publish-queued', obj)
     obj
 
   resetPlan: (id) ->

--- a/tutor/src/helpers/job.coffee
+++ b/tutor/src/helpers/job.coffee
@@ -12,6 +12,14 @@ JOB_KILLED = 'killed'
 JOB_UNKNOWN = 'unknown'
 JOB_NOT_FOUND = 404
 
+JOB_URL_BASE = '/api/jobs/'
+
+getJobIdFromJobUrl = (jobUrl) ->
+  jobUrlSegments = jobUrl.split(JOB_URL_BASE)
+  jobId = jobUrlSegments[1] if jobUrlSegments[1]?
+
+  jobId
+
 JobListenerConfig = (checkIntervals, checkRepeats) ->
   {
     _asyncStatus: {}
@@ -127,6 +135,6 @@ JobListenerConfig = (checkIntervals, checkRepeats) ->
         status is JOBBED
   }
 
-JobHelper = {JobListenerConfig}
+JobHelper = {JobListenerConfig, getJobIdFromJobUrl}
 
 module.exports = JobHelper

--- a/tutor/src/helpers/plan.coffee
+++ b/tutor/src/helpers/plan.coffee
@@ -20,9 +20,12 @@ PlanHelper =
     publishStatus = PlanPublishStore.getAsyncStatus(id)
     isPublishingInStore = PlanPublishStore.isPublishing(id)
 
-    if isPublishing and not isPublishingInStore and not PlanPublishStore.isPublished(id)
-      TaskPlanActions.load(plan.id)
-      PlanPublishStore.once("progress.#{id}.queued", _.partial(PlanHelper.startChecking, _, callback))
+    if isPublishing and
+      not isPublishingInStore and
+      not PlanPublishStore.isPublished(id) and
+      not jobId
+        TaskPlanActions.load(plan.id)
+        PlanPublishStore.once("progress.#{id}.queued", _.partial(PlanHelper.startChecking, _, callback))
 
     else if isPublishing or isPublishingInStore
 


### PR DESCRIPTION
… on calendar with much less delay

This is an improvement to #1428; while this is slightly gross with the url parsing, it removes the extra call to the plan api, and updates the plans list with the `POST` response from publishing instantaneously as opposed to on `GET` response from the full plans list load.  The user therefore experiences a quicker visual update of their publishing plan.