### PR TITLE
CC fixes for scores report header borders

### DIFF
--- a/tutor/resources/styles/components/scores/header.less
+++ b/tutor/resources/styles/components/scores/header.less
@@ -1,3 +1,7 @@
+.public_fixedDataTableCell_main {
+  border-right: 1px solid @nav-tabs-border-color;
+}
+
 .header-cell-wrapper {
   @row-height: 30px;
   @short-row-height: 26px;
@@ -90,34 +94,26 @@
       line-height: @row-height;
       font-style: italic;
       color: @tutor-neutral-lite;
-      border-right: 1px solid @nav-tabs-border-color;
     }
 
     .header-row {
       font-weight: normal;
       border-top: @thick-grey-border;
-      .average {
-        width: 50%;
-        font-weight: 600;
+
+      > * {
         border-right: 1px solid @nav-tabs-border-color;
-        &.wide {
+        width: 50%;
+        &:only-child { // override "split" styling if it's the only child
+          border-right: 0;
           width: 100%;
         }
       }
-      .review-link {
-        border-right: 1px solid @nav-tabs-border-color;
-        width: 50%;
-        &.wide {
-          width: 100%;
-        }
+
+      .average {
+        font-weight: 600;
       }
       .scores-cell {
-        width: 100%;
         text-align: center;
-        border-right: 1px solid @nav-tabs-border-color;
-        &.click-rate {
-          width: 100%;
-        }
       }
     }
   }
@@ -131,7 +127,6 @@
     text-overflow: ellipsis;
     width: 100%;
     position: relative;
-    border-right: 1px solid @nav-tabs-border-color;
     &.sortable {
       font-size: 1.2rem;
       background-color: @student-header-bg-color;
@@ -152,7 +147,8 @@
     &.is-ascending::after  { content: @fa-var-sort-asc;  }
     &.is-descending::after { content: @fa-var-sort-desc; }
     &.group.title {
-      // border-top styles are defaults which are overridden by the .tutor-plan-set() mixin for specific types
+      // border-top rules are defaults for the cell and are overridden by .tutor-plan-set() mixin
+      // for various assignment types
       border-top-width: 1px;
       border-top-style: solid;
       border-top-color: @nav-tabs-border-color;
@@ -166,21 +162,5 @@
       background: lighten(@student-header-bg-color, 4%);
       .transition(background 0.2s);
     }
-  }
-
-
-}
-
-// If any of the items on the last column fail to render because they're a type of cell that
-// doesn't use them (external, CC, etc), then we end up without a border on the table which looks weird.
-//
-// To workaround that we add a border on the entire right side of the header cell and remove
-// it from any cells that may be inside to prevent double-borders
-.public_fixedDataTable_header .public_fixedDataTableCell_main:last-child {
-  border-right: 1px solid @nav-tabs-border-color;
-  .due,
-  .header-row .review-link,
-  .header-cell-wrapper .header-cell {
-    border-right: 0;
   }
 }

--- a/tutor/resources/styles/components/scores/header.less
+++ b/tutor/resources/styles/components/scores/header.less
@@ -164,4 +164,19 @@
     }
   }
 
+
+}
+
+// If any of the items on the last column fail to render because they're a type of cell that
+// doesn't use them (external, CC, etc), then we end up without a border on the table which looks weird.
+//
+// To workaround that we add a border on the entire right side of the header cell and remove
+// it from any cells that may be inside to prevent double-borders
+.public_fixedDataTable_header .public_fixedDataTableCell_main:last-child {
+  border-right: 1px solid @nav-tabs-border-color;
+  .due,
+  .header-row .review-link,
+  .header-cell-wrapper .header-cell {
+    border-right: 0;
+  }
 }

