### PR TITLE
Skip selecting course only if offering is set

### DIFF
--- a/tutor/specs/components/new-course/__snapshots__/select-course.spec.cjsx.snap
+++ b/tutor/specs/components/new-course/__snapshots__/select-course.spec.cjsx.snap
@@ -2,7 +2,7 @@ exports[`CreateCourse: Selecting course subject matches snapshot 1`] = `
 <div
   className="list-group">
   <div
-    className="list-group-item choice active"
+    className="list-group-item choice"
     data-appearance="college_biology"
     onClick={[Function]}
     role="button">

--- a/tutor/specs/components/new-course/select-course.spec.cjsx
+++ b/tutor/specs/components/new-course/select-course.spec.cjsx
@@ -34,10 +34,12 @@ describe 'CreateCourse: Selecting course subject', ->
 
     undefined
 
-  it 'only skips if offering id is set', ->
+  it 'only skips if offering id is set and valid', ->
     Router.currentParams.mockReturnValue({sourceId: 1})
     expect(SelectCourse.shouldSkip()).to.be.false
-    NewCourseActions.set({offering_id: 22})
+    NewCourseActions.set({offering_id: 1234}) ## not a valid offering_id
+    expect(SelectCourse.shouldSkip()).to.be.false
+    NewCourseActions.set({offering_id: OFFERINGS.items[0].id})
     expect(SelectCourse.shouldSkip()).to.be.true
     undefined
 

--- a/tutor/specs/components/new-course/select-course.spec.cjsx
+++ b/tutor/specs/components/new-course/select-course.spec.cjsx
@@ -1,16 +1,20 @@
 {React, SnapShot} = require '../helpers/component-testing'
 
+jest.mock('../../../src/helpers/router')
+Router = require '../../../src/helpers/router'
+
 SelectCourse = require '../../../src/components/new-course/select-course'
 OFFERINGS = require '../../../api/offerings'
 
 {OfferingsActions} = require '../../../src/flux/offerings'
-{NewCourseStore} = require '../../../src/flux/new-course'
+{NewCourseStore, NewCourseActions} = require '../../../src/flux/new-course'
 
 CourseInformation = require '../../../src/flux/course-information'
 
 describe 'CreateCourse: Selecting course subject', ->
 
   beforeEach ->
+    NewCourseActions.set({offering_id: null})
     OfferingsActions.loaded(OFFERINGS)
 
   it 'it sets offering_id when clicked', ->
@@ -28,6 +32,13 @@ describe 'CreateCourse: Selecting course subject', ->
       offeringItemSelector = "[data-book-title='#{CourseInformation.forAppearanceCode(OFFERINGS.items[index].appearance_code).title}']"
       expect(wrapper.find(offeringItemSelector)).to.have.length(1)
 
+    undefined
+
+  it 'only skips if offering id is set', ->
+    Router.currentParams.mockReturnValue({sourceId: 1})
+    expect(SelectCourse.shouldSkip()).to.be.false
+    NewCourseActions.set({offering_id: 22})
+    expect(SelectCourse.shouldSkip()).to.be.true
     undefined
 
 

--- a/tutor/src/components/new-course/select-course.cjsx
+++ b/tutor/src/components/new-course/select-course.cjsx
@@ -26,7 +26,11 @@ SelectCourse = React.createClass
   statics:
     title: 'Which course are you teaching?'
     shouldSkip: ->
-      Boolean( NewCourseStore.get('offering_id') and TutorRouter.currentParams().sourceId )
+      Boolean(
+        TutorRouter.currentParams().sourceId and
+        NewCourseStore.get('offering_id') and
+        OfferingsStore.get(NewCourseStore.get('offering_id'))
+      )
 
   getInitialState: ->
     offerings = OfferingsStore.filter(is_concept_coach: NewCourseStore.get('course_type') is 'cc')

--- a/tutor/src/components/new-course/select-course.cjsx
+++ b/tutor/src/components/new-course/select-course.cjsx
@@ -26,7 +26,7 @@ SelectCourse = React.createClass
   statics:
     title: 'Which course are you teaching?'
     shouldSkip: ->
-      TutorRouter.currentParams().sourceId
+      !!( NewCourseStore.get('offering_id') and TutorRouter.currentParams().sourceId )
 
   getInitialState: ->
     offerings = OfferingsStore.filter(is_concept_coach: NewCourseStore.get('course_type') is 'cc')

--- a/tutor/src/components/new-course/select-course.cjsx
+++ b/tutor/src/components/new-course/select-course.cjsx
@@ -26,7 +26,7 @@ SelectCourse = React.createClass
   statics:
     title: 'Which course are you teaching?'
     shouldSkip: ->
-      !!( NewCourseStore.get('offering_id') and TutorRouter.currentParams().sourceId )
+      ( NewCourseStore.get('offering_id') and TutorRouter.currentParams().sourceId ) or false
 
   getInitialState: ->
     offerings = OfferingsStore.filter(is_concept_coach: NewCourseStore.get('course_type') is 'cc')

--- a/tutor/src/components/new-course/select-course.cjsx
+++ b/tutor/src/components/new-course/select-course.cjsx
@@ -26,7 +26,7 @@ SelectCourse = React.createClass
   statics:
     title: 'Which course are you teaching?'
     shouldSkip: ->
-      ( NewCourseStore.get('offering_id') and TutorRouter.currentParams().sourceId ) or false
+      Boolean( NewCourseStore.get('offering_id') and TutorRouter.currentParams().sourceId )
 
   getInitialState: ->
     offerings = OfferingsStore.filter(is_concept_coach: NewCourseStore.get('course_type') is 'cc')


### PR DESCRIPTION
Some courses do not have an offering_id, which means that even thought they're selected as a source, we can't pair them with an offering.

We'll have to fix them in the admin screen for production, but in the meantime we shouldn't blow up the FE code