### PR TITLE
Update UiSettings so that it's storage is more compact

### DIFF
--- a/shared/specs/model/ui-settings.spec.coffee
+++ b/shared/specs/model/ui-settings.spec.coffee
@@ -60,14 +60,14 @@ describe 'UiSettings', ->
     undefined
 
   it 'migrates old dot keys when initialized', ->
-    UiSettings.initialize({ 'one.two': 4, 'four.five.size': 18 })
+    UiSettings.initialize({ 'one.2': 4, 'four.five.size': 18 })
     jest.runAllTimers()
     expect(Networking.perform).to.have.been.calledOnce
     expect(Networking.perform.lastCall.args[0].data?.ui_settings).to.eql(
-      'one': { 'two': 4 }, 'four': { five: { size: 18 } }
+      'one': { '2': 4 }, 'four': { five: { size: 18 } }
     )
     expect(Networking.perform.lastCall.args[0].data?.previous_ui_settings).to.eql(
-      { 'one.two': 4, 'four.five.size': 18 }
+      { 'one.2': 4, 'four.five.size': 18 }
     )
 
     undefined

--- a/shared/specs/model/ui-settings.spec.coffee
+++ b/shared/specs/model/ui-settings.spec.coffee
@@ -3,6 +3,8 @@
 UiSettings = require 'model/ui-settings'
 Networking = require 'model/networking'
 
+jest.useFakeTimers();
+
 describe 'UiSettings', ->
 
   beforeEach ->
@@ -25,16 +27,13 @@ describe 'UiSettings', ->
     initialSetting = {'one': 1, 'two':'II'}
     UiSettings.initialize(initialSetting)
     UiSettings.set(one: 'five')
-    return new Promise (resolve) ->
-      _.delay( ->
-        expect(Networking.perform).to.have.been.called
-        expect(Networking.perform.lastCall.args[0].data?.previous_ui_settings).to.eql(initialSetting)
-        expect(Networking.perform.lastCall.args[0].data?.ui_settings).to.eql(
-          one: 'five', two: 'II'
-        )
-        resolve(@)
-      , 20)
-
+    jest.runAllTimers()
+    expect(Networking.perform).to.have.been.called
+    expect(Networking.perform.lastCall.args[0].data?.previous_ui_settings).to.eql(initialSetting)
+    expect(Networking.perform.lastCall.args[0].data?.ui_settings).to.eql(
+      one: 'five', two: 'II'
+    )
+    undefined
 
   it 'groups saves together', ->
     initialSetting = {one: 18, two:'III', deep: {key: 'value', bar: 'bz'}}
@@ -42,11 +41,33 @@ describe 'UiSettings', ->
     UiSettings.set(one: 'five')
     UiSettings.set(one: 'six', deep: {bar: 'foo'})
     UiSettings.set(one: 'seven')
-    return new Promise (resolve) ->
-      _.delay( ->
-        expect(Networking.perform).to.have.been.calledOnce
-        expect(Networking.perform.lastCall.args[0].data?.ui_settings).to.eql(
-          one: 'seven', two: 'III', deep: {key: 'value', bar: 'foo'}
-        )
-        resolve(@)
-      , 20)
+    jest.runAllTimers()
+    expect(Networking.perform).to.have.been.calledOnce
+    expect(Networking.perform.lastCall.args[0].data?.ui_settings).to.eql(
+      one: 'seven', two: 'III', deep: { bar: 'foo'}
+    )
+    undefined
+
+  it 'saves nested keys using dot notation', ->
+    initialSetting = {one: 18, two:'III', deep: {key: 'value', bar: 'bz'}}
+    UiSettings.initialize(initialSetting)
+    UiSettings.set('deep.bar', 'UPDATE')
+    jest.runAllTimers()
+    expect(Networking.perform).to.have.been.calledOnce
+    expect(Networking.perform.lastCall.args[0].data?.ui_settings).to.eql(
+      "one": 18, "two": "III", "deep": {"key":"value", "bar":"UPDATE"}
+    )
+    undefined
+
+  it 'migrates old dot keys when initialized', ->
+    UiSettings.initialize({ 'one.two': 4, 'four.five.size': 18 })
+    jest.runAllTimers()
+    expect(Networking.perform).to.have.been.calledOnce
+    expect(Networking.perform.lastCall.args[0].data?.ui_settings).to.eql(
+      'one': { 'two': 4 }, 'four': { five: { size: 18 } }
+    )
+    expect(Networking.perform.lastCall.args[0].data?.previous_ui_settings).to.eql(
+      { 'one.two': 4, 'four.five.size': 18 }
+    )
+
+    undefined