--- a/tutor/resources/styles/components/scores/header.less
+++ b/tutor/resources/styles/components/scores/header.less
@@ -152,6 +152,10 @@
     &.is-ascending::after  { content: @fa-var-sort-asc;  }
     &.is-descending::after { content: @fa-var-sort-desc; }
     &.group.title {
+      // border-top styles are defaults which are overridden by the .tutor-plan-set() mixin for specific types
+      border-top-width: 1px;
+      border-top-style: solid;
+      border-top-color: @nav-tabs-border-color;
       .tutor-plan-set(heading);
       .flex(1);
       padding: 8px;

--- a/tutor/resources/styles/components/scores/table.less
+++ b/tutor/resources/styles/components/scores/table.less
@@ -14,6 +14,9 @@
 
   @import "./header";
 
+  .tutor-tabs {
+    border-bottom: 0; // Prevent double border; report has a top border that meets the tabs bottom one
+  }
   .overall-border-style() {
     border-style: solid;
     border-width: 2px;

--- a/tutor/resources/styles/components/scores/table.less
+++ b/tutor/resources/styles/components/scores/table.less
@@ -56,10 +56,6 @@
     border: none;
   }
 
-  .public_fixedDataTableCell_main {
-    border: none;
-  }
-
   .public_fixedDataTableRow_fixedColumnsDivider {
     border: none;
   }

--- a/tutor/specs/components/scores/__snapshots__/assignment-header.spec.cjsx.snap
+++ b/tutor/specs/components/scores/__snapshots__/assignment-header.spec.cjsx.snap
@@ -1,0 +1,114 @@
+exports[`Scores Report: assignment column header for a CC course matches snapshot 1`] = `
+<div
+  className="header-cell-wrapper assignment">
+  <div
+    aria-describedby="header-cell-title-0"
+    className="expanded-header-row"
+    onBlur={[Function]}
+    onClick={null}
+    onFocus={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}>
+    <div
+      className="header-cell group title cc"
+      data-assignment-type="homework">
+      Homework Test
+    </div>
+  </div>
+  <div
+    className="header-row">
+    <span
+      className="average">
+      ---
+    </span>
+  </div>
+  <div
+    className="header-row short">
+    <div
+      className="scores-cell">
+      <div
+        className="header-cell sortable"
+        data-assignment-type="homework"
+        onClick={[Function]}>
+        <div>
+          Score
+        </div>
+      </div>
+      <div
+        className="header-cell sortable"
+        data-assignment-type="homework"
+        onClick={[Function]}>
+        <div>
+          Progress
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Scores Report: assignment column header renders and matches snapshot 1`] = `
+<div
+  className="header-cell-wrapper assignment">
+  <div
+    aria-describedby="header-cell-title-0"
+    className="expanded-header-row"
+    onBlur={[Function]}
+    onClick={null}
+    onFocus={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}>
+    <div
+      className="header-cell group title"
+      data-assignment-type="homework">
+      Homework Test
+    </div>
+    <div
+      className="due">
+      due 
+      <time>
+        5/31
+      </time>
+    </div>
+  </div>
+  <div
+    className="header-row">
+    <span
+      className="average">
+      ---
+    </span>
+    <span
+      className="review-link">
+      <a
+        className=""
+        href="/"
+        onClick={[Function]}
+        style={Object {}}>
+        Review
+      </a>
+    </span>
+  </div>
+  <div
+    className="header-row short">
+    <div
+      className="scores-cell">
+      <div
+        className="header-cell sortable"
+        data-assignment-type="homework"
+        onClick={[Function]}>
+        <div>
+          Score
+        </div>
+      </div>
+      <div
+        className="header-cell sortable"
+        data-assignment-type="homework"
+        onClick={[Function]}>
+        <div>
+          Progress
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/tutor/specs/components/scores/__snapshots__/index.spec.cjsx.snap
+++ b/tutor/specs/components/scores/__snapshots__/index.spec.cjsx.snap
@@ -1,0 +1,2957 @@
+exports[`Scores Report renders and matches snapshot 1`] = `
+<div
+  className="course-scores-wrap">
+  <span
+    className="course-scores-title">
+    Student Scores
+  </span>
+  <div
+    className="export-button">
+    <div
+      className="export-button-buttons">
+      <button
+        className="async-button btn btn-primary"
+        disabled={false}
+        onClick={[Function]}
+        type="button">
+        Export
+      </button>
+    </div>
+    <iframe
+      id="downloadExport"
+      src={null} />
+  </div>
+  <div
+    className="course-nav-container">
+    <nav
+      className="tutor-tabs">
+      <ul
+        className="nav nav-tabs"
+        role="tablist">
+        <li
+          className="active"
+          tabIndex={0}>
+          <a
+            aria-selected="true"
+            href="#"
+            onClick={[Function]}
+            role="tab"
+            tabIndex={-1}>
+            <div
+              className="">
+              <span
+                aria-describedby="course-periods-nav-tab-0"
+                className="tab-item-period-name"
+                onBlur={[Function]}
+                onClick={null}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}>
+                1st
+              </span>
+            </div>
+          </a>
+        </li>
+        <li
+          className=""
+          tabIndex={1}>
+          <a
+            aria-selected={undefined}
+            href="#"
+            onClick={[Function]}
+            role="tab"
+            tabIndex={0}>
+            <div
+              className="">
+              <span
+                aria-describedby="course-periods-nav-tab-1"
+                className="tab-item-period-name"
+                onBlur={[Function]}
+                onClick={null}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}>
+                2nd
+              </span>
+            </div>
+          </a>
+        </li>
+        <li
+          className=""
+          tabIndex={2}>
+          <a
+            aria-selected={undefined}
+            href="#"
+            onClick={[Function]}
+            role="tab"
+            tabIndex={0}>
+            <div
+              className="">
+              <span
+                aria-describedby="course-periods-nav-tab-2"
+                className="tab-item-period-name"
+                onBlur={[Function]}
+                onClick={null}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}>
+                3rd
+              </span>
+            </div>
+          </a>
+        </li>
+        <li
+          className=""
+          tabIndex={3}>
+          <a
+            aria-selected={undefined}
+            href="#"
+            onClick={[Function]}
+            role="tab"
+            tabIndex={0}>
+            <div
+              className="">
+              <span
+                aria-describedby="course-periods-nav-tab-3"
+                className="tab-item-period-name"
+                onBlur={[Function]}
+                onClick={null}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}>
+                5th
+              </span>
+            </div>
+          </a>
+        </li>
+        <li
+          className=""
+          tabIndex={4}>
+          <a
+            aria-selected={undefined}
+            href="#"
+            onClick={[Function]}
+            role="tab"
+            tabIndex={0}>
+            <div
+              className="">
+              <span
+                aria-describedby="course-periods-nav-tab-4"
+                className="tab-item-period-name"
+                onBlur={[Function]}
+                onClick={null}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}>
+                6th
+              </span>
+            </div>
+          </a>
+        </li>
+        <li
+          className=""
+          tabIndex={5}>
+          <a
+            aria-selected={undefined}
+            href="#"
+            onClick={[Function]}
+            role="tab"
+            tabIndex={0}>
+            <div
+              className="">
+              <span
+                aria-describedby="course-periods-nav-tab-5"
+                className="tab-item-period-name"
+                onBlur={[Function]}
+                onClick={null}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}>
+                10th
+              </span>
+            </div>
+          </a>
+        </li>
+      </ul>
+      <span
+        className="course-scores-note tab">
+        Scores reflect work submitted on time.
+         
+        To accept late work, click the orange triangle.
+      </span>
+    </nav>
+    <div
+      className="filter-row">
+      <div
+        className="filter-item">
+        <div
+          className="filter-label">
+          Display as
+        </div>
+        <div
+          className="filter-group btn-group">
+          <button
+            className="selected btn btn-sm btn-default"
+            disabled={false}
+            onClick={[Function]}
+            type="button">
+            percentage
+          </button>
+          <button
+            className="btn btn-sm btn-default"
+            disabled={false}
+            onClick={[Function]}
+            type="button">
+            number
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="course-scores-container">
+    <div
+      className="fixedDataTableLayout_main public_fixedDataTable_main"
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      onWheel={[Function]}
+      style={
+        Object {
+          "height": 628,
+          "width": 1024,
+        }
+      }>
+      <div
+        className="fixedDataTableLayout_rowsContainer"
+        style={
+          Object {
+            "height": 626,
+            "width": 1024,
+          }
+        }>
+        <div
+          className="fixedDataTableColumnResizerLineLayout_main fixedDataTableColumnResizerLineLayout_hiddenElem public_fixedDataTableColumnResizerLine_main"
+          style={
+            Object {
+              "height": 628,
+              "left": 0,
+              "width": 0,
+            }
+          }>
+          <div
+            className="fixedDataTableColumnResizerLineLayout_mouseArea"
+            style={
+              Object {
+                "height": 628,
+              }
+            } />
+        </div>
+        <div
+          className="fixedDataTableRowLayout_rowWrapper"
+          style={
+            Object {
+              "height": 0,
+              "left": "0px",
+              "top": "0px",
+              "width": 1024,
+              "zIndex": 1,
+            }
+          }>
+          <div
+            className="fixedDataTableRowLayout_main public_fixedDataTableRow_main public_fixedDataTableRow_even fixedDataTableLayout_header public_fixedDataTable_header"
+            onClick={null}
+            onDoubleClick={null}
+            onMouseDown={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            style={
+              Object {
+                "height": 0,
+                "width": 1024,
+              }
+            }>
+            <div
+              className="fixedDataTableRowLayout_body">
+              <div
+                className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 0,
+                  }
+                }>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroup"
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": "0px",
+                      "position": "absolute",
+                      "top": "0px",
+                      "width": 240,
+                      "zIndex": 2,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                    style={
+                      Object {
+                        "height": 0,
+                        "left": 0,
+                        "width": 240,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_wrap1 public_fixedDataTableCell_wrap1"
+                      style={
+                        Object {
+                          "height": 0,
+                          "width": 240,
+                        }
+                      }>
+                      <div
+                        className="fixedDataTableCellLayout_wrap2 public_fixedDataTableCell_wrap2">
+                        <div
+                          className="fixedDataTableCellLayout_wrap3 public_fixedDataTableCell_wrap3">
+                          <div
+                            className="public_fixedDataTableCell_cellContent" />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 240,
+                  }
+                }>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroup"
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": "0px",
+                      "position": "absolute",
+                      "top": "0px",
+                      "width": 480,
+                      "zIndex": 0,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                    style={
+                      Object {
+                        "height": 0,
+                        "left": 0,
+                        "width": 480,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_wrap1 public_fixedDataTableCell_wrap1"
+                      style={
+                        Object {
+                          "height": 0,
+                          "width": 480,
+                        }
+                      }>
+                      <div
+                        className="fixedDataTableCellLayout_wrap2 public_fixedDataTableCell_wrap2">
+                        <div
+                          className="fixedDataTableCellLayout_wrap3 public_fixedDataTableCell_wrap3">
+                          <div
+                            className="public_fixedDataTableCell_cellContent" />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="fixedDataTableRowLayout_fixedColumnsDivider public_fixedDataTableRow_fixedColumnsDivider"
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 240,
+                  }
+                } />
+            </div>
+          </div>
+        </div>
+        <div
+          className="fixedDataTableRowLayout_rowWrapper"
+          style={
+            Object {
+              "height": 150,
+              "left": "0px",
+              "top": "0px",
+              "width": 1024,
+              "zIndex": 1,
+            }
+          }>
+          <div
+            className="fixedDataTableRowLayout_main public_fixedDataTableRow_main fixedDataTableLayout_header public_fixedDataTable_header"
+            onClick={null}
+            onDoubleClick={null}
+            onMouseDown={null}
+            onMouseEnter={null}
+            onMouseLeave={null}
+            style={
+              Object {
+                "height": 150,
+                "width": 1024,
+              }
+            }>
+            <div
+              className="fixedDataTableRowLayout_body">
+              <div
+                className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                style={
+                  Object {
+                    "height": 150,
+                    "left": 0,
+                  }
+                }>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroup"
+                  style={
+                    Object {
+                      "height": 150,
+                      "left": "0px",
+                      "position": "absolute",
+                      "top": "0px",
+                      "width": 240,
+                      "zIndex": 2,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                    style={
+                      Object {
+                        "height": 150,
+                        "left": 0,
+                        "width": 160,
+                      }
+                    }>
+                    <div
+                      className="header-cell-wrapper student-names">
+                      <div
+                        className="overall-header-cell" />
+                      <div
+                        className="header-row">
+                        Class Performance
+                        <i
+                          aria-describedby="scores-average-info-popover"
+                          className="tutor-icon fa fa-info-circle clickable"
+                          onClick={[Function]}
+                          type="info-circle" />
+                      </div>
+                      <div
+                        className="header-row short">
+                        <div
+                          className="header-cell sortable"
+                          data-assignment-type={undefined}
+                          onClick={[Function]}>
+                          <div
+                            className="student-name">
+                            Name and Student ID
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                    style={
+                      Object {
+                        "height": 150,
+                        "left": 160,
+                        "width": 80,
+                      }
+                    }>
+                    <div
+                      className="header-cell-wrapper overall-average">
+                      <div
+                        className="overall-header-cell">
+                        Overall
+                      </div>
+                      <div
+                        className="header-row">
+                        <span>
+                          17%
+                        </span>
+                      </div>
+                      <div
+                        className="header-row short" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                style={
+                  Object {
+                    "height": 150,
+                    "left": 240,
+                  }
+                }>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroup"
+                  style={
+                    Object {
+                      "height": 150,
+                      "left": "0px",
+                      "position": "absolute",
+                      "top": "0px",
+                      "width": 480,
+                      "zIndex": 0,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                    style={
+                      Object {
+                        "height": 150,
+                        "left": 0,
+                        "width": 160,
+                      }
+                    }>
+                    <div
+                      className="header-cell-wrapper assignment">
+                      <div
+                        aria-describedby="header-cell-title-0"
+                        className="expanded-header-row"
+                        onBlur={[Function]}
+                        onClick={null}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}>
+                        <div
+                          className="header-cell group title"
+                          data-assignment-type="homework">
+                          Homework Test
+                        </div>
+                        <div
+                          className="due">
+                          due 
+                          <time>
+                            5/31
+                          </time>
+                        </div>
+                      </div>
+                      <div
+                        className="header-row">
+                        <span
+                          className="average">
+                          ---
+                        </span>
+                        <span
+                          className="review-link">
+                          <a
+                            className=""
+                            href="/"
+                            onClick={[Function]}
+                            style={Object {}}>
+                            Review
+                          </a>
+                        </span>
+                      </div>
+                      <div
+                        className="header-row short">
+                        <div
+                          className="scores-cell">
+                          <div
+                            className="header-cell sortable"
+                            data-assignment-type="homework"
+                            onClick={[Function]}>
+                            <div>
+                              Score
+                            </div>
+                          </div>
+                          <div
+                            className="header-cell sortable"
+                            data-assignment-type="homework"
+                            onClick={[Function]}>
+                            <div>
+                              Progress
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                    style={
+                      Object {
+                        "height": 150,
+                        "left": 160,
+                        "width": 160,
+                      }
+                    }>
+                    <div
+                      className="header-cell-wrapper assignment">
+                      <div
+                        aria-describedby="header-cell-title-1"
+                        className="expanded-header-row"
+                        onBlur={[Function]}
+                        onClick={null}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}>
+                        <div
+                          className="header-cell group title"
+                          data-assignment-type="reading">
+                          Reading Test
+                        </div>
+                        <div
+                          className="due">
+                          due 
+                          <time>
+                            5/31
+                          </time>
+                        </div>
+                      </div>
+                      <div
+                        className="header-row">
+                        <span
+                          className="review-link">
+                          <a
+                            className=""
+                            href="/"
+                            onClick={[Function]}
+                            style={Object {}}>
+                            Review
+                          </a>
+                        </span>
+                      </div>
+                      <div
+                        className="header-row short">
+                        <div
+                          className="scores-cell">
+                          <div
+                            className="header-cell sortable wide"
+                            data-assignment-type="reading"
+                            onClick={[Function]}>
+                            <div
+                              className="completed">
+                              Progress
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                    style={
+                      Object {
+                        "height": 150,
+                        "left": 320,
+                        "width": 160,
+                      }
+                    }>
+                    <div
+                      className="header-cell-wrapper assignment">
+                      <div
+                        aria-describedby="header-cell-title-2"
+                        className="expanded-header-row"
+                        onBlur={[Function]}
+                        onClick={null}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}>
+                        <div
+                          className="header-cell group title"
+                          data-assignment-type="external">
+                          eternal assignment
+                        </div>
+                        <div
+                          className="due">
+                          due 
+                          <time>
+                            2/4
+                          </time>
+                        </div>
+                      </div>
+                      <div
+                        className="header-row">
+                        <span
+                          className="click-rate">
+                          0
+                          % have clicked link
+                        </span>
+                      </div>
+                      <div
+                        className="header-row short">
+                        <div
+                          className="scores-cell">
+                          <div
+                            className="header-cell sortable wide"
+                            data-assignment-type="external"
+                            onClick={[Function]}>
+                            <div
+                              className="completed">
+                              Progress
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="fixedDataTableRowLayout_fixedColumnsDivider public_fixedDataTableRow_fixedColumnsDivider"
+                style={
+                  Object {
+                    "height": 150,
+                    "left": 240,
+                  }
+                } />
+            </div>
+          </div>
+        </div>
+        <div>
+          <div
+            className="fixedDataTableRowLayout_rowWrapper"
+            style={
+              Object {
+                "height": 50,
+                "left": "0px",
+                "top": "150px",
+                "width": 1024,
+                "zIndex": 0,
+              }
+            }>
+            <div
+              className="fixedDataTableRowLayout_main public_fixedDataTableRow_main public_fixedDataTableRow_even public_fixedDataTable_bodyRow"
+              onClick={null}
+              onDoubleClick={null}
+              onMouseDown={null}
+              onMouseEnter={null}
+              onMouseLeave={null}
+              style={
+                Object {
+                  "height": 50,
+                  "width": 1024,
+                }
+              }>
+              <div
+                className="fixedDataTableRowLayout_body">
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 0,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 240,
+                        "zIndex": 2,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="name-cell-wrapper">
+                        <a
+                          className="name-cell"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span
+                            aria-describedby="name-tooltip-Rabbit-Angstrom"
+                            className="student-name"
+                            onBlur={[Function]}
+                            onClick={null}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}>
+                            Rabbit Angstrom
+                          </span>
+                          <span
+                            className="student-id">
+                            O7I5E8YQBR
+                          </span>
+                        </a>
+                        <div
+                          className="overall-cell">
+                          50%
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 80,
+                        }
+                      }>
+                      <div
+                        className="fixedDataTableCellLayout_wrap1 public_fixedDataTableCell_wrap1 overall-cell"
+                        style={
+                          Object {
+                            "height": undefined,
+                            "width": undefined,
+                          }
+                        }>
+                        <div
+                          className="fixedDataTableCellLayout_wrap2 public_fixedDataTableCell_wrap2">
+                          <div
+                            className="fixedDataTableCellLayout_wrap3 public_fixedDataTableCell_wrap3">
+                            <div
+                              className="public_fixedDataTableCell_cellContent">
+                              50
+                              %
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 480,
+                        "zIndex": 0,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell">
+                        <div
+                          className="score">
+                          <a
+                            className=""
+                            data-assignment-type="homework"
+                            href="/"
+                            onClick={[Function]}
+                            style={Object {}}>
+                            50%
+                          </a>
+                        </div>
+                        <div
+                          className="worked"
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <svg
+                            className="pie-progress"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            width="20">
+                            <g
+                              id="q4">
+                              <circle
+                                className="slice late"
+                                cx="12.03"
+                                cy="11.583"
+                                r="12" />
+                              <g>
+                                <line
+                                  fill="none"
+                                  stroke="#FFFFFF"
+                                  strokeMiterlimit="10"
+                                  x1="12.03"
+                                  x2="12.03"
+                                  y1="-0.418"
+                                  y2="23.582" />
+                                <line
+                                  fill="none"
+                                  stroke="#FFFFFF"
+                                  strokeMiterlimit="10"
+                                  x1="0.03"
+                                  x2="24.03"
+                                  y1="11.582"
+                                  y2="11.582" />
+                              </g>
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell"
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}>
+                        <div
+                          className="worked wide">
+                          <svg
+                            className="pie-progress"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            width="20">
+                            <g
+                              id="q4">
+                              <circle
+                                className="slice late"
+                                cx="12.03"
+                                cy="11.583"
+                                r="12" />
+                              <g>
+                                <line
+                                  fill="none"
+                                  stroke="#FFFFFF"
+                                  strokeMiterlimit="10"
+                                  x1="12.03"
+                                  x2="12.03"
+                                  y1="-0.418"
+                                  y2="23.582" />
+                                <line
+                                  fill="none"
+                                  stroke="#FFFFFF"
+                                  strokeMiterlimit="10"
+                                  x1="0.03"
+                                  x2="24.03"
+                                  y1="11.582"
+                                  y2="11.582" />
+                              </g>
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 320,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="external-cell">
+                        <a
+                          className="task-result status-cell undefined"
+                          data-assignment-type="external"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span>
+                            ---
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableRowLayout_fixedColumnsDivider public_fixedDataTableRow_fixedColumnsDivider"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  } />
+              </div>
+            </div>
+          </div>
+          <div
+            className="fixedDataTableRowLayout_rowWrapper"
+            style={
+              Object {
+                "height": 50,
+                "left": "0px",
+                "top": "200px",
+                "width": 1024,
+                "zIndex": 0,
+              }
+            }>
+            <div
+              className="fixedDataTableRowLayout_main public_fixedDataTableRow_main public_fixedDataTableRow_highlighted public_fixedDataTableRow_odd public_fixedDataTable_bodyRow"
+              onClick={null}
+              onDoubleClick={null}
+              onMouseDown={null}
+              onMouseEnter={null}
+              onMouseLeave={null}
+              style={
+                Object {
+                  "height": 50,
+                  "width": 1024,
+                }
+              }>
+              <div
+                className="fixedDataTableRowLayout_body">
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 0,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 240,
+                        "zIndex": 2,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="name-cell-wrapper">
+                        <a
+                          className="name-cell"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span
+                            aria-describedby="name-tooltip-Molly-Bloom"
+                            className="student-name"
+                            onBlur={[Function]}
+                            onClick={null}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}>
+                            Molly Bloom
+                          </span>
+                          <span
+                            className="student-id">
+                            52VY7XAW4Q
+                          </span>
+                        </a>
+                        <div
+                          className="overall-cell">
+                          50%
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 80,
+                        }
+                      }>
+                      <div
+                        className="fixedDataTableCellLayout_wrap1 public_fixedDataTableCell_wrap1 overall-cell"
+                        style={
+                          Object {
+                            "height": undefined,
+                            "width": undefined,
+                          }
+                        }>
+                        <div
+                          className="fixedDataTableCellLayout_wrap2 public_fixedDataTableCell_wrap2">
+                          <div
+                            className="fixedDataTableCellLayout_wrap3 public_fixedDataTableCell_wrap3">
+                            <div
+                              className="public_fixedDataTableCell_cellContent">
+                              50
+                              %
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 480,
+                        "zIndex": 0,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell">
+                        <div
+                          className="score">
+                          <a
+                            className=""
+                            data-assignment-type="homework"
+                            href="/"
+                            onClick={[Function]}
+                            style={Object {}}>
+                            100%
+                          </a>
+                        </div>
+                        <div
+                          className="worked"
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <svg
+                            className="pie-progress"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            width="20">
+                            <g
+                              id="q2">
+                              <g>
+                                <circle
+                                  cx="11.566"
+                                  cy="11.582"
+                                  fill="#DDDDDD"
+                                  r="12" />
+                                <path
+                                  className="slice late"
+                                  d="M11.566-0.417v24c6.629,0,12-5.371,12-12C23.566,4.955,18.195-0.417,11.566-0.417z" />
+                              </g>
+                              <line
+                                fill="none"
+                                stroke="#FFFFFF"
+                                strokeMiterlimit="10"
+                                x1="11.566"
+                                x2="11.566"
+                                y1="-0.417"
+                                y2="23.582" />
+                              <line
+                                fill="none"
+                                stroke="#FFFFFF"
+                                strokeMiterlimit="10"
+                                x1="-0.434"
+                                x2="23.566"
+                                y1="11.583"
+                                y2="11.583" />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell"
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}>
+                        <div
+                          className="worked wide">
+                          <svg
+                            className="pie-progress"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            width="20">
+                            <g
+                              id="q1">
+                              <g>
+                                <circle
+                                  cx="12.334"
+                                  cy="11.583"
+                                  fill="#DDDDDD"
+                                  r="12" />
+                                <path
+                                  className="slice late"
+                                  d="M12.334,11.582h12l0,0c0-6.628-5.371-12-12-12V11.582z" />
+                              </g>
+                              <line
+                                fill="none"
+                                stroke="#FFFFFF"
+                                strokeMiterlimit="10"
+                                x1="12.334"
+                                x2="12.334"
+                                y1="-0.417"
+                                y2="23.582" />
+                              <line
+                                fill="none"
+                                stroke="#FFFFFF"
+                                strokeMiterlimit="10"
+                                x1="0.334"
+                                x2="24.334"
+                                y1="11.583"
+                                y2="11.583" />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 320,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="external-cell">
+                        <a
+                          className="task-result status-cell undefined"
+                          data-assignment-type="external"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span>
+                            ---
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableRowLayout_fixedColumnsDivider public_fixedDataTableRow_fixedColumnsDivider"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  } />
+              </div>
+            </div>
+          </div>
+          <div
+            className="fixedDataTableRowLayout_rowWrapper"
+            style={
+              Object {
+                "height": 50,
+                "left": "0px",
+                "top": "250px",
+                "width": 1024,
+                "zIndex": 0,
+              }
+            }>
+            <div
+              className="fixedDataTableRowLayout_main public_fixedDataTableRow_main public_fixedDataTableRow_even public_fixedDataTable_bodyRow"
+              onClick={null}
+              onDoubleClick={null}
+              onMouseDown={null}
+              onMouseEnter={null}
+              onMouseLeave={null}
+              style={
+                Object {
+                  "height": 50,
+                  "width": 1024,
+                }
+              }>
+              <div
+                className="fixedDataTableRowLayout_body">
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 0,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 240,
+                        "zIndex": 2,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="name-cell-wrapper">
+                        <a
+                          className="name-cell"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span
+                            aria-describedby="name-tooltip-Seymour-Glass"
+                            className="student-name"
+                            onBlur={[Function]}
+                            onClick={null}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}>
+                            Seymour Glass
+                          </span>
+                          <span
+                            className="student-id">
+                            4C5208Z6SW
+                          </span>
+                        </a>
+                        <div
+                          className="overall-cell">
+                          50%
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 80,
+                        }
+                      }>
+                      <div
+                        className="fixedDataTableCellLayout_wrap1 public_fixedDataTableCell_wrap1 overall-cell"
+                        style={
+                          Object {
+                            "height": undefined,
+                            "width": undefined,
+                          }
+                        }>
+                        <div
+                          className="fixedDataTableCellLayout_wrap2 public_fixedDataTableCell_wrap2">
+                          <div
+                            className="fixedDataTableCellLayout_wrap3 public_fixedDataTableCell_wrap3">
+                            <div
+                              className="public_fixedDataTableCell_cellContent">
+                              50
+                              %
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 480,
+                        "zIndex": 0,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell">
+                        <div
+                          className="score">
+                          <a
+                            className=""
+                            data-assignment-type="homework"
+                            href="/"
+                            onClick={[Function]}
+                            style={Object {}}>
+                            50%
+                          </a>
+                        </div>
+                        <div
+                          className="worked"
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <svg
+                            className="pie-progress"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            width="20">
+                            <g
+                              id="q4">
+                              <circle
+                                className="slice late"
+                                cx="12.03"
+                                cy="11.583"
+                                r="12" />
+                              <g>
+                                <line
+                                  fill="none"
+                                  stroke="#FFFFFF"
+                                  strokeMiterlimit="10"
+                                  x1="12.03"
+                                  x2="12.03"
+                                  y1="-0.418"
+                                  y2="23.582" />
+                                <line
+                                  fill="none"
+                                  stroke="#FFFFFF"
+                                  strokeMiterlimit="10"
+                                  x1="0.03"
+                                  x2="24.03"
+                                  y1="11.582"
+                                  y2="11.582" />
+                              </g>
+                            </g>
+                          </svg>
+                        </div>
+                        <div
+                          className="late-caret-trigger"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <div
+                            className="late-caret" />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell"
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}>
+                        <div
+                          className="worked wide">
+                          <svg
+                            className="pie-progress"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            width="20">
+                            <g
+                              id="q1">
+                              <g>
+                                <circle
+                                  cx="12.334"
+                                  cy="11.583"
+                                  fill="#DDDDDD"
+                                  r="12" />
+                                <path
+                                  className="slice late"
+                                  d="M12.334,11.582h12l0,0c0-6.628-5.371-12-12-12V11.582z" />
+                              </g>
+                              <line
+                                fill="none"
+                                stroke="#FFFFFF"
+                                strokeMiterlimit="10"
+                                x1="12.334"
+                                x2="12.334"
+                                y1="-0.417"
+                                y2="23.582" />
+                              <line
+                                fill="none"
+                                stroke="#FFFFFF"
+                                strokeMiterlimit="10"
+                                x1="0.334"
+                                x2="24.334"
+                                y1="11.583"
+                                y2="11.583" />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 320,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="external-cell">
+                        <a
+                          className="task-result status-cell undefined"
+                          data-assignment-type="external"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span>
+                            ---
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableRowLayout_fixedColumnsDivider public_fixedDataTableRow_fixedColumnsDivider"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  } />
+              </div>
+            </div>
+          </div>
+          <div
+            className="fixedDataTableRowLayout_rowWrapper"
+            style={
+              Object {
+                "height": 50,
+                "left": "0px",
+                "top": "300px",
+                "width": 1024,
+                "zIndex": 0,
+              }
+            }>
+            <div
+              className="fixedDataTableRowLayout_main public_fixedDataTableRow_main public_fixedDataTableRow_highlighted public_fixedDataTableRow_odd public_fixedDataTable_bodyRow"
+              onClick={null}
+              onDoubleClick={null}
+              onMouseDown={null}
+              onMouseEnter={null}
+              onMouseLeave={null}
+              style={
+                Object {
+                  "height": 50,
+                  "width": 1024,
+                }
+              }>
+              <div
+                className="fixedDataTableRowLayout_body">
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 0,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 240,
+                        "zIndex": 2,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="name-cell-wrapper">
+                        <a
+                          className="name-cell"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span
+                            aria-describedby="name-tooltip-Bettie-Hackett"
+                            className="student-name"
+                            onBlur={[Function]}
+                            onClick={null}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}>
+                            Bettie Hackett
+                          </span>
+                          <span
+                            className="student-id">
+                            3UPNAI8JD2
+                          </span>
+                        </a>
+                        <div
+                          className="overall-cell">
+                          0%
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 80,
+                        }
+                      }>
+                      <div
+                        className="fixedDataTableCellLayout_wrap1 public_fixedDataTableCell_wrap1 overall-cell"
+                        style={
+                          Object {
+                            "height": undefined,
+                            "width": undefined,
+                          }
+                        }>
+                        <div
+                          className="fixedDataTableCellLayout_wrap2 public_fixedDataTableCell_wrap2">
+                          <div
+                            className="fixedDataTableCellLayout_wrap3 public_fixedDataTableCell_wrap3">
+                            <div
+                              className="public_fixedDataTableCell_cellContent">
+                              0
+                              %
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 480,
+                        "zIndex": 0,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell">
+                        <div
+                          className="score">
+                          <a
+                            className=""
+                            data-assignment-type="homework"
+                            href="/"
+                            onClick={[Function]}
+                            style={Object {}}>
+                            0%
+                          </a>
+                        </div>
+                        <div
+                          className="worked"
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <span
+                            className="not-started">
+                            ---
+                          </span>
+                        </div>
+                        <div
+                          className="late-caret-trigger"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <div
+                            className="late-caret" />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell"
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}>
+                        <div
+                          className="worked wide">
+                          <span
+                            className="not-started">
+                            ---
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 320,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="external-cell">
+                        <a
+                          className="task-result status-cell undefined"
+                          data-assignment-type="external"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span>
+                            Clicked
+                          </span>
+                          <i
+                            aria-describedby="late-icon-tooltip-705"
+                            className="late"
+                            onBlur={[Function]}
+                            onClick={null}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]} />
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableRowLayout_fixedColumnsDivider public_fixedDataTableRow_fixedColumnsDivider"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  } />
+              </div>
+            </div>
+          </div>
+          <div
+            className="fixedDataTableRowLayout_rowWrapper"
+            style={
+              Object {
+                "height": 50,
+                "left": "0px",
+                "top": "350px",
+                "width": 1024,
+                "zIndex": 0,
+              }
+            }>
+            <div
+              className="fixedDataTableRowLayout_main public_fixedDataTableRow_main public_fixedDataTableRow_even public_fixedDataTable_bodyRow"
+              onClick={null}
+              onDoubleClick={null}
+              onMouseDown={null}
+              onMouseEnter={null}
+              onMouseLeave={null}
+              style={
+                Object {
+                  "height": 50,
+                  "width": 1024,
+                }
+              }>
+              <div
+                className="fixedDataTableRowLayout_body">
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 0,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 240,
+                        "zIndex": 2,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="name-cell-wrapper">
+                        <a
+                          className="name-cell"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span
+                            aria-describedby="name-tooltip-Giovanny-Jaskolski"
+                            className="student-name"
+                            onBlur={[Function]}
+                            onClick={null}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}>
+                            Giovanny Jaskolski
+                          </span>
+                          <span
+                            className="student-id">
+                            W4OQZ5CV2S
+                          </span>
+                        </a>
+                        <div
+                          className="overall-cell">
+                          0%
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 80,
+                        }
+                      }>
+                      <div
+                        className="fixedDataTableCellLayout_wrap1 public_fixedDataTableCell_wrap1 overall-cell"
+                        style={
+                          Object {
+                            "height": undefined,
+                            "width": undefined,
+                          }
+                        }>
+                        <div
+                          className="fixedDataTableCellLayout_wrap2 public_fixedDataTableCell_wrap2">
+                          <div
+                            className="fixedDataTableCellLayout_wrap3 public_fixedDataTableCell_wrap3">
+                            <div
+                              className="public_fixedDataTableCell_cellContent">
+                              0
+                              %
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 480,
+                        "zIndex": 0,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell">
+                        <div
+                          className="score not-started">
+                          ---
+                        </div>
+                        <div
+                          className="worked"
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <span
+                            className="not-started">
+                            ---
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell"
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}>
+                        <div
+                          className="worked wide">
+                          <span
+                            className="not-started">
+                            ---
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 320,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="external-cell">
+                        <a
+                          className="task-result status-cell undefined"
+                          data-assignment-type="external"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span>
+                            Clicked
+                          </span>
+                          <i
+                            aria-describedby="late-icon-tooltip-706"
+                            className="late"
+                            onBlur={[Function]}
+                            onClick={null}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]} />
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableRowLayout_fixedColumnsDivider public_fixedDataTableRow_fixedColumnsDivider"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  } />
+              </div>
+            </div>
+          </div>
+          <div
+            className="fixedDataTableRowLayout_rowWrapper"
+            style={
+              Object {
+                "height": 50,
+                "left": "0px",
+                "top": "400px",
+                "width": 1024,
+                "zIndex": 0,
+              }
+            }>
+            <div
+              className="fixedDataTableRowLayout_main public_fixedDataTableRow_main public_fixedDataTableRow_highlighted public_fixedDataTableRow_odd public_fixedDataTable_bodyRow"
+              onClick={null}
+              onDoubleClick={null}
+              onMouseDown={null}
+              onMouseEnter={null}
+              onMouseLeave={null}
+              style={
+                Object {
+                  "height": 50,
+                  "width": 1024,
+                }
+              }>
+              <div
+                className="fixedDataTableRowLayout_body">
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 0,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 240,
+                        "zIndex": 2,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="name-cell-wrapper">
+                        <a
+                          className="name-cell"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span
+                            aria-describedby="name-tooltip-Albin-Kirlin"
+                            className="student-name"
+                            onBlur={[Function]}
+                            onClick={null}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}>
+                            Albin Kirlin
+                          </span>
+                          <span
+                            className="student-id">
+                            UQ5NDASCJX
+                          </span>
+                        </a>
+                        <div
+                          className="overall-cell">
+                          0%
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 80,
+                        }
+                      }>
+                      <div
+                        className="fixedDataTableCellLayout_wrap1 public_fixedDataTableCell_wrap1 overall-cell"
+                        style={
+                          Object {
+                            "height": undefined,
+                            "width": undefined,
+                          }
+                        }>
+                        <div
+                          className="fixedDataTableCellLayout_wrap2 public_fixedDataTableCell_wrap2">
+                          <div
+                            className="fixedDataTableCellLayout_wrap3 public_fixedDataTableCell_wrap3">
+                            <div
+                              className="public_fixedDataTableCell_cellContent">
+                              0
+                              %
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 480,
+                        "zIndex": 0,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell">
+                        <div
+                          className="score not-started">
+                          ---
+                        </div>
+                        <div
+                          className="worked"
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <span
+                            className="not-started">
+                            ---
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell"
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}>
+                        <div
+                          className="worked wide">
+                          <span
+                            className="not-started">
+                            ---
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 320,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="external-cell">
+                        <a
+                          className="task-result status-cell undefined"
+                          data-assignment-type="external"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span>
+                            ---
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableRowLayout_fixedColumnsDivider public_fixedDataTableRow_fixedColumnsDivider"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  } />
+              </div>
+            </div>
+          </div>
+          <div
+            className="fixedDataTableRowLayout_rowWrapper"
+            style={
+              Object {
+                "height": 50,
+                "left": "0px",
+                "top": "450px",
+                "width": 1024,
+                "zIndex": 0,
+              }
+            }>
+            <div
+              className="fixedDataTableRowLayout_main public_fixedDataTableRow_main public_fixedDataTableRow_even public_fixedDataTable_bodyRow"
+              onClick={null}
+              onDoubleClick={null}
+              onMouseDown={null}
+              onMouseEnter={null}
+              onMouseLeave={null}
+              style={
+                Object {
+                  "height": 50,
+                  "width": 1024,
+                }
+              }>
+              <div
+                className="fixedDataTableRowLayout_body">
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 0,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 240,
+                        "zIndex": 2,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="name-cell-wrapper">
+                        <a
+                          className="name-cell"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span
+                            aria-describedby="name-tooltip-Kevin-Lowe"
+                            className="student-name"
+                            onBlur={[Function]}
+                            onClick={null}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}>
+                            Kevin Lowe
+                          </span>
+                          <span
+                            className="student-id">
+                            AJZ0CVERLD
+                          </span>
+                        </a>
+                        <div
+                          className="overall-cell">
+                          0%
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 80,
+                        }
+                      }>
+                      <div
+                        className="fixedDataTableCellLayout_wrap1 public_fixedDataTableCell_wrap1 overall-cell"
+                        style={
+                          Object {
+                            "height": undefined,
+                            "width": undefined,
+                          }
+                        }>
+                        <div
+                          className="fixedDataTableCellLayout_wrap2 public_fixedDataTableCell_wrap2">
+                          <div
+                            className="fixedDataTableCellLayout_wrap3 public_fixedDataTableCell_wrap3">
+                            <div
+                              className="public_fixedDataTableCell_cellContent">
+                              0
+                              %
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 480,
+                        "zIndex": 0,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell">
+                        <div
+                          className="score">
+                          <a
+                            className=""
+                            data-assignment-type="homework"
+                            href="/"
+                            onClick={[Function]}
+                            style={Object {}}>
+                            0%
+                          </a>
+                        </div>
+                        <div
+                          className="worked"
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <span
+                            className="not-started">
+                            ---
+                          </span>
+                        </div>
+                        <div
+                          className="late-caret-trigger"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <div
+                            className="late-caret" />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell"
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}>
+                        <div
+                          className="worked wide">
+                          <span
+                            className="not-started">
+                            ---
+                          </span>
+                        </div>
+                        <div
+                          className="late-caret-trigger"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <div
+                            className="late-caret" />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 320,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="external-cell">
+                        <a
+                          className="task-result status-cell undefined"
+                          data-assignment-type="external"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span>
+                            ---
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableRowLayout_fixedColumnsDivider public_fixedDataTableRow_fixedColumnsDivider"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  } />
+              </div>
+            </div>
+          </div>
+          <div
+            className="fixedDataTableRowLayout_rowWrapper"
+            style={
+              Object {
+                "height": 50,
+                "left": "0px",
+                "top": "500px",
+                "width": 1024,
+                "zIndex": 0,
+              }
+            }>
+            <div
+              className="fixedDataTableRowLayout_main public_fixedDataTableRow_main public_fixedDataTableRow_highlighted public_fixedDataTableRow_odd public_fixedDataTable_bodyRow"
+              onClick={null}
+              onDoubleClick={null}
+              onMouseDown={null}
+              onMouseEnter={null}
+              onMouseLeave={null}
+              style={
+                Object {
+                  "height": 50,
+                  "width": 1024,
+                }
+              }>
+              <div
+                className="fixedDataTableRowLayout_body">
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 0,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 240,
+                        "zIndex": 2,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="name-cell-wrapper">
+                        <a
+                          className="name-cell"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span
+                            aria-describedby="name-tooltip-Ignatius-Reilly"
+                            className="student-name"
+                            onBlur={[Function]}
+                            onClick={null}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}>
+                            Ignatius Reilly
+                          </span>
+                          <span
+                            className="student-id">
+                            RG1TOYCQFJ
+                          </span>
+                        </a>
+                        <div
+                          className="overall-cell">
+                          0%
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 80,
+                        }
+                      }>
+                      <div
+                        className="fixedDataTableCellLayout_wrap1 public_fixedDataTableCell_wrap1 overall-cell"
+                        style={
+                          Object {
+                            "height": undefined,
+                            "width": undefined,
+                          }
+                        }>
+                        <div
+                          className="fixedDataTableCellLayout_wrap2 public_fixedDataTableCell_wrap2">
+                          <div
+                            className="fixedDataTableCellLayout_wrap3 public_fixedDataTableCell_wrap3">
+                            <div
+                              className="public_fixedDataTableCell_cellContent">
+                              0
+                              %
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 480,
+                        "zIndex": 0,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell">
+                        <div
+                          className="score not-started">
+                          ---
+                        </div>
+                        <div
+                          className="worked"
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <span
+                            className="not-started">
+                            ---
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell"
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}>
+                        <div
+                          className="worked wide">
+                          <span
+                            className="not-started">
+                            ---
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 320,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="external-cell">
+                        <a
+                          className="task-result status-cell undefined"
+                          data-assignment-type="external"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span>
+                            ---
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableRowLayout_fixedColumnsDivider public_fixedDataTableRow_fixedColumnsDivider"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  } />
+              </div>
+            </div>
+          </div>
+          <div
+            className="fixedDataTableRowLayout_rowWrapper"
+            style={
+              Object {
+                "height": 50,
+                "left": "0px",
+                "top": "550px",
+                "width": 1024,
+                "zIndex": 0,
+              }
+            }>
+            <div
+              className="fixedDataTableRowLayout_main public_fixedDataTableRow_main public_fixedDataTableRow_even public_fixedDataTable_bodyRow fixedDataTableLayout_hasBottomBorder public_fixedDataTable_hasBottomBorder"
+              onClick={null}
+              onDoubleClick={null}
+              onMouseDown={null}
+              onMouseEnter={null}
+              onMouseLeave={null}
+              style={
+                Object {
+                  "height": 50,
+                  "width": 1024,
+                }
+              }>
+              <div
+                className="fixedDataTableRowLayout_body">
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 0,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 240,
+                        "zIndex": 2,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="name-cell-wrapper">
+                        <a
+                          className="name-cell"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span
+                            aria-describedby="name-tooltip-Alyce-Tromp"
+                            className="student-name"
+                            onBlur={[Function]}
+                            onClick={null}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}>
+                            Alyce Tromp
+                          </span>
+                          <span
+                            className="student-id">
+                            LSH4YEFUZB
+                          </span>
+                        </a>
+                        <div
+                          className="overall-cell">
+                          0%
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 80,
+                        }
+                      }>
+                      <div
+                        className="fixedDataTableCellLayout_wrap1 public_fixedDataTableCell_wrap1 overall-cell"
+                        style={
+                          Object {
+                            "height": undefined,
+                            "width": undefined,
+                          }
+                        }>
+                        <div
+                          className="fixedDataTableCellLayout_wrap2 public_fixedDataTableCell_wrap2">
+                          <div
+                            className="fixedDataTableCellLayout_wrap3 public_fixedDataTableCell_wrap3">
+                            <div
+                              className="public_fixedDataTableCell_cellContent">
+                              0
+                              %
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableCellGroupLayout_cellGroupWrapper"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  }>
+                  <div
+                    className="fixedDataTableCellGroupLayout_cellGroup"
+                    style={
+                      Object {
+                        "height": 50,
+                        "left": "0px",
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 480,
+                        "zIndex": 0,
+                      }
+                    }>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 0,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell">
+                        <div
+                          className="score not-started">
+                          ---
+                        </div>
+                        <div
+                          className="worked"
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}>
+                          <span
+                            className="not-started">
+                            ---
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 160,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="scores-cell"
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}>
+                        <div
+                          className="worked wide">
+                          <span
+                            className="not-started">
+                            ---
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="fixedDataTableCellLayout_main public_fixedDataTableCell_main"
+                      style={
+                        Object {
+                          "height": 50,
+                          "left": 320,
+                          "width": 160,
+                        }
+                      }>
+                      <div
+                        className="external-cell">
+                        <a
+                          className="task-result status-cell undefined"
+                          data-assignment-type="external"
+                          href="/"
+                          onClick={[Function]}
+                          style={Object {}}>
+                          <span>
+                            ---
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="fixedDataTableRowLayout_fixedColumnsDivider public_fixedDataTableRow_fixedColumnsDivider"
+                  style={
+                    Object {
+                      "height": 50,
+                      "left": 240,
+                    }
+                  } />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/tutor/specs/components/scores/assignment-header.spec.cjsx
+++ b/tutor/specs/components/scores/assignment-header.spec.cjsx
@@ -1,6 +1,4 @@
-{React} = require '../helpers/component-testing'
-_ = require 'lodash'
-SnapShot = require 'react-test-renderer'
+{React, SnapShot, Wrapper} = require '../helpers/component-testing'
 
 COURSE_ID = '1'
 DATA = require   '../../../api/courses/1/performance.json'
