### PR TITLE
remove ellipsis from due dates

### DIFF
--- a/tutor/resources/styles/components/student-dashboard/task.less
+++ b/tutor/resources/styles/components/student-dashboard/task.less
@@ -29,6 +29,8 @@
     .title, .feedback, .due-at {
       line-height: @student-dashboard-row-height;
       white-space: nowrap;
+    }
+    .title, .feedback {
       overflow: hidden;
       text-overflow: ellipsis;
     }


### PR DESCRIPTION
It's too important of information to be hidden, instead it should overflow if needed even if it looks not-so-great.

Before:
![screen shot 2017-02-22 at 3 58 53 pm](https://cloud.githubusercontent.com/assets/79566/23234488/dd0bd0ca-f917-11e6-967d-312801e55eab.png)

After:
![screen shot 2017-02-22 at 3 58 27 pm](https://cloud.githubusercontent.com/assets/79566/23234489/dd1b6b48-f917-11e6-86ca-cbc5ec756f15.png)
