### PR TITLE
remove global font-size and padding

### DIFF
--- a/tutor/resources/styles/global/forms.less
+++ b/tutor/resources/styles/global/forms.less
@@ -16,12 +16,5 @@ textarea {
   }
 }
 
-// match size of add-on buttons set in global/buttons
-.form-group .input-group {
-  input[type=text],
-  input[type=number] {
-    padding: 20px 8px;
-    font-size: 1.6rem;
-  }
-}
+
 button i.fa { margin-right: 0.5rem; }


### PR DESCRIPTION
This makes me nervous but I don't see any areas of the app that are adversely affected.  I think that we needed the rule to fix material-design bugs, but don't need it any longer now that we're not using that.

The bug that i'm attempting to fix is that the recent addition of `[type=number]` to the rule caused Safari to style numeric inputs like this:

![screen shot 2016-11-30 at 1 10 19 pm](https://cloud.githubusercontent.com/assets/79566/20767042/60ea7be6-b6fe-11e6-88de-04b60313c21d.png)
