### PR TITLE
Task plan builder should always display help icon

### DIFF
--- a/tutor/specs/components/task-plan/footer.spec.coffee
+++ b/tutor/specs/components/task-plan/footer.spec.coffee
@@ -94,3 +94,7 @@ describe 'Task Plan Footer', ->
       expect(dom.querySelector('.delete-link')).to.not.be.null
       expect(dom.querySelector('.-save')).to.be.null
       expect(dom.querySelector('.-publish')).to.not.be.null
+
+  it 'should have help tooltip', ->
+    helper(PUBLISHED_READING).then ({dom}) ->
+      expect(dom.querySelector('.footer-instructions')).to.not.be.null

--- a/tutor/specs/components/task-plan/footer/help-tooltip.spec.cjsx
+++ b/tutor/specs/components/task-plan/footer/help-tooltip.spec.cjsx
@@ -1,0 +1,32 @@
+{React, _} = require '../../helpers/component-testing'
+
+HelpTooltip = require '../../../../src/components/task-plan/footer/help-tooltip'
+
+displayPopover = (props) ->
+  new Promise( (resolve, reject) ->
+    wrapper = mount(<HelpTooltip {...props} />)
+    wrapper.simulate('click')
+    resolve(_.last document.querySelectorAll('#plan-footer-popover'))
+  )
+
+
+describe 'Task Plan Builder: Help tooltip', ->
+  beforeEach ->
+    @props =
+      isPublished: false
+
+  it 'displays popover that mentions publishing', ->
+    displayPopover(@props).then (dom) ->
+      expect(dom.textContent).to.include("Publish")
+
+  it 'doesn’t mention publishing if task plan is published', ->
+    @props.isPublished = true
+    displayPopover(@props).then (dom) ->
+      expect(dom.textContent).to.not.include("Publish")
+
+  it 'doesn’t mention delete unless task plan is published', ->
+    displayPopover(@props).then (dom) ->
+      expect(dom.textContent).not.to.include("Delete Assignment")
+    @props.isPublished = true
+    displayPopover(@props).then (dom) ->
+      expect(dom.textContent).to.include("Delete Assignment")

--- a/tutor/src/components/task-plan/footer/help-tooltip.cjsx
+++ b/tutor/src/components/task-plan/footer/help-tooltip.cjsx
@@ -2,19 +2,35 @@ React = require 'react'
 BS = require 'react-bootstrap'
 {TaskPlanStore} = require '../../../flux/task-plan'
 
-Tooltip =
+buildTooltip = ({isPublished}) ->
+  saveMessage = if isPublished
+    <div>
+      <p>
+        <strong>Save</strong> will update the assignment.
+      </p>
+    </div>
+  else
+    <div>
+      <p>
+        <strong>Publish</strong> will make the assignment visible to students on the open date.
+        If open date is today, it will be available immediately.
+      </p>
+      <p>
+        <strong>Save as draft</strong> will add the assignment to the teacher calendar only.
+        It will not be visible to students, even if the open date has passed.
+      </p>
+    </div>
+
   <BS.Popover id='plan-footer-popover'>
-    <p>
-      <strong>Publish</strong> will make the assignment visible to students on the open date.
-      If open date is today, it will be available immediately.
-    </p>
+    {saveMessage}
     <p>
       <strong>Cancel</strong> will discard all changes and return to the calendar.
     </p>
-    <p>
-      <strong>Save as draft</strong> will add the assignment to the teacher calendar only.
-      It will not be visible to students, even if the open date has passed.
-    </p>
+    {<p>
+      <strong>Delete Assignment</strong>
+      will remove the assignment from students dashboards.  Students who
+      have worked the assignment will still be able to review their work.
+    </p> if isPublished}
   </BS.Popover>
 
 HelpTooltip = React.createClass
@@ -23,9 +39,9 @@ HelpTooltip = React.createClass
     isPublished: React.PropTypes.bool.isRequired
 
   render: ->
-    return null if @props.isPublished
-
-    <BS.OverlayTrigger trigger='click' placement='top' overlay={Tooltip} rootClose={true}>
+    <BS.OverlayTrigger trigger='click' placement='top'
+      overlay={buildTooltip(@props)} rootClose={true}
+    >
       <BS.Button className="footer-instructions" bsStyle="link">
         <i className="fa fa-info-circle"></i>
       </BS.Button>


### PR DESCRIPTION
But it's help message should be appropriate for the status of the current task plan

For a new task plan:
![screen shot 2017-01-26 at 12 17 00 pm](https://cloud.githubusercontent.com/assets/79566/22344315/5c64b736-e3c1-11e6-8550-cf9c278d251b.png)

When published:
![screen shot 2017-01-26 at 12 15 49 pm](https://cloud.githubusercontent.com/assets/79566/22344282/364c6ff8-e3c1-11e6-85c0-39f8e1a9a127.png)
