### PR TITLE
various plan dragging editing details

### DIFF
--- a/tutor/src/components/course-calendar/month.cjsx
+++ b/tutor/src/components/course-calendar/month.cjsx
@@ -7,9 +7,10 @@ _ = require 'underscore'
 classnames = require 'classnames'
 qs = require 'qs'
 extend = require 'lodash/extend'
+find = require 'lodash/find'
 {DropTarget} = require 'react-dnd'
 {Calendar, Month, Week, Day} = require 'react-calendar'
-{TeacherTaskPlanStore} = require '../../flux/teacher-task-plan'
+
 {TimeStore} = require '../../flux/time'
 TimeHelper = require '../../helpers/time'
 TutorRouter = require '../../helpers/router'
@@ -228,6 +229,12 @@ CourseMonth = React.createClass
     @setState(showingSideBar: isOpen)
   onEditorHide: ->
     @setState(editingPlanId: null, cloningPlanId: null)
+  onIfIsEditing: (plan) ->
+    if plan.id is @state.editingPlanId or
+      plan.cloned_from_id is @state.cloningPlan?.id
+        @setState(showMiniEditor: true)
+  offIfIsEditing: (plan) ->
+    @setState(showMiniEditor: false) if plan.id is @state.editingPlanId
 
   render: ->
     {plansList, courseId, className, date, hasPeriods, termStart, termEnd} = @props
@@ -245,7 +252,7 @@ CourseMonth = React.createClass
         groupingDurations={calendarWeeks}
         courseId={courseId}
         ref='courseDurations'>
-        <CoursePlan courseId={courseId}/>
+        <CoursePlan courseId={courseId} onShow={@onIfIsEditing} onHide={@offIfIsEditing}/>
       </CourseDuration>
 
     <div className={calendarClassName}>
@@ -307,7 +314,7 @@ CourseMonth = React.createClass
         termEnd={termEnd}
         onHide={@onEditorHide}
         findPopOverTarget={@getEditingPlanEl}
-      /> if @state.editingPlanId}
+      /> if @state.editingPlanId and @state.showMiniEditor}
 
     </div>
 

--- a/tutor/src/components/course-calendar/plan.cjsx
+++ b/tutor/src/components/course-calendar/plan.cjsx
@@ -49,6 +49,8 @@ CoursePlan = React.createClass
       ).isRequired
     )
     activeHeight: React.PropTypes.number
+    onShow: React.PropTypes.func
+    onHide: React.PropTypes.func
 
   contextTypes:
     router: React.PropTypes.object.isRequired
@@ -154,7 +156,11 @@ CoursePlan = React.createClass
     else
       @syncRoute()
 
+  componentDidMount: ->
+    @props.onShow?(@props.item.plan)
+
   componentWillUnmount: ->
+    @props.onHide?(@props.item.plan)
     @stopCheckingPlan(@props.item.plan)
 
   stopCheckingPlan: (plan) ->

--- a/tutor/src/components/task-plan/mini-editor/editor.cjsx
+++ b/tutor/src/components/task-plan/mini-editor/editor.cjsx
@@ -60,9 +60,18 @@ TaskPlanMiniEditor = React.createClass
     @props.handleError(error)
     @setState({error})
 
-  componentWillMount: ->
-    {id, courseId, termStart, termEnd} = @props
+  initializePlan: (props) ->
+    props ?= @props
+    {id, courseId, termStart, termEnd} = props
     taskPlanEditingInitialize(id, courseId, {start: termStart, end: termEnd})
+
+  componentWillMount: ->
+    @initializePlan()
+
+  componentWillReceiveProps: (nextProps) ->
+    if @props.id isnt nextProps.id or
+      @props.courseId isnt nextProps.courseId
+        @initializePlan(nextProps)
 
   onSave: ->
     @setState({saving: true, publishing: false})

--- a/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -5,7 +5,7 @@ _ = require 'underscore'
 
 LoadableItem = require '../loadable-item'
 {TeacherTaskPlanStore, TeacherTaskPlanActions} = require '../../flux/teacher-task-plan'
-{TaskPlanStore} = require '../../flux/task-plan'
+{TaskPlanStore, TaskPlanActions} = require '../../flux/task-plan'
 {CourseStore} = require '../../flux/course'
 {TimeStore} = require '../../flux/time'
 TimeHelper = require '../../helpers/time'
@@ -103,6 +103,7 @@ TeacherTaskPlanListing = React.createClass
     courseTimezone = CourseStore.getTimezone(courseId)
     TimeHelper.syncCourseTimezone(courseTimezone)
 
+    TeacherTaskPlanActions.clearPendingClone(courseId)
     TaskPlanStore.on('saved.*', @loadToListing)
 
   componentWillUnmount: ->


### PR DESCRIPTION
https://trello.com/c/QcSuNFGk/337-bug-un-clickable-gray-bar-on-calendar

- [x] plan gray thing should only ever show one at a time
- [x] only one plan can be pending cloning at a time
- [x] switching months away from displayed cloning plan should hide mini editor until original month is back in view