### PR TITLE
move QA view's edit link up a bit so it sits completly on card

### DIFF
--- a/tutor/resources/styles/qa.less
+++ b/tutor/resources/styles/qa.less
@@ -41,7 +41,7 @@
       .edit-link {
         .tutor-external-link-indicator();
         position: absolute;
-        bottom: 5px;
+        bottom: 15px;
         right: 10px;
       }
       // override the default hover styles for the card from the teacher's exercise picker


### PR DESCRIPTION

![screen shot 2017-02-22 at 4 22 31 pm](https://cloud.githubusercontent.com/assets/79566/23235438/20fe4986-f91b-11e6-8e17-2a84170bb64c.png)


After:
![screen shot 2017-02-22 at 4 21 54 pm](https://cloud.githubusercontent.com/assets/79566/23235431/17bd241e-f91b-11e6-9ba3-3850f87d5a08.png)
