### PR TITLE
ignore spec and test directories from coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,9 @@
 comment:
   layout: "header, diff, changes, uncovered, tree"
   behavior: default
+ignore:
+  - "**/specs/*"
+  - "**/test/*"
 
 # To Turn off comments completely:
 # comment: false


### PR DESCRIPTION
I noticed on the reports that these folders were being included, seems like they shouldn't be