### PR TITLE
explicitly remove the style from detailed cards

### DIFF
--- a/tutor/resources/styles/components/exercises.less
+++ b/tutor/resources/styles/components/exercises.less
@@ -39,10 +39,12 @@
 
   .exercise-card {
     width: 800px;
+    &:focus { outline: none; }
 
     .panel-body {
       min-height: 600px;
       padding: 70px 70px 70px 100px !important;
+
     }
 
     .controls-overlay {


### PR DESCRIPTION
It was inheriting the outline from the card view.  Not sure why chrome et al didn't also show it