### PR TITLE
Set stage after offerings are loaded

### DIFF
--- a/tutor/api/courses/1.json
+++ b/tutor/api/courses/1.json
@@ -3,6 +3,7 @@
   "book_id": "123",
   "ecosystem_id": "1",
   "appearance_code": "biology",
+  "offering_id": "1",
   "periods": [{
     "id": "1",
     "name" : "1st",

--- a/tutor/specs/components/new-course/wizard.spec.cjsx
+++ b/tutor/specs/components/new-course/wizard.spec.cjsx
@@ -1,9 +1,15 @@
+jest.mock('../../../src/helpers/router')
+Router = require '../../../src/helpers/router'
+
 {React, spyOnComponentMethod, pause} = require '../helpers/component-testing'
 extend = require 'lodash/extend'
 uniqueId = require 'lodash/uniqueId'
 Wizard = require '../../../src/components/new-course/wizard'
 OFFERINGS = require '../../../api/offerings'
 
+{CourseActions, CourseStore} = require '../../../src/flux/course'
+COURSE  = require '../../../api/courses/1.json'
+COURSE_ID = '1'
 {OfferingsActions} = require '../../../src/flux/offerings'
 
 {CourseListingActions} = require '../../../src/flux/course-listing'
@@ -19,8 +25,22 @@ describe 'Creating a course', ->
   beforeEach ->
     CourseListingActions.loaded([ stubCourse(is_concept_coach: true)])
     OfferingsActions.loaded(OFFERINGS)
+    Router.currentParams.mockReturnValue({})
     @props =
       isLoading: false
+
+  it 'displays as loading and then sets stage when done', ->
+    CourseActions.loaded(COURSE, COURSE_ID)
+    Router.currentParams.mockReturnValue({sourceId: '1'})
+    @props.isLoading = true
+    wrapper = shallow(<Wizard {...@props} />)
+    expect(wrapper.find('OXFancyLoader[isLoading=true]')).to.have.length(1)
+    wrapper.setProps(isLoading: false)
+    expect(wrapper.find('OXFancyLoader[isLoading=false]')).to.have.length(1)
+    expect(wrapper.find('SelectDates')).to.have.length(1)
+    expect(wrapper.state('firstStage')).to.eq(2)
+    expect(wrapper.state('currentStage')).to.eq(2)
+    undefined
 
   it 'it skips course type if a single kind was previously taught', ->
     CourseListingActions.loaded([ stubCourse(is_concept_coach: false)])

--- a/tutor/src/components/new-course/wizard.cjsx
+++ b/tutor/src/components/new-course/wizard.cjsx
@@ -47,11 +47,19 @@ NewCourseWizard = React.createClass
     NewCourseActions.initialize(
       TutorRouter.currentParams()
     )
+    @setStage()
+
+  setStage: ->
     if STAGES.offering_id.shouldSkip()
       firstStage = 2
     else
       firstStage = if NewCourseStore.canSelectCourseType() then 0 else 1
     @setState({firstStage, currentStage: firstStage})
+
+  componentWillReceiveProps: (nextProps) ->
+    # we're switching from loading to not loading
+    if @props.isLoading and not nextProps.isLoading
+      @setStage()
 
   mixins: [BindStoreMixin]
   bindStore: NewCourseStore


### PR DESCRIPTION
When the offerings aren't present then the source course won't be found
in the offerings store, causing the wizard to display the "choose
course" panel, even when the source id was present.

By re-testing after the load, that panel can be skipped if a source
course is given.