### PR TITLE
Use ecosystemId from task when loading exercises

### DIFF
--- a/shared/specs/helpers/fake-dom-node.coffee
+++ b/shared/specs/helpers/fake-dom-node.coffee
@@ -1,0 +1,24 @@
+extend = require 'lodash/extend'
+
+# implements just enought to work with ScrollSpy and HTML mixins
+
+class FakeDOMNode
+  constructor: (attrs) ->
+    extend(this, {
+      style: {}
+      ownerDocument: { styleSheets: [] }
+      querySelectorAll: jest.fn( ->
+        []
+      )
+      querySelector: jest.fn( ->
+        undefined
+      )
+      getElementsByTagName: jest.fn( ->
+        []
+      )
+      getBoundingClientRect: jest.fn( ->
+        {}
+      )
+  }, attrs)
+
+module.exports = FakeDOMNode

--- a/tutor/specs/components/task-plan/homework/__snapshots__/add-exercises.spec.cjsx.snap
+++ b/tutor/specs/components/task-plan/homework/__snapshots__/add-exercises.spec.cjsx.snap
@@ -1,0 +1,947 @@
+exports[`choose exercises component matches snapshot 1`] = `
+<div
+  className="pinned-container"
+  style={
+    Object {
+      "marginTop": "50px",
+    }
+  }>
+  <div
+    className="pinned-header">
+    <div
+      className="exercise-controls-bar">
+      <div
+        className="controls">
+        <div
+          className="sectionizer">
+          <div
+            className="prev"
+            onClick={[Function]}>
+            ❮❮
+          </div>
+          <div
+            className="section"
+            onClick={[Function]}>
+            1.1
+          </div>
+          <div
+            className="next"
+            onClick={[Function]}>
+            ❯❯
+          </div>
+        </div>
+      </div>
+      <div
+        className="indicators">
+        <div
+          className="num total">
+          <h2>
+            NaN
+          </h2>
+          <span>
+            Total Problems
+          </span>
+        </div>
+        <div
+          className="num mine">
+          <h2>
+            1
+          </h2>
+          <span>
+            My Selections
+          </span>
+        </div>
+        <div
+          className="num tutor">
+          <div
+            className="tutor-selections">
+            <span
+              className="circle-btn-placeholder" />
+            <h2 />
+            <span
+              className="circle-btn-placeholder" />
+          </div>
+          <span>
+            Tutor Selections
+          </span>
+        </div>
+        <div
+          className="tutor-added-later">
+          <span>
+            Tutor selections are added later to support spaced practice and personalized learning.
+          </span>
+        </div>
+      </div>
+      <div
+        className="actions">
+        <button
+          className="-review-exercises btn btn-primary"
+          disabled={false}
+          onClick={undefined}
+          type="button">
+          Next
+        </button>
+        <button
+          className="-cancel-add btn btn-default"
+          disabled={false}
+          onClick={undefined}
+          type="button">
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    className="exercise-cards">
+    <div
+      className="exercise-sections"
+      data-section="1.1">
+      <label
+        className="exercises-section-label">
+        <span
+          className="chapter-section"
+          data-chapter-section="1.1">
+          1.1
+        </span>
+         
+        Kinematics in 1 dim
+      </label>
+      <div
+        className="exercises">
+        <div
+          className="openstax-exercise-preview exercise-card has-actions is-selected non-interactive is-vertically-truncated panel panel-default"
+          data-exercise-id="1616"
+          id={undefined}
+          tabIndex={-1}>
+          <div
+            className="panel-body">
+            <div
+              className="selected-mask" />
+            <div
+              className="controls-overlay"
+              onClick={undefined}>
+              <div
+                className="message">
+                <div
+                  className="action exclude"
+                  onClick={[Function]}>
+                  <span>
+                    Remove question
+                  </span>
+                </div>
+                <div
+                  className="action details"
+                  onClick={[Function]}>
+                  <span>
+                    Question details
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              className="exercise-body">
+              <div
+                className="openstax-has-html stimulus"
+                dangerouslySetInnerHTML={undefined} />
+              <div
+                className="openstax-question openstax-question-preview"
+                data-question-number={undefined}>
+                <div
+                  className="openstax-has-html question-stem"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "Which statement best compares and contrasts the aims and topics of natural philosophy had versus physics?",
+                    }
+                  }
+                  data-question-number={undefined} />
+                <div
+                  className="answers-table">
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1663-option-0"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: a"
+                          className="answer-letter">
+                          a
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Natural philosophy and physics are essentially the same thing.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1663-option-1"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: b"
+                          className="answer-letter">
+                          b
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Natural philosophy and physics are different.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1663-option-2"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: c"
+                          className="answer-letter">
+                          c
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Natural philosophy included all aspects of nature excluding physics.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled answer-correct">
+                      <label
+                        className="answer-label"
+                        htmlFor="1663-option-3"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: d"
+                          className="answer-letter">
+                          d
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Natural philosophy included all aspects of nature including physics.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="exercise-tags">
+              <span
+                className="exercise-tag">
+                ID: 1663@1
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="openstax-exercise-preview exercise-card has-actions non-interactive is-vertically-truncated panel panel-default"
+          data-exercise-id="1617"
+          id={undefined}
+          tabIndex={-1}>
+          <div
+            className="panel-body">
+            <div
+              className="controls-overlay"
+              onClick={undefined}>
+              <div
+                className="message">
+                <div
+                  className="action include"
+                  onClick={[Function]}>
+                  <span>
+                    Add question
+                  </span>
+                </div>
+                <div
+                  className="action details"
+                  onClick={[Function]}>
+                  <span>
+                    Question details
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              className="exercise-body">
+              <div
+                className="openstax-has-html stimulus"
+                dangerouslySetInnerHTML={undefined} />
+              <div
+                className="openstax-question openstax-question-preview"
+                data-question-number={undefined}>
+                <div
+                  className="openstax-has-html question-stem"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "What conditions imply that we can use classical physics without considering special relativity or quantum mechanics?",
+                    }
+                  }
+                  data-question-number={undefined} />
+                <div
+                  className="answers-table">
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled answer-correct">
+                      <label
+                        className="answer-label"
+                        htmlFor="1664-option-0"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: a"
+                          className="answer-letter">
+                          a
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<ol>
+                                <li>matter is moving at speeds of less than roughly 1% the speed of light,</li>
+                                <li>objects are large enough to be seen with the naked eye, and</li>
+                                <li>there is the involvement of a weak gravitational field</li>
+                              </ol>
+                              ",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1664-option-1"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: b"
+                          className="answer-letter">
+                          b
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<ol>
+                                <li>matter is moving at speeds of less than roughly 1% the speed of light,</li>
+                                <li>objects are too small to be seen with the naked eye, and</li>
+                                <li>there is the involvement of only a weak gravitational field</li>
+                              </ol>
+                              ",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1664-option-2"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: c"
+                          className="answer-letter">
+                          c
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<ol>
+                                <li>matter is moving at speeds greater than roughly 1% the speed of light,</li>
+                                <li>objects are large enough to be seen with the naked eye, and</li>
+                                <li>there is the involvement of a strong gravitational field</li>
+                              </ol>
+                              ",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1664-option-3"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: d"
+                          className="answer-letter">
+                          d
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<ol>
+                                <li>matter is moving at speeds of less than roughly 1% the speed of light,</li>
+                                <li>objects are large enough to be seen with the naked eye, and</li>
+                                <li>there is the involvement of a strong gravitational field</li>
+                              </ol>
+                              ",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="exercise-tags">
+              <span
+                className="exercise-tag">
+                ID: 1664@1
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="openstax-exercise-preview exercise-card has-actions non-interactive is-vertically-truncated panel panel-default"
+          data-exercise-id="1618"
+          id={undefined}
+          tabIndex={-1}>
+          <div
+            className="panel-body">
+            <div
+              className="controls-overlay"
+              onClick={undefined}>
+              <div
+                className="message">
+                <div
+                  className="action include"
+                  onClick={[Function]}>
+                  <span>
+                    Add question
+                  </span>
+                </div>
+                <div
+                  className="action details"
+                  onClick={[Function]}>
+                  <span>
+                    Question details
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              className="exercise-body">
+              <div
+                className="openstax-has-html stimulus"
+                dangerouslySetInnerHTML={undefined} />
+              <div
+                className="openstax-question openstax-question-preview"
+                data-question-number={undefined}>
+                <div
+                  className="openstax-has-html question-stem"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "How could physics be useful in weather prediction?",
+                    }
+                  }
+                  data-question-number={undefined} />
+                <div
+                  className="answers-table">
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1665-option-0"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: a"
+                          className="answer-letter">
+                          a
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Physics helps in predicting how the flowing water affects Earth’s surface.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1665-option-1"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: b"
+                          className="answer-letter">
+                          b
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Physics helps in predicting the motion of tectonic plates.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled answer-correct">
+                      <label
+                        className="answer-label"
+                        htmlFor="1665-option-2"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: c"
+                          className="answer-letter">
+                          c
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Physics helps in predicting dynamics and movement of weather phenomena.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1665-option-3"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: d"
+                          className="answer-letter">
+                          d
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Physics helps in predicting how burning fossil fuel releases pollutants.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="exercise-tags">
+              <span
+                className="exercise-tag">
+                ID: 1665@1
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="openstax-exercise-preview exercise-card has-actions non-interactive is-vertically-truncated panel panel-default"
+          data-exercise-id="1619"
+          id={undefined}
+          tabIndex={-1}>
+          <div
+            className="panel-body">
+            <div
+              className="controls-overlay"
+              onClick={undefined}>
+              <div
+                className="message">
+                <div
+                  className="action include"
+                  onClick={[Function]}>
+                  <span>
+                    Add question
+                  </span>
+                </div>
+                <div
+                  className="action details"
+                  onClick={[Function]}>
+                  <span>
+                    Question details
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              className="exercise-body">
+              <div
+                className="openstax-has-html stimulus"
+                dangerouslySetInnerHTML={undefined} />
+              <div
+                className="openstax-question openstax-question-preview"
+                data-question-number={undefined}>
+                <div
+                  className="openstax-has-html question-stem"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "In what sense does Einstein’s theory of relativity illustrate that physics describes fundamental aspects of our universe?",
+                    }
+                  }
+                  data-question-number={undefined} />
+                <div
+                  className="answers-table">
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1666-option-0"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: a"
+                          className="answer-letter">
+                          a
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "It describes how a frame of reference is necessary to describe position or motion.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1666-option-1"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: b"
+                          className="answer-letter">
+                          b
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "It describes how people think of other people’s views from their own frame of reference.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1666-option-2"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: c"
+                          className="answer-letter">
+                          c
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "It describes how different parts of the universe are far apart and do not affect each other",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled answer-correct">
+                      <label
+                        className="answer-label"
+                        htmlFor="1666-option-3"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: d"
+                          className="answer-letter">
+                          d
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "It describes how speed affects different observers’ measurements of time and space.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="exercise-tags">
+              <span
+                className="exercise-tag">
+                ID: 1666@1
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="openstax-exercise-preview exercise-card has-actions non-interactive is-vertically-truncated panel panel-default"
+          data-exercise-id="1620"
+          id={undefined}
+          tabIndex={-1}>
+          <div
+            className="panel-body">
+            <div
+              className="controls-overlay"
+              onClick={undefined}>
+              <div
+                className="message">
+                <div
+                  className="action include"
+                  onClick={[Function]}>
+                  <span>
+                    Add question
+                  </span>
+                </div>
+                <div
+                  className="action details"
+                  onClick={[Function]}>
+                  <span>
+                    Question details
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              className="exercise-body">
+              <div
+                className="openstax-has-html stimulus"
+                dangerouslySetInnerHTML={undefined} />
+              <div
+                className="openstax-question openstax-question-preview"
+                data-question-number={undefined}>
+                <div
+                  className="openstax-has-html question-stem"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "Can classical physics be used to accurately describe a satellite moving at a speed of? Explain why or why not.",
+                    }
+                  }
+                  data-question-number={undefined} />
+                <div
+                  className="answers-table">
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1667-option-0"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: a"
+                          className="answer-letter">
+                          a
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Yes, because the satellite is moving at a speed much smaller than the speed of the light and is in a strong gravitational field.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled answer-correct">
+                      <label
+                        className="answer-label"
+                        htmlFor="1667-option-1"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: b"
+                          className="answer-letter">
+                          b
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Yes, because the satellite is moving at a speed much smaller than the speed of the light and it is not in a strong gravitational field.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1667-option-2"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: c"
+                          className="answer-letter">
+                          c
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "No, because the satellite is moving at a speed much smaller than the speed of the light and is in a strong gravitational field.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    className="openstax-answer">
+                    <div
+                      className="answers-answer disabled">
+                      <label
+                        className="answer-label"
+                        htmlFor="1667-option-3"
+                        onKeyPress={[Function]}>
+                        <div
+                          aria-labelledby="Answer choice: d"
+                          className="answer-letter">
+                          d
+                        </div>
+                        <div
+                          className="answer-answer">
+                          <span
+                            className="openstax-has-html answer-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "No, because the satellite is moving at a speed much smaller than the speed of the light and is not in a strong gravitational field.",
+                              }
+                            } />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="exercise-tags">
+              <span
+                className="exercise-tag">
+                ID: 1667@1
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/tutor/specs/components/task-plan/homework/add-exercises.spec.cjsx
+++ b/tutor/specs/components/task-plan/homework/add-exercises.spec.cjsx
@@ -1,0 +1,52 @@
+jest.mock('react-dom')
+
+ReactDOM = require 'react-dom'
+
+{Testing, sinon, _, SnapShot, React} = require '../../helpers/component-testing'
+
+{TocActions, TocStore} = require '../../../../src/flux/toc'
+{TaskPlanActions, TaskPlanStore} = require '../../../../src/flux/task-plan'
+{ExtendBasePlan, PlanRenderHelper} = require '../../helpers/task-plan'
+{CourseActions, CourseStore} = require '../../../../src/flux/course'
+{ExerciseActions} = require  '../../../../src/flux/exercise'
+
+FakeDOMNode = require 'shared/specs/helpers/fake-dom-node'
+
+NEW_PLAN = ExtendBasePlan({id: PLAN_ID, type: 'homework', settings: { exercise_ids: ["1616"] } })
+
+EXERCISES = require '../../../../api/exercises'
+READINGS  = require '../../../../api/ecosystems/1/readings.json'
+COURSE = require '../../../../api/user/courses/1.json'
+SECTION_IDS  = [234..242]
+ECOSYSTEM_ID = '1'
+COURSE_ID    = '1'
+PLAN_ID      = '1'
+
+AddExercises = require '../../../../src/components/task-plan/homework/add-exercises'
+
+describe 'choose exercises component', ->
+
+  beforeEach ->
+    ReactDOM.findDOMNode = jest.fn(-> new FakeDOMNode)
+    @props =
+      courseId: COURSE_ID
+      planId: PLAN_ID
+      onAddClick: sinon.spy()
+      sectionIds: SECTION_IDS
+    CourseActions.loaded(COURSE, COURSE_ID)
+    ExerciseActions.loadedForCourse(EXERCISES, COURSE_ID, SECTION_IDS)
+    TocActions.loaded(READINGS, ECOSYSTEM_ID)
+    TaskPlanActions.loaded(NEW_PLAN, PLAN_ID)
+
+  it 'uses ecosystemId from task when loading', ->
+    plan = ExtendBasePlan({id: PLAN_ID, ecosystem_id: '42'})
+    TaskPlanActions.loaded(plan, PLAN_ID)
+    @props.sectionIds = ['99']
+    ExerciseActions.loadForCourse = jest.fn()
+    exercises = shallow(<AddExercises {...@props} />)
+    expect(ExerciseActions.loadForCourse).toHaveBeenCalledWith(COURSE_ID, @props.sectionIds, '42')
+
+
+  it 'matches snapshot', ->
+    expect(SnapShot.create(<AddExercises {...@props} />).toJSON()).toMatchSnapshot()
+    undefined

--- a/tutor/src/components/exercises/cards.cjsx
+++ b/tutor/src/components/exercises/cards.cjsx
@@ -15,7 +15,7 @@ Icon = require '../icon'
 ExercisePreview = require './preview'
 
 SectionsExercises = React.createClass
-
+  displayName: 'SectionsExercises'
   propTypes:
     ecosystemId:            React.PropTypes.string.isRequired
     exercises:              React.PropTypes.array.isRequired
@@ -44,7 +44,7 @@ SectionsExercises = React.createClass
 
 
 ExerciseCards = React.createClass
-
+  displayName: 'ExerciseCards'
   propTypes:
     ecosystemId:            React.PropTypes.string.isRequired
     exercises:              React.PropTypes.object.isRequired

--- a/tutor/src/components/task-plan/homework/add-exercises.cjsx
+++ b/tutor/src/components/task-plan/homework/add-exercises.cjsx
@@ -90,7 +90,8 @@ AddExercises = React.createClass
 
   render: ->
     return @renderLoading() if @exercisesAreLoading()
-    ecosystemId = CourseStore.get(@props.courseId)?.ecosystem_id
+    ecosystemId = TaskPlanStore.getEcosystemId(@props.planId, @props.courseId)
+
     exercises = ExerciseStore.groupBySectionsAndTypes(
       ecosystemId, @props.sectionIds
     )

--- a/tutor/src/components/task-plan/homework/choose-exercises.cjsx
+++ b/tutor/src/components/task-plan/homework/choose-exercises.cjsx
@@ -28,7 +28,10 @@ ChooseExercises = React.createClass
     showProblems: false
 
   selectProblems: ->
-    ExerciseActions.loadForCourse(@props.courseId, TaskPlanStore.getTopics(@props.planId) )
+
+    ExerciseActions.loadForCourse(
+      @props.courseId, TaskPlanStore.getTopics(@props.planId), @props.ecosystemId
+    )
     @setState(showProblems: true)
 
   onAddClick: ->

--- a/tutor/src/components/task-plan/homework/loading-exercises-mixin.cjsx
+++ b/tutor/src/components/task-plan/homework/loading-exercises-mixin.cjsx
@@ -1,6 +1,7 @@
 _     = require 'underscore'
 React = require 'react'
 
+{TaskPlanStore} = require '../../../flux/task-plan'
 {ExerciseStore, ExerciseActions} = require '../../../flux/exercise'
 Icon = require '../../icon'
 
@@ -12,7 +13,8 @@ LoadingExercisesMixin =
   componentWillUnmount: -> ExerciseStore.removeChangeListener(@exerciseLoadListenerOnUpdate)
 
   requestExerciseLoad: ->
-    ExerciseActions.loadForCourse(@props.courseId, @props.sectionIds, @props.ecosystemId)
+    ecosystemId = @props.ecosystemId or TaskPlanStore.getEcosystemId(@props.planId, @props.courseId)
+    ExerciseActions.loadForCourse(@props.courseId, @props.sectionIds, ecosystemId)
 
   exercisesNeedLoading: ->
     not _.isEmpty(@props.sectionIds) and

--- a/tutor/src/flux/exercise.coffee
+++ b/tutor/src/flux/exercise.coffee
@@ -74,7 +74,7 @@ ExerciseConfig =
     @_exerciseCache = {}
     @_unsavedExclusions = {}
 
-  loadForCourse: (courseId, pageIds) -> # Used by API
+  loadForCourse: (courseId, pageIds, ecosystemId) -> # Used by API
     @_asyncStatus = LOADING
   loadedForCourse: (obj, courseId, pageIds) ->
     @processLoad(obj, pageIds)


### PR DESCRIPTION
Fixes several areas where we were using the course ecosystem id to load exercises.  That works fine normally, but fails when a cloned task is loaded that refers to a past ecosystem.