### PR TITLE
firefox arrow adjustment in paging navigation

### DIFF
--- a/tutor/resources/styles/components/paging-navigation.less
+++ b/tutor/resources/styles/components/paging-navigation.less
@@ -1,3 +1,19 @@
+@tutor-paging-default-offsets: {
+  margin-left: -75px;
+};
+
+.paging-handle-browser-offsets(@handle-offset: @tutor-paging-default-offsets) {
+  // work around IE and Firefox flexbox bug where the icon is placed outside it's container
+  // this shifts it back into position
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    @handle-offset();
+  }
+  @-moz-document url-prefix() {
+    @handle-offset();
+  }
+}
+
+
 .tutor-paging-navigation {
   @arrow-height: 150px;
   .flex-display();
@@ -26,9 +42,7 @@
         .flex-display();
         .justify-content(flex-end);
         .icon {
-          // work around IE flexbox bug where the icon is placed outside it's container
-          // this shifts it back into position
-          @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) { margin-left: -75px; }
+          .paging-handle-browser-offsets();
         }
       }
     }

--- a/tutor/resources/styles/components/task/index.less
+++ b/tutor/resources/styles/components/task/index.less
@@ -14,7 +14,12 @@
     // small screens
     @media screen and (max-width: (@tutor-task-width + 200px)){
       .icon.arrow.left  { margin-left: -30px; }
-      .icon.arrow.right { margin-left: 30px; }
+      .icon.arrow.right {
+        margin-left: 30px;
+        .paging-handle-browser-offsets({
+          margin-left: -45px;
+        });
+      }
     }
   }
 


### PR DESCRIPTION
fixes https://trello.com/c/rSo2elYe/270-bug-it-s-difficult-to-navigate-tutor-readings

works now in firefox and chrome

i wanted to test on safari...but my safari crashes as soon as i load tutor...so that doesnt bode well...