### PR TITLE
Strip non word characters from last segment

### DIFF
--- a/tutor/src/components/course-listing/course.cjsx
+++ b/tutor/src/components/course-listing/course.cjsx
@@ -16,7 +16,7 @@ getCourseNameSegments = (course, courseSubject) ->
     {index} = courseNameMatches
 
     before = course.name.substring(0, index)
-    after = course.name.substring(index + courseSubject.length)
+    after = course.name.substring(index + courseSubject.length).replace(/^\W+/, '')
 
     [before, courseSubject, after]
 
@@ -70,7 +70,7 @@ Course = React.createClass
     {course, courseSubject} = @props
     courseNameSegments = getCourseNameSegments(course, courseSubject)
     hasNoSubject = _.isEmpty(courseNameSegments)
-    courseNameSegments ?= course.name.split(' ')
+    courseNameSegments ?= course.name.split(/\W+/)
 
     <TutorLink
       className={classnames('no-subject': hasNoSubject)}


### PR DESCRIPTION
When a course is named something like "College Biology, Mr Jones", the
last segment would end up as ', Mr Jones' and look weird.

Turns
![screen shot 2016-12-09 at 2 46 29 pm](https://cloud.githubusercontent.com/assets/79566/21064093/ae102a3e-be1e-11e6-9b13-dd17625e1ca7.png)


Into:
![screen shot 2016-12-09 at 2 49 07 pm](https://cloud.githubusercontent.com/assets/79566/21064096/b1c9fbaa-be1e-11e6-9387-8f4ae82eface.png)
