### PR TITLE
Fix timezone missyncing

### DIFF
--- a/tutor/src/components/course-calendar/month.cjsx
+++ b/tutor/src/components/course-calendar/month.cjsx
@@ -224,8 +224,6 @@ CourseMonth = React.createClass
     )
 
   onDragHover: (day) ->
-    # console.info(TimeHelper.toDateTimeISO(TimeHelper.getZonedMoment(day)))
-    # console.info(TimeHelper.toDateTimeISO(TimeHelper.getMomentPreserveDate(day)))
     @setState(hoveredDay: TimeHelper.getMomentPreserveDate(day))
   onSidebarToggle: (isOpen) ->
     @setState(showingSideBar: isOpen)

--- a/tutor/src/components/task-plan/builder/index.cjsx
+++ b/tutor/src/components/task-plan/builder/index.cjsx
@@ -61,12 +61,16 @@ TaskPlanBuilder = React.createClass
   componentWillMount: ->
     {id, courseId} = @props
     {term} = @state
+
+    # better to have `syncCourseTimezone` out here to make the symmetry
+    # of the unsync in the unmount obvious.
+    courseTimezone = CourseStore.getTimezone(courseId)
+    TimeHelper.syncCourseTimezone(courseTimezone)
+
     nextState = taskPlanEditingInitialize(id, courseId, term)
     @setState(nextState)
 
   componentWillUnmount: ->
-    {id, courseId} = @props
-
     TimeHelper.unsyncCourseTimezone()
 
   changeTaskPlan: ->

--- a/tutor/src/components/task-plan/initialize-editing.coffee
+++ b/tutor/src/components/task-plan/initialize-editing.coffee
@@ -69,8 +69,6 @@ loadCourseDefaults = (courseId) ->
 
 
 module.exports = (taskPlanId, courseId, term) ->
-  courseTimezone = CourseStore.getTimezone(courseId)
-  TimeHelper.syncCourseTimezone(courseTimezone)
   TaskingActions.loadTaskToCourse(taskPlanId, courseId)
   loadCourseDefaults(courseId)
 

--- a/tutor/src/components/task-plan/mini-editor/editor.cjsx
+++ b/tutor/src/components/task-plan/mini-editor/editor.cjsx
@@ -15,6 +15,8 @@ BindStoresMixin = require '../../bind-stores-mixin'
 {TutorInput, TutorTextArea} = require '../../tutor-input'
 {TaskingStore, TaskingActions} = require '../../../flux/tasking'
 {TeacherTaskPlanActions} = require '../../../flux/teacher-task-plan'
+{CourseStore, CourseActions} = require '../../../flux/course'
+
 TimeHelper = require '../../../helpers/time'
 
 taskPlanEditingInitialize = require '../initialize-editing'
@@ -64,6 +66,11 @@ TaskPlanMiniEditor = React.createClass
   initializePlan: (props) ->
     props ?= @props
     {id, courseId, termStart, termEnd} = props
+
+    # make sure timezone is synced before working with plan
+    courseTimezone = CourseStore.getTimezone(courseId)
+    TimeHelper.syncCourseTimezone(courseTimezone)
+
     taskPlanEditingInitialize(id, courseId, {start: termStart, end: termEnd})
 
   componentWillMount: ->

--- a/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -106,6 +106,12 @@ TeacherTaskPlanListing = React.createClass
     TeacherTaskPlanActions.clearPendingClone(courseId)
     TaskPlanStore.on('saved.*', @loadToListing)
 
+  componentDidMount: ->
+    # the unmount from the builder often get's called after
+    # the initial `componentWillMount`
+    courseTimezone = CourseStore.getTimezone(@props.params.courseId)
+    TimeHelper.syncCourseTimezone(courseTimezone)
+
   componentWillUnmount: ->
     TimeHelper.unsyncCourseTimezone()
 

--- a/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
+++ b/tutor/src/components/task-plan/teacher-task-plans-listing.cjsx
@@ -108,7 +108,8 @@ TeacherTaskPlanListing = React.createClass
 
   componentDidMount: ->
     # the unmount from the builder often get's called after
-    # the initial `componentWillMount`
+    # the initial `componentWillMount` so this is needed to make sure
+    # the time gets synced
     courseTimezone = CourseStore.getTimezone(@props.params.courseId)
     TimeHelper.syncCourseTimezone(courseTimezone)
 


### PR DESCRIPTION
https://trello.com/c/GMlX0LA7/353-bug-intermittent-assignments-shift-back-one-day-after-dragging-to-intended-due-date

can be triggered as easily as going to calendar, click on an assignment to edit, and then clicking cancel.  Builder unmount to unsync timezone was getting called after the calendar's sync call.