@@ -13,14 +11,18 @@ describe 'Scores Report: assignment column header', ->
     @props =
       courseId: COURSE_ID
       columnIndex: 0
+      onSort: jest.fn()
+      sort: {}
       headings: DATA[0].data_headings
 
 
-  it 'renders', ->
+  it 'renders and matches snapshot', ->
     wrapper = shallow(<Header {...@props} />)
     expect(wrapper.find('.header-cell.title').render().text()).toEqual(@props.headings[0].title)
     expect(wrapper).toHaveRendered("Time[date=\"#{@props.headings[0].due_at}\"]")
-    undefined
+    expect(SnapShot.create(
+      <Wrapper _wrapped_component={Header} noReference {...@props}/>).toJSON()
+    ).toMatchSnapshot()
 
   context 'for a CC course', ->
 
@@ -34,6 +36,7 @@ describe 'Scores Report: assignment column header', ->
     it 'hides due date', ->
       expect(@wrapper).not.toHaveRendered("Time")
 
-    it 'renders cell width as "wide"', ->
-      expect(@wrapper).toHaveRendered('AverageLabel[cellWidth="wide"]')
-      expect(@wrapper).toHaveRendered('ReviewLink[cellWidth="wide"]')
+    it 'matches snapshot', ->
+      expect(SnapShot.create(
+        <Wrapper _wrapped_component={Header} noReference {...@props}/>).toJSON()
+      ).toMatchSnapshot()

