### PR TITLE
Remove apostrophe from on boarding choices for SF

### DIFF
--- a/tutor/specs/models/courses/standard-ux.spec.js
+++ b/tutor/specs/models/courses/standard-ux.spec.js
@@ -40,7 +40,7 @@ describe('Course Preview UX', () => {
   it('#recordExpectedUse(decision)', () => {
     ux.recordExpectedUse('wu');
     expect(User.logEvent).toHaveBeenCalledWith({
-      category: 'onboarding', code: 'made_adoption_decision', data: { decision: 'I won\'t be using it' },
+      category: 'onboarding', code: 'made_adoption_decision', data: { decision: 'I wont be using it' },
     });
     expect(UiSettings.set).toHaveBeenCalledWith('OBC', 1, 'wu');
   });

--- a/tutor/src/models/course/standard-ux.js
+++ b/tutor/src/models/course/standard-ux.js
@@ -14,8 +14,8 @@ const CHOICES = {
   cc: 'For course credit',
   exc: 'For extra credit',
   adr: 'As an additional resource',
-  dn: 'I don\'t know yet',
-  wu: 'I won\'t be using it',
+  dn: 'I dont know yet',
+  wu: 'I wont be using it',
 };
 
 export default class StandardCourseUX extends BasicCourseUX {


### PR DESCRIPTION
Appears that salesforce or one of the libraries in-between doesn't like 'em