### PR TITLE
Fix email validation bar

### DIFF
--- a/shared/src/components/notifications/email.cjsx
+++ b/shared/src/components/notifications/email.cjsx
@@ -65,7 +65,7 @@ EmailNotification = React.createClass
       <span className="message">
         Check your email inbox. Enter the 6-digit verification code:
       </span>
-      <input autofocus ref='verifyInput' onKeyPress={@onVerifyKey} type="text" />
+      <input autoFocus ref='verifyInput' onKeyPress={@onVerifyKey} type="text" />
       <a className='pin-check action' onClick={@onPinCheck}>Go</a>
     </span>
 

--- a/shared/src/model/networking.coffee
+++ b/shared/src/model/networking.coffee
@@ -4,8 +4,9 @@ defaultsDeep = require 'lodash/defaultsDeep'
 
 OPTIONS = {}
 
-emitError = (response) ->
+emitError = ({response}) ->
   OPTIONS.handlers?.onFail?({response})
+  response
 
 Networking = {
 


### PR DESCRIPTION
what was happening is that i the xhr was an error then the catch block for errors would fire, but it would receive an exception, not the response.  That would cause the error modal to say "no response received" even though there was a response, but on the `response` key.

The other bug was that when the error handler finished it would return null, breaking following `.then` blocks.