### PR TITLE
Share options with standalone networking

### DIFF
--- a/shared/specs/model/networking.spec.coffee
+++ b/shared/specs/model/networking.spec.coffee
@@ -1,0 +1,22 @@
+jest.mock 'axios', ->
+  jest.fn( -> Promise.resolve() )
+
+axios = require 'axios'
+
+Networking = require 'model/networking'
+
+describe 'Stand-alone Networking', ->
+
+  it 'extends itself with set options when calling', ->
+    Networking.setOptions(xhr: {CSRF_Token: '1234'})
+    Networking.perform(
+      method: 'PUT',
+      url: '/test'
+      withCredentials: true
+      data: { foo: 'bar' }
+    )
+    expect(axios).toHaveBeenCalledWith(
+      "method": "PUT",  "url": "/test", "withCredentials": true,
+      "CSRF_Token": "1234", "data": {"foo": "bar"}
+    )
+    undefined

--- a/shared/src/api/index.coffee
+++ b/shared/src/api/index.coffee
@@ -18,7 +18,7 @@ isEmpty   = require 'lodash/isEmpty'
 require 'extract-values'
 
 EventEmitter2 = require 'eventemitter2'
-
+Networking = require '../model/networking'
 {Routes, XHRRecords, utils, METHODS_TO_ACTIONS} = require './collections'
 {Interceptors} = require './interceptors'
 
@@ -103,6 +103,7 @@ ALL_EVENTS =
 
 
 
+
 class APIHandlerBase
   constructor: (options, channel) ->
     @setOptions(options)
@@ -143,6 +144,7 @@ class APIHandlerBase
   setOptions: (options) =>
     previousOptions = @getOptions?() or {}
     options = merge({}, API_DEFAULTS, previousOptions, options)
+    Networking.setOptions(options)
 
     @getOptions = -> options
 

--- a/shared/src/model/networking.coffee
+++ b/shared/src/model/networking.coffee
@@ -1,20 +1,18 @@
 axios = require 'axios'
+extend = require 'lodash/extend'
 
-ERROR_HANDLERS = []
+OPTIONS = {}
 
-emitError = (resp) ->
-  for handler in ERROR_HANDLERS
-    try
-      handler(resp)
-
+emitError = (response) ->
+  OPTIONS.handlers?.onFail?({response})
 
 Networking = {
 
-  onError: (fn) -> ERROR_HANDLERS.push(fn)
-
+  setOptions: (options) ->
+    OPTIONS = options
 
   perform: (opts) ->
-    axios(opts).catch(emitError)
+    axios(extend({}, OPTIONS?.xhr, opts)).catch(emitError)
 }
 
 module.exports = Networking


### PR DESCRIPTION
And use them when making non-routed requests. This way the CRSF token is used if it's set.  Firefox needs is it save ui-settings