### PR TITLE
IE fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "axios": "0.15.3",
     "bootstrap": "3.3.7",
-    "camelcase": "3.0.0",
     "classnames": "2.2.5",
     "dateformat": "2.0.0",
     "es6-object-assign": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "axios": "0.15.3",
     "bootstrap": "3.3.7",
-    "camelcase": "4.0.0",
+    "camelcase": "3.0.0",
     "classnames": "2.2.5",
     "dateformat": "2.0.0",
     "es6-object-assign": "1.0.3",

--- a/shared/src/components/exercise/group.cjsx
+++ b/shared/src/components/exercise/group.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 _ = require 'underscore'
 BS = require 'react-bootstrap'
-camelCase = require 'camelcase'
+camelCase = require 'lodash/camelCase'
 
 ChapterSectionMixin = require '../chapter-section-mixin'
 ExerciseIdentifierLink = require '../exercise-identifier-link'

--- a/shared/src/components/exercise/part.cjsx
+++ b/shared/src/components/exercise/part.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 _ = require 'underscore'
 
-camelCase = require 'camelcase'
+camelCase = require 'lodash/camelCase'
 
 ExerciseStepCard = require './part-card'
 {propTypes} = require './props'

--- a/shared/src/helpers/array-polyfill.js
+++ b/shared/src/helpers/array-polyfill.js
@@ -1,0 +1,44 @@
+// Copied from MDN:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill
+if (!Array.prototype.fill) {
+  Array.prototype.fill = function(value) {
+
+    // Steps 1-2.
+    if (this == null) {
+      throw new TypeError('this is null or not defined');
+    }
+
+    var O = Object(this);
+
+    // Steps 3-5.
+    var len = O.length >>> 0;
+
+    // Steps 6-7.
+    var start = arguments[1];
+    var relativeStart = start >> 0;
+
+    // Step 8.
+    var k = relativeStart < 0 ?
+      Math.max(len + relativeStart, 0) :
+      Math.min(relativeStart, len);
+
+    // Steps 9-10.
+    var end = arguments[2];
+    var relativeEnd = end === undefined ?
+      len : end >> 0;
+
+    // Step 11.
+    var final = relativeEnd < 0 ?
+      Math.max(len + relativeEnd, 0) :
+      Math.min(relativeEnd, len);
+
+    // Step 12.
+    while (k < final) {
+      O[k] = value;
+      k++;
+    }
+
+    // Step 13.
+    return O;
+  };
+}

--- a/shared/src/helpers/array-polyfill.js
+++ b/shared/src/helpers/array-polyfill.js
@@ -42,3 +42,32 @@ if (!Array.prototype.fill) {
     return O;
   };
 }
+
+
+// Array::find likewise from
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
+if (!Array.prototype.find) {
+  Object.defineProperty(Array.prototype, 'find', {
+    value: function(predicate) {
+     'use strict';
+     if (this == null) {
+       throw new TypeError('Array.prototype.find called on null or undefined');
+     }
+     if (typeof predicate !== 'function') {
+       throw new TypeError('predicate must be a function');
+     }
+     var list = Object(this);
+     var length = list.length >>> 0;
+     var thisArg = arguments[1];
+     var value;
+
+     for (var i = 0; i < length; i++) {
+       value = list[i];
+       if (predicate.call(thisArg, value, i, list)) {
+         return value;
+       }
+     }
+     return undefined;
+    }
+  });
+}

--- a/shared/src/helpers/polyfills.coffee
+++ b/shared/src/helpers/polyfills.coffee
@@ -1,3 +1,4 @@
 # adds Object.assign to browsers that lack it (IE)
 require('es6-object-assign').polyfill()
 require('es6-promise').polyfill()
+require './array-polyfill'

--- a/tutor/specs/components/helpers/calendar/checks.coffee
+++ b/tutor/specs/components/helpers/calendar/checks.coffee
@@ -1,7 +1,7 @@
 {expect} = require 'chai'
 {Promise} = require 'es6-promise'
 _ = require 'underscore'
-camelCase = require 'camelcase'
+camelCase = require 'lodash/camelCase'
 
 moment = require 'moment-timezone'
 twix = require 'twix'

--- a/tutor/src/components/course-calendar/duration.cjsx
+++ b/tutor/src/components/course-calendar/duration.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 moment = require 'moment-timezone'
 twix = require 'twix'
 _ = require 'underscore'
-camelCase = require 'camelcase'
+camelCase = require 'lodash/camelCase'
 padStart = require 'lodash/padStart'
 
 

--- a/tutor/src/components/course-calendar/plan-details.cjsx
+++ b/tutor/src/components/course-calendar/plan-details.cjsx
@@ -1,4 +1,4 @@
-camelCase = require 'camelcase'
+camelCase = require 'lodash/camelCase'
 classnames = require 'classnames'
 React = require 'react'
 BS = require 'react-bootstrap'

