### PR TITLE
Add toHaveRendered jasmine/jest expectation

### DIFF
--- a/configs/test/jest.setup.coffee
+++ b/configs/test/jest.setup.coffee
@@ -28,12 +28,6 @@ originalExpect = global.expect
 # bump up timeout to 30 seconds
 global.jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000
 
-global.expect = (actual) ->
-  originalMatchers = originalExpect(actual)
-  chaiMatchers = chai.expect(actual)
-  combinedMatchers = Object.assign(chaiMatchers, originalMatchers)
-  combinedMatchers
-
 process.on 'unhandledRejection', (reason, p) ->
   console.error("Possibly Unhandled Rejection at: Promise ", p, " reason: ", reason)
 

--- a/configs/test/jest.setup.coffee
+++ b/configs/test/jest.setup.coffee
@@ -47,3 +47,7 @@ global.expect = (actual) ->
   chaiMatchers = chai.expect(actual)
   combinedMatchers = Object.assign(chaiMatchers, originalMatchers)
   combinedMatchers
+
+global.expect.extend = originalExpect.extend
+
+require './matchers'

--- a/configs/test/matchers.coffee
+++ b/configs/test/matchers.coffee
@@ -1,0 +1,11 @@
+jasmine.addMatchers
+
+  toHaveRendered: ->
+    compare: (wrapper, selector) ->
+      matchCount = wrapper.find(selector).length
+      result = { pass: matchCount is 1 }
+      if result.pass
+        result.message =  "#{selector} was found"
+      else
+        result.message =  "Expected wrapper to contain `#{selector}` only once, but it was found #{matchCount} times"
+      result


### PR DESCRIPTION
Allows expectations such as:

`expect(wrapper).toHaveRendered('FooComponent')`

And get meaninful error messages such as:
```
  Expected wrapper to contain `FooComponent` only once, but it was found 0 times
```