### PR TITLE
Treat entire course title the same on course listing

### DIFF
--- a/tutor/resources/styles/components/course-listings.less
+++ b/tutor/resources/styles/components/course-listings.less
@@ -210,13 +210,9 @@
 
       a {
         height: 18.1rem;
-      }
-
-      [data-is-subject=true],
-      .no-subject span:first-child {
         #fonts > .book-cover();
         font-weight: 800;
-        font-size: 3rem;
+        font-size: 2rem;
         line-height: 1.25em;
         display: block;
       }

--- a/tutor/specs/helpers/course-data.spec.coffee
+++ b/tutor/specs/helpers/course-data.spec.coffee
@@ -1,6 +1,7 @@
 CD = require '../../src/helpers/course-data'
 
 mapValues = require 'lodash/mapValues'
+TimeHelper = require '../../src/helpers/time'
 
 {CourseActions, CourseStore} = require '../../src/flux/course'
 
@@ -34,6 +35,10 @@ describe 'Course Data helpers', ->
 
   it 'getCourseBounds', ->
     CourseActions.loaded(COURSE, COURSE_ID)
-    expect(mapValues(CD.getCourseBounds(COURSE_ID), (m) -> m.toString())).toEqual(
-        {"end": "Sat Dec 31 2016 12:00:00 GMT-0600", "start": "Fri Jul 01 2016 12:00:00 GMT-0500"}
-      )
+    bounds = CD.getCourseBounds(COURSE_ID)
+    expect(bounds.start).toEqual(
+      TimeHelper.getMomentPreserveDate(COURSE.starts_at, TimeHelper.ISO_DATE_FORMAT)
+    )
+    expect(bounds.end).toEqual(
+      TimeHelper.getMomentPreserveDate(COURSE.ends_at, TimeHelper.ISO_DATE_FORMAT)
+    )

--- a/tutor/specs/helpers/course-data.spec.coffee
+++ b/tutor/specs/helpers/course-data.spec.coffee
@@ -10,23 +10,6 @@ COURSE_ID = '1'
 
 describe 'Course Data helpers', ->
 
