### PR TITLE
Update course banner title

### DIFF
--- a/shared/resources/styles/variables/openstax-bootstrap.less
+++ b/shared/resources/styles/variables/openstax-bootstrap.less
@@ -498,17 +498,17 @@
 // @state-success-bg:               #dff0d8;
 // @state-success-border:           darken(spin(@state-success-bg, -10), 5%);
 
-@state-info-text:                shade(@openstax-info, 60%);
+@state-info-text:                shade(@openstax-info, 40%);
 @state-info-bg:                  tint(@openstax-info, 80%);
-@state-info-border:              shade(@openstax-info, 40%);
+@state-info-border:              shade(@openstax-info, 60%);
 
 // @state-warning-text:             #8a6d3b;
 // @state-warning-bg:               #fcf8e3;
 // @state-warning-border:           darken(spin(@state-warning-bg, -10), 5%);
 
-@state-danger-text:              shade(@openstax-danger, 60%);
+@state-danger-text:              shade(@openstax-danger, 40%);
 @state-danger-bg:                tint(@openstax-danger, 80%);
-@state-danger-border:            shade(@openstax-danger, 40%);
+@state-danger-border:            shade(@openstax-danger, 60%);
 
 
 // //== Tooltips

--- a/tutor/api/courses/1.json
+++ b/tutor/api/courses/1.json
@@ -64,5 +64,7 @@
   }],
   "time_zone": "Central Time (US & Canada)",
   "default_due_time": "00:01",
-  "default_open_time": "07:00"
+  "default_open_time": "07:00",
+  "starts_at": "2016-07-01T00:00:00.000Z",
+  "ends_at": "2016-12-31T23:59:59.000Z"
 }

--- a/tutor/api/user/courses.json
+++ b/tutor/api/user/courses.json
@@ -12,6 +12,8 @@
     "time_zone": "Central Time (US & Canada)",
     "default_open_time": "00:01",
     "default_due_time": "07:00",
+    "starts_at": "2016-07-01T00:00:00.000Z",
+    "ends_at": "2016-12-31T23:59:59.000Z",
     "periods": [{
         "id": "1",
         "name" : "1st",

--- a/tutor/resources/styles/components/cc-dashboard/index.less
+++ b/tutor/resources/styles/components/cc-dashboard/index.less
@@ -129,21 +129,8 @@
   }
 
   .course-title-banner + div {
-    .tutor-booksplash-adjust-top-margin();
+    margin-top: 0;
   }
-  // .tutor-booksplash-background {
-  //   height: @cc-dashboard-banner-height;
-  //   > .title {
-  //     height: @cc-dashboard-banner-height;
-  //     font-size: 88px;
-  //     text-align: left;
-  //     padding-left: 50px;
-  //     padding-right: 50px;
-  //     line-height: @cc-dashboard-banner-height - 20px; // manually tweak vertical position to center text
-  //   }
-  // }
-
-
 
 }
 

--- a/tutor/resources/styles/components/cc-dashboard/index.less
+++ b/tutor/resources/styles/components/cc-dashboard/index.less
@@ -128,18 +128,20 @@
     }
   }
 
-  .tutor-booksplash-adjust-top-margin(@cc-dashboard-banner-height + 40px);
-  .tutor-booksplash-background {
-    height: @cc-dashboard-banner-height;
-    > .title {
-      height: @cc-dashboard-banner-height;
-      font-size: 88px;
-      text-align: left;
-      padding-left: 50px;
-      padding-right: 50px;
-      line-height: @cc-dashboard-banner-height - 20px; // manually tweak vertical position to center text
-    }
+  .course-title-banner + div {
+    .tutor-booksplash-adjust-top-margin();
   }
+  // .tutor-booksplash-background {
+  //   height: @cc-dashboard-banner-height;
+  //   > .title {
+  //     height: @cc-dashboard-banner-height;
+  //     font-size: 88px;
+  //     text-align: left;
+  //     padding-left: 50px;
+  //     padding-right: 50px;
+  //     line-height: @cc-dashboard-banner-height - 20px; // manually tweak vertical position to center text
+  //   }
+  // }
 
 
 

--- a/tutor/resources/styles/components/course-calendar/add.less
+++ b/tutor/resources/styles/components/course-calendar/add.less
@@ -6,7 +6,8 @@
     background: @tutor-neutral-light;
     .no-add-text {
       display: block;
-      padding: 3px 20px;
+      padding: 8px 20px;
+      line-height: 1.25em;
     }
   }
 

--- a/tutor/resources/styles/components/course-calendar/month.less
+++ b/tutor/resources/styles/components/course-calendar/month.less
@@ -150,7 +150,9 @@
         }
       }
 
