### PR TITLE
display add course menu option in spy mode when user has no courses

### DIFF
--- a/tutor/src/components/navbar/user-actions-menu.cjsx
+++ b/tutor/src/components/navbar/user-actions-menu.cjsx
@@ -66,7 +66,7 @@ UserActionsMenu = React.createClass
     # MenuItem doesn't pass on props to the li currently, so using className instead for route.name visual control.
     <BS.MenuItem
       {...props}
-      className={classnames(route.name, 'active': isActive)}
+      className={classnames(route.name, route.options?.className, 'active': isActive)}
       key={key}
       data-name={route.name}
       eventKey={index + 2}

--- a/tutor/src/flux/current-user.coffee
+++ b/tutor/src/flux/current-user.coffee
@@ -78,7 +78,9 @@ ROUTES =
     isTeacherOnly: true
   addOrCopyCourse:
     label: 'Add or Copy a Course'
-    allowedForCourse: (course) -> (not course) and CurrentUserStore.isTeacher() and CourseListingStore.hasCourses()
+    options: ->
+      className: if CourseListingStore.hasCourses() then '' else 'visible-when-debugging unstyled'
+    allowedForCourse: (course) -> (not course) and CurrentUserStore.isTeacher()
     roles:
       default: 'createNewCourse'
 


### PR DESCRIPTION
Previously in https://github.com/openstax/tutor-js/pull/1651 it was unavailable when user had no courses, but that posed issues for QA.