### PR TITLE
fix a few missing default exports on teacher metrics

### DIFF
--- a/tutor/src/components/plan-stats/index.cjsx
+++ b/tutor/src/components/plan-stats/index.cjsx
@@ -11,7 +11,7 @@ CourseGroupingLabel = require '../course-grouping-label'
 CourseBar = require './course-bar'
 {ChaptersPerformance, PracticesPerformance} = require './performances'
 
-PeriodHelper = require '../../helpers/period'
+{default: PeriodHelper} = require '../../helpers/period'
 TutorLink = require '../link'
 
 NoStudents = ({courseId}) ->

--- a/tutor/src/flux/task-plan-stats.coffee
+++ b/tutor/src/flux/task-plan-stats.coffee
@@ -1,6 +1,6 @@
 {CrudConfig, makeSimpleStore, extendConfig} = require './helpers'
 _ = require 'underscore'
-PeriodHelper = require '../helpers/period'
+{default: PeriodHelper} = require '../helpers/period'
 
 TaskPlanStatsConfig = {
 


### PR DESCRIPTION
Pretty sure I'd gripped for this before, but must have missed 'em.

I checked and this should be it though