### PR TITLE
a few more udpatesss

### DIFF
--- a/coach/demo.cjsx
+++ b/coach/demo.cjsx
@@ -40,6 +40,7 @@ loadApp = ->
     collectionUUID: settings.COLLECTION_UUID
     moduleUUID: settings.MODULE_UUID
     cnxUrl: settings.CNX_URL
+    enrollmentCode: '388938'
     processHtmlAndMath: typesetMath # from demo
     getNextPage: ->
       nextChapter: '2.2'

--- a/coach/resources/styles/components/concept-coach/launcher.less
+++ b/coach/resources/styles/components/concept-coach/launcher.less
@@ -29,11 +29,6 @@
     .flex-display();
     .align-items(center);
     .justify-content(space-between);
-    // button {
-    //   .button(#3aab47);
-    //   padding: 8px;
-    //   margin: 1rem 2rem;
-    // }
   }
 
 
@@ -72,7 +67,6 @@
         font-size: 18px;
         margin-top: 10px;
         padding: 10px 40px;
-        color: @openstax-white;
       }
     }
     .openstax-graphics-coach {
@@ -82,8 +76,6 @@
   &.is-loading {
     .words {
       .fine-print {
-      // ,
-      // button {
         visibility: hidden;
       }
     }

--- a/coach/resources/styles/components/concept-coach/launcher.less
+++ b/coach/resources/styles/components/concept-coach/launcher.less
@@ -60,6 +60,7 @@
     }
     .openstax-graphics-coach {
       .flex(1);
+      .openstax-shadow(pop-down);
     }
   }
   &.is-loading {

--- a/coach/resources/styles/components/concept-coach/launcher.less
+++ b/coach/resources/styles/components/concept-coach/launcher.less
@@ -3,24 +3,6 @@
   min-height: 388px;
   height: 100%;
 
-  // .button(@color) {
-  //   background-color: @color;
-  //   color: @openstax-neutral-lightest;
-  //   border: 1px solid transparent;
-  //   border-radius: 4px;
-  //   span  { display: block; }
-  //   .warn {
-  //     font-size: 90%;
-  //     font-weight: 300;
-  //   }
-  //   &:active,
-  //   &:focus,
-  //   &:hover {
-  //     background-color: darken(@color, 10%);
-  //     border-color: darken(@color, 15%);
-  //   }
-  // }
-
   .header {
     border-bottom: 1px solid @openstax-neutral-light;
     font-size: 18px;
@@ -29,6 +11,12 @@
     .flex-display();
     .align-items(center);
     .justify-content(space-between);
+
+    .actions {
+      .btn {
+        margin-left: 1rem;
+      }
+    }
   }
 
 
@@ -50,10 +38,9 @@
         .flex-direction(column);
         .justify-content(center);
         color: @dark-blue;
-        h1 {
+        h2 {
           margin: 0;
-          font-size: 2.4vw;
-          color: @dark-blue;
+          font-weight: 800;
         }
       }
       .fine-print {

--- a/coach/resources/styles/components/concept-coach/launcher.less
+++ b/coach/resources/styles/components/concept-coach/launcher.less
@@ -19,6 +19,9 @@
     }
   }
 
+  a:not(.btn) {
+    color: @openstax-info;
+  }
 
   .body {
     .flex-display();
@@ -46,7 +49,6 @@
       .fine-print {
         p {
           margin: 0;
-          font-size: 1.8rem;
         }
       }
       button {
@@ -70,9 +72,6 @@
   &.is-logged-in,
   &.is-loading {
     .header .actions { display: none; }
-  }
-  &.is-enrolled {
-    // .words button { .button(@green); }
   }
 
 }

--- a/coach/resources/styles/components/course/registration.less
+++ b/coach/resources/styles/components/course/registration.less
@@ -5,7 +5,8 @@
   position: relative;
 }
 
