### PR TITLE
Course listing needs to be updated after successful enrollment

### DIFF
--- a/tutor/src/components/enroll/index.cjsx
+++ b/tutor/src/components/enroll/index.cjsx
@@ -6,6 +6,7 @@ Router = require '../../helpers/router'
 
 {CourseEnrollmentActions, CourseEnrollmentStore} = require '../../flux/course-enrollment'
 {CourseActions, CourseStore} = require '../../flux/course'
+{CourseListingActions, CourseListingStore} = require '../../flux/course-listing'
 {MessageList} = require 'shared'
 
 ConfirmJoin = require './confirm-join'
@@ -57,8 +58,16 @@ Enroll = React.createClass
       CourseStore.once('course.loaded', resolve)
       CourseActions.load(CourseEnrollmentStore.getCourseId())
     )
+    # On page load of this page, the student is not yet enrolled to this course,
+    # so the bootstrapped data that gets loaded into CourseListingStore does not include this new course.
+    # We need to make sure we load the full course listing after enrollment, otherwise
+    # dashboard will continue to think we're not enrolled in the new course.
+    loadCourseListing = new Promise((resolve, reject) ->
+      CourseListingStore.once('loaded', resolve)
+      CourseListingActions.load()
+    )
     successTimer = new Promise((resolve, reject) -> _.delay(resolve, 1500))
-    Promise.all([loadCourse, successTimer]).then(@redirectToDashboard)
+    Promise.all([loadCourse, loadCourseListing, successTimer]).then(@redirectToDashboard)
 
   isTeacher: ->
     CourseStore.isTeacher(CourseEnrollmentStore.courseId)

--- a/tutor/src/flux/course-enrollment.coffee
+++ b/tutor/src/flux/course-enrollment.coffee
@@ -111,10 +111,14 @@ CourseEnrollmentStore = flux.createStore
     @emit('change')
 
   confirmed: (response) ->
-    throw new Error("response is empty in confirmed") if _.isEmpty(response)
+    throw new Error('response is empty in confirmed') if _.isEmpty(response)
     @storeResponse(response)
 
-    @enrollmentChange.status = "process_error" if CourseEnrollmentStore.hasErrors()
+    if CourseEnrollmentStore.hasErrors()
+      @enrollmentChange.status = 'process_error'
+    else
+      # need to actually set this so that `isRegistered` get's to be true at some point.
+      @enrollmentChange.status = 'processed'
 
     @emit('change')
 


### PR DESCRIPTION
https://trello.com/c/AyiPjKha/386-bug-sign-up-with-a-tutor-student-join-url-doesn-t-get-students-to-the-right-place

dashboard now has all classes, including the new one i just joined without page reload

## Before
going to the dashboard after enrollment shows this:
![screen shot 2016-12-22 at 12 41 26 pm](https://cloud.githubusercontent.com/assets/2483873/21436428/0b7e62b0-c844-11e6-9ba4-f758a40efcf4.png)

## After
now, going to the dashboard after enrollment shows this if this is the only class for the student.
![screen shot 2016-12-22 at 12 41 42 pm](https://cloud.githubusercontent.com/assets/2483873/21436427/0b7e52b6-c844-11e6-8071-e3a37f84e5ab.png)

It shows the full list of courses including the new one if student is in more than one course.


