### PR TITLE
Set sidebar toggle icon to correct value when rendering open

### DIFF
--- a/tutor/specs/components/course-calendar/__snapshots__/sidebar-toggle.spec.cjsx.snap
+++ b/tutor/specs/components/course-calendar/__snapshots__/sidebar-toggle.spec.cjsx.snap
@@ -1,0 +1,16 @@
+exports[`CourseCalendar Sidebar Toggle matches snapshot 1`] = `
+<button
+  className="sidebar-toggle btn btn-default"
+  disabled={false}
+  onClick={[Function]}
+  onTransitionEnd={[Function]}
+  type="button">
+  <i
+    className="tutor-icon fa fa-bars"
+    type="bars" />
+  <span
+    className="text">
+    Add Assignment
+  </span>
+</button>
+`;

--- a/tutor/specs/components/course-calendar/sidebar-toggle.spec.cjsx
+++ b/tutor/specs/components/course-calendar/sidebar-toggle.spec.cjsx
@@ -35,3 +35,20 @@ describe 'CourseCalendar Sidebar Toggle', ->
     wrapper.simulate('click')
     expect(Helper.setSidebarOpen).toHaveBeenCalledWith(@props.courseId, true)
     undefined
+
+
+  it 'displays the correct icon after animation finishes', ->
+    wrapper = shallow(<Toggle {...@props} />)
+    expect(wrapper.hasClass('open')).to.equal false
+    wrapper.simulate('click')
+    expect(wrapper.find('Icon[type="bars"]').length).to.equal(1)
+    wrapper.simulate('transitionEnd')
+    expect(wrapper.find('Icon[type="times"]').length).to.equal(1)
+    undefined
+
+  it 'defaults to last opened value', ->
+    Helper.isSidebarOpen.mockReturnValueOnce(true)
+    wrapper = shallow(<Toggle {...@props} />)
+    expect(wrapper.hasClass('open')).to.equal true
+    expect(wrapper.find('Icon[type="times"]').length).to.equal(1)
+    undefined

--- a/tutor/specs/components/course-calendar/sidebar-toggle.spec.cjsx
+++ b/tutor/specs/components/course-calendar/sidebar-toggle.spec.cjsx
@@ -1,4 +1,4 @@
-{React} = require '../helpers/component-testing'
+{React, SnapShot} = require '../helpers/component-testing'
 {UiSettings} = require 'shared'
 
 jest.mock('../../../src/components/course-calendar/helper')
@@ -52,3 +52,10 @@ describe 'CourseCalendar Sidebar Toggle', ->
     expect(wrapper.hasClass('open')).to.equal true
     expect(wrapper.find('Icon[type="times"]').length).to.equal(1)
     undefined
+
+  it 'matches snapshot', ->
+    component = SnapShot.create(
+      <Toggle {...@props} />
+    )
+    tree = component.toJSON()
+    expect(tree).toMatchSnapshot()

--- a/tutor/src/components/course-calendar/sidebar-toggle.cjsx
+++ b/tutor/src/components/course-calendar/sidebar-toggle.cjsx
@@ -5,6 +5,9 @@ classnames = require 'classnames'
 Icon = require '../icon'
 CalendarHelper = require './helper'
 
+OPEN_ICON = 'times'
+CLOSED_ICON = 'bars'
+
 CalendarSidebarToggle = React.createClass
 
   displayName: 'CalendarSidebarToggle'
@@ -17,8 +20,9 @@ CalendarSidebarToggle = React.createClass
     defaultOpen: false
 
   getInitialState: ->
-    iconType: 'bars'
-    isOpen: CalendarHelper.isSidebarOpen(@props.courseId)
+    isOpen = CalendarHelper.isSidebarOpen(@props.courseId)
+    iconType = if isOpen then OPEN_ICON else CLOSED_ICON
+    {isOpen, iconType}
 
   componentWillMount: ->
     if @state.isOpen
@@ -30,7 +34,7 @@ CalendarSidebarToggle = React.createClass
     CalendarHelper.clearScheduledEvent(@state.pendingIntroTimeout)
 
   setIconType: ->
-    @setState(iconType: if @state.isOpen then 'times' else 'bars')
+    @setState(iconType: if @state.isOpen then OPEN_ICON else CLOSED_ICON)
 
   onToggle: ->
     isOpen = not @state.isOpen


### PR DESCRIPTION
Fixes a small bug, previously when the sidebar was defaulted to open, the icon would be wrong and have the bars even though it's open:

![screen shot 2016-12-13 at 10 10 57 am](https://cloud.githubusercontent.com/assets/79566/21148012/75f493f0-c11c-11e6-90b3-64c6b912bee0.png)




it's now the correct 'X':

![screen shot 2016-12-13 at 10 10 27 am](https://cloud.githubusercontent.com/assets/79566/21147985/63bc312a-c11c-11e6-9a18-77e45482a83d.png)
