### PR TITLE
students should redirect only when there is only one current course. …

### DIFF
--- a/tutor/specs/components/course-listing.spec.cjsx
+++ b/tutor/specs/components/course-listing.spec.cjsx
@@ -72,6 +72,7 @@ describe 'Course Listing Component', ->
     undefined
 
   it 'renders past courses in past courses listing', ->
+    loadTeacherUser()
     CourseListingActions.loaded([TEACHER_PAST_COURSE, STUDENT_PAST_COURSE])
 
     wrapper = mount(<CourseListing />, EnzymeContext.withDnD())

--- a/tutor/src/components/course-listing/index.cjsx
+++ b/tutor/src/components/course-listing/index.cjsx
@@ -20,7 +20,9 @@ CourseListing = React.createClass
     router: React.PropTypes.object
 
   shouldRedirect: (past, current) ->
-    current.length is 1
+    CurrentUserStore.getCourseRole(current[0].id) is 'student' and
+      current.length is 1 and
+      past.length is 0
 
   shouldShowEmpty: (past, current) ->
     _.isEmpty(past) and _.isEmpty(current) # and some way to determine if student?!

--- a/tutor/src/components/course-listing/index.cjsx
+++ b/tutor/src/components/course-listing/index.cjsx
@@ -20,7 +20,7 @@ CourseListing = React.createClass
     router: React.PropTypes.object
 
   shouldRedirect: (past, current) ->
-    CurrentUserStore.getCourseRole(current[0].id) is 'student' and
+    not CurrentUserStore.isTeacher() and
       current.length is 1 and
       past.length is 0
 

--- a/tutor/src/flux/current-user.coffee
+++ b/tutor/src/flux/current-user.coffee
@@ -166,6 +166,7 @@ CurrentUserStore = flux.createStore
     @_token = null
     @_user.name = 'Guest'
     @_user.profile_url = null
+    @_user.faculty_status = undefined
     @_viewingCourseId = null
     @emitChange()
 


### PR DESCRIPTION
… also teachers should no longer redirect

As described in: https://trello.com/c/lZWvDxtV/230-t3-09-15-update-course-picker-page-as-faculty-i-want-to-distinguish-between-previously-taught-courses-and-new-courses-and-to-sta