### PR TITLE
multiple GA tracker support

### DIFF
--- a/tutor/src/components/app.jsx
+++ b/tutor/src/components/app.jsx
@@ -41,9 +41,9 @@ class App extends React.PureComponent {
   }
 
   componentDidMount() {
+    Analytics.setGa(window.ga);
     User.recordSessionStart();
     this.storeHistory();
-    Analytics.setTracker(window.ga);
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
Adds support for multiple GA trackers.  Sends tracking commands to each tracker found under `window.ga`.  

The BE PR that adds multiple trackers is https://github.com/openstax/tutor-server/pull/1410.  This PR can be used with or without that PR.