### PR TITLE
update dashboard tours content and position menu tours

### DIFF
--- a/tutor/resources/styles/components/tours.less
+++ b/tutor/resources/styles/components/tours.less
@@ -10,4 +10,8 @@
     &:extend(.tutor-icon.best-practices);
   }
 
+  &[data-target^='[data-tour-anchor-id="menu-option-'] {
+    margin-top: -26px;
+  }
+
 }

--- a/tutor/src/components/tours/custom/how-to-use-preview.jsx
+++ b/tutor/src/components/tours/custom/how-to-use-preview.jsx
@@ -16,12 +16,12 @@ export default class HowToUsePreview extends React.PureComponent {
             What can you do in a preview course?
           </h1>
           <h2 className="sub-heading">
-            Test drive all the features, but your work will stay in here.
+            Test drive all the features, but your work won't transfer to a live course.
           </h2>
           <ColumnContent>
             <Column className="all-features">
               <p>
-                Try out all features
+                Try all the features
               </p>
             </Column>
             <Column className="view-analytics">
@@ -31,13 +31,12 @@ export default class HowToUsePreview extends React.PureComponent {
             </Column>
             <Column className="view-textbook-questions">
               <p>
-                See the textbook and questions
+                Browse the textbook and questions
               </p>
             </Column>
             <Column className="cant-save-work">
               <p>
-                Work you do here won't<br/>
-                be saved
+                Remember, work you do here won't be saved
               </p>
             </Column>
           </ColumnContent>

--- a/tutor/src/components/tours/custom/tips-now-or-later.jsx
+++ b/tutor/src/components/tours/custom/tips-now-or-later.jsx
@@ -60,7 +60,6 @@ export default class TipsNowOrLater extends React.PureComponent {
 
     return (
       <Tooltip
-        position="left"
         {...omit(this.props, 'style', 'buttons')}
         className={className}
         step={step}

--- a/tutor/src/tours/teacher-calendar.json
+++ b/tutor/src/tours/teacher-calendar.json
@@ -56,7 +56,7 @@
       "title": "Manage your question library",
       "body": "View all OpenStax Tutor questions here.",
       "anchor_id": "menu-option-viewQuestionsLibrary",
-      "position": "bottom-right",
+      "position": "left",
       "is_fixed": true,
       "action": {
         "id": "open-user-menu"
@@ -65,7 +65,7 @@
       "title": "Browse the book",
       "body": "Review the OpenStax textbook here.",
       "anchor_id": "menu-option-browse-book",
-      "position": "bottom-right",
+      "position": "left",
       "is_fixed": true,
       "action": {
         "id": "open-user-menu"
@@ -84,7 +84,7 @@
       "title": "Get help",
       "body": "Get help with a page tour, support articles, or chat.",
       "anchor_id": "support-menu-button",
-      "position": "bottom-center",
+      "position": "left",
       "is_fixed": true,
       "action": {
         "id": "open-support-menu"

--- a/tutor/src/tours/teacher-calendar.json
+++ b/tutor/src/tours/teacher-calendar.json
@@ -14,7 +14,8 @@
       "anchor_id": "menu-option-page-tips",
       "action": {
         "id": "open-support-menu"
-      }
+      },
+      "position": "left"
     }
   ]
 }, {
@@ -28,8 +29,8 @@
       "title": "Welcome to your dashboard!",
       "body": "Think of your dashboard as base camp -- you can create and manage assignments, see student progress, and review the book."
     }, {
-      "title": "Here’s where you add your assignments",
-      "body": "Create an assignment by clicking it or dragging to the calendar.",
+      "title": "Here's where you add your assignments",
+      "body": "Create an assignment by clicking it or dragging to the calendar.  Events are important class dates, like the final exam.",
       "anchor_id": "sidebar-add-tasks",
       "position": "right",
       "action": {
@@ -37,24 +38,24 @@
       }
     }, {
       "title": "Managing assignments",
-      "body": "You can edit an assignment or review student progress and performance by clicking an assignment in your calendar.",
+      "body": "You can edit an assignment or review student progress and performance by clicking on the assignment on your calendar.",
       "anchor_id": "calendar-task-plan",
       "action": {
         "id": "reposition"
       }
     }, {
-      "title": "Here’s where you see section analytics",
+      "title": "Here's where you see section analytics",
       "body": "The Performance Forecast is the compass in your pocket: it helps you measure how your class is understanding concepts so you can target your teaching!",
       "anchor_id": "performance-forcast-button",
       "position": "bottom-left"
     }, {
-      "title": "View student scores",
+      "title": "View student scores here",
       "body": "View individual student performance and completion, and export student scores for your learning management system.",
       "anchor_id": "student-scores-button",
       "position": "bottom-right"
     }, {
       "title": "Manage your question library",
-      "body": "View all OpenStax Tutor questions here.",
+      "body": "View all OpenStax Tutor questions and exclude questions you don't want students to get in your course.",
       "anchor_id": "menu-option-viewQuestionsLibrary",
       "position": "left",
       "is_fixed": true,
@@ -82,7 +83,7 @@
       "position": "bottom-center"
     }, {
       "title": "Get help",
-      "body": "Get help with a page tour, support articles, or chat.",
+      "body": "Get help with a page tour, support articles, or live chat.",
       "anchor_id": "support-menu-button",
       "position": "left",
       "is_fixed": true,


### PR DESCRIPTION
menu item tours dont block menu anymore, and content as updated in https://trello.com/c/8GTjENnb/548-onboarding01c-training-wheel-tour-for-preview-course-dashboard mockup

![screen shot 2017-06-13 at 5 28 58 pm](https://user-images.githubusercontent.com/2483873/27107496-e62eb1f2-505d-11e7-8492-4630403e36e0.png)

![screen shot 2017-06-13 at 5 53 08 pm](https://user-images.githubusercontent.com/2483873/27108130-32edb800-5061-11e7-8d02-6c92cbac0f2c.png)
