### PR TITLE
Fix score report column sorting

### DIFF
--- a/tutor/specs/components/scores/index.spec.cjsx
+++ b/tutor/specs/components/scores/index.spec.cjsx
@@ -1,0 +1,44 @@
+{React} = require '../helpers/component-testing'
+_ = require 'lodash'
+SnapShot = require 'react-test-renderer'
+
+EnzymeContext = require '../helpers/enzyme-context'
+
+COURSE = require '../../../api/user/courses/1.json'
+DATA = require   '../../../api/courses/1/performance.json'
+COURSE_ID = '1'
+Sorter = require '../../../src/components/scores/student-data-sorter'
+{ScoresActions} = require '../../../src/flux/scores'
+{CourseActions} = require '../../../src/flux/course'
+
+
+{Scores} = require '../../../src/components/scores/index'
+
+getStudentNames = (wrapper) ->
+  names = wrapper.find('.student-name').map (el) -> el.text()
+  names.slice(1)
+
+describe 'Scores Report', ->
+
+  beforeEach ->
+    @props = {
+      courseId: COURSE_ID
+      isConceptCoach: false
+    }
+    CourseActions.loaded(COURSE, COURSE_ID)
+    ScoresActions.loaded(DATA, COURSE_ID)
+
+  it 'renders', ->
+    wrapper = mount(<Scores {...@props} />, EnzymeContext.build())
+    expect(getStudentNames(wrapper)).to.deep.equal(_.map(DATA[0].students, 'name'))
+    undefined
+
+  it 'sorts', ->
+    wrapper = mount(<Scores {...@props} />, EnzymeContext.build())
+    wrapper.find('.header-cell.sortable').at(1).simulate('click')
+    sorter = Sorter(sort: {key: 0, dataType: 'score'}, displayAs: 'percentage')
+    sorted = _.sortBy(DATA[0].students, sorter).reverse()
+    expect(getStudentNames(wrapper)).to.deep.equal(_.map(sorted, 'name'))
+    wrapper.find('.header-cell.sortable').at(1).simulate('click')
+    expect(getStudentNames(wrapper)).to.deep.equal(_.map(sorted.reverse(), 'name'))
+    undefined

--- a/tutor/specs/components/scores/student-data-sorter.spec.coffee
+++ b/tutor/specs/components/scores/student-data-sorter.spec.coffee
@@ -25,7 +25,7 @@ describe 'Student Scores Data Sorter', ->
     undefined
 
   it 'can sort by homework score', ->
-    @args.sort.key = 2
+    @args.sort.key = 0
     @args.sort.asc = false
     scores = _.map(_.sortBy(@students, StudentDataSorter(@args)), (s) ->
       s.data[0].correct_on_time_exercise_count)
@@ -33,7 +33,7 @@ describe 'Student Scores Data Sorter', ->
     undefined
 
   it 'can sort by reading progress', ->
-    @args.sort.key = 3
+    @args.sort.key = 1
     @args.sort.asc = false
     steps = _.map(_.sortBy(@students, StudentDataSorter(@args)), (s) ->
       s.data[1].completed_on_time_step_count)

--- a/tutor/src/components/scores/assignment-header.cjsx
+++ b/tutor/src/components/scores/assignment-header.cjsx
@@ -59,6 +59,7 @@ AssignmentSortingHeader = (props) ->
         sortKey={columnIndex}
         sortState={sort}
         onSort={onSort}
+        dataType='score'
       >
         <div className='completed'>Progress</div>
       </SortingHeader>
@@ -68,7 +69,7 @@ AssignmentSortingHeader = (props) ->
       <SortingHeader
         type={heading.type}
         sortKey={columnIndex}
-        dataType={dataType}
+        dataType='score'
         sortState={sort}
         onSort={onSort}
       >
@@ -77,7 +78,7 @@ AssignmentSortingHeader = (props) ->
       <SortingHeader
         type={heading.type}
         sortKey={columnIndex}
-        dataType={dataType}
+        dataType='completed'
         sortState={sort}
         onSort={onSort}
       >

--- a/tutor/src/components/scores/assignment-header.cjsx
+++ b/tutor/src/components/scores/assignment-header.cjsx
@@ -88,7 +88,7 @@ AssignmentSortingHeader = (props) ->
 
 
 AssignmentHeader = (props) ->
-  {isConceptCoach, periodIndex, period_id, courseId, sort, onSort, dataType, columnIndex, width} = props
+  {isConceptCoach, periodIndex, period_id, courseId, sort, onSort, columnIndex, width} = props
   heading = props.headings[columnIndex]
 
   cellWidth = getCellWidth({isConceptCoach, heading})

