### PR TITLE
fix disappearing navbar

### DIFF
--- a/shared/src/components/pinned-header-footer-card/index.cjsx
+++ b/shared/src/components/pinned-header-footer-card/index.cjsx
@@ -3,7 +3,6 @@ ReactDOM = require 'react-dom'
 
 union = require 'lodash/union'
 omit  = require 'lodash/omit'
-without = require 'lodash/without'
 
 ScrollListenerMixin = require '../../mixins/ScrollListener'
 
@@ -34,6 +33,7 @@ module.exports = React.createClass
     shouldBeShy: false
     headerHeight: 0
     containerMarginTop: '0px'
+    originalClassName: document.body.className
 
   mixins: [ScrollListenerMixin, ResizeListenerMixin, GetPositionMixin]
 
@@ -46,7 +46,7 @@ module.exports = React.createClass
     @setBodyClassList()
 
   componentWillUnmount: ->
-    document.body.className = without(document.body.classList, @desiredBodyClassList()).join(' ')
+    document.body.className = @state.originalClassName
 
   setBodyClassList: ->
     document.body.className = union(document.body.classList, @desiredBodyClassList()).join(' ')


### PR DESCRIPTION
this is the simplest way to reset the classes on the pinned components.  `without` wasnt working because the function expects the excluded values as individual and not the whole array of values to exclude. for that, `difference` is the function to use.  also, pinned-on and pinned-shy, classes added or removed based on scroll were not being considered despite needing to be removed on unmount

https://trello.com/c/suWaGT0S/358-bug-menu-disappearing-on-all-browsers-randomly

a reliable way to reproduce this is to go to homework builder from calendar, scroll down to where the main menu hides, and then click the back button

