### PR TITLE
Fix performance bar colors

### DIFF
--- a/tutor/resources/styles/components/performance-forecast/colors-mixin.less
+++ b/tutor/resources/styles/components/performance-forecast/colors-mixin.less
@@ -1,11 +1,11 @@
 .performance-forecast-colors() {
-  &.high {
+  &.high .progress-bar {
     background: @tutor-secondary;
   }
-  &.medium {
+  &.medium .progress-bar {
     background: @tutor-quaternary;
   }
-  &.low {
+  &.low .progress-bar {
     background: @tutor-primary;
   }
 }

--- a/tutor/resources/styles/components/performance-forecast/guide-key-mixin.less
+++ b/tutor/resources/styles/components/performance-forecast/guide-key-mixin.less
@@ -4,11 +4,11 @@
   .item {
     .flex-display();
     .align-items(center);
-    .box {
+    .performance-forecast-colors();
+    .progress-bar {
       width: 10px;
       height: 10px;
       margin-right: 5px;
-      .performance-forecast-colors()
     }
     .title {
       #fonts > .sans(1.2rem, 1.2rem);
@@ -16,7 +16,7 @@
       font-style: italic;
     }
     &+.item {
-      .box {
+      .progress-bar {
         margin-left: 15px;
       }
     }

--- a/tutor/resources/styles/components/performance-forecast/section-mixin.less
+++ b/tutor/resources/styles/components/performance-forecast/section-mixin.less
@@ -48,8 +48,6 @@
 
   .progress {
     height: 0.8rem;
-    .progress-bar {
-      .performance-forecast-colors();
-    }
+    .performance-forecast-colors();
   }
 }

--- a/tutor/resources/styles/components/student-dashboard/progress-guide.less
+++ b/tutor/resources/styles/components/student-dashboard/progress-guide.less
@@ -34,6 +34,8 @@
     // full width buttons
     .practice,
     .view-performance-forecast {
+      margin-left: 0;
+      margin-bottom: 0.5rem;
       width: 100%;
     }
 

--- a/tutor/src/components/performance-forecast/color-key.cjsx
+++ b/tutor/src/components/performance-forecast/color-key.cjsx
@@ -6,16 +6,16 @@ module.exports = React.createClass
 
   render: ->
     <div className='guide-key'>
-      <div className='item'>
-        <div className='box high'></div>
+      <div className='item high'>
+        <div className='progress-bar'></div>
         <span className='title'>looking good</span>
       </div>
-      <div className='item'>
-        <div className='box medium'></div>
+      <div className='item medium'>
+        <div className='progress-bar'></div>
         <span className='title'>almost there</span>
       </div>
-      <div className='item'>
-        <div className='box low'></div>
+      <div className='item low'>
+        <div className='progress-bar'></div>
         <span className='title'>keep trying</span>
       </div>
     </div>


### PR DESCRIPTION
The new BS code sets the component class on the parent element, not the bar itself.  This updates styles to match.


![screen shot 2016-12-05 at 10 03 10 am](https://cloud.githubusercontent.com/assets/79566/20892054/407d408c-bad2-11e6-8186-d4e248e4e6a4.png)
