### PR TITLE
intro popover hides on sidebar cloase

### DIFF
--- a/tutor/src/components/course-calendar/add-assignment-sidebar.cjsx
+++ b/tutor/src/components/course-calendar/add-assignment-sidebar.cjsx
@@ -93,7 +93,7 @@ AddAssignmentSidebar = React.createClass
         >
           {@renderAddActions()}
         </ul>
-        <IntroPopover onClose={@onPopoverClose} show={@state.showPopover} />
+        <IntroPopover onClose={@onPopoverClose} show={@state.showPopover and @props.isOpen} />
       </div>
       <PastAssignments
         className='sidebar-section'


### PR DESCRIPTION
Fixes https://trello.com/c/0Or0r08U/431-bug-close-hide-the-tooltip-when-the-sidebar-closes

![screen shot 2016-12-14 at 2 47 53 pm](https://cloud.githubusercontent.com/assets/2483873/21232873/d1159a30-c2b2-11e6-8c9d-0df70a3dd835.png)
