### PR TITLE
Update CC breadcrumbs when user's course changes

### DIFF
--- a/coach/src/breadcrumbs/index.cjsx
+++ b/coach/src/breadcrumbs/index.cjsx
@@ -56,18 +56,14 @@ Breadcrumbs = React.createClass
     currentStep: React.PropTypes.number
     canReview: React.PropTypes.bool
 
-  getInitialState: ->
-    {collectionUUID, moduleUUID} = @props
+  render: ->
+    {currentStep, canReview, collectionUUID, moduleUUID} = @props
     taskId = "#{collectionUUID}/#{moduleUUID}"
 
-    task: tasks.get(taskId)
-    moduleInfo: tasks.getModuleInfo(taskId)
+    task = tasks.get(taskId)
+    return null if _.isEmpty(task) or _.isEmpty(task.steps)
 
-  render: ->
-    {task, moduleInfo} = @state
-    {currentStep, canReview} = @props
-    return null if _.isEmpty(task.steps)
-
+    moduleInfo = tasks.getModuleInfo(taskId)
     task.title = moduleInfo.title
 
     crumbs = TaskHelper.mapSteps(task)

--- a/coach/src/exercise/collection.coffee
+++ b/coach/src/exercise/collection.coffee
@@ -87,7 +87,7 @@ getAllParts = (stepId) ->
     get(part.id)
 
 init = ->
-  user.channel.on 'logout.received', ->
+  user.channel.on 'change', ->
     steps = {}
 
   api.channel.on("exercise.*.*.receive.success", update)

--- a/coach/src/task/collection.coffee
+++ b/coach/src/task/collection.coffee
@@ -87,8 +87,9 @@ getAsPage = (taskId) ->
   page
 
 init = ->
-  user.channel.on 'logout.received', ->
+  user.channel.on 'change', ->
     tasks = {}
+
   api.channel.on('task.*.*.receive.*', update)
 
 module.exports = {

--- a/coach/src/user/model.coffee
+++ b/coach/src/user/model.coffee
@@ -97,6 +97,7 @@ User =
     _.extend(this, BLANK_USER)
     @isLoggingOut = true
     @channel.emit('logout.received')
+    @channel.emit('change')
 
   init: ->
     api.channel.on 'user.status.fetch.receive.*', ({data}) ->


### PR DESCRIPTION
When I investigated this I found two bugs.  

The first is that when the User adds a second-semester course, the task and exercise stores weren't reset.  This would cause them to have stale data that was referring to the previous course.

The other is that the breadcrumbs component was storing the task in it's `@state`, and not refreshing it when the props changed.  I moved it out of and am fetching it from the store on render.  That way it won't be stale.