### PR TITLE
upload jest code coverage to codecov.io

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, changes, uncovered, tree"
+  behavior: default
+
+# To Turn off comments completely:
+# comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,7 @@ script:
 after_failure:
   - npm list
 after_success:
-  - cat ./coverage/all.lcov.txt | node ./node_modules/.bin/coveralls --verbose
+  # Report coverage to codecov
+  - bash <(curl -s https://codecov.io/bash)
+  # Report to coveralls
+  - cat ./coverage/*/lcov.info | node ./node_modules/.bin/coveralls --verbose

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tutor-js
 [![build status][travis-image]][travis-url]
-[![code coverage][coveralls-image]][coveralls-url]
+[![Coverage][codecov-image]][codecov-url]
 [![dependency status][dependency-image]][dependency-url]
 [![dev dependency status][dev-dependency-image]][dev-dependency-url]
 
@@ -71,5 +71,5 @@ Before starting up vagrant, you can debug using a more production-like config by
 [dependency-url]: https://david-dm.org/openstax/tutor-js
 [dev-dependency-image]: https://img.shields.io/david/dev/openstax/tutor-js.svg?style=flat-square
 [dev-dependency-url]: https://david-dm.org/openstax/tutor-js#info=devDependencies
-[coveralls-image]: https://img.shields.io/coveralls/openstax/tutor-js.svg
-[coveralls-url]: https://coveralls.io/github/openstax/tutor-js
+[codecov-image]: https://img.shields.io/codecov/c/github/openstax/tutor-js.svg
+[codecov-url]: https://codecov.io/gh/openstax/tutor-js

--- a/configs/test/jest.coach.json
+++ b/configs/test/jest.coach.json
@@ -1,4 +1,5 @@
 {
+  "coverageDirectory": "../coverage/coach/",
   "rootDir": "../../coach",
   "cacheDirectory": "/tmp/coach",
   "preset": "../configs/test/jest.config.json"

--- a/configs/test/jest.config.json
+++ b/configs/test/jest.config.json
@@ -1,6 +1,10 @@
 {
   "verbose": true,
   "notify": true,
+  "collectCoverage": true,
+  "collectCoverageFrom": ["**/*.{js,jsx,cjsx}", "!**/node_modules/**"],
+  "coverageDirectory": "../coverage/",
+  "coverageReporters": ["json", "lcov", "text-summary"],
   "testRegex": "specs\/.*\\.spec\\.(coffee|js|jsx|cjsx|json)$",
   "transform": {
     "\\.(coffee|cjsx)$": "<rootDir>/../configs/test/jest.preprocessor.js"

--- a/configs/test/jest.exercises.json
+++ b/configs/test/jest.exercises.json
@@ -1,4 +1,5 @@
 {
+  "coverageDirectory": "../coverage/exercises/",
   "rootDir": "../../exercises",
   "cacheDirectory": "/tmp/exercises",
   "preset": "../configs/test/jest.config.json"

--- a/configs/test/jest.shared.json
+++ b/configs/test/jest.shared.json
@@ -1,4 +1,5 @@
 {
+  "coverageDirectory": "../coverage/shared/",
   "rootDir": "../../shared",
   "preset": "../configs/test/jest.config.json"
 }

--- a/configs/test/jest.tutor.json
+++ b/configs/test/jest.tutor.json
@@ -1,4 +1,5 @@
 {
+  "coverageDirectory": "../coverage/tutor/",
   "rootDir": "../../tutor",
   "cacheDirectory": "/tmp/tutor",
   "preset": "../configs/test/jest.config.json"


### PR DESCRIPTION
Inspired by [cnx-recipes#136](https://github.com/Connexions/cnx-recipes/pull/136), this generates code coverage for each of `tutor`, `exercises`, `coach`, and `shared` using https://facebook.github.io/jest/docs/configuration.html#collectcoveragefrom-array


You can see the results at https://codecov.io/gh/openstax/tutor-js/commits and then click a commit, and then click the "Files" tab near the top

Thanks @nathanstitt for the how-to! It was surprisingly simple!

# Questions

- [x] should I also add a config for `shared`?
- [x] will codecov.io properly OR all the coverage files from the various builds together?
- [ ] should I change the inclusion/exclusion patterns (do they spend extra time instrumenting files that do not end up being run?)
- [ ] should the karma code get removed?

# Screenshots

![image](https://cloud.githubusercontent.com/assets/253202/21626812/79b58ae6-d1e1-11e6-8507-e0cd0d51a3e1.png)

![image](https://cloud.githubusercontent.com/assets/253202/21626825/8b4f85cc-d1e1-11e6-8db9-7f23ed3ec66c.png)

refs openstax/napkin-notes#68