--- a/tutor/specs/components/scores/index.spec.cjsx
+++ b/tutor/specs/components/scores/index.spec.cjsx
@@ -1,6 +1,6 @@
-{React} = require '../helpers/component-testing'
+{React, SnapShot, Wrapper} = require '../helpers/component-testing'
 _ = require 'lodash'
-SnapShot = require 'react-test-renderer'
+
 
 EnzymeContext = require '../helpers/enzyme-context'
 
@@ -42,3 +42,8 @@ describe 'Scores Report', ->
     wrapper.find('.header-cell.sortable').at(1).simulate('click')
     expect(getStudentNames(wrapper)).to.deep.equal(_.map(sorted.reverse(), 'name'))
     undefined
+
+  it 'renders and matches snapshot', ->
+    expect(SnapShot.create(
+      <Wrapper _wrapped_component={Scores} noReference {...@props}/>).toJSON()
+    ).toMatchSnapshot()

--- a/tutor/src/components/scores/assignment-header.cjsx
+++ b/tutor/src/components/scores/assignment-header.cjsx
@@ -8,7 +8,7 @@ Time   = require '../time'
 
 ReviewLink = (props) ->
   return null if props.isConceptCoach or props.heading.type is 'external' or not props.heading.plan_id?
-  <span className="review-link #{props.cellWidth}">
+  <span className="review-link">
     <TutorLink
       to='reviewTask'
       query={tab: props.periodIndex}
