### PR TITLE
NO-MERGE: set URL back to google docs errata form

### DIFF
--- a/shared/specs/components/exercise-identifier-link.spec.cjsx
+++ b/shared/specs/components/exercise-identifier-link.spec.cjsx
@@ -2,7 +2,7 @@
 
 ExerciseIdentifierLink = require 'components/exercise-identifier-link'
 
-BASE = 'https://oscms-dev.openstax.org/errata/form'
+BASE = 'https://docs.google.com/a/rice.edu/forms/d/e/1FAIpQLSd5rLsdKv75nkpary6dfJMRuw0bcqSetYV3hO-pFbzqqplM0Q/viewform'
 
 describe 'Exercise Identifier Link', ->
 
@@ -14,7 +14,7 @@ describe 'Exercise Identifier Link', ->
 
   it 'reads the parts from props and sets the url', ->
     link = shallow(<ExerciseIdentifierLink {...@props} />)
-    expect(link).toHaveRendered("a[href=\"#{BASE}?source=tutor&location=Exercise%3A%201234%4042&book=College%20Physics\"]")
+    expect(link).toHaveRendered("a[href=\"#{BASE}?entry.649352110=1234%4042&entry.1091629000=College%20Physics\"]")
     undefined
 
   it 'falls back to context if props are missing', ->
@@ -25,7 +25,7 @@ describe 'Exercise Identifier Link', ->
       oxProject: 'TESTING'
     })
     expect(link).toHaveRendered(
-      "a[href=\"#{BASE}?source=TESTING&location=Exercise%3A%201234%4042&book=Principles%20of%20Microeconomics\"]"
+      "a[href=\"#{BASE}?entry.649352110=1234%4042&entry.1091629000=Principles%20of%20Microeconomics\"]"
     )
     undefined
 

--- a/shared/specs/model/exercise.spec.coffee
+++ b/shared/specs/model/exercise.spec.coffee
@@ -10,9 +10,9 @@ describe 'Exercise Helper', ->
       bookUUID: '185cbf87-c72e-48f5-b51e-f14f21b5eabd'
       project: 'tutor',
       exerciseId: '22@22'
-    })).toEqual('https://oscms-dev.openstax.org/errata/form?source=tutor&location=Exercise%3A%2022%4022&book=Biology')
+    })).toEqual('https://docs.google.com/a/rice.edu/forms/d/e/1FAIpQLSd5rLsdKv75nkpary6dfJMRuw0bcqSetYV3hO-pFbzqqplM0Q/viewform?entry.649352110=22%4022&entry.1091629000=Biology')
 
   it 'skips missing parts', ->
     expect(Exercise.troubleUrl({
       exerciseId: '42@1'
-    })).toEqual('https://oscms-dev.openstax.org/errata/form?location=Exercise%3A%2042%401')
+    })).toEqual('https://docs.google.com/a/rice.edu/forms/d/e/1FAIpQLSd5rLsdKv75nkpary6dfJMRuw0bcqSetYV3hO-pFbzqqplM0Q/viewform?entry.649352110=42%401')

--- a/shared/src/model/exercise.coffee
+++ b/shared/src/model/exercise.coffee
@@ -16,14 +16,15 @@ BOOK_UID_XREF =
   '185cbf87-c72e-48f5-b51e-f14f21b5eabd': 'Biology'
   '405335a3-7cff-4df2-a9ad-29062a4af261': 'College Physics'
 
+FORM_URL =
+  'https://docs.google.com/a/rice.edu/forms/d/e/1FAIpQLSd5rLsdKv75nkpary6dfJMRuw0bcqSetYV3hO-pFbzqqplM0Q/viewform?'
+
 Exercises =
 
   troubleUrl: ({bookUUID, project, exerciseId}) ->
-    # FIXME - get correct url
-    'https://oscms-dev.openstax.org/errata/form?' + qs.stringify(
-      source: project, # either tutor or CC
-      location: "Exercise: #{exerciseId}",
-      book: BOOK_UID_XREF[bookUUID]
+    FORM_URL + qs.stringify(
+      'entry.649352110': exerciseId,
+      'entry.1091629000': BOOK_UID_XREF[bookUUID]
     )
 
   getParts: (exercise) ->


### PR DESCRIPTION
Not intended for merging, as the new errata form should be ready by next release and it's URL can remain in the master branch