-.enroll-or-login {
+.enroll-or-login,
+.new-registration {
   min-height: 280px;
 
   .flex-display();
@@ -14,8 +15,6 @@
 
   .laptop-and-mug {
     position: absolute;
-    top: -50px;
-    left: -450px;
 
     width: 800px;
     .launcher-coffee-steam path {
@@ -24,9 +23,29 @@
   }
 
   .body {
-    margin-left: 300px;
     text-align: center;
   }
+}
+
+.new-registration {
+  .laptop-and-mug {
+    left: -40px;
+    top: -20px;
+  }
+  h3 {
+    margin-top: 4px;
+  }
+}
+
+.enroll-or-login {
+  .laptop-and-mug {
+    top: -50px;
+    left: -450px;
+  }
+
+  .body {
+    margin-left: 300px;
+  } 
 
   .title {
     margin-top: 5rem;
@@ -49,7 +68,7 @@
     }
 
     &.is-closed {
-        cursor: pointer;
+      cursor: pointer;
     }
 
     &.sign-up {
@@ -80,5 +99,4 @@
       }
     }
   }
-
 }

--- a/coach/resources/styles/components/course/registration.less
+++ b/coach/resources/styles/components/course/registration.less
@@ -29,7 +29,7 @@
 
 .new-registration {
   .laptop-and-mug {
-    left: -40px;
+    left: -70px;
     top: -20px;
   }
   h3 {

--- a/coach/resources/styles/components/course/registration.less
+++ b/coach/resources/styles/components/course/registration.less
@@ -40,7 +40,11 @@
 .enroll-or-login {
   .laptop-and-mug {
     top: -50px;
-    left: -450px;
+    left: -300px;
+  }
+
+  .launcher-coffee {
+    display: none;
   }
 
   .body {

--- a/coach/resources/styles/components/graphics/laptop-and-mug.less
+++ b/coach/resources/styles/components/graphics/laptop-and-mug.less
@@ -18,5 +18,7 @@
     }
   }
 
-
+  .openstax-graphics-coach-wrapper {
+    .transform(~'scale(.612) translateX(652px) translateY(180px)');
+  }
 }

--- a/coach/resources/styles/components/graphics/launcher-animation.less
+++ b/coach/resources/styles/components/graphics/launcher-animation.less
@@ -194,10 +194,6 @@
     .launcher-concepts-animate();
     .animation(launcher-answer-enter ease-in);
   }
