### PR TITLE
set a min height on CC launcher's body

### DIFF
--- a/coach/resources/styles/components/concept-coach/launcher.less
+++ b/coach/resources/styles/components/concept-coach/launcher.less
@@ -45,7 +45,6 @@
         h2 {
           font-size: 2.6rem;
           letter-spacing: -1px;
-          color: @dark-blue;
           margin: 0;
           font-weight: 800;
         }

--- a/coach/resources/styles/components/concept-coach/launcher.less
+++ b/coach/resources/styles/components/concept-coach/launcher.less
@@ -28,7 +28,7 @@
     .align-items(center);
     min-height: 300px;
     padding: 30px;
-    .words {
+    #words {
       text-align: left;
       margin-right: 1rem;
       .align-self(stretch);
@@ -68,7 +68,7 @@
     }
   }
   &.is-loading {
-    .words {
+    #words {
       .fine-print {
         visibility: hidden;
       }

--- a/coach/resources/styles/components/concept-coach/launcher.less
+++ b/coach/resources/styles/components/concept-coach/launcher.less
@@ -26,6 +26,7 @@
   .body {
     .flex-display();
     .align-items(center);
+    min-height: 300px;
     padding: 30px;
     .words {
       text-align: left;

--- a/coach/resources/styles/components/concept-coach/launcher.less
+++ b/coach/resources/styles/components/concept-coach/launcher.less
@@ -43,6 +43,9 @@
         .justify-content(center);
         color: @dark-blue;
         h2 {
+          font-size: 2.6rem;
+          letter-spacing: -1px;
+          color: @dark-blue;
           margin: 0;
           font-weight: 800;
         }

--- a/coach/specs/concept-coach/launcher/__snapshots__/index.spec.cjsx.snap
+++ b/coach/specs/concept-coach/launcher/__snapshots__/index.spec.cjsx.snap
@@ -154,7 +154,7 @@ exports[`Launcher renders as enrolled 1`] = `
     <div
       className="body">
       <div
-        className="words">
+        id="words">
         <div
           className="cta">
           <h2>
@@ -560,7 +560,7 @@ exports[`Launcher renders as logged in 1`] = `
     <div
       className="body">
       <div
-        className="words">
+        id="words">
         <div
           className="cta">
           <h2>
@@ -976,7 +976,7 @@ exports[`Launcher renders with launching status 1`] = `
     <div
       className="body">
       <div
-        className="words">
+        id="words">
         <div
           className="cta">
           <h2>

--- a/coach/src/concept-coach/launcher/index.cjsx
+++ b/coach/src/concept-coach/launcher/index.cjsx
@@ -108,7 +108,7 @@ Launcher = React.createClass
           <LoginAction onLogin={@props.onLogin} isVisible={not isLoggedIn} />
         </div>
         <div className="body">
-          <div className="words">
+          <div id="words">
             <div className="cta">
               {words}
               <BS.Button className={


### PR DESCRIPTION
Otherwise it'll get squished when page is very narrow and things wrap

Turns this:
![screen shot 2017-01-09 at 1 02 10 pm](https://cloud.githubusercontent.com/assets/79566/21779143/ebc7c84a-d66b-11e6-95ed-7bed9f4a410a.png)


Into this:

![screen shot 2017-01-09 at 1 19 22 pm](https://cloud.githubusercontent.com/assets/79566/21779677/4c0e1838-d66e-11e6-91e9-cff147be7520.png)