@@ -21,7 +21,7 @@ ReviewLink.displayName = 'ReviewLink'
 
 AverageLabel = (props) ->
   if props.average_score
-    <span className="average #{props.cellWidth}">
+    <span className="average">
       {(props.average_score * 100).toFixed(0)}%
     </span>
   else
@@ -41,15 +41,6 @@ AverageLabel = (props) ->
     else
       null
 AverageLabel.displayName = 'AverageLabel'
-
-getCellWidth = ({isConceptCoach, heading}) ->
-  if isConceptCoach
-    'wide'
-  else
-    switch heading.type
-      when 'reading' then 'wide'
-      when 'external' then 'wide'
-      else ''
 
 AssignmentSortingHeader = (props) ->
   {heading, dataType, columnIndex, sort, onSort} = props
@@ -93,8 +84,6 @@ AssignmentHeader = (props) ->
   {isConceptCoach, periodIndex, period_id, courseId, sort, onSort, columnIndex, width} = props
   heading = props.headings[columnIndex]
 
-  cellWidth = getCellWidth({isConceptCoach, heading})
-
   <div className='header-cell-wrapper assignment'>
     <BS.OverlayTrigger
       placement='top'
@@ -119,8 +108,8 @@ AssignmentHeader = (props) ->
       </div>
     </BS.OverlayTrigger>
     <div className='header-row'>
-      <AverageLabel {...props} heading={heading} cellWidth={cellWidth} />
-      <ReviewLink {...props} heading={heading} cellWidth={cellWidth} />
+      <AverageLabel {...props} heading={heading} />
+      <ReviewLink {...props} heading={heading} />
     </div>
     <div className='header-row short'>
       <AssignmentSortingHeader {...props} heading={heading} />


### PR DESCRIPTION
More styles for scores to fix some missing and duplicated borders with CC.   I also struck on a neat solution using `only-child` to set header borders and widths for split cells that neatened up the rules a bit.

Before:
![screen shot 2017-02-07 at 1 02 34 pm](https://cloud.githubusercontent.com/assets/79566/22706697/d53fc31c-ed35-11e6-8ce1-b86dde5bf224.png)

After:
![screen shot 2017-02-07 at 1 01 35 pm](https://cloud.githubusercontent.com/assets/79566/22706735/fede626e-ed35-11e6-8528-b91cca7cdd07.png)

Tutor styles remain the same, except the duplicated border under tabs is fixed.
![screen shot 2017-02-07 at 1 01 11 pm](https://cloud.githubusercontent.com/assets/79566/22706790/35687612-ed36-11e6-88a8-92c40c67f5bc.png)



