### PR TITLE
Fix coach wrong enrollment

### DIFF
--- a/coach/demo.cjsx
+++ b/coach/demo.cjsx
@@ -16,6 +16,7 @@ SETTINGS =
     COLLECTION_UUID: "3402dc53-113d-45f3-954e-8d2ad1e73659"
     MODULE_UUID: '68ae7446-32b4-4cc7-89a7-4615dd20f3bd'
     CNX_URL: 'http://localhost:8000'
+    ENROLLMENT_CODE: '388938'
   SERVER:
     API_BASE_URL: 'https://tutor-dev.openstax.org'
     COLLECTION_UUID: 'f10533ca-f803-490d-b935-88899941197f'
@@ -40,7 +41,7 @@ loadApp = ->
     collectionUUID: settings.COLLECTION_UUID
     moduleUUID: settings.MODULE_UUID
     cnxUrl: settings.CNX_URL
-    enrollmentCode: '388938'
+    enrollmentCode: settings.ENROLLMENT_CODE
     processHtmlAndMath: typesetMath # from demo
     getNextPage: ->
       nextChapter: '2.2'

--- a/coach/src/concept-coach/coach.cjsx
+++ b/coach/src/concept-coach/coach.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 _ = require 'underscore'
-
+deepMerge = require 'lodash/merge'
 
 {ConceptCoach, channel} = require './base'
 {CCModal} = require './modal'
@@ -21,6 +21,7 @@ Coach = React.createClass
 
   getInitialState: ->
     isLoaded: false
+    isEnrollmentCodeValid: false
 
   getDefaultProps: ->
     open: false
@@ -44,14 +45,20 @@ Coach = React.createClass
   setIsLoaded: ->
     @setState(isLoaded: true)
 
-  Modal: ->
-    coachProps = _.omit(@props, 'open')
+  setIsEnrollmentCodeValid: (isValid) ->
+    @setState(isEnrollmentCodeValid: isValid)
+
+  Modal: (props) ->
+    propsToOmit = ['open']
+    propsToOmit.push('enrollmentCode') unless @state.isEnrollmentCodeValid
+    coachProps = deepMerge(_.omit(@props, propsToOmit), props)
+
     <CCModal filterClick={@props.filterClick}>
       <ConceptCoach {...coachProps} />
     </CCModal>
 
-  Launcher: ->
-    launcherProps = _.pick(@props, 'enrollmentCode')
+  Launcher: (props) ->
+    launcherProps = deepMerge(_.pick(@props, 'enrollmentCode'), props)
 
     <Launcher
       isLaunching={@props.open}
@@ -64,7 +71,7 @@ Coach = React.createClass
   render: ->
     <div className='concept-coach-wrapper'>
       {<@Modal setIsLoaded={@setIsLoaded}/> if @props.open or @state.loginWindow}
-      {<@Launcher /> unless @state.isLoaded}
+      {<@Launcher setIsEnrollmentCodeValid={@setIsEnrollmentCodeValid}/> unless @state.isLoaded}
     </div>
 
 module.exports = {Coach, channel}

--- a/coach/src/concept-coach/launcher/index.cjsx
+++ b/coach/src/concept-coach/launcher/index.cjsx
@@ -41,6 +41,7 @@ Launcher = React.createClass
     onEnroll: React.PropTypes.func.isRequired
     collectionUUID: React.PropTypes.string.isRequired
     enrollmentCode: React.PropTypes.string
+    setIsEnrollmentCodeValid: React.PropTypes.func
 
   getDefaultProps: ->
     isLaunching: false
@@ -63,6 +64,7 @@ Launcher = React.createClass
     course.validate(enrollmentCode)
 
   setIsEnrollmentCodeValid: ->
+    @props.setIsEnrollmentCodeValid?(true)
     @setState(isEnrollmentCodeValid: true)
 
   mixins: [UserStatusMixin]

--- a/shared/src/api/collections.coffee
+++ b/shared/src/api/collections.coffee
@@ -16,6 +16,7 @@ memoize   = require 'lodash/memoize'
 forEach   = require 'lodash/forEach'
 isEmpty   = require 'lodash/isEmpty'
 cloneDeep = require 'lodash/cloneDeep'
+isString = require 'lodash/isString'
 
 validateOptions = (requiredProperties...) ->
   (options) ->
@@ -127,7 +128,13 @@ class Routes extends Collection
 
 simplifyRequestConfig = (requestConfig) ->
   requestConfig = pick(requestConfig, 'method', 'data', 'url', 'params')
-  requestConfig = omit(requestConfig, 'data') if isEmpty(requestConfig.data)
+  if isEmpty(requestConfig.data)
+    requestConfig = omit(requestConfig, 'data')
+  else if isString(requestConfig.data)
+    try
+      requestConfig.data = JSON.parse(requestConfig.data)
+    catch e
+
   requestConfig
 
 class XHRRecords


### PR DESCRIPTION
Previously, if the wrong enrollment code url was loaded, the launcher would display the enrollment code fine-print, but the main coach modal would try to auto enroll you with the wrong code afterwards.  this makes sure the code is valid before passing it onwards for auto enrollment.

included in this PR is a fix that helps the FE know better about whether the api is still pending a response if an error was received.