### PR TITLE
Only bind to 'step.completed' once

### DIFF
--- a/tutor/src/components/breadcrumb/index.cjsx
+++ b/tutor/src/components/breadcrumb/index.cjsx
@@ -78,8 +78,9 @@ BreadcrumbTaskDynamic = React.createClass
     stepId = crumb.id
     taskId = crumb.task.id
 
-    unless TaskStore.hasIncompleteCoreStepsIndexes(taskId)
-      TaskStepActions.loadPersonalized(stepId)
+    unless TaskStore.hasIncompleteCoreStepsIndexes(taskId) or
+      TaskStepStore.isLoadingPersonalized(stepId)
+        TaskStepActions.loadPersonalized(stepId)
 
   update: (id) ->
     {crumb} = @props

--- a/tutor/src/components/breadcrumb/index.cjsx
+++ b/tutor/src/components/breadcrumb/index.cjsx
@@ -48,22 +48,15 @@ BreadcrumbTaskDynamic = React.createClass
   displayName: 'BreadcrumbTaskDynamic'
   componentWillMount: ->
     {crumb} = @props
-
     @setStep(@props)
-
     TaskStepStore.on('step.completed', @update)
-
     if TaskStepStore.isPlaceholder(crumb.id)
-      TaskStepStore.on('step.completed', @checkPlaceholder)
       TaskStepStore.on('step.loaded', @update)
 
-  removeListeners: ->
+  componentWillUnmount: ->
     TaskStepStore.off('step.completed', @update)
-    TaskStepStore.off('step.completed', @checkPlaceholder)
     TaskStepStore.off('step.loaded', @update)
 
-  componentWillUnmount: ->
-    @removeListeners()
 
   componentDidMount: ->
     @props.onMount?()
@@ -90,6 +83,7 @@ BreadcrumbTaskDynamic = React.createClass
 
   update: (id) ->
     {crumb} = @props
+    @checkPlaceholder() if TaskStepStore.isPlaceholder(crumb.id)
 
     if (crumb.id is id)
       @setStep(@props)

--- a/tutor/src/flux/task-step.coffee
+++ b/tutor/src/flux/task-step.coffee
@@ -15,6 +15,7 @@ isMissingExercises = (response) ->
 TaskStepConfig =
   _asyncStatus: {}
   _recoveryTarget: {}
+  _loadingPersonalizedStatus: {}
 
   _loaded: (obj, id) ->
     if not obj.task_id
@@ -22,6 +23,8 @@ TaskStepConfig =
     @emit('step.loaded', id)
     _.each(@_recoveryTarget, _.partial(@_updateRecoveredFor, id), @)
     StepTitleActions.parseStep(obj)
+
+    @_loadingPersonalizedStatus[id] = false if @_loadingPersonalizedStatus[id]
 
     obj
 
@@ -31,6 +34,7 @@ TaskStepConfig =
 
   loadPersonalized: (id) ->
     @load(id)
+    @_loadingPersonalizedStatus[id] = true
 
   loadedNoPersonalized: (obj, id) ->
     {data, status, statusMessage} = obj
@@ -114,6 +118,9 @@ TaskStepConfig =
     isPlaceholder: (id) ->
       step = @_get(id)
       step?.type is 'placeholder'
+
+    isLoadingPersonalized: (id) ->
+      @_loadingPersonalizedStatus[id]
 
     shouldExist: (id) ->
       @_get(id)?.exists isnt false


### PR DESCRIPTION
While debugging a different bug I noticed we were binding step.completed
to different functions.  This binds once and then calls checkPlaceholder
from update.

I think this is a good idea so that we'll have fewer event listeners bound and lessen the maxListeners warning.

