### PR TITLE
Remove global line-height style rule

### DIFF
--- a/tutor/resources/styles/components/course-calendar/month.less
+++ b/tutor/resources/styles/components/course-calendar/month.less
@@ -28,6 +28,7 @@
 
 .calendar-container{
   .bootstrap-column-padding-override();
+  line-height: 3rem; // needs to be a known value that matches the task layout logic
   padding-bottom: @tutor-card-body-padding-vertical;
 
   .calendar-body {

--- a/tutor/resources/styles/components/scores/header.less
+++ b/tutor/resources/styles/components/scores/header.less
@@ -41,6 +41,8 @@
       border-top:  @table-outer-border-width solid @table-outer-border-color;
       border-left: @table-outer-border-width solid @table-outer-border-color;
       padding-left: @left-column-padding - @table-outer-border-width;
+      font-weight: 500;
+      white-space: nowrap;
       &.short {
         background: @student-header-bg-color;
         .sortable { justify-content: space-between; }

--- a/tutor/resources/styles/components/scores/table.less
+++ b/tutor/resources/styles/components/scores/table.less
@@ -73,7 +73,8 @@
   .external-cell {
     border-right: 1px solid @nav-tabs-border-color;
   }
-  .scores-cell {
+  .scores-cell,
+  .external-cell {
     .flex-display();
     .align-items(center);
     .justify-content(center);

--- a/tutor/resources/styles/components/sections-chooser.less
+++ b/tutor/resources/styles/components/sections-chooser.less
@@ -77,7 +77,7 @@
         cursor: pointer;
         background: white;
         transition: background .05s ease-in;
-
+        line-height: 3rem;
         &:hover {
           background: @state-info-bg;
           transition: background .05s ease-in;

--- a/tutor/resources/styles/global/typography.less
+++ b/tutor/resources/styles/global/typography.less
@@ -21,7 +21,7 @@
 @tutor-default-font-face: "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
 
 #fonts {
-  .sans (@size: 1.5rem, @line-height: 3rem) {
+  .sans (@size: 1.5rem, @line-height: normal) {
     font-family: @tutor-default-font-face;
     font-weight: 400;
     font-style: normal;

--- a/tutor/src/components/scores/pie-progress.cjsx
+++ b/tutor/src/components/scores/pie-progress.cjsx
@@ -87,7 +87,7 @@ PieProgress = React.createClass
         {if progress is 100 then q4}
       </svg>
     finishedIcon =
-      <svg className='finished'>
+      <svg width="#{size}" height="#{size}" viewBox={"0 0 24 24"} className='finished'>
         <g>
           <circle className="slice #{lateClass}" cx="11.778" cy="12.296" r="12"/>
           <g>


### PR DESCRIPTION
Since we switched from lato to Helvetica font stack, It was negatively affecting scores icons, course picker panels, and scores names column.

However removing the line-height caused regressions in other areas, which this PR hopefully fixes.