-      &--past {
+      &--past,
+      &.before-term,
+      &.after-term {
         color: @tutor-neutral;
         background-color: @tutor-neutral-lightest;
       }

--- a/tutor/resources/styles/components/course-calendar/month.less
+++ b/tutor/resources/styles/components/course-calendar/month.less
@@ -56,11 +56,13 @@
     &.is-dragging {
       .rc-Day--upcoming,
       .rc-Day--current {
-        &.hovered {
+        &.hovered:not(.before-term):not(.after-term) {
           border: 1px solid @tutor-tertiary-light;
         }
       }
-      .rc-Day--past {
+      .rc-Day--past,
+      .before-term,
+      .after-term {
         &.hovered {
            background: fade(@tutor-danger, 10%);
         }

--- a/tutor/resources/styles/components/course-calendar/sidebar.less
+++ b/tutor/resources/styles/components/course-calendar/sidebar.less
@@ -11,7 +11,7 @@
       border-width: 7px 7px 7px 0;
     }
 
-    border-radius: 0;
+    border-radius: 2px;
   }
 }
 .add-assignment-sidebar {

--- a/tutor/resources/styles/components/course-settings.less
+++ b/tutor/resources/styles/components/course-settings.less
@@ -20,6 +20,7 @@
   .course-settings-title {
     font-size: 3rem;
     display: inline-block;
+    font-weight: 600;
   }
   .course-settings-subtitle {
     font-size: 2.5rem;
@@ -28,6 +29,18 @@
     }
     padding-bottom: 15px;
     display: inline-block;
+  }
+  .course-settings-term {
+    margin-top: 0;
+  }
+  .course-settings-detail {
+    color: @tutor-neutral-lite;
+    margin-right: 1rem;
+  }
+  .course-settings-timezone {
+    .edit-course {
+      padding: 0;
+    }
   }
 
   .nav-tabs {

--- a/tutor/resources/styles/components/student-dashboard/dashboard.less
+++ b/tutor/resources/styles/components/student-dashboard/dashboard.less
@@ -1,7 +1,7 @@
 .student-dashboard {
   @small-height-breakpoint: 600px;
   .container {
-    .tutor-booksplash-adjust-top-margin();
+    margin-top: 2rem;
   }
 
   .actions-box {

--- a/tutor/resources/styles/components/task-plan/mini-editor.less
+++ b/tutor/resources/styles/components/task-plan/mini-editor.less
@@ -65,7 +65,7 @@
       margin-bottom: 0;
     }
     a {
-      color: darken(@state-danger-text, 10%);
+      color: @state-danger-text;
       text-decoration: underline;
     }
   }

--- a/tutor/resources/styles/components/task-plan/mini-editor.less
+++ b/tutor/resources/styles/components/task-plan/mini-editor.less
@@ -58,7 +58,8 @@
     h3 {
       margin: 0;
       text-align: left;
-      font-size: 20px;
+      font-size: 1.6rem;
+      font-weight: 600;
     }
     p {
       margin-bottom: 0;

--- a/tutor/resources/styles/global/buttons.less
+++ b/tutor/resources/styles/global/buttons.less
@@ -73,7 +73,9 @@
 
 .btn {
 
-  .btn-round();
+  &:not(.btn-link) {
+    .btn-round();    
+  }
 
   &.btn-lg {
     font-size: 1.8rem;

--- a/tutor/resources/styles/global/tutor-booksplash-background.less
+++ b/tutor/resources/styles/global/tutor-booksplash-background.less
@@ -19,10 +19,6 @@
   > .book-title,
   > .course-term {
     &:extend(.container);
-    // white-space: nowrap;
-    // overflow: hidden;
-    // text-overflow: ellipsis;
-
   }
 
   > .book-title {
@@ -35,6 +31,7 @@
   > .course-term {
     font-weight: 200;
     line-height: 1em;
+    font-size: 1.6rem;
   }
 
   .apply-booksplash-background(@code; @fg; @bg) {

--- a/tutor/resources/styles/global/tutor-booksplash-background.less
+++ b/tutor/resources/styles/global/tutor-booksplash-background.less
@@ -5,16 +5,8 @@
 .tutor-booksplash-background {
   color: @openstax-book-default-fg;
   background-color: @openstax-book-default-bg;
-
-  #fonts > .book-cover();
-  z-index: -1;
-
-  position: fixed;
-  top: 60px;
-  left: 0px;
-  right: 0px;
-
   padding: 3rem 0;
+  #fonts > .book-cover();
 
   > .book-title,
   > .course-term {

--- a/tutor/resources/styles/global/tutor-booksplash-background.less
+++ b/tutor/resources/styles/global/tutor-booksplash-background.less
@@ -15,24 +15,24 @@
   left: 0px;
   right: 0px;
 
-  height: 8rem;
-  line-height: 9rem;
-  font-size: 8rem;
-  @media (min-width: @screen-sm-min) {
-    height: 10.5rem;
-    line-height: 10.5rem;
-    font-size: 5rem;
-  }
-  @media (min-width: @screen-md-min) {
-    height: 10.5rem;
-    line-height: 10.5rem;
-    font-size: 5rem;
-  }
-  @media (min-width: @screen-lg-min) {
-    height: 10.5rem;
-    line-height: 10.5rem;
-    font-size: 5rem;
-  }
+  font-size: 3.8rem;
+  line-height: 4rem;
+  padding: 1.5rem 0;
+  // @media (min-width: @screen-sm-min) {
+  //   height: 10.5rem;
+  //   line-height: 10.5rem;
+  //   font-size: 5rem;
+  // }
+  // @media (min-width: @screen-md-min) {
+  //   height: 10.5rem;
+  //   line-height: 10.5rem;
+  //   font-size: 5rem;
+  // }
+  // @media (min-width: @screen-lg-min) {
+  //   height: 10.5rem;
+  //   line-height: 10.5rem;
+  //   font-size: 5rem;
+  // }
 
   > .book-title {
     &:extend(.container);
@@ -55,7 +55,4 @@
 }
 .tutor-booksplash-adjust-top-margin(@normal-top-margin: 100px, @short-top-margin: 35px){
   margin-top: @normal-top-margin;
-  // if the screen is short, move up even though it means
-  // the booksplash background won't be as visible
-  @media screen and ( max-height: 600px ){ margin-top: @short-top-margin; }
 }

--- a/tutor/resources/styles/global/tutor-booksplash-background.less
+++ b/tutor/resources/styles/global/tutor-booksplash-background.less
@@ -6,7 +6,6 @@
   color: @openstax-book-default-fg;
   background-color: @openstax-book-default-bg;
 
-  letter-spacing: -2px;
   #fonts > .book-cover();
   z-index: -1;
 
@@ -15,31 +14,27 @@
   left: 0px;
   right: 0px;
 
-  font-size: 3.8rem;
-  line-height: 4rem;
-  padding: 1.5rem 0;
-  // @media (min-width: @screen-sm-min) {
-  //   height: 10.5rem;
-  //   line-height: 10.5rem;
-  //   font-size: 5rem;
-  // }
-  // @media (min-width: @screen-md-min) {
-  //   height: 10.5rem;
-  //   line-height: 10.5rem;
-  //   font-size: 5rem;
-  // }
-  // @media (min-width: @screen-lg-min) {
-  //   height: 10.5rem;
-  //   line-height: 10.5rem;
-  //   font-size: 5rem;
-  // }
+  padding: 3rem 0;
+
+  > .book-title,
+  > .course-term {
+    &:extend(.container);
+    // white-space: nowrap;
+    // overflow: hidden;
+    // text-overflow: ellipsis;
+
+  }
 
   > .book-title {
-    &:extend(.container);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    letter-spacing: -2px;
+    font-size: 3.8rem;
+    line-height: 4.4rem;
+    margin-top: -0.3rem;
+  }
 
+  > .course-term {
+    font-weight: 200;
+    line-height: 1em;
   }
 
   .apply-booksplash-background(@code; @fg; @bg) {

--- a/tutor/specs/components/task-plan/mini-editor/editor.spec.cjsx
+++ b/tutor/specs/components/task-plan/mini-editor/editor.spec.cjsx
@@ -1,8 +1,11 @@
 {React, _} = require '../../helpers/component-testing'
 
+moment = require 'moment'
+
 MiniEditor = require '../../../../src/components/task-plan/mini-editor/editor'
 {CourseActions} = require '../../../../src/flux/course'
 {TaskPlanActions, TaskPlanStore} = require '../../../../src/flux/task-plan'
+{TimeStore} = require '../../../../src/flux/time'
 
 COURSE  = require '../../../../api/courses/1.json'
 COURSE_ID = '1'
@@ -19,6 +22,13 @@ getButtons = (wrapper) ->
   save: wrapper.find('.-save')
   cancel: wrapper.find('.btn.cancel')
 
+fakeTerm = ->
+  now = moment(TimeStore.getNow())
+  start = now.clone().add(1, 'year').startOf('year')
+  end = start.clone().add(6, 'months')
+
+  {start, end}
+
 describe 'TaskPlan MiniEditor wrapper', ->
 
   beforeEach ->
@@ -31,10 +41,16 @@ describe 'TaskPlan MiniEditor wrapper', ->
     CourseActions.loaded(COURSE, COURSE_ID)
 
     TaskPlanActions.loaded(PLAN, PLAN.id)
+
+    term = fakeTerm()
+
     @props =
       id: PLAN.id
       courseId: COURSE_ID
       onHide: sinon.spy()
+      termStart: term.start
+      termEnd: term.end
+      handleError: sinon.spy()
 
 
   afterEach ->

--- a/tutor/specs/components/task-plan/mini-editor/editor.spec.cjsx
+++ b/tutor/specs/components/task-plan/mini-editor/editor.spec.cjsx
@@ -6,6 +6,7 @@ MiniEditor = require '../../../../src/components/task-plan/mini-editor/editor'
 {CourseActions} = require '../../../../src/flux/course'
 {TaskPlanActions, TaskPlanStore} = require '../../../../src/flux/task-plan'
 {TimeStore} = require '../../../../src/flux/time'
+TimeHelper = require '../../../../src/helpers/time'
 
 COURSE  = require '../../../../api/courses/1.json'
 COURSE_ID = '1'
@@ -110,7 +111,21 @@ describe 'TaskPlan MiniEditor wrapper', ->
     undefined
 
   it 'calls handleError when server error is thrown', ->
-    wrapper = mount(<MiniEditor {...@props} />)
+    wrapper = shallow(<MiniEditor {...@props} />)
     TaskPlanStore.emit('errored', {status: 404, statusMessage: "There's been an error", config: {}})
     expect(@props.handleError).to.have.been.called
+    undefined
+
+  it 'renders error when server error is thrown', ->
+    wrapper = mount(<MiniEditor {...@props} />)
+    TaskPlanStore.emit('errored', {status: 404, statusMessage: "There's been an error", config: {}})
+    expect(wrapper.find('ServerErrorMessage')).length.to.be(1)
+    undefined
+
+  it 'limits opens date and due date to term dates', ->
+    wrapper = mount(<MiniEditor {...@props} />)
+    datePickers = wrapper.find("DatePicker")
+
+    expect(datePickers.at(0).props().minDate.isSame(@props.termStart, 'day')).to.equal(true)
+    expect(datePickers.at(1).props().maxDate.isSame(@props.termEnd, 'day')).to.equal(true)
     undefined

--- a/tutor/specs/components/task-plan/mini-editor/editor.spec.cjsx
+++ b/tutor/specs/components/task-plan/mini-editor/editor.spec.cjsx
@@ -108,3 +108,9 @@ describe 'TaskPlan MiniEditor wrapper', ->
     cancel.simulate('click')
     expect(@props.onHide).to.have.been.called
     undefined
+
+  it 'calls handleError when server error is thrown', ->
+    wrapper = mount(<MiniEditor {...@props} />)
+    TaskPlanStore.emit('errored', {status: 404, statusMessage: "There's been an error", config: {}})
+    expect(@props.handleError).to.have.been.called
+    undefined

--- a/tutor/src/components/course-calendar/add.cjsx
+++ b/tutor/src/components/course-calendar/add.cjsx
@@ -7,6 +7,7 @@ BS = require 'react-bootstrap'
 classnames = require 'classnames'
 
 {TimeStore} = require '../../flux/time'
+TimeHelper = require '../../helpers/time'
 
 CourseAddMenuMixin = require './add-menu-mixin'
 
@@ -14,7 +15,9 @@ CourseAdd = React.createClass
   displayName: 'CourseAdd'
 
   propTypes:
-    courseId: React.PropTypes.string.isRequired
+    courseId:   React.PropTypes.string.isRequired
+    termStart:  TimeHelper.PropTypes.moment
+    termEnd:    TimeHelper.PropTypes.moment
 
   mixins: [CourseAddMenuMixin]
 
@@ -38,6 +41,19 @@ CourseAdd = React.createClass
       open: false
     })
 
+  getDateType: ->
+    {referenceDate, addDate} = @state
+    {termStart, termEnd} = @props
+
+    if addDate?.isBefore(termStart, 'day')
+      'day before term starts'
+    else if addDate?.isAfter(termEnd, 'day')
+      'day after term ends'
+    else if addDate?.isBefore(referenceDate, 'day')
+      'past day'
+    else if addDate?.isSame(referenceDate, 'day')
+      'today'
+
   render: ->
     {referenceDate, addDate, open} = @state
 
@@ -49,17 +65,17 @@ CourseAdd = React.createClass
 
     style['display'] = if open then 'block' else 'none'
 
+    addDateType = @getDateType()
     className = classnames 'course-add-dropdown',
-      'no-add': not addDate?.isAfter(referenceDate, 'day')
+      'no-add': addDateType
 
     # only allow add if addDate is on or after reference date
-    if addDate?.isAfter(referenceDate, 'day')
-      dropdownContent = @renderAddActions()
-    else
-      dayType = if addDate?.isSame(referenceDate, 'day') then 'today' else 'past day'
+    if addDateType
       dropdownContent = <li>
-        <span className='no-add-text'>Cannot assign to {dayType}</span>
+        <span className='no-add-text'>Cannot assign to {addDateType}</span>
       </li>
+    else
+      dropdownContent = @renderAddActions()
 
     <BS.Dropdown.Menu
     id='course-add-dropdown'

--- a/tutor/src/components/course-calendar/add.cjsx
+++ b/tutor/src/components/course-calendar/add.cjsx
@@ -44,14 +44,15 @@ CourseAdd = React.createClass
   getDateType: ->
     {referenceDate, addDate} = @state
     {termStart, termEnd} = @props
+    return null unless addDate?
 
-    if addDate?.isBefore(termStart, 'day')
+    if addDate.isBefore(termStart, 'day')
       'day before term starts'
-    else if addDate?.isAfter(termEnd, 'day')
+    else if addDate.isAfter(termEnd, 'day')
       'day after term ends'
-    else if addDate?.isBefore(referenceDate, 'day')
+    else if addDate.isBefore(referenceDate, 'day')
       'past day'
-    else if addDate?.isSame(referenceDate, 'day')
+    else if addDate.isSame(referenceDate, 'day')
       'today'
 
   render: ->

--- a/tutor/src/components/course-calendar/month.cjsx
+++ b/tutor/src/components/course-calendar/month.cjsx
@@ -189,7 +189,11 @@ CourseMonth = React.createClass
     @props.date?.format?('MMMM')
 
   onDrop: (item, offset) ->
-    return unless @state.hoveredDay and @state.hoveredDay.isSameOrAfter(TimeStore.getNow(), 'day')
+    {termStart, termEnd} = @props
+    return unless @state.hoveredDay and
+      @state.hoveredDay.isBetween(termStart, termEnd, 'day', '[]') and
+      @state.hoveredDay.isSameOrAfter(TimeStore.getNow(), 'day')
+
     if item.pathname # is a link to create an assignment
       url = item.pathname + "?" + qs.stringify({
         due_at: @state.hoveredDay.format(@props.dateFormat)
@@ -291,7 +295,6 @@ CourseMonth = React.createClass
         planId={@state.cloningPlan.id}
         planType={@state.cloningPlan.type}
         position={@state.cloningPlan.position}
-        onLoad={@onCloneLoaded}
         courseId={@props.courseId}
         due_at={@state.cloningPlan.due_at}
         onLoad={@onCloneLoaded}

--- a/tutor/src/components/course-calendar/month.cjsx
+++ b/tutor/src/components/course-calendar/month.cjsx
@@ -36,10 +36,12 @@ CourseMonth = React.createClass
     router: React.PropTypes.object
 
   propTypes:
-    plansList: React.PropTypes.array
-    date: TimeHelper.PropTypes.moment
+    plansList:  React.PropTypes.array
+    date:       TimeHelper.PropTypes.moment
+    termStart:  TimeHelper.PropTypes.moment
+    termEnd:    TimeHelper.PropTypes.moment
     hasPeriods: React.PropTypes.bool.isRequired
-    courseId: React.PropTypes.string.isRequired
+    courseId:   React.PropTypes.string.isRequired
 
   childContextTypes:
     date: TimeHelper.PropTypes.moment
@@ -69,6 +71,8 @@ CourseMonth = React.createClass
 
   getMonthMods: (calendarDuration) ->
     date = moment(TimeStore.getNow())
+    {termStart, termEnd} = @props
+
     mods = [
       {
         component: [ 'day' ]
@@ -86,7 +90,14 @@ CourseMonth = React.createClass
           'upcoming'
         else
           'current'
-      classnames(className,
+
+      termClasses =
+        if dateToModify.isBefore(termStart, 'day')
+          'before-term'
+        else if dateToModify.isAfter(termEnd, 'day')
+          'after-term'
+
+      classnames(className, termClasses,
         hovered: hoveredDay and dateToModify.isSame(hoveredDay, 'day')
       )
 
@@ -215,7 +226,7 @@ CourseMonth = React.createClass
     @setState(editingPlanId: null, cloningPlanId: null)
 
   render: ->
-    {plansList, courseId, className, date, hasPeriods} = @props
+    {plansList, courseId, className, date, hasPeriods, termStart, termEnd} = @props
     {calendarDuration, calendarWeeks} = @getDurationInfo(date)
 
     calendarClassName = classnames('calendar-container', 'container', className,
@@ -235,12 +246,18 @@ CourseMonth = React.createClass
 
     <div className={calendarClassName}>
 
-      <CourseAdd ref='addOnDay' hasPeriods={hasPeriods} courseId={@props.courseId} />
+      <CourseAdd
+        ref='addOnDay'
+        hasPeriods={hasPeriods}
+        courseId={courseId}
+        termStart={termStart}
+        termEnd={termEnd}
+      />
 
       <CourseCalendarHeader
         defaultOpen={@state.showingSideBar}
         onSidebarToggle={@onSidebarToggle}
-        courseId={@props.courseId}
+        courseId={courseId}
         hasPeriods={hasPeriods}
       />
 
@@ -282,7 +299,9 @@ CourseMonth = React.createClass
       {<TaskPlanMiniEditor
         planId={@state.editingPlanId}
         position={@state.editingPosition}
-        courseId={@props.courseId}
+        courseId={courseId}
+        termStart={termStart}
+        termEnd={termEnd}
         onHide={@onEditorHide}
         findPopOverTarget={@getEditingPlanEl}
       /> if @state.editingPlanId}

--- a/tutor/src/components/course-calendar/task-dnd.cjsx
+++ b/tutor/src/components/course-calendar/task-dnd.cjsx
@@ -26,7 +26,7 @@ CloneTaskDrag =
     # hopefully the load will have completed by the time it's dropped
     offHover()
     unless TaskPlanStore.isLoaded(plan.id) or TaskPlanStore.isLoading(plan.id)
-      TaskPlanActions.load(plan.id)
+      TaskPlanActions.loaded(plan, plan.id)
     plan
 
   endDrag: (props, monitor) ->

--- a/tutor/src/components/course-settings/settings.cjsx
+++ b/tutor/src/components/course-settings/settings.cjsx
@@ -5,6 +5,7 @@ _  = require 'underscore'
 LoadableItem = require '../loadable-item'
 {CourseStore} = require '../../flux/course'
 {RosterStore, RosterActions} = require '../../flux/roster'
+TimeHelper = require '../../helpers/time'
 
 Roster = require './roster'
 TeacherRoster = require './teacher-roster'
@@ -25,9 +26,29 @@ module.exports = React.createClass
         <RenameCourse courseId={@props.courseId}  course={course}/>
       </div>
 
-      <div className='course-settings-timezone'>{CourseStore.getTimezone(@props.courseId)}
-        <SetTimezone courseId={@props.courseId}/>
-      </div>
+      <h4 className='course-settings-term'>
+        {CourseStore.getTerm(@props.courseId)}
+      </h4>
+
+      <BS.Row>
+
+        <BS.Col sm={6} className='course-settings-start-end-dates'>
+          <span className='course-settings-detail'>
+            Starts: {TimeHelper.toHumanDate(course.starts_at)}
+          </span>
+          <span className='course-settings-detail'>
+            Ends: {TimeHelper.toHumanDate(course.ends_at)}
+          </span>
+        </BS.Col>
+
+        <BS.Col sm={6} className='course-settings-timezone text-right'>
+          <span className='course-settings-detail'>
+            {CourseStore.getTimezone(@props.courseId)}
+          </span>
+          <SetTimezone courseId={@props.courseId}/>
+        </BS.Col>
+
+      </BS.Row>
 
       <div className="settings-section teachers">
         <LoadableItem

--- a/tutor/src/components/course-title-banner.cjsx
+++ b/tutor/src/components/course-title-banner.cjsx
@@ -15,14 +15,17 @@ CourseTitleBanner = React.createClass
       'data-title': CourseStore.getName(@props.courseId)
       'data-appearance': CourseStore.getAppearanceCode(@props.courseId)
 
-    dataProps.term = CourseStore.getTerm(@props.courseId)
+    dataProps['data-term'] = CourseStore.getTerm(@props.courseId)
 
     <div
       className="course-title-banner"
       {...dataProps}
     >
-      <div className="book-title">
-        {dataProps['data-title']}
+      <div className='book-title'>
+        {dataProps['data-title']} pretending to be a super long name for a course
+      </div>
+      <div className='course-term'>
+        {CourseStore.getTerm(@props.courseId)}
       </div>
     </div>
 

--- a/tutor/src/components/course-title-banner.cjsx
+++ b/tutor/src/components/course-title-banner.cjsx
@@ -22,7 +22,7 @@ CourseTitleBanner = React.createClass
       {...dataProps}
     >
       <div className='book-title'>
-        {dataProps['data-title']} pretending to be a super long name for a course
+        {dataProps['data-title']}
       </div>
       <div className='course-term'>
         {CourseStore.getTerm(@props.courseId)}

--- a/tutor/src/components/course-title-banner.cjsx
+++ b/tutor/src/components/course-title-banner.cjsx
@@ -15,6 +15,8 @@ CourseTitleBanner = React.createClass
       'data-title': CourseStore.getName(@props.courseId)
       'data-appearance': CourseStore.getAppearanceCode(@props.courseId)
 
+    dataProps.term = CourseStore.getTerm(@props.courseId)
+
     <div
       className="course-title-banner"
       {...dataProps}

--- a/tutor/src/components/task-plan/builder/index.cjsx
+++ b/tutor/src/components/task-plan/builder/index.cjsx
@@ -13,6 +13,7 @@ taskPlanEditingInitialize = require '../initialize-editing'
 
 {TimeStore} = require '../../../flux/time'
 TimeHelper = require '../../../helpers/time'
+CourseDataHelper = require '../../../helpers/course-data'
 {PeriodActions, PeriodStore} = require '../../../flux/period'
 
 {TaskPlanStore, TaskPlanActions} = require '../../../flux/task-plan'
@@ -45,6 +46,7 @@ TaskPlanBuilder = React.createClass
   getInitialState: ->
     {id} = @props
 
+    term: CourseDataHelper.getCourseBounds(@props.courseId)
     showingPeriods: not TaskingStore.getTaskingsIsAll(id)
     currentLocale: TimeHelper.getCurrentLocales()
 
@@ -58,7 +60,8 @@ TaskPlanBuilder = React.createClass
 
   componentWillMount: ->
     {id, courseId} = @props
-    nextState = taskPlanEditingInitialize(id, courseId)
+    {term} = @state
+    nextState = taskPlanEditingInitialize(id, courseId, term)
     @setState(nextState)
 
   componentWillUnmount: ->
@@ -209,7 +212,7 @@ TaskPlanBuilder = React.createClass
 
   renderTaskPlanRow: (period) ->
     {id, courseId, isVisibleToStudents, isEditable, isSwitchable} = @props
-    {showingPeriods, currentLocale} = @state
+    {showingPeriods, currentLocale, term} = @state
 
     taskingIdentifier = TaskingStore.getTaskingIndex(period)
     isEnabled = TaskingStore.isTaskingEnabled(id, period)
@@ -218,6 +221,8 @@ TaskPlanBuilder = React.createClass
     <Tasking
       key={period?.id or 'all'}
       {...@props}
+      termStart={term.start}
+      termEnd={term.end}
       isEnabled={isEnabled}
       ref={"tasking-#{taskingIdentifier}"}
       period={period}

--- a/tutor/src/components/task-plan/external/index.cjsx
+++ b/tutor/src/components/task-plan/external/index.cjsx
@@ -7,7 +7,7 @@ classnames = require 'classnames'
 
 {TutorInput, TutorDateInput, TutorTextArea} = require '../../tutor-input'
 {TaskPlanStore, TaskPlanActions} = require '../../../flux/task-plan'
-{TaskingStore, TaskingActions} = require '../../../flux/tasking'
+{TaskingStore} = require '../../../flux/tasking'
 
 PlanFooter = require '../footer'
 PlanMixin = require '../plan-mixin'

--- a/tutor/src/components/task-plan/mini-editor/editor.cjsx
+++ b/tutor/src/components/task-plan/mini-editor/editor.cjsx
@@ -12,7 +12,7 @@ TutorLink = require '../../link'
 TaskingDateTimes = require '../builder/tasking-date-times'
 BindStoresMixin = require '../../bind-stores-mixin'
 {TutorInput, TutorTextArea} = require '../../tutor-input'
-{TaskingStore, TaskingActions} = require '../../../flux/tasking'
+{TaskingStore} = require '../../../flux/tasking'
 {TeacherTaskPlanActions} = require '../../../flux/teacher-task-plan'
 TimeHelper = require '../../../helpers/time'
 
@@ -74,15 +74,13 @@ TaskPlanMiniEditor = React.createClass
 
   afterSave: ->
     @setState({saving: false, publishing: false})
-    @props.onHide()
+    @onCancel()
 
   onCancel: ->
-    plan = TaskPlanStore.get(@props.id)
     @props.onHide()
     if TaskPlanStore.isNew(@props.id)
       TaskPlanActions.removeUnsavedDraftPlan(@props.id)
       TeacherTaskPlanActions.removeClonedPlan(@props.courseId, @props.id)
-      #TaskTeacherReviewActions.removeTask(@props.id)
 
   render: ->
     {id, courseId, termStart, termEnd} = @props

--- a/tutor/src/components/task-plan/mini-editor/editor.cjsx
+++ b/tutor/src/components/task-plan/mini-editor/editor.cjsx
@@ -125,7 +125,7 @@ TaskPlanMiniEditor = React.createClass
         </BS.Col>
       </div>
 
-      {<BS.Alert bsStyle='danger' onDismiss={@onCancel}>
+      {<BS.Alert bsStyle='danger'>
         <ServerErrorMessage {...@state.error} debug={false} />
       </BS.Alert> if @state.error}
 

--- a/tutor/src/components/task-plan/mini-editor/editor.cjsx
+++ b/tutor/src/components/task-plan/mini-editor/editor.cjsx
@@ -103,7 +103,7 @@ TaskPlanMiniEditor = React.createClass
             value={plan.title or ''}
             required={true}
             onChange={@setTitle}
-            disabled={@state.error} />
+            disabled={@state.error?} />
         </BS.Col>
       </div>
       <div className="row times">
@@ -145,14 +145,14 @@ TaskPlanMiniEditor = React.createClass
           isEditable={!!@state.isEditable}
           isPublishing={!!@state.publishing}
           isPublished={isPublished}
-          disabled={@isWaiting() or @state.error}
+          disabled={@isWaiting() or @state.error?}
         />
         <DraftButton
           bsSize='small'
           isSavable={@isSaveable()}
           onClick={@onSave}
           isWaiting={!!(@isWaiting() and @state.saving and isEmpty(@state.error))}
-          disabled={@isWaiting() or @state.error}
+          disabled={@isWaiting() or @state.error?}
           isFailed={TaskPlanStore.isFailed(id)}
         />
         <BS.Button
@@ -160,7 +160,7 @@ TaskPlanMiniEditor = React.createClass
           className='cancel'
           bsStyle={if @state.error? then 'primary'}
           onClick={@onCancel}
-          disabled={@isWaiting() and not @state.error}
+          disabled={@isWaiting() and not @state.error?}
         >
           Cancel
         </BS.Button>

--- a/tutor/src/components/task-plan/mini-editor/editor.cjsx
+++ b/tutor/src/components/task-plan/mini-editor/editor.cjsx
@@ -14,6 +14,8 @@ BindStoresMixin = require '../../bind-stores-mixin'
 {TutorInput, TutorTextArea} = require '../../tutor-input'
 {TaskingStore, TaskingActions} = require '../../../flux/tasking'
 {TeacherTaskPlanActions} = require '../../../flux/teacher-task-plan'
+TimeHelper = require '../../../helpers/time'
+
 taskPlanEditingInitialize = require '../initialize-editing'
 
 PublishButton = require '../footer/save-button'
@@ -26,6 +28,8 @@ TaskPlanMiniEditor = React.createClass
 
   propTypes:
     courseId:     React.PropTypes.string.isRequired
+    termStart:    TimeHelper.PropTypes.moment
+    termEnd:      TimeHelper.PropTypes.moment
     id:           React.PropTypes.string.isRequired
     onHide:       React.PropTypes.func.isRequired
     handleError:  React.PropTypes.func.isRequired
@@ -57,8 +61,8 @@ TaskPlanMiniEditor = React.createClass
     @setState({error})
 
   componentWillMount: ->
-    {id, courseId} = @props
-    taskPlanEditingInitialize(id, courseId)
+    {id, courseId, termStart, termEnd} = @props
+    taskPlanEditingInitialize(id, courseId, {start: termStart, end: termEnd})
 
   onSave: ->
     @setState({saving: true, publishing: false})
@@ -81,8 +85,10 @@ TaskPlanMiniEditor = React.createClass
       #TaskTeacherReviewActions.removeTask(@props.id)
 
   render: ->
-    plan = TaskPlanStore.get(@props.id)
-    isPublished = TaskPlanStore.isPublished(@props.id)
+    {id, courseId, termStart, termEnd} = @props
+
+    plan = TaskPlanStore.get(id)
+    isPublished = TaskPlanStore.isPublished(id)
 
     <div className='task-plan-mini-editor'>
       <div className="row">
@@ -107,7 +113,9 @@ TaskPlanMiniEditor = React.createClass
           bsSizes={{}}
           id={plan.id}
           isEditable={not @state.error?}
-          courseId={@props.courseId}
+          courseId={courseId}
+          termStart={termStart}
+          termEnd={termEnd}
           taskingIdentifier='all'
         />
       </div>
@@ -118,7 +126,7 @@ TaskPlanMiniEditor = React.createClass
         <BS.Col xs=6 className='text-right'>
           <TutorLink
             to={camelCase("edit-#{plan.type}")}
-            params={id: plan.id, courseId: @props.courseId}
+            params={id: plan.id, courseId: courseId}
           >
               Edit other assignment details
           </TutorLink>
@@ -147,7 +155,7 @@ TaskPlanMiniEditor = React.createClass
           onClick={@onSave}
           isWaiting={!!(@isWaiting() and @state.saving and isEmpty(@state.error))}
           disabled={@isWaiting() or @state.error}
-          isFailed={TaskPlanStore.isFailed(@props.id)}
+          isFailed={TaskPlanStore.isFailed(id)}
         />
         <BS.Button
           bsSize='small'

--- a/tutor/src/components/task-plan/mini-editor/editor.cjsx
+++ b/tutor/src/components/task-plan/mini-editor/editor.cjsx
@@ -147,11 +147,12 @@ TaskPlanMiniEditor = React.createClass
           onClick={@onSave}
           isWaiting={!!(@isWaiting() and @state.saving and isEmpty(@state.error))}
           disabled={@isWaiting() or @state.error}
-          isFailed={TaskPlanStore.isFailed(@props.idinde)}
+          isFailed={TaskPlanStore.isFailed(@props.id)}
         />
         <BS.Button
           bsSize='small'
           className='cancel'
+          bsStyle={if @state.error? then 'primary'}
           onClick={@onCancel}
           disabled={@isWaiting() and not @state.error}
         >

--- a/tutor/src/components/task-plan/mini-editor/index.cjsx
+++ b/tutor/src/components/task-plan/mini-editor/index.cjsx
@@ -12,7 +12,7 @@ TaskPlanMiniEditorShell = React.createClass
   propTypes:
     courseId: React.PropTypes.string.isRequired
     planId:   React.PropTypes.string.isRequired
-    onHide: React.PropTypes.func.isRequired
+    onHide:   React.PropTypes.func.isRequired
     findPopOverTarget: React.PropTypes.func.isRequired
     position: React.PropTypes.shape(
       x: React.PropTypes.number
@@ -30,6 +30,8 @@ TaskPlanMiniEditorShell = React.createClass
       id={@props.planId}
       onHide={@props.onHide}
       courseId={@props.courseId}
+      termStart={@props.termStart}
+      termEnd={@props.termEnd}
       save={TaskPlanActions.saveSilent}
       handleError={@handleError}
     />

--- a/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -156,15 +156,7 @@ TeacherTaskPlanListing = React.createClass
       loadPlansList, courseId, date, displayAs, hasPeriods, params, termStart, termEnd
     }
     loadingCalendarProps = if hasPeriods
-      {
-        loadPlansList,
-        courseId,
-        date,
-        displayAs,
-        hasPeriods,
-        params,
-        className: 'calendar-loading'
-      }
+      _.extend(className: 'calendar-loading', loadedCalendarProps)
     else
       loadedCalendarProps
 

--- a/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -9,6 +9,7 @@ LoadableItem = require '../loadable-item'
 {CourseStore} = require '../../flux/course'
 {TimeStore} = require '../../flux/time'
 TimeHelper = require '../../helpers/time'
+CourseDataHelper = require '../../helpers/course-data'
 PH = require '../../helpers/period'
 CourseTitleBanner = require '../course-title-banner'
 CourseCalendar = require '../course-calendar'
@@ -83,7 +84,8 @@ TeacherTaskPlanListing = React.createClass
       displayAs: 'month'
 
   getDateStates: (state) ->
-    courseDates = @getBoundsForCourse()
+    term = CourseDataHelper.getCourseBounds(@props.params.courseId)
+    courseDates = {termStart: term.start, termEnd: term.end}
     date = @getDateFromParams(courseDates)
 
     bounds = @getBoundsForDate(date, state)

--- a/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -103,12 +103,12 @@ TeacherTaskPlanListing = React.createClass
     courseTimezone = CourseStore.getTimezone(courseId)
     TimeHelper.syncCourseTimezone(courseTimezone)
 
-    TaskPlanStore.on('publish-queued', @loadToListing)
+    TaskPlanStore.on('saved.*', @loadToListing)
 
   componentWillUnmount: ->
     TimeHelper.unsyncCourseTimezone()
 
-    TaskPlanStore.off('publish-queued', @loadToListing)
+    TaskPlanStore.off('saved.*', @loadToListing)
 
   loadToListing: (plan) ->
     TeacherTaskPlanActions.addPublishingPlan(plan, @props.params.courseId)

--- a/tutor/src/components/task-step/step-with-reading-content.cjsx
+++ b/tutor/src/components/task-step/step-with-reading-content.cjsx
@@ -5,7 +5,6 @@ React = require 'react'
 CourseData = require '../../helpers/course-data'
 {BookContentMixin, LinkContentMixin} = require '../book-content-mixin'
 RelatedContent = require '../related-content'
-CourseTitleBanner = require '../course-title-banner'
 Router = require '../../helpers/router'
 
 # TODO: will combine with below, after BookContentMixin clean up

--- a/tutor/src/flux/course.coffee
+++ b/tutor/src/flux/course.coffee
@@ -1,5 +1,8 @@
-# coffeelint: disable=no_empty_functions
-_ = require 'underscore'
+capitalize  = require 'lodash/capitalize'
+extend  = require 'lodash/extend'
+find    = require 'lodash/find'
+values  = require 'lodash/values'
+pick    = require 'lodash/pick'
 
 {TaskActions, TaskStore} = require './task'
 {CrudConfig, makeSimpleStore, extendConfig, STATES} = require './helpers'
@@ -17,7 +20,7 @@ CourseConfig =
     @emit('saved')
 
     # make sure all of course remains loaded after course gets saved to
-    _.extend {}, @_local[id], result
+    extend {}, @_local[id], result
 
 
   exports:
@@ -48,30 +51,34 @@ CourseConfig =
     getName: (courseId) ->
       @_get(courseId)?.name or ""
 
+    getTerm: (courseId) ->
+      course = @_get(courseId)
+      capitalize("#{course?.term} #{course?.year}") if course
+
     getPeriods: (courseId, options = {includeArchived: false}) ->
       course = @_get(courseId)
       periods = if options.includeArchived then course.periods else PeriodHelper.activePeriods(course)
       sortedPeriods = if periods then PeriodHelper.sort(periods) else []
 
     getTimeDefaults: (courseId) ->
-      _.pick(@_get(courseId), 'default_due_time', 'default_open_time')
+      pick(@_get(courseId), 'default_due_time', 'default_open_time')
 
     getTimezone: (courseId) ->
       @_get(courseId)?.time_zone or DEFAULT_TIME_ZONE
 
     isTeacher: (courseId) ->
-      !!_.findWhere(@_get(courseId)?.roles, type: 'teacher')
+      !!find(@_get(courseId)?.roles, type: 'teacher')
 
     isStudent: (courseId) ->
-      !!_.findWhere(@_get(courseId)?.roles, type: 'student')
+      !!find(@_get(courseId)?.roles, type: 'student')
 
     getByEcosystemId: (ecosystemId) ->
-      _.findWhere(_.values(@_local), ecosystem_id: ecosystemId)
+      find(values(@_local), ecosystem_id: ecosystemId)
 
     getStudentId: (courseId) ->
       course = @_get(courseId)
-      role = _.findWhere(course?.roles, type: 'student')
-      if role then _.findWhere(course.students, role_id: role.id).student_identifier else null
+      role = find(course?.roles, type: 'student')
+      if role then find(course.students, role_id: role.id).student_identifier else null
 
     isCloned: (courseId) ->
       !!@_get(courseId)?.cloned_from_id

--- a/tutor/src/flux/past-task-plans.coffee
+++ b/tutor/src/flux/past-task-plans.coffee
@@ -1,9 +1,14 @@
 {makeStandardStore} = require './helpers'
 isEmpty = require 'lodash/isEmpty'
+reject = require 'lodash/reject'
 
 StoreDefinition = makeStandardStore('PastTaskPlans', {
   _loaded: (data, courseId) ->
     data.items
+
+  unload: (courseId, planId) ->
+    newItems = reject(@_get(courseId), {id: planId})
+    @loaded({items: newItems}, courseId)
 
   exports:
     hasPlans: (courseId) ->

--- a/tutor/src/flux/task-plan.coffee
+++ b/tutor/src/flux/task-plan.coffee
@@ -232,6 +232,7 @@ TaskPlanConfig =
     @emitChange()
 
   _saved: (obj, id) ->
+    @emit("saved.#{id}", obj)
     if obj.is_publishing
       PlanPublishActions.queued(obj, id)
       @emit('publish-queued', obj)

--- a/tutor/src/helpers/course-data.coffee
+++ b/tutor/src/helpers/course-data.coffee
@@ -1,5 +1,6 @@
 {CourseStore} = require '../flux/course'
 Router = require '../helpers/router'
+TimeHelper = require '../helpers/time'
 
 module.exports =
   getCourseDataProps: (courseId) ->
@@ -10,3 +11,12 @@ module.exports =
       'data-title': CourseStore.getName(courseId)
       'data-book-title': CourseStore.getBookName(courseId) or ""
       'data-appearance': CourseStore.getAppearanceCode(courseId)
+
+  getCourseBounds: (courseId) ->
+    course = CourseStore.get(courseId)
+
+    start = TimeHelper.getMomentPreserveDate(course.starts_at, TimeHelper.ISO_DATE_FORMAT)
+    end = TimeHelper.getMomentPreserveDate(course.ends_at, TimeHelper.ISO_DATE_FORMAT)
+
+    {start, end}
+

--- a/tutor/src/helpers/time.coffee
+++ b/tutor/src/helpers/time.coffee
@@ -29,7 +29,7 @@ TimeHelper =
   ISO_DATE_FORMAT: 'YYYY-MM-DD'
   ISO_TIME_FORMAT: 'HH:mm'
   HUMAN_TIME_FORMAT: 'h:mm a'
-  HUMAN_DATE_FORMAT: 'MM-DD-YYYY'
+  HUMAN_DATE_FORMAT: 'MM/DD/YYYY'
 
   toHumanDate: (datething) ->
     moment(datething).format(@HUMAN_DATE_FORMAT)


### PR DESCRIPTION
https://trello.com/c/EVoQDgxF/268-t3-09-22-allow-tutor-instructors-to-start-setting-up-assignments-before-the-course-opens

- [x] update course settings with dates and term
- [x] update course banners with term
- [x] open dashboard to course start date if start date is in the future by default
- [x] set min/max for due date for assignment creation
- [x] only allow drop add on in term dates
- [x] update click add as well
- [x] check if existing courses have `starts_at` and `ends_at` from BE
- [x] fix and add tests

![screen shot 2016-11-29 at 3 14 55 pm](https://cloud.githubusercontent.com/assets/2483873/20729208/a4441e6e-b646-11e6-99f4-ca2d660c5c1a.png)

![screen shot 2016-11-29 at 12 40 38 pm](https://cloud.githubusercontent.com/assets/2483873/20723689/1f36358c-b631-11e6-887e-fb577b9bbe49.png)
![screen shot 2016-11-29 at 12 40 05 pm](https://cloud.githubusercontent.com/assets/2483873/20723690/1f41c60e-b631-11e6-9a45-99ccd9e87482.png)
