### PR TITLE
use slighly less horizontal padding so product names do not wrap

### DIFF
--- a/tutor/resources/styles/components/course-listings.less
+++ b/tutor/resources/styles/components/course-listings.less
@@ -159,7 +159,7 @@
     .course-listing-item-details {
       > a {
         display: block;
-        padding: 1.5em 1em;
+        padding: 1.5em 0.75em;
         text-decoration: none;
       }
     }


### PR DESCRIPTION
Turns 
![screen shot 2017-03-13 at 11 32 03 am](https://cloud.githubusercontent.com/assets/79566/23864499/b62ff5a8-07e0-11e7-966d-0d53fdfce192.png)


Into:
![screen shot 2017-03-13 at 11 31 33 am](https://cloud.githubusercontent.com/assets/79566/23864500/b63f700a-07e0-11e7-8682-3442649fc196.png)