--- a/tutor/src/components/course-calendar/plan-display.cjsx
+++ b/tutor/src/components/course-calendar/plan-display.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
-camelCase = require 'camelcase'
+camelCase = require 'lodash/camelCase'
 BS = require 'react-bootstrap'
 _ = require 'underscore'
 

--- a/tutor/src/components/course-calendar/plan.cjsx
+++ b/tutor/src/components/course-calendar/plan.cjsx
@@ -3,7 +3,6 @@ twix = require 'twix'
 
 React = require 'react'
 
-camelCase = require 'camelcase'
 BS = require 'react-bootstrap'
 classnames = require 'classnames'
 

--- a/tutor/src/components/course-periods-nav.cjsx
+++ b/tutor/src/components/course-periods-nav.cjsx
@@ -3,7 +3,6 @@ BS = require 'react-bootstrap'
 Router = require '../helpers/router'
 LoadableItem = require './loadable-item'
 _ = require 'underscore'
-camelCase = require 'camelcase'
 classnames = require 'classnames'
 
 {CourseActions, CourseStore} = require '../flux/course'

--- a/tutor/src/components/task-plan/mini-editor/editor.cjsx
+++ b/tutor/src/components/task-plan/mini-editor/editor.cjsx
@@ -5,7 +5,7 @@ isEmpty = require 'lodash/isEmpty'
 
 {TaskPlanStore, TaskPlanActions} = require '../../../flux/task-plan'
 
-camelCase = require 'camelcase'
+camelCase = require 'lodash/camelCase'
 Icon = require '../../icon'
 Loading = require './loading'
 TutorLink = require '../../link'

--- a/tutor/src/components/task-step/step-footer-mixin.cjsx
+++ b/tutor/src/components/task-step/step-footer-mixin.cjsx
@@ -1,6 +1,6 @@
 _ = require 'underscore'
 React = require 'react'
-camelCase = require 'camelcase'
+camelCase = require 'lodash/camelCase'
 
 classnames = require 'classnames'
 TutorLink = require '../link'

--- a/tutor/src/components/task-teacher-review/crumb-mixin.cjsx
+++ b/tutor/src/components/task-teacher-review/crumb-mixin.cjsx
@@ -1,6 +1,6 @@
 # For handling steps logic outside of breadcrumb and task review rendering.
 _ = require 'underscore'
-camelCase = require 'camelcase'
+camelCase = require 'lodash/camelCase'
 
 {TaskTeacherReviewStore} = require '../../flux/task-teacher-review'
 

--- a/tutor/src/components/task/index.cjsx
+++ b/tutor/src/components/task/index.cjsx
@@ -3,7 +3,6 @@ ReactDOM = require 'react-dom'
 BS = require 'react-bootstrap'
 
 _ = require 'underscore'
-camelCase = require 'camelcase'
 classnames = require 'classnames'
 
 {TaskActions, TaskStore} = require '../../flux/task'

--- a/tutor/src/flux/task-step.coffee
+++ b/tutor/src/flux/task-step.coffee
@@ -1,6 +1,5 @@
 # coffeelint: disable=no_empty_functions
 _ = require 'underscore'
-camelCase = require 'camelcase'
 flux = require 'flux-react'
 Durations = require '../helpers/durations'
 {StepTitleActions} = require './step-title'

--- a/tutor/test-integration/helpers/ui/test-element.coffee
+++ b/tutor/test-integration/helpers/ui/test-element.coffee
@@ -1,6 +1,6 @@
 selenium = require 'selenium-webdriver'
 _ = require 'underscore'
-camelCase = require 'camelcase'
+camelCase = require 'lodash/camelCase'
 S = require '../../../src/helpers/string'
 {curry} = require 'lodash'
 

--- a/tutor/test/components/course-calendar/plan.spec.cjsx
+++ b/tutor/test/components/course-calendar/plan.spec.cjsx
@@ -8,7 +8,7 @@ React = require 'react'
 _ = require 'underscore'
 moment = require 'moment'
 twix = require 'twix'
-camelCase = require 'camelcase'
+camelCase = require 'lodash/camelCase'
 
 {TimeActions, TimeStore} = require '../../../src/flux/time'
 {PlanPublishStore, PlanPublishActions} = require '../../../src/flux/plan-publish'


### PR DESCRIPTION
React-calendar uses Array(7).fill(day)  and Array.prototype.find internally without providing it's
own polyfill

camelCase uses `let` for variable declarations,

I also considered using https://www.npmjs.com/package/array-fill but I like MDN's version better.  