### PR TITLE
Use a titleized version of code instead of "default" for course info

### DIFF
--- a/tutor/specs/flux/course-information.spec.coffee
+++ b/tutor/specs/flux/course-information.spec.coffee
@@ -1,0 +1,17 @@
+CourseInfo = require '../../src/flux/course-information'
+
+describe 'Course Information lookup', ->
+
+  it 'returns info for a valid appearance_code', ->
+    expect(CourseInfo.forAppearanceCode('college_biology')).to.deep.equal({
+      title: 'College Biology'
+      subject: 'Biology'
+    })
+    undefined
+
+  it 'returns a default values for unknown codes', ->
+    expect(CourseInfo.forAppearanceCode('yo_yo_yo')).to.deep.equal({
+      title: 'Yo Yo Yo',
+      subject: ''
+    })
+    undefined

--- a/tutor/src/flux/course-information.coffee
+++ b/tutor/src/flux/course-information.coffee
@@ -1,3 +1,5 @@
+String = require '../helpers/string'
+
 SUBJECTS =
   PHYSICS:    'Physics'
   BIOLOGY:    'Biology'
@@ -50,4 +52,4 @@ module.exports =
     subject:    SUBJECTS.ANATOMY_PHYSIOLOGY
 
   forAppearanceCode: (code) ->
-    @[code] or { title: 'default', subject: '' }
+    @[code] or { title: String.titleize(code), subject: '' }


### PR DESCRIPTION
When a appearance code isn't found it's usually because admin has set
something that's just like the book's title.  In that case we're better
off to send back a cleaned up code instead of 'default'