### PR TITLE
Only allow teachers who have courses from adding a new one

### DIFF
--- a/tutor/src/flux/course-listing.coffee
+++ b/tutor/src/flux/course-listing.coffee
@@ -75,6 +75,8 @@ CourseListingStore = flux.createStore
         CourseListingActions.load() unless CourseListingStore.isLoading()
         true
 
+    hasCourses: -> not _.isEmpty(@_course_ids)
+
     allCourses: ->
       return _.compact _.map @_course_ids, CourseStore.get
 

--- a/tutor/src/flux/current-user.coffee
+++ b/tutor/src/flux/current-user.coffee
@@ -78,7 +78,7 @@ ROUTES =
     isTeacherOnly: true
   addOrCopyCourse:
     label: 'Add or Copy a Course'
-    allowedForCourse: (course) -> CurrentUserStore.isTeacher() and not course
+    allowedForCourse: (course) -> (not course) and CurrentUserStore.isTeacher() and CourseListingStore.hasCourses()
     roles:
       default: 'createNewCourse'
 


### PR DESCRIPTION
Fixes loophole where `faculty_verified` instructors from elsewhere could wander into Tutor and create a course even though they aren't part of the beta.