### PR TITLE
need to fetch whenever getting an outside update, and also, need to o…

### DIFF
--- a/tutor/src/components/course-calendar/index.jsx
+++ b/tutor/src/components/course-calendar/index.jsx
@@ -93,6 +93,9 @@ export default class TeacherTaskPlanListing extends React.PureComponent {
   componentWillMount() {
     const courseTimezone = this.course.time_zone;
     TimeHelper.syncCourseTimezone(courseTimezone);
+  }
+
+  componentWillUpdate(nextProps, nextState) {
     this.loader.fetch(this.fetchParams);
     TaskPlans.forCourseId(this.course.id).clearPendingClones();
   }

--- a/tutor/src/models/loader.js
+++ b/tutor/src/models/loader.js
@@ -21,12 +21,14 @@ export default class ModelLoader {
   fetch(props, options = { reload: false }) {
     const key = hash(props);
     const isInProgress = this.inProgress.has(key);
-    this.inProgress.set(key, true);
+
     return new Promise((resolve) => {
       if (!isInProgress && (options.reload || !this.completed.has(key))) {
+        this.inProgress.set(key, true);
+
         this._model[this._method](props).then((args) => {
-          this.inProgress.delete(key);
           this.completed.set(key, true);
+          this.inProgress.delete(key);
           resolve(this);
           return args;
         });


### PR DESCRIPTION
…nly set as in progress when about to actually send request, otherwise, in progress is true more than it should be


should eventually move to using a `ux` model for this component

https://trello.com/c/1CRvb41n/739-bug-assignments-earlier-than-1-month-ago-arent-loading-when-moving-the-calendar