### PR TITLE
Fix reference book labels on firefox..

### DIFF
--- a/tutor/resources/styles/book-content/note.less
+++ b/tutor/resources/styles/book-content/note.less
@@ -52,7 +52,8 @@
   padding: 0 40px;
   height: @tutor-book-ui-top-height;
   display: inline-block;
-  margin: @book-content-note-with-background-margin;
+  top: @book-content-note-with-background-top;
+  left: @book-content-note-with-background-left;
 };
 
 .tutor-book-before-manual-label(@content: attr(data-label)) {

--- a/tutor/resources/styles/book-content/variables.less
+++ b/tutor/resources/styles/book-content/variables.less
@@ -32,6 +32,10 @@
 @tutor-book-padding-vertical: @tutor-card-body-padding-vertical;
 @tutor-book-ui-top-height: 40px;
 @reading-ui-banner-height: @tutor-book-ui-top-height;
+// top is 50 with border, this moves it down ontop
+@book-content-note-with-background-top: -48px;
+@book-content-note-with-background-left: 0;
+
 
 @book-content-note-with-background-margin: -68px 0 0 -40px;
 @book-content-note-without-background-margin: -68px 0 0 0;


### PR DESCRIPTION
Firefox doesn't like the `position: absolute` without any given position and flows it after smaller items

I tested the positioned element on Firefox, Safari, and Chrome (didn't have IE handy)

Before
![screen shot 2017-02-16 at 4 04 01 pm](https://cloud.githubusercontent.com/assets/79566/23043406/c4732604-f461-11e6-9a37-395a8c9b8bb7.png)



After:
![screen shot 2017-02-16 at 4 01 41 pm](https://cloud.githubusercontent.com/assets/79566/23043408/c48c1556-f461-11e6-996a-998b487e738d.png)
