### PR TITLE
make all images inside figures expand to fill the figure (100% wide)

### DIFF
--- a/tutor/resources/styles/book-content/base.less
+++ b/tutor/resources/styles/book-content/base.less
@@ -1,5 +1,3 @@
-
-
 // This file is part of the book-content mixin and should not be included directly
 // Hide titles, abstracts and CNX Processing instructions
 
@@ -70,9 +68,11 @@ figure {
   }
   &.tutor-ui-horizontal-img {
     &.full-width {
-      img { width: 100%; }
+      width: 100%;
     }
   }
+
+  img { width: 100%; }
 
   figcaption {
     border-bottom: 1px solid;


### PR DESCRIPTION
I think on balance this is better than the tiny images we get sometimes.  

example at https://tutor-qa.openstax.org/books/236/section/1.4

![screen shot 2017-03-02 at 12 18 00 pm](https://cloud.githubusercontent.com/assets/79566/23521022/e7124e42-ff42-11e6-9a92-4c1b470b4181.png)


![screen shot 2017-03-02 at 12 17 33 pm](https://cloud.githubusercontent.com/assets/79566/23521023/e7263506-ff42-11e6-80bc-31bd30175fc3.png)