### PR TITLE
taskings were not being reset on cancel

### DIFF
--- a/tutor/src/components/task-plan/plan-mixin.cjsx
+++ b/tutor/src/components/task-plan/plan-mixin.cjsx
@@ -138,6 +138,7 @@ PlanMixin =
   reset: ->
     {id, courseId} = @props
     TaskPlanActions.resetPlan(id)
+    TaskingActions.resetFor(id)
     @goBackToCalendar()
 
   # TODO move to helper type thing.

--- a/tutor/src/flux/tasking.coffee
+++ b/tutor/src/flux/tasking.coffee
@@ -231,14 +231,7 @@ TaskingConfig =
     @_originalTaskings = {}
 
   resetFor: (taskId) ->
-    courseId = @_tasksToCourse[taskId]
-
-    delete @_taskings[taskId]
-    delete @_tasksToCourse[taskId]
-    delete @_taskingsIsAll[taskId]
-    delete @_originalTaskings[taskId]
-
-    delete @_defaults[courseId] unless courseId in _.values(@_tasksToCourse)
+    @loadTaskings(taskId, @_originalTaskings[taskId]) unless _.isEmpty(@_originalTaskings[taskId])
 
   loadDefaults: (courseId, course, periods) ->
     @_defaults[courseId] = transformCourseToDefaults(course, periods)


### PR DESCRIPTION
https://trello.com/c/ni4A6orX/415-bug-cancel-assignments-edits-doesn-t-discard-edited-dates-immediately-the-changes-aren-t-really-there-but-you-can-see-them