--- a/tutor/src/components/scores/sorting-header.cjsx
+++ b/tutor/src/components/scores/sorting-header.cjsx
@@ -1,6 +1,8 @@
 React    = require 'react'
 Router = require 'react-router'
 
+classnames = require 'classnames'
+
 module.exports = React.createClass
   displayName: 'SortingHeader'
 
@@ -11,22 +13,17 @@ module.exports = React.createClass
     dataType: React.PropTypes.string
 
   onClick: ->
-    @props.onSort(@props.sortKey, @props.children.ref)
-
-  isSplitHeader: ->
-    if @props.dataType?
-      if (@props.dataType is @props.children.ref) then true else false
-    else
-      true
+    @props.onSort(@props.sortKey, @props.dataType)
 
   render: ->
-    classNames = ['header-cell', 'sortable', @props.className]
-    if @props.sortState.key is @props.sortKey and @isSplitHeader()
-      classNames.push if @props.sortState.asc then 'is-ascending' else 'is-descending'
+    ascDesc = if @props.sortState.asc then 'is-ascending' else 'is-descending'
+    classNames = classnames('header-cell', 'sortable', @props.className, {
+      "#{ascDesc}" : @props.sortState.key is @props.sortKey and @props.sortState.dataType is @props.dataType
+    })
 
     <div
       data-assignment-type={@props.type}
       onClick={@onClick}
-      className={classNames.join(' ')}>
+      className={classNames}>
         {@props.children}
     </div>

--- a/tutor/src/components/scores/student-data-sorter.coffee
+++ b/tutor/src/components/scores/student-data-sorter.coffee
@@ -1,16 +1,14 @@
 _ = require 'underscore'
 
-FIRST_DATA_COLUMN = 2
 
 percent = (num, total) ->
   Math.round((num / total) * 100) or 0
 
 
-getSortValue = (student, key, dataType, displayAs) ->
+getSortValue = (student, index, dataType, displayAs) ->
 
-  return (student.last_name or student.name).toLowerCase() unless _.isNumber(key)
+  return (student.last_name or student.name).toLowerCase() unless _.isNumber(index)
 
-  index = key - FIRST_DATA_COLUMN
   record = student.data[index]
   return -1 unless record
 

--- a/tutor/src/components/scores/table.cjsx
+++ b/tutor/src/components/scores/table.cjsx
@@ -113,6 +113,7 @@ module.exports = React.createClass
               sortKey='name'
               sortState={sort}
               onSort={onSort}
+              dataType={'name'}
             >
                 <div className='student-name'>Name and Student ID</div>
             </SortingHeader>

--- a/tutor/src/components/scores/table.cjsx
+++ b/tutor/src/components/scores/table.cjsx
@@ -51,19 +51,19 @@ module.exports = React.createClass
 
   tableWidth: ->
     windowEl = @_getWindowSize()
-    tableContainer = ReactDOM.findDOMNode(@refs.tableContainer) #.course-scores-container
+    tableContainer = ReactDOM.findDOMNode(@refs.tableContainer) or { currentStyle: {} }
     style = tableContainer.currentStyle or window.getComputedStyle(tableContainer)
-    padding = parseInt(style.paddingLeft) + parseInt(style.paddingRight)
-    tableContainerWidth = tableContainer.clientWidth - padding
-    tableHorzSpacing = document.body.clientWidth - tableContainerWidth
+    padding = parseInt(style.paddingLeft or 0) + parseInt(style.paddingRight or 0)
+    tableContainerWidth = (tableContainer?.clientWidth or 0) - padding
+    tableHorzSpacing = (document.body.clientWidth or 0) - tableContainerWidth
     # since table.clientWidth returns 0 on initial load in IE, include windowEl as a fallback
     Math.max(windowEl.width - tableHorzSpacing, tableContainerWidth)
 
   tableHeight: ->
     windowEl = @_getWindowSize()
-    table = ReactDOM.findDOMNode(@refs.tableContainer)
+    table = ReactDOM.findDOMNode(@refs.tableContainer) or {}
     bottomMargin = 140
-    windowEl.height - table.offsetTop - bottomMargin
+    windowEl.height - (table.offsetTop or 0) - bottomMargin
 
   renderNoAssignments: ->
     <div className='course-scores-container' ref='tableContainer'>


### PR DESCRIPTION
The code was using weird `children.refs` to determine the type of sort that should be performed and was also looking at the wrong column.  I'm not sure what the `FIRST_DATA_COLUMN` was doing?