-  it 'getCourseNameSegments', ->
-    expect(CD.getCourseNameSegments({name: 'a physics course'}, 'Physics')).toEqual(
-      ["a", "physics", "course"]
-    )
-    expect(CD.getCourseNameSegments({name: 'physics course'}, 'Physics')).toEqual(
-      ["", "physics", "course"]
-    )
-    expect(CD.getCourseNameSegments({name: 'Dr Goods physics'}, 'Physics')).toEqual(
-      ["Dr Goods", "physics", ""]
-    )
-    expect(CD.getCourseNameSegments({name: 'A Long Preamble about physics, then some stuff at end'}, 'Physics')).toEqual(
-      ["A Long Preamble about", "physics", "then some stuff at end"]
-    )
-    # extra chars on start/end
-    expect(CD.getCourseNameSegments({name: 'a physicss course'}, 'Physics')).toBeUndefined()
-    expect(CD.getCourseNameSegments({name: 'aphysics course'}, 'Physics')).toBeUndefined()
-
   it 'getCourseDataProps', ->
     CourseActions.loaded(COURSE, COURSE_ID)
     expect(CD.getCourseDataProps(COURSE_ID)).toEqual(

--- a/tutor/specs/helpers/course-data.spec.coffee
+++ b/tutor/specs/helpers/course-data.spec.coffee
@@ -1,0 +1,39 @@
+CD = require '../../src/helpers/course-data'
+
+mapValues = require 'lodash/mapValues'
+
+{CourseActions, CourseStore} = require '../../src/flux/course'
+
+COURSE  = require '../../api/courses/1.json'
+COURSE_ID = '1'
+
+describe 'Course Data helpers', ->
+
+  it 'getCourseNameSegments', ->
+    expect(CD.getCourseNameSegments({name: 'a physics course'}, 'Physics')).toEqual(
+      ["a", "physics", "course"]
+    )
+    expect(CD.getCourseNameSegments({name: 'physics course'}, 'Physics')).toEqual(
+      ["", "physics", "course"]
+    )
+    expect(CD.getCourseNameSegments({name: 'Dr Goods physics'}, 'Physics')).toEqual(
+      ["Dr Goods", "physics", ""]
+    )
+    expect(CD.getCourseNameSegments({name: 'A Long Preamble about physics, then some stuff at end'}, 'Physics')).toEqual(
+      ["A Long Preamble about", "physics", "then some stuff at end"]
+    )
+    # extra chars on start/end
+    expect(CD.getCourseNameSegments({name: 'a physicss course'}, 'Physics')).toBeUndefined()
+    expect(CD.getCourseNameSegments({name: 'aphysics course'}, 'Physics')).toBeUndefined()
+
+  it 'getCourseDataProps', ->
+    CourseActions.loaded(COURSE, COURSE_ID)
+    expect(CD.getCourseDataProps(COURSE_ID)).toEqual(
+      {"data-appearance": "biology", "data-book-title": "Biology", "data-title": "Local Test Course"}
+    )
+
+  it 'getCourseBounds', ->
+    CourseActions.loaded(COURSE, COURSE_ID)
+    expect(mapValues(CD.getCourseBounds(COURSE_ID), (m) -> m.toString())).toEqual(
+        {"end": "Sat Dec 31 2016 12:00:00 GMT-0600", "start": "Fri Jul 01 2016 12:00:00 GMT-0500"}
+      )

--- a/tutor/src/components/course-listing/course.cjsx
+++ b/tutor/src/components/course-listing/course.cjsx
@@ -9,17 +9,7 @@ Router = require '../../helpers/router'
 DnD = require './course-dnd'
 BRAND = 'OpenStax'
 
-getCourseNameSegments = (course, courseSubject) ->
-  courseRegex = new RegExp(courseSubject, 'i')
-  courseNameMatches = courseRegex.exec(course.name)
-  if courseSubject and courseNameMatches
-    {index} = courseNameMatches
-
-    before = course.name.substring(0, index)
-    after = course.name.substring(index + courseSubject.length).replace(/^\W+/, '')
-
-    [before, courseSubject, after]
-
+CourseData = require '../../helpers/course-data'
 
 CoursePropType = React.PropTypes.shape(
   id:   React.PropTypes.string.isRequired
@@ -68,7 +58,7 @@ Course = React.createClass
 
   CourseName: ->
     {course, courseSubject} = @props
-    courseNameSegments = getCourseNameSegments(course, courseSubject)
+    courseNameSegments = CourseData.getCourseNameSegments(course, courseSubject)
     hasNoSubject = _.isEmpty(courseNameSegments)
     courseNameSegments ?= course.name.split(/\W+/)
 

--- a/tutor/src/components/course-listing/course.cjsx
+++ b/tutor/src/components/course-listing/course.cjsx
@@ -58,23 +58,15 @@ Course = React.createClass
 
   CourseName: ->
     {course, courseSubject} = @props
-    courseNameSegments = CourseData.getCourseNameSegments(course, courseSubject)
-    hasNoSubject = _.isEmpty(courseNameSegments)
-    courseNameSegments ?= course.name.split(/\W+/)
+    # courseNameSegments = CourseData.getCourseNameSegments(course, courseSubject)
+    # hasNoSubject = _.isEmpty(courseNameSegments)
+    # courseNameSegments ?= course.name.split(/\W+/)
 
     <TutorLink
-      className={classnames('no-subject': hasNoSubject)}
       to='dashboard'
       params={courseId: course.id}
     >
-      {_.map(courseNameSegments, (courseNameSegment, index) ->
-        <span
-          key="course-name-segment-#{index}"
-          data-is-subject={courseNameSegment is courseSubject}
-        >
-          {"#{courseNameSegment} "}
-        </span>
-      )}
+      {course.name}
     </TutorLink>
 
   render: ->

--- a/tutor/src/helpers/course-data.coffee
+++ b/tutor/src/helpers/course-data.coffee
@@ -4,13 +4,6 @@ TimeHelper = require '../helpers/time'
 
 module.exports =
 
-  getCourseNameSegments: (course, courseSubject) ->
-    return unless courseSubject
-    courseRegex = new RegExp('^(.*)\s*(?:^|\\W|\\s)+('+courseSubject+')(?:\\s|\\W|$)+(.*)$', 'i')
-    courseNameMatches = courseRegex.exec(course.name)
-    if courseNameMatches
-      return courseNameMatches[1..3]
-
   getCourseDataProps: (courseId) ->
     unless courseId?
       {courseId} = Router.currentParams()

--- a/tutor/src/helpers/course-data.coffee
+++ b/tutor/src/helpers/course-data.coffee
@@ -3,6 +3,14 @@ Router = require '../helpers/router'
 TimeHelper = require '../helpers/time'
 
 module.exports =
+
+  getCourseNameSegments: (course, courseSubject) ->
+    return unless courseSubject
+    courseRegex = new RegExp('^(.*)\s*(?:^|\\W|\\s)+('+courseSubject+')(?:\\s|\\W|$)+(.*)$', 'i')
+    courseNameMatches = courseRegex.exec(course.name)
+    if courseNameMatches
+      return courseNameMatches[1..3]
+
   getCourseDataProps: (courseId) ->
     unless courseId?
       {courseId} = Router.currentParams()
@@ -19,4 +27,3 @@ module.exports =
     end = TimeHelper.getMomentPreserveDate(course.ends_at, TimeHelper.ISO_DATE_FORMAT)
 
     {start, end}
-


### PR DESCRIPTION
Blocked while @Fredasaurus ponders the proper size the text should be

This is 2rem:

![screen shot 2017-02-23 at 11 34 40 am](https://cloud.githubusercontent.com/assets/79566/23271246/6927757e-f9bc-11e6-93fe-344f1ad1c9a5.png)

