### PR TITLE
assuming tasking is for all on mini editor, and check if tasking exis…

### DIFF
--- a/tutor/api/courses/1/dashboard.json
+++ b/tutor/api/courses/1/dashboard.json
@@ -242,6 +242,43 @@
           "due_at": "2015-10-14T12:00:00.000Z"
         }
       ]
+    },
+    {
+      "id": "29",
+      "ecosystem_id": "4",
+      "type": "homework",
+      "title": "test d",
+      "is_feedback_immediate": false,
+      "is_draft": false,
+      "is_publishing": false,
+      "is_published": true,
+      "first_published_at": "2016-12-07T18:23:24.615Z",
+      "last_published_at": "2016-12-07T19:18:28.195Z",
+      "settings": {
+        "page_ids": [
+          "762",
+          "763"
+        ],
+        "exercise_ids": [
+          "20650",
+          "21167"
+        ],
+        "exercises_count_dynamic": 3
+      },
+      "tasking_plans": [
+        {
+          "target_id": "29",
+          "target_type": "period",
+          "opens_at": "2016-12-08T06:01:00.000Z",
+          "due_at": "2016-12-17T13:00:00.000Z"
+        },
+        {
+          "target_id": "30",
+          "target_type": "period",
+          "opens_at": "2016-12-08T06:01:00.000Z",
+          "due_at": "2016-12-17T13:00:00.000Z"
+        }
+      ]
     }
   ],
   "role": {

--- a/tutor/specs/components/task-plan/builder/index.spec.coffee
+++ b/tutor/specs/components/task-plan/builder/index.spec.coffee
@@ -30,7 +30,6 @@ getISODateString = (value) -> TimeHelper.getZonedMoment(value).format(ISO_DATE_F
 
 COURSES = require '../../../../api/user/courses.json'
 NEW_READING = ExtendBasePlan({id: "_CREATING_1", settings: {page_ids: []}}, false, false)
-console.info('NEW_READING', NEW_READING)
 PUBLISHED_MODEL = ExtendBasePlan({
   id: '1'
   title: 'hello',

--- a/tutor/specs/components/task-plan/builder/index.spec.coffee
+++ b/tutor/specs/components/task-plan/builder/index.spec.coffee
@@ -2,7 +2,10 @@ _ = require 'underscore'
 moment = require 'moment-timezone'
 
 Builder = require '../../../../src/components/task-plan/builder'
+taskPlanEditingInitialize = require '../../../../src/components/task-plan/initialize-editing'
 PlanMixin = require '../../../../src/components/task-plan/plan-mixin'
+CourseDataHelper = require '../../../../src/helpers/course-data'
+
 {TaskPlanActions, TaskPlanStore} = require '../../../../src/flux/task-plan'
 {TaskingActions, TaskingStore} = require '../../../../src/flux/tasking'
 {Testing, sinon, _, React} = require '../../helpers/component-testing'
@@ -27,6 +30,7 @@ getISODateString = (value) -> TimeHelper.getZonedMoment(value).format(ISO_DATE_F
 
 COURSES = require '../../../../api/user/courses.json'
 NEW_READING = ExtendBasePlan({id: "_CREATING_1", settings: {page_ids: []}}, false, false)
+console.info('NEW_READING', NEW_READING)
 PUBLISHED_MODEL = ExtendBasePlan({
   id: '1'
   title: 'hello',
@@ -42,10 +46,14 @@ makeTaskingPeriodKey = (period) ->
 
 helper = (model, routerQuery) ->
   {id} = model
+  props = {id, courseId: "1"}
   # Load the plan into the store
   TaskPlanActions.loaded(model, id)
 
-  props = {id, courseId: "1"}
+  unless TaskPlanStore.isNew(id)
+    term = CourseDataHelper.getCourseBounds(props.courseId)
+    taskPlanEditingInitialize(id, props.courseId, term)
+
   PlanMixin.props = props
   moreProps = PlanMixin.getStates()
   props = _.extend(props, moreProps)
@@ -105,6 +113,7 @@ getDueDateAtInput = (element, period) ->
 describe 'Task Plan Builder', ->
   beforeEach ->
     TaskPlanActions.reset()
+    TaskingActions.reset()
     CourseListingActions.loaded(COURSES)
 
   it 'should load expected plan', ->

--- a/tutor/specs/components/task-plan/mini-editor/editor.spec.cjsx
+++ b/tutor/specs/components/task-plan/mini-editor/editor.spec.cjsx
@@ -18,6 +18,15 @@ PLAN = _.extend({
   settings: { exercise_ids: [1, 2, 3] }
 }, _.findWhere(DATA.plans, id: '7'))
 
+today = moment(TimeStore.getNow()).format(TimeHelper.ISO_DATE_FORMAT)
+dayAfter = moment(TimeStore.getNow()).add(2, 'day').format(TimeHelper.ISO_DATE_FORMAT)
+
+PLAN.tasking_plans = _.map(PLAN.tasking_plans, (tasking) ->
+  tasking = _.clone(tasking)
+  tasking.opens_at = today
+  tasking.due_at = dayAfter
+  tasking
+)
 
 getButtons = (wrapper) ->
   publish: wrapper.find('.-publish')

--- a/tutor/specs/flux/task-plan.spec.coffee
+++ b/tutor/specs/flux/task-plan.spec.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore'
 moment = require 'moment'
+cloneDeep = require 'lodash/cloneDeep'
 
 {TaskPlanActions, TaskPlanStore} = require '../../src/flux/task-plan'
 
@@ -10,6 +11,7 @@ COURSE_ID = '1'
 
 DATA   = require '../../api/courses/1/dashboard'
 PLAN = _.findWhere(DATA.plans, id: '7')
+HOMEWORK_WITH_FALSE = _.findWhere(DATA.plans, id: '29')
 
 describe 'TaskPlan Store', ->
 
@@ -27,6 +29,23 @@ describe 'TaskPlan Store', ->
       expect(clone[attr]).to.deep.equal(PLAN[attr])
 
     expect(clone.cloned_from_id).to.equal(PLAN.id)
+    for period in CourseStore.getPeriods(COURSE_ID)
+      tasking_plan = _.find(clone.tasking_plans, target_id: period.id)
+      expect(tasking_plan).to.exist
+
+    undefined
+
+  it 'can clone a task plan even when one of the properties is false', ->
+    newId = '111'
+    TaskPlanActions.loaded(HOMEWORK_WITH_FALSE, HOMEWORK_WITH_FALSE.id)
+    TaskPlanActions.createClonedPlan( newId, {
+      planId: HOMEWORK_WITH_FALSE.id, courseId: COURSE_ID, due_at: moment()
+    })
+    clone = TaskPlanStore.getChanged(newId)
+    for attr in ['title', 'description', 'type', 'settings', 'is_feedback_immediate']
+      expect(clone[attr]).to.deep.equal(HOMEWORK_WITH_FALSE[attr])
+
+    expect(clone.cloned_from_id).to.equal(HOMEWORK_WITH_FALSE.id)
     for period in CourseStore.getPeriods(COURSE_ID)
       tasking_plan = _.find(clone.tasking_plans, target_id: period.id)
       expect(tasking_plan).to.exist

--- a/tutor/src/components/task-plan/builder/index.cjsx
+++ b/tutor/src/components/task-plan/builder/index.cjsx
@@ -73,7 +73,7 @@ TaskPlanBuilder = React.createClass
     {id} = @props
 
     taskings = TaskingStore.getChanged(id)
-    TaskPlanActions.replaceTaskings(id, taskings)
+    TaskPlanActions.replaceTaskings(id, taskings) if taskings?
 
   setAllPeriods: ->
     {id} = @props

--- a/tutor/src/components/task-plan/builder/index.cjsx
+++ b/tutor/src/components/task-plan/builder/index.cjsx
@@ -73,7 +73,7 @@ TaskPlanBuilder = React.createClass
     {id} = @props
 
     taskings = TaskingStore.getChanged(id)
-    TaskPlanActions.replaceTaskings(id, taskings) if taskings?
+    TaskPlanActions.replaceTaskings(id, taskings)
 
   setAllPeriods: ->
     {id} = @props

--- a/tutor/src/components/task-plan/initialize-editing.coffee
+++ b/tutor/src/components/task-plan/initialize-editing.coffee
@@ -45,12 +45,13 @@ getTaskPlanOpensAt = (planId) ->
 
 
 setPeriodDefaults = (courseId, planId, term) ->
-  if TaskPlanStore.isNew(planId) and not TaskingStore.hasTasking(planId)
-    due_date = getQueriedDueAt() or getTaskPlanOpensAt(planId)
-    TaskingActions.create(planId, {open_date: getQueriedOpensAt(planId, term.start), due_date})
-  else
-    {tasking_plans} = TaskPlanStore.get(planId)
-    TaskingActions.loadTaskings(planId, tasking_plans)
+  unless TaskingStore.hasTasking(planId)
+    if TaskPlanStore.isNew(planId) and not TaskingStore.hasTasking(planId)
+      due_date = getQueriedDueAt() or getTaskPlanOpensAt(planId)
+      TaskingActions.create(planId, {open_date: getQueriedOpensAt(planId, term.start), due_date})
+    else
+      {tasking_plans} = TaskPlanStore.get(planId)
+      TaskingActions.loadTaskings(planId, tasking_plans)
 
   nextState = {}
   nextState.showingPeriods = not TaskingStore.getTaskingsIsAll(planId)

--- a/tutor/src/components/task-plan/initialize-editing.coffee
+++ b/tutor/src/components/task-plan/initialize-editing.coffee
@@ -45,8 +45,7 @@ getTaskPlanOpensAt = (planId) ->
 
 
 setPeriodDefaults = (courseId, planId, term) ->
-
-  if TaskPlanStore.isNew(planId)
+  if TaskPlanStore.isNew(planId) and not TaskingStore.hasTasking(planId)
     due_date = getQueriedDueAt() or getTaskPlanOpensAt(planId)
     TaskingActions.create(planId, {open_date: getQueriedOpensAt(planId, term.start), due_date})
   else

--- a/tutor/src/components/task-plan/mini-editor/editor.cjsx
+++ b/tutor/src/components/task-plan/mini-editor/editor.cjsx
@@ -13,7 +13,7 @@ TutorLink = require '../../link'
 TaskingDateTimes = require '../builder/tasking-date-times'
 BindStoresMixin = require '../../bind-stores-mixin'
 {TutorInput, TutorTextArea} = require '../../tutor-input'
-{TaskingStore} = require '../../../flux/tasking'
+{TaskingStore, TaskingActions} = require '../../../flux/tasking'
 {TeacherTaskPlanActions} = require '../../../flux/teacher-task-plan'
 TimeHelper = require '../../../helpers/time'
 
@@ -68,11 +68,13 @@ TaskPlanMiniEditor = React.createClass
 
   componentWillMount: ->
     @initializePlan()
+    TaskingActions.updateTaskingsIsAll(@props.id, true)
 
   componentWillReceiveProps: (nextProps) ->
     if @props.id isnt nextProps.id or
       @props.courseId isnt nextProps.courseId
         @initializePlan(nextProps)
+        TaskingActions.updateTaskingsIsAll(@props.id, true)
 
   onSave: ->
     saving = @save()

--- a/tutor/src/components/task-plan/plan-mixin.cjsx
+++ b/tutor/src/components/task-plan/plan-mixin.cjsx
@@ -29,7 +29,7 @@ PlanMixin =
     isPublishedOrPublishing = TaskPlanStore.isPublished(id) or TaskPlanStore.isPublishing(id)
     isTaskOpened = TaskingStore.isTaskOpened(id)
 
-    isVisibleToStudents = !!((isPublishedOrPublishing and isTaskOpened) or false)
+    isVisibleToStudents = (isPublishedOrPublishing and isTaskOpened) or false
     isEditable = TaskPlanStore.isEditable(id)
     isSwitchable = not isVisibleToStudents or TaskingStore.hasAllTaskings(id)
 

--- a/tutor/src/flux/task-plan.coffee
+++ b/tutor/src/flux/task-plan.coffee
@@ -270,6 +270,8 @@ TaskPlanConfig =
     copyKeys = ['title', 'description', 'is_feedback_immediate', 'settings']
     each(copyKeys, (key) ->
       originalPlan[key] = cloneDeep(original[key])
+      # need to prevent false from being returned and ending the each loop early.
+      true
     )
 
     periods = CourseStore.getPeriods(courseId)

--- a/tutor/src/flux/tasking.coffee
+++ b/tutor/src/flux/tasking.coffee
@@ -410,7 +410,7 @@ TaskingConfig =
 
     _getTaskingFor: (taskId, tasking) ->
       storedTaskings = @exports._getTaskings.call(@, taskId)
-      tasking = getFromForTasking(storedTaskings, tasking)
+      tasking = if storedTaskings? then getFromForTasking(storedTaskings, tasking)
 
     isTaskingEnabled: (taskId, tasking) ->
       tasking = @exports._getTaskingFor.call(@, taskId, tasking)

--- a/tutor/src/flux/tasking.coffee
+++ b/tutor/src/flux/tasking.coffee
@@ -410,7 +410,7 @@ TaskingConfig =
 
     _getTaskingFor: (taskId, tasking) ->
       storedTaskings = @exports._getTaskings.call(@, taskId)
-      tasking = if storedTaskings? then getFromForTasking(storedTaskings, tasking)
+      tasking = getFromForTasking(storedTaskings, tasking)
 
     isTaskingEnabled: (taskId, tasking) ->
       tasking = @exports._getTaskingFor.call(@, taskId, tasking)
@@ -451,6 +451,9 @@ TaskingConfig =
       tasking["#{type}_time"] is defaults["#{type}_time"]
 
     hasTasking: (taskId, tasking) ->
+      storedTaskings = @exports._getTaskings.call(@, taskId)
+      return false unless storedTaskings?
+
       tasking = @exports._getTaskingFor.call(@, taskId, tasking)
       tasking?
 
@@ -503,7 +506,7 @@ TaskingConfig =
 
     isTaskOpened: (taskId) ->
       firstTasking = _.first(@exports._getTaskingsSortedByOpenDate.call(@, taskId))
-      !!(firstTasking and isTaskingOpened(firstTasking))
+      (firstTasking and isTaskingOpened(firstTasking)) or false
 
     getFirstDueDate: (taskId) ->
       firstTasking = _.first(@exports._getTaskingsSortedByDueDate.call(@, taskId))


### PR DESCRIPTION
…ts before overriding when initializing

Taskings was being ignored when changed on mini-editor since it was unaware that it should be updating taskings for all.  Also we were re-initializing taskings on builder mount if the plan has a new id, so always resetting the dates when the builder loaded from the editor