### PR TITLE
Attempt to fix safari 9 right arrow on narrow screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "bootstrap": "3.3.7",
     "classnames": "2.2.5",
     "dateformat": "2.0.0",
+    "detect-browser": "1.6.2",
     "es6-object-assign": "1.0.3",
     "es6-promise": "4.0.5",
     "eventemitter2": "2.2.1",

--- a/shared/src/helpers/react.coffee
+++ b/shared/src/helpers/react.coffee
@@ -8,6 +8,7 @@ pickBy         = require 'lodash/pickBy'
 concat         = require 'lodash/concat'
 some           = require 'lodash/some'
 kebabCase      = require 'lodash/kebabCase'
+browser        = require 'detect-browser'
 
 getBaseName = (context) -> kebabCase(context.constructor.displayName)
 
@@ -25,8 +26,11 @@ filterProps = (props, options = {}) ->
 renderRoot = (getComponent, rootEl) ->
   unless rootEl
     rootEl = document.createElement('div')
-    rootEl.id = 'ox-react-root-container'
     document.body.appendChild(rootEl)
+
+  rootEl.id = 'ox-react-root-container'
+  rootEl.setAttribute('data-browser', browser.name)
+  rootEl.setAttribute('data-browser-version', browser.version)
 
   render = ->
     Root = getComponent()

--- a/tutor/resources/styles/components/paging-navigation.less
+++ b/tutor/resources/styles/components/paging-navigation.less
@@ -1,26 +1,19 @@
-@tutor-paging-default-offsets: {
-  margin-left: -75px;
-};
-
-.paging-handle-browser-offsets(@handle-offset: @tutor-paging-default-offsets) {
-  // work around IE and Firefox flexbox bug where the icon is placed outside it's container
-  // this shifts it back into position
-  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-    @handle-offset();
+.paging-handle-browser-left-offset(@left-offset: -75px) {
+  // Only Chrome properly positions the right arrow properly.
+  // (Firefox/Safari/IE) place it to the right of the .arrow-wrapper element
+  // this rule shifts it back inside
+  #ox-react-root-container[data-browser="ie"]      &,
+  #ox-react-root-container[data-browser="safari"]  &,
+  #ox-react-root-container[data-browser="firefox"] &
+  {
+    margin-left: @left-offset;
   }
-  @-moz-document url-prefix() {
-    @handle-offset();
-  }
-  // safari 9 only
-  _::-webkit-:not(:root:root) {
-    @handle-offset();
-  }
-
 }
 
 
 .tutor-paging-navigation {
   @arrow-height: 150px;
+  @arrow-width: 75px;
   .flex-display();
   .justify-content(center);
 
@@ -46,9 +39,7 @@
       .arrow-wrapper {
         .flex-display();
         .justify-content(flex-end);
-        .icon {
-          .paging-handle-browser-offsets();
-        }
+        .icon { .paging-handle-browser-left-offset(-@arrow-width);  }
       }
     }
     &.prev {

--- a/tutor/resources/styles/components/paging-navigation.less
+++ b/tutor/resources/styles/components/paging-navigation.less
@@ -11,6 +11,11 @@
   @-moz-document url-prefix() {
     @handle-offset();
   }
+  // safari 9 only
+  _::-webkit-:not(:root:root) {
+    @handle-offset();
+  }
+
 }
 
 

--- a/tutor/resources/styles/components/task/index.less
+++ b/tutor/resources/styles/components/task/index.less
@@ -16,9 +16,7 @@
       .icon.arrow.left  { margin-left: -30px; }
       .icon.arrow.right {
         margin-left: 30px;
-        .paging-handle-browser-offsets({
-          margin-left: -45px;
-        });
+        .paging-handle-browser-left-offset(-45px);
       }
     }
   }


### PR DESCRIPTION
While I'm not a fan of browser sniffing, this seems like the only way to get this to work :(