### PR TITLE
Move withdrawn icon to left and adjust padding

### DIFF
--- a/tutor/resources/styles/components/student-dashboard/task.less
+++ b/tutor/resources/styles/components/student-dashboard/task.less
@@ -1,5 +1,5 @@
 .student-dashboard {
-  .due-at, .due-at-label { padding-left: 0; }
+  .due-at, .due-at-label { padding: 0; }
 
   .task {
     background: @tutor-white;
@@ -48,9 +48,8 @@
     .btn.hide-task {
       line-height: 12px;
       padding: 5px 7px;
-      margin: 0 0 0 15px;
       background: #fff;
-
+      margin-right: 0.4rem;
       .fa {
         font-size: 12px;
         font-weight: normal;

--- a/tutor/src/components/student-dashboard/event-row.cjsx
+++ b/tutor/src/components/student-dashboard/event-row.cjsx
@@ -62,12 +62,12 @@ module.exports = React.createClass
       }
       hideButton =
         <span>
-          Withdrawn
           <SuretyGuard {...guardProps}>
             <BS.Button className="hide-task" onClick={@stopEventPropagation}>
               <i className="fa fa-close" />
             </BS.Button>
           </SuretyGuard>
+          Withdrawn
         </span>
 
     else


### PR DESCRIPTION
So it remains visible on narrow screens, otherwise it got pushed
off the column and couldn't be clicked.

Before:

![screen shot 2017-02-22 at 3 52 38 pm](https://cloud.githubusercontent.com/assets/79566/23234215/f390abdc-f916-11e6-926f-0e4c8136cfc1.png)



After:

![screen shot 2017-02-22 at 3 51 46 pm](https://cloud.githubusercontent.com/assets/79566/23234219/f781bcc2-f916-11e6-8174-b6d8590c39a4.png)