--- a/shared/src/model/ui-settings.coffee
+++ b/shared/src/model/ui-settings.coffee
@@ -1,5 +1,9 @@
-_ = require 'underscore'
-deepMerge = require 'lodash/merge'
+get       = require 'lodash/get'
+setWith   = require 'lodash/set'
+debounce  = require 'lodash/debounce'
+includes  = require 'lodash/includes'
+assign    = require 'lodash/assign'
+isObject  = require 'lodash/isObject'
 cloneDeep = require 'lodash/cloneDeep'
 URLs = require './urls'
 Networking = require './networking'
@@ -7,7 +11,7 @@ Networking = require './networking'
 SETTINGS = {}
 PREVIOUS_SETTINGS = {}
 
-saveSettings = _.debounce( ->
+saveSettings = debounce( ->
   Networking.perform(
     method: 'PUT',
     url: URLs.construct('tutor_api', 'user', 'ui_settings')
@@ -25,18 +29,37 @@ UiSettings = {
   initialize: (settings) ->
     SETTINGS = cloneDeep(settings) or {}
     PREVIOUS_SETTINGS = cloneDeep SETTINGS
+    this._migrateBadKeys()
 
   get: (key) ->
-    SETTINGS[key]
+    get(SETTINGS, key)
 
   set: (key, value) ->
-    attrs = if _.isObject(key) then key else {"#{key}": value}
-    deepMerge(SETTINGS, attrs)
+    if isObject(key)
+      assign(SETTINGS, key)
+    else
+      setWith(SETTINGS, key, value, Object)
+
+    # key else
+    # attrVal = SETTINGS, key)
     saveSettings()
 
   # for use by specs to reset
   _reset: ->
     SETTINGS = {}
+
+  _migrateBadKeys: ->
+    badKeys = []
+    for key, value of SETTINGS
+      if includes(key, '.') # legacy key from before we were using lodash set
+        setWith(SETTINGS, key, value, Object)
+        badKeys.push(key)
+    if badKeys.length
+      delete SETTINGS[key] for key in badKeys
+      saveSettings()
+
+  # for debugging purposes
+  _dump: -> cloneDeep(SETTINGS)
 }
 
 module.exports = UiSettings

--- a/shared/src/model/ui-settings.coffee
+++ b/shared/src/model/ui-settings.coffee
@@ -1,5 +1,5 @@
 get       = require 'lodash/get'
-setWith   = require 'lodash/set'
+setWith   = require 'lodash/setWith'
 debounce  = require 'lodash/debounce'
 includes  = require 'lodash/includes'
 assign    = require 'lodash/assign'
@@ -39,9 +39,6 @@ UiSettings = {
       assign(SETTINGS, key)
     else
       setWith(SETTINGS, key, value, Object)
-
-    # key else
-    # attrVal = SETTINGS, key)
     saveSettings()
 
   # for use by specs to reset
@@ -50,13 +47,15 @@ UiSettings = {
 
   _migrateBadKeys: ->
     badKeys = []
-    for key, value of SETTINGS
+    keys = Object.getOwnPropertyNames(SETTINGS) # make a copy since it'll be mutated
+    for key in keys
       if includes(key, '.') # legacy key from before we were using lodash set
+        value = SETTINGS[key]
+        delete SETTINGS[key]
         setWith(SETTINGS, key, value, Object)
         badKeys.push(key)
-    if badKeys.length
-      delete SETTINGS[key] for key in badKeys
-      saveSettings()
+
+    saveSettings() if badKeys.length
 
   # for debugging purposes
   _dump: -> cloneDeep(SETTINGS)

--- a/tutor/index.coffee
+++ b/tutor/index.coffee
@@ -19,6 +19,7 @@ ErrorMonitoring = require 'shared/src/helpers/error-monitoring'
 {Logging, ReactHelpers} = require 'shared'
 
 window._STORES =
+  SETTINGS: UiSettings
   APP: require './src/flux/app'
   COURSE: require './src/flux/course'
   CURRENT_USER: require './src/flux/current-user'


### PR DESCRIPTION
Previously we were setting keys for the calendar sidebar as: `calsidebar.<course id>`.  The code would then create an object with that key so we ended up very flat structure.

This uses lodash's set so that it'll still accept dot notation, but create a nested structure with only one top-level `calsidebar`  

Along with https://github.com/openstax/tutor-server/pull/1362 this should fix the size issue