### PR TITLE
remove 100% rule for full-width

### DIFF
--- a/tutor/resources/styles/book-content/base.less
+++ b/tutor/resources/styles/book-content/base.less
@@ -66,11 +66,6 @@ figure {
       float: left;
     }
   }
-  &.tutor-ui-horizontal-img {
-    &.full-width {
-      width: 100%;
-    }
-  }
 
   img { width: 100%; }
 


### PR DESCRIPTION
It interferrs with `.splash` and is also spec'ed above with `:not(.splash)` for that reason

<img width="1054" alt="screen shot 2017-03-09 at 10 40 39 am" src="https://cloud.githubusercontent.com/assets/79566/23760303/de345780-04b4-11e7-976f-51a2fa231f9c.png">

<img width="1076" alt="screen shot 2017-03-09 at 10 39 20 am" src="https://cloud.githubusercontent.com/assets/79566/23760282/d3ec872a-04b4-11e7-8690-056ddd29bf84.png">