-
-  .btn {
-    .box-shadow(0 1px 6px rgba(0, 0, 0, 0.5));
-  }
 }
 
 .launcher-animate(launching) {

--- a/coach/specs/concept-coach/launcher/__snapshots__/index.spec.cjsx.snap
+++ b/coach/specs/concept-coach/launcher/__snapshots__/index.spec.cjsx.snap
@@ -157,14 +157,14 @@ exports[`Launcher renders as enrolled 1`] = `
         className="words">
         <div
           className="cta">
-          <h1>
+          <h2>
             Study Smarter with OpenStax
-          </h1>
-          <h1>
+          </h2>
+          <h2>
             Concept Coach
-          </h1>
+          </h2>
           <button
-            className="btn-openstax-primary btn btn-default"
+            className="btn btn-default"
             disabled={false}
             onClick={[Function]}
             type="button">
@@ -563,12 +563,12 @@ exports[`Launcher renders as logged in 1`] = `
         className="words">
         <div
           className="cta">
-          <h1>
+          <h2>
             Study Smarter with OpenStax
-          </h1>
-          <h1>
+          </h2>
+          <h2>
             Concept Coach
-          </h1>
+          </h2>
           <button
             className="btn-openstax-primary btn btn-default"
             disabled={false}
@@ -979,12 +979,12 @@ exports[`Launcher renders with launching status 1`] = `
         className="words">
         <div
           className="cta">
-          <h1>
+          <h2>
             Study Smarter with OpenStax
-          </h1>
-          <h1>
+          </h2>
+          <h2>
             Concept Coach
-          </h1>
+          </h2>
           <button
             className="btn-openstax-primary btn btn-default"
             disabled={false}

--- a/coach/specs/user/login-gateway.spec.cjsx
+++ b/coach/specs/user/login-gateway.spec.cjsx
@@ -12,14 +12,14 @@ describe 'User login gateway component', ->
   beforeEach ->
     User.endpoints = {login: 'test-login'}
     @props =
-      type: 'profile'
+      loginType: 'profile'
       onLogin: jest.fn()
-      loginWindow: new FakeWindow()
       windowImpl: new FakeWindow()
 
   it 'calls callback when complete', ->
     wrapper = shallow(<LoginGateway {...@props}><span>Child</span></LoginGateway>)
     expect(wrapper.text()).to.include('reopen window')
+    wrapper.find('a').simulate('click')
     expect(SnapShot.create(<LoginGateway {...@props} />).toJSON()).toMatchSnapshot()
     @props.windowImpl.addEventListener.lastCall.args[1](
       data: '{"user":{"id":1}}'

--- a/coach/src/concept-coach/index.cjsx
+++ b/coach/src/concept-coach/index.cjsx
@@ -14,7 +14,7 @@ task = require '../task/collection'
 {Coach} = require './coach'
 coachWrapped = helpers.wrapComponent(Coach)
 
-PROPS = ['moduleUUID', 'collectionUUID', 'cnxUrl', 'getNextPage', 'processHtmlAndMath']
+PROPS = ['moduleUUID', 'collectionUUID', 'cnxUrl', 'getNextPage', 'processHtmlAndMath', 'enrollmentCode']
 WRAPPER_CLASSNAME = 'concept-coach-wrapper'
 
 listenAndBroadcast = (componentAPI) ->
@@ -135,6 +135,8 @@ class ConceptCoachAPI extends EventEmitter2
       module.hot.accept('./coach', =>
         pastProps = coachWrapped.props
         coachWrapped.unmount()
+        {Coach} = require('./coach')
+        coachWrapped = helpers.wrapComponent(Coach)
         @component = coachWrapped.render(mountNode, pastProps)
       )
 

--- a/coach/src/concept-coach/index.cjsx
+++ b/coach/src/concept-coach/index.cjsx
@@ -135,8 +135,6 @@ class ConceptCoachAPI extends EventEmitter2
       module.hot.accept('./coach', =>
         pastProps = coachWrapped.props
         coachWrapped.unmount()
-        {Coach} = require('./coach')
-        coachWrapped = helpers.wrapComponent(Coach)
         @component = coachWrapped.render(mountNode, pastProps)
       )
 

--- a/coach/src/concept-coach/launcher/index.cjsx
+++ b/coach/src/concept-coach/launcher/index.cjsx
@@ -102,9 +102,12 @@ Launcher = React.createClass
         <div className="body">
           <div className="words">
             <div className="cta">
-              <h1>Study Smarter with OpenStax</h1>
-              <h1>Concept Coach</h1>
-              <BS.Button className='btn-openstax-primary' onClick={@props.onEnroll}>
+              <h2>Study Smarter with OpenStax</h2>
+              <h2>Concept Coach</h2>
+              <BS.Button className={
+                classnames(
+                  'btn-openstax-primary': not @getUser().isEnrolled(@props.collectionUUID)
+                )} onClick={@props.onEnroll}>
                 {@primaryActionText()}
               </BS.Button>
             </div>

--- a/coach/src/concept-coach/launcher/index.cjsx
+++ b/coach/src/concept-coach/launcher/index.cjsx
@@ -53,18 +53,17 @@ Launcher = React.createClass
     @setState(height: @getHeight(nextProps)) if @props.isLaunching isnt nextProps.isLaunching
 
   componentWillMount: ->
-    if @props.enrollmentCode and not @getUser().isEnrolled(@props.collectionUUID)
+    if @props.enrollmentCode? and not @getUser().isEnrolled(@props.collectionUUID)
       @validateEnrollmentCode()
 
   validateEnrollmentCode: ->
     {enrollmentCode} = @props
-    validationSignal = "course.#{@props.collectionUUID}.prevalidation.receive.*"
-    @getCourse().validate(enrollmentCode)
-    @getCourse().channel.once(validationSignal, @setIsEnrollmentCodeValid)
+    course = @getCourse()
+    course.channel.once('validated', @setIsEnrollmentCodeValid)
+    course.validate(enrollmentCode)
 
-  setIsEnrollmentCodeValid: (validationResponse) ->
-    {data} = validationResponse
-    @setState(isEnrollmentCodeValid: data?.response is true)
+  setIsEnrollmentCodeValid: ->
+    @setState(isEnrollmentCodeValid: true)
 
   mixins: [UserStatusMixin]
 

--- a/coach/src/course/model.coffee
+++ b/coach/src/course/model.coffee
@@ -104,7 +104,9 @@ class Course
     @_checkForFailure(response)
     {data} = response
     delete @isBusy
-    @status = 'validated' if data?.response is true
+    if data?.response is true
+      @status = 'validated'
+      @channel.emit('validated')
     @channel.emit('change')
 
   # Submits pending course change for confirmation

--- a/coach/src/course/model.coffee
+++ b/coach/src/course/model.coffee
@@ -131,6 +131,14 @@ class Course
     delete @isBusy
     @channel.emit('change')
 
+  validate: (enrollment_code) ->
+    @enrollment_code = enrollment_code
+    book_uuid = @ecosystem_book_uuid
+    data = {enrollment_code, book_uuid}
+    @isBusy = true
+    api.channel.once "course.#{@ecosystem_book_uuid}.prevalidation.receive.*", @_onValidated
+    api.channel.emit("course.#{@ecosystem_book_uuid}.prevalidation.send", {book_uuid}, data)
+
   # Submits a course invite for registration.  If user is signed in
   # the registration will be saved, otherwise it will only be validated
   register: (enrollment_code, user) ->
@@ -142,8 +150,7 @@ class Course
       api.channel.once "course.#{@ecosystem_book_uuid}.registration.receive.*", @_onRegistered
       api.channel.emit("course.#{@ecosystem_book_uuid}.registration.send", {book_uuid}, data)
     else
-      api.channel.once "course.#{@ecosystem_book_uuid}.prevalidation.receive.*", @_onValidated
-      api.channel.emit("course.#{@ecosystem_book_uuid}.prevalidation.send", {book_uuid}, data)
+      @validate(enrollment_code)
     @channel.emit('change')
 
   _onStudentUpdated: (response) ->

--- a/coach/src/course/new-registration.cjsx
+++ b/coach/src/course/new-registration.cjsx
@@ -26,21 +26,27 @@ NewCourseRegistration = React.createClass
 
   getDefaultProps: ->
     title: 'Register for this Concept Coach course'
+
+  getInitialState: ->
+    course: getCourse.call(@)
     isAutoRegistering: false
 
   componentWillMount: ->
-    course = getCourse.call(@)
-    @registerIfReady(course)
-    course.channel.on('change', @onCourseChange)
-    @setState({course})
+    @state.course.channel.on('change', @onCourseChange)
+    @registerIfReady()
 
   componentWillUnmount: ->
     @state.course.channel.off('change', @onCourseChange)
 
-  registerIfReady: (course) ->
-    if User.isLoggedIn() and @props.enrollmentCode and not course.isRegistered()
-      course.register(@props.enrollmentCode, User)
-      @setState(isAutoRegistering: true)
+  registerIfReady: ->
+    {course} = @state
+
+    if User.isLoggedIn() and
+      @props.enrollmentCode and
+      not course.isPending() and
+      not course.isRegistered()
+        course.register(@props.enrollmentCode, User)
+        @setState(isAutoRegistering: true)
 
   onComplete: ->
     @state.course.persist(User)
@@ -48,11 +54,14 @@ NewCourseRegistration = React.createClass
 
   onCourseChange: ->
     if @state.course.isRegistered()
-      @setState(isAutoRegistering: false)
       # wait 1.5 secs so our success message is briefly displayed, then call onComplete
       _.delay(@onComplete, 1500)
     else if @state.course.isValidated()
       @onComplete()
+    else if @state.course.isPending()
+      _.delay( =>
+        @setState(isAutoRegistering: false)
+      , 1000)
 
     @forceUpdate()
 
@@ -60,29 +69,33 @@ NewCourseRegistration = React.createClass
     <p className="lead">Redirecting to login...</p>
 
   renderComplete: (course) ->
-    <h3 className="text-center">
-      You have successfully joined {course.description()}
-    </h3>
+    <div>
+      <h3 className="text-center">
+        You have successfully joined {course.description()}
+      </h3>
+      <p>We are loading your first exercise.</p>
+    </div>
 
   isTeacher: ->
     User.isTeacherForCourse(@props.collectionUUID)
 
   renderCurrentStep: ->
     {course, isAutoRegistering} = @state
+
     if course.isValidated()
       @renderValidated()
-    else if course.isIncomplete()
-      title = if @isTeacher() then '' else @props.title
-      <EnrollmentCodeInput course={course} currentCourses={User.registeredCourses()} title={title} />
-    else if course.isConflicting()
-      <JoinConflict course={course} />
-    else if course.isPending()
-      <ConfirmJoin course={course} />
     else if isAutoRegistering
       <div>
         <h3>Please wait while we enroll you in this course.</h3>
         <LaptopAndMug height=400 />
       </div>
+    else if course.isPending()
+      <ConfirmJoin course={course} />
+    else if course.isIncomplete()
+      title = if @isTeacher() then '' else @props.title
+      <EnrollmentCodeInput course={course} currentCourses={User.registeredCourses()} title={title} />
+    else if course.isConflicting()
+      <JoinConflict course={course} />
     else
       @renderComplete(course)
 

--- a/coach/src/course/registration.cjsx
+++ b/coach/src/course/registration.cjsx
@@ -4,7 +4,7 @@ NewCourseRegistration = require './new-registration'
 ModifyCourseRegistration = require './modify-registration'
 EnrollOrLogin = require './enroll-or-login'
 
-UserStatus = require '../user/status-mixin'
+UserStatusMixin = require '../user/status-mixin'
 Course = require './model'
 
 CourseRegistration = React.createClass
@@ -12,11 +12,11 @@ CourseRegistration = React.createClass
   propTypes:
     collectionUUID: React.PropTypes.string.isRequired
 
-  mixins: [UserStatus]
+  mixins: [UserStatusMixin]
 
   render: ->
     user = @getUser()
-    course = user.getCourse(@props.collectionUUID)
+
     body = if user.isLoggedIn()
       <NewCourseRegistration {...@props} />
     else

--- a/coach/src/graphics/coach.cjsx
+++ b/coach/src/graphics/coach.cjsx
@@ -7,10 +7,10 @@ class CoachGraphic extends React.Component
   @displayName: 'CoachGraphic'
   render: ->
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 435 289.71" className={CLASSNAME_BASE}>
-      <CoachGraphic.Question/>
+      <CoachGraphic.Coach/>
     </svg>
 
-CoachGraphic.Question = ->
+CoachGraphic.Coach = ->
   <g className="#{CLASSNAME_BASE}-wrapper">
     <g className="#{CLASSNAME_BASE}-browser">
       <rect className="#{CLASSNAME_BASE}-browser-base" width="435" height="289.71" rx="3" ry="3"/>

--- a/coach/src/graphics/laptop-and-mug.cjsx
+++ b/coach/src/graphics/laptop-and-mug.cjsx
@@ -1,6 +1,6 @@
 # coffeelint: disable=max_line_length
 React = require 'react'
-{CoachGraphic} = require './coach'
+{Coach} = require './coach'
 
 Laptop = ->
   <g className='launcher-laptop'>
@@ -115,7 +115,7 @@ LaptopAndMug = React.createClass
 
       <LaptopAndMug.Laptop/>
       <LaptopAndMug.Mug/>
-      <LaptopAndMug.ConceptCoach/>
+      <Coach/>
 
     </svg>
 

--- a/coach/src/helpers/index.coffee
+++ b/coach/src/helpers/index.coffee
@@ -20,14 +20,13 @@ helpers =
       cache.component
 
     update: (props = {}) ->
-      @props = deepMerge({}, cache.component.props, props)
+      deepMerge(@props, props)
       ReactDOM.render(
         React.createElement(AppContainer, {}, React.createElement(component, @props))
         cache.DOMNode
       )
 
     unmount: ->
-      debugger
       ReactDOM.unmountComponentAtNode(cache.DOMNode)
 
 module.exports = helpers

--- a/coach/src/user/menu.cjsx
+++ b/coach/src/user/menu.cjsx
@@ -3,7 +3,7 @@ BS = require 'react-bootstrap'
 EventEmitter2 = require 'eventemitter2'
 {CloseButton} = require 'shared'
 
-Status = require './status-mixin'
+UserStatusMixin = require './status-mixin'
 
 Course = require '../course/model'
 
@@ -16,7 +16,7 @@ getWaitingText = (status) ->
   "#{status}…"
 
 UserMenu = React.createClass
-  mixins: [Status]
+  mixins: [UserStatusMixin]
 
   contextTypes:
     close: React.PropTypes.func

--- a/coach/src/user/status-mixin.coffee
+++ b/coach/src/user/status-mixin.coffee
@@ -1,4 +1,5 @@
 User = require './model'
+Course = require '../course/model'
 
 UserStatusMixin = {
 
@@ -10,6 +11,10 @@ UserStatusMixin = {
     @forceUpdate() if @isMounted()
   getUser: ->
     User
+  getCourse: ->
+    @props.course or
+      User.getCourse(@props.collectionUUID) or
+      new Course({ecosystem_book_uuid: @props.collectionUUID})
 }
 
 module.exports = UserStatusMixin

--- a/shared/specs/helpers/fake-window.coffee
+++ b/shared/specs/helpers/fake-window.coffee
@@ -1,6 +1,7 @@
 defer = require 'lodash/defer'
 merge = require 'lodash/merge'
 isFunction = require 'lodash/isFunction'
+cloneDeep = require 'lodash/cloneDeep'
 
 
 EmptyFn = ->
@@ -25,13 +26,15 @@ class FakeWindow
   constructor: (attrs = {}) ->
     merge(@, attrs)
     for name, method of @ when isFunction(method)
-      sinon.spy(@, name)
+      # sinon.spy(@, name) was causing some weird stack trace on the above methods...
+      @[name] = sinon.spy(method)
     @localStorage =
       getItem: sinon.stub().returns('[]')
       setItem: sinon.stub()
     @history =
       pushState: sinon.spy()
-    @open = sinon.spy()
+    windowRef = cloneDeep(@)
+    @open = sinon.spy( => windowRef )
     @screen =
       height: 1024
       width:  768


### PR DESCRIPTION
i think we should leave style overrides to webview side -- i.e.button text being white is already the default for webview buttons.

- [x] validate enrollment code before hiding enrollment code message
- [x] enrolling status when auto-enrolling
- [x] style details

Note that styles appear as in screenshots when embedded into webview.  they will look a little different in demo mode.

likely for other PRs
- [ ] login/sign up post message back to main coach base
- [ ] login/sign up different accounts workflow pages
- [ ] "Change enrollment" should go to proper panel
- [ ] coach opening state
- [ ] maybe move mug to be same plane horizontally as laptop, without desk background, floating mug looks weird.

![screen shot 2016-12-27 at 2 42 36 am](https://cloud.githubusercontent.com/assets/2483873/21495681/a2842dd2-cbde-11e6-83be-681bc772cf63.png)
![screen shot 2016-12-27 at 2 43 11 am](https://cloud.githubusercontent.com/assets/2483873/21495680/a283db16-cbde-11e6-9260-f6e960cdf09a.png)
![screen shot 2016-12-27 at 2 45 06 am](https://cloud.githubusercontent.com/assets/2483873/21495679/a283b67c-cbde-11e6-9718-6ddf4d8ef059.png)
![screen shot 2016-12-27 at 2 45 40 am](https://cloud.githubusercontent.com/assets/2483873/21495682/a284b518-cbde-11e6-8213-980fb5d9b541.png)
