### PR TITLE
reading and homework wheels

### DIFF
--- a/tutor/resources/styles/components/task-plan/controls.less
+++ b/tutor/resources/styles/components/task-plan/controls.less
@@ -20,7 +20,13 @@
     }
   }
 
-  .tour-anchor { display: inline; }
+  .footer-instructions {
+    i.fa {
+      margin-right: 0;
+    }
+  }
+
+  .tour-anchor { display: inline-block; }
   .save {
     background: @openstax-neutral;
     color: @openstax-white;
@@ -31,4 +37,10 @@
     }
   }
 
+}
+
+#plan-footer-popover {
+  strong {
+    margin-right: 0.25em;
+  }
 }

--- a/tutor/resources/styles/components/task-plan/homework/exercise-summary.less
+++ b/tutor/resources/styles/components/task-plan/homework/exercise-summary.less
@@ -2,6 +2,7 @@
   height: 90px;
   flex-wrap: wrap;
   background-color: white;
+  position: relative;
 
   &.navbar-fixed-top-lower {
     top: 51px;
@@ -79,5 +80,10 @@
     flex-wrap: wrap;
   }
 
+  #homework-selections-trigger {
+    position: absolute;
+    bottom: -.1em;
+    padding: 0;
+  }
 
 }

--- a/tutor/resources/styles/components/tours/value-prop.less
+++ b/tutor/resources/styles/components/tours/value-prop.less
@@ -88,6 +88,16 @@
       padding: @spacing*0.25 @spacing;
     }
 
+    &.build-reading {
+      .column-content {      
+        padding: @spacing 90px;
+      }
+
+      .column + .column {
+        margin-left: 60px;
+      }
+    }
+
     &.cc-to-tutor,
     &.welcome-to-tutor {
       .column {
@@ -122,7 +132,8 @@
         &.view-textbook-questions   { .tutor-background-image("course-preview/view-textbook-questions.svg");  }
       }
     }
-    &.question-library {
+    &.question-library,
+    &.build-reading {
       .column {
         .column-icons-embiggen();
 

--- a/tutor/specs/components/questions/exercises-display.spec.cjsx
+++ b/tutor/specs/components/questions/exercises-display.spec.cjsx
@@ -10,7 +10,7 @@ SECTION_IDS  = [234..242]
 COURSE_ID = '1'
 ECOSYSTEM_ID = '1'
 
-{ExerciseActions} = require '../../../src/flux/exercise'
+{ExerciseActions, ExerciseStore} = require '../../../src/flux/exercise'
 {CourseActions} = require '../../../src/flux/course'
 {TocActions, TocStore} = require '../../../src/flux/toc'
 
@@ -30,10 +30,14 @@ describe 'QL exercises display', ->
   afterEach ->
     ExerciseActions.saveExerciseExclusion.restore()
 
-  it 'renders cards', ->
+  it 'renders reading cards', ->
+    defaultReadingCards = ExerciseStore.groupBySectionsAndTypes(
+      ECOSYSTEM_ID, SECTION_IDS, withExcluded: true
+    )?['reading']
+
     Testing.renderComponent( ExercisesDisplay, props: @props, unmountAfter: 20 ).then ({dom}) ->
       expect( dom.querySelectorAll('.openstax-exercise-preview').length ).to
-        .equal(EXERCISES.items.length)
+        .equal(defaultReadingCards.count)
 
 
   it 'displays dialog when exercises are at minimum (5)', ->

--- a/tutor/specs/components/task-plan/__snapshots__/select-topics.spec.cjsx.snap
+++ b/tutor/specs/components/task-plan/__snapshots__/select-topics.spec.cjsx.snap
@@ -2,1889 +2,1894 @@
 
 exports[`Select Topics matches snapshot 1`] = `
 <div
-  className="dialog default-dialog select-topics panel panel-default"
-  id={undefined}
+  className="undefined-plan-select-topics"
+  data-tour-region-id="add-undefined-choose-sections"
 >
   <div
-    className="panel-heading"
-  >
-    Section Chooser Header
-    <button
-      className="openstax-close-x close"
-      onClick={[Function]}
-    />
-  </div>
-  <div
-    className="panel-body"
+    className="dialog default-dialog select-topics panel panel-default"
+    id={undefined}
   >
     <div
-      className="select-chapters"
-      data-ecosystem-id="3"
+      className="panel-heading"
+    >
+      Section Chooser Header
+      <button
+        className="openstax-close-x close"
+        onClick={[Function]}
+      />
+    </div>
+    <div
+      className="panel-body"
     >
       <div
-        className="sections-chooser"
+        className="select-chapters"
+        data-ecosystem-id="3"
       >
         <div
-          className="panel-group"
-          expanded={true}
-          role="tablist"
+          className="sections-chooser"
         >
           <div
-            className="panel panel-default"
-            id={null}
+            className="panel-group"
+            expanded={true}
+            role="tablist"
           >
             <div
-              className="panel-heading"
+              className="panel panel-default"
+              id={null}
             >
               <div
-                className="chapter-heading panel-title"
-                data-chapter-section={1}
+                className="panel-heading"
               >
-                <a
-                  aria-controls={undefined}
-                  aria-expanded={true}
-                  aria-selected={true}
-                  className={null}
-                  href={undefined}
-                  onClick={[Function]}
-                  role="tab"
+                <div
+                  className="chapter-heading panel-title"
+                  data-chapter-section={1}
                 >
-                  <span
-                    className="chapter-checkbox"
+                  <a
+                    aria-controls={undefined}
+                    aria-expanded={true}
+                    aria-selected={true}
+                    className={null}
+                    href={undefined}
+                    onClick={[Function]}
+                    role="tab"
                   >
                     <span
-                      className="tri-state-checkbox unchecked"
-                      onClick={[Function]}
-                      tabIndex={1}
+                      className="chapter-checkbox"
                     >
-                      <i
-                        className="tutor-icon fa fa-square-o clickable"
+                      <span
+                        className="tri-state-checkbox unchecked"
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "cursor": "pointer",
+                        tabIndex={1}
+                      >
+                        <i
+                          className="tutor-icon fa fa-square-o clickable"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "cursor": "pointer",
+                            }
                           }
-                        }
-                        type="square-o"
+                          type="square-o"
+                        />
+                      </span>
+                    </span>
+                    <span
+                      className="chapter-number"
+                    >
+                      Chapter 
+                      <span
+                        className="chapter-section"
+                        data-chapter-section="1"
+                      >
+                        1
+                      </span>
+                       -
+                    </span>
+                    <span
+                      className="chapter-title"
+                    >
+                       
+                      What Is Physics?
+                    </span>
+                  </a>
+                </div>
+              </div>
+              <div
+                aria-expanded={null}
+                aria-hidden={false}
+                className="panel-collapse collapse in"
+                id={undefined}
+                role="tabpanel"
+              >
+                <div
+                  className="panel-body"
+                >
+                  <div
+                    className="section"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
                       />
                     </span>
-                  </span>
-                  <span
-                    className="chapter-number"
-                  >
-                    Chapter 
                     <span
                       className="chapter-section"
                       data-chapter-section="1"
                     >
                       1
                     </span>
-                     -
-                  </span>
-                  <span
-                    className="chapter-title"
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Introduction
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    What Is Physics?
-                  </span>
-                </a>
-              </div>
-            </div>
-            <div
-              aria-expanded={null}
-              aria-hidden={false}
-              className="panel-collapse collapse in"
-              id={undefined}
-              role="tabpanel"
-            >
-              <div
-                className="panel-body"
-              >
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="1.1"
+                    >
+                      1.1
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Physics: Definitions and Applications
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="1"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="1.2"
+                    >
+                      1.2
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      The Scientific Method
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    1
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Introduction
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="1.1"
-                  >
-                    1.1
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Physics: Definitions and Applications
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="1.2"
-                  >
-                    1.2
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    The Scientific Method
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="1.3"
-                  >
-                    1.3
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    The Language of Physics: Physical Quantities and Units
-                  </span>
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="1.3"
+                    >
+                      1.3
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      The Language of Physics: Physical Quantities and Units
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="panel-group"
-          expanded={false}
-          role="tablist"
-        >
           <div
-            className="panel panel-default"
-            id={null}
+            className="panel-group"
+            expanded={false}
+            role="tablist"
           >
             <div
-              className="panel-heading"
+              className="panel panel-default"
+              id={null}
             >
               <div
-                className="chapter-heading panel-title"
-                data-chapter-section={2}
+                className="panel-heading"
               >
-                <a
-                  aria-controls={undefined}
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="collapsed"
-                  href={undefined}
-                  onClick={[Function]}
-                  role="tab"
+                <div
+                  className="chapter-heading panel-title"
+                  data-chapter-section={2}
                 >
-                  <span
-                    className="chapter-checkbox"
+                  <a
+                    aria-controls={undefined}
+                    aria-expanded={false}
+                    aria-selected={false}
+                    className="collapsed"
+                    href={undefined}
+                    onClick={[Function]}
+                    role="tab"
                   >
                     <span
-                      className="tri-state-checkbox unchecked"
-                      onClick={[Function]}
-                      tabIndex={1}
+                      className="chapter-checkbox"
                     >
-                      <i
-                        className="tutor-icon fa fa-square-o clickable"
+                      <span
+                        className="tri-state-checkbox unchecked"
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "cursor": "pointer",
+                        tabIndex={1}
+                      >
+                        <i
+                          className="tutor-icon fa fa-square-o clickable"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "cursor": "pointer",
+                            }
                           }
-                        }
-                        type="square-o"
+                          type="square-o"
+                        />
+                      </span>
+                    </span>
+                    <span
+                      className="chapter-number"
+                    >
+                      Chapter 
+                      <span
+                        className="chapter-section"
+                        data-chapter-section="2"
+                      >
+                        2
+                      </span>
+                       -
+                    </span>
+                    <span
+                      className="chapter-title"
+                    >
+                       
+                      Motion in One Dimension
+                    </span>
+                  </a>
+                </div>
+              </div>
+              <div
+                aria-expanded={null}
+                aria-hidden={true}
+                className="panel-collapse collapse"
+                id={undefined}
+                role="tabpanel"
+              >
+                <div
+                  className="panel-body"
+                >
+                  <div
+                    className="section"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
                       />
                     </span>
-                  </span>
-                  <span
-                    className="chapter-number"
-                  >
-                    Chapter 
                     <span
                       className="chapter-section"
                       data-chapter-section="2"
                     >
                       2
                     </span>
-                     -
-                  </span>
-                  <span
-                    className="chapter-title"
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Introduction
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    Motion in One Dimension
-                  </span>
-                </a>
-              </div>
-            </div>
-            <div
-              aria-expanded={null}
-              aria-hidden={true}
-              className="panel-collapse collapse"
-              id={undefined}
-              role="tabpanel"
-            >
-              <div
-                className="panel-body"
-              >
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="2.1"
+                    >
+                      2.1
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Relative Motion, Distance and Displacement
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="2"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="2.2"
+                    >
+                      2.2
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Speed and Velocity
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    2
-                  </span>
-                  <span
-                    className="-section-title"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="2.3"
+                    >
+                      2.3
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Position vs. Time Graphs
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    Introduction
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="2.1"
-                  >
-                    2.1
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Relative Motion, Distance and Displacement
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="2.2"
-                  >
-                    2.2
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Speed and Velocity
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="2.3"
-                  >
-                    2.3
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Position vs. Time Graphs
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="2.4"
-                  >
-                    2.4
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Velocity vs. Time Graphs
-                  </span>
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="2.4"
+                    >
+                      2.4
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Velocity vs. Time Graphs
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="panel-group"
-          expanded={false}
-          role="tablist"
-        >
           <div
-            className="panel panel-default"
-            id={null}
+            className="panel-group"
+            expanded={false}
+            role="tablist"
           >
             <div
-              className="panel-heading"
+              className="panel panel-default"
+              id={null}
             >
               <div
-                className="chapter-heading panel-title"
-                data-chapter-section={3}
+                className="panel-heading"
               >
-                <a
-                  aria-controls={undefined}
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="collapsed"
-                  href={undefined}
-                  onClick={[Function]}
-                  role="tab"
+                <div
+                  className="chapter-heading panel-title"
+                  data-chapter-section={3}
                 >
-                  <span
-                    className="chapter-checkbox"
+                  <a
+                    aria-controls={undefined}
+                    aria-expanded={false}
+                    aria-selected={false}
+                    className="collapsed"
+                    href={undefined}
+                    onClick={[Function]}
+                    role="tab"
                   >
                     <span
-                      className="tri-state-checkbox unchecked"
-                      onClick={[Function]}
-                      tabIndex={1}
+                      className="chapter-checkbox"
                     >
-                      <i
-                        className="tutor-icon fa fa-square-o clickable"
+                      <span
+                        className="tri-state-checkbox unchecked"
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "cursor": "pointer",
+                        tabIndex={1}
+                      >
+                        <i
+                          className="tutor-icon fa fa-square-o clickable"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "cursor": "pointer",
+                            }
                           }
-                        }
-                        type="square-o"
+                          type="square-o"
+                        />
+                      </span>
+                    </span>
+                    <span
+                      className="chapter-number"
+                    >
+                      Chapter 
+                      <span
+                        className="chapter-section"
+                        data-chapter-section="3"
+                      >
+                        3
+                      </span>
+                       -
+                    </span>
+                    <span
+                      className="chapter-title"
+                    >
+                       
+                      Acceleration
+                    </span>
+                  </a>
+                </div>
+              </div>
+              <div
+                aria-expanded={null}
+                aria-hidden={true}
+                className="panel-collapse collapse"
+                id={undefined}
+                role="tabpanel"
+              >
+                <div
+                  className="panel-body"
+                >
+                  <div
+                    className="section"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
                       />
                     </span>
-                  </span>
-                  <span
-                    className="chapter-number"
-                  >
-                    Chapter 
                     <span
                       className="chapter-section"
                       data-chapter-section="3"
                     >
                       3
                     </span>
-                     -
-                  </span>
-                  <span
-                    className="chapter-title"
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Introduction
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    Acceleration
-                  </span>
-                </a>
-              </div>
-            </div>
-            <div
-              aria-expanded={null}
-              aria-hidden={true}
-              className="panel-collapse collapse"
-              id={undefined}
-              role="tabpanel"
-            >
-              <div
-                className="panel-body"
-              >
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="3.1"
+                    >
+                      3.1
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Acceleration
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="3"
-                  >
-                    3
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Introduction
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="3.1"
-                  >
-                    3.1
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Acceleration
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="3.2"
-                  >
-                    3.2
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Representing Acceleration with Equations and Graphs
-                  </span>
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="3.2"
+                    >
+                      3.2
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Representing Acceleration with Equations and Graphs
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="panel-group"
-          expanded={false}
-          role="tablist"
-        >
           <div
-            className="panel panel-default"
-            id={null}
+            className="panel-group"
+            expanded={false}
+            role="tablist"
           >
             <div
-              className="panel-heading"
+              className="panel panel-default"
+              id={null}
             >
               <div
-                className="chapter-heading panel-title"
-                data-chapter-section={4}
+                className="panel-heading"
               >
-                <a
-                  aria-controls={undefined}
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="collapsed"
-                  href={undefined}
-                  onClick={[Function]}
-                  role="tab"
+                <div
+                  className="chapter-heading panel-title"
+                  data-chapter-section={4}
                 >
-                  <span
-                    className="chapter-checkbox"
+                  <a
+                    aria-controls={undefined}
+                    aria-expanded={false}
+                    aria-selected={false}
+                    className="collapsed"
+                    href={undefined}
+                    onClick={[Function]}
+                    role="tab"
                   >
                     <span
-                      className="tri-state-checkbox unchecked"
-                      onClick={[Function]}
-                      tabIndex={1}
+                      className="chapter-checkbox"
                     >
-                      <i
-                        className="tutor-icon fa fa-square-o clickable"
+                      <span
+                        className="tri-state-checkbox unchecked"
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "cursor": "pointer",
+                        tabIndex={1}
+                      >
+                        <i
+                          className="tutor-icon fa fa-square-o clickable"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "cursor": "pointer",
+                            }
                           }
-                        }
-                        type="square-o"
+                          type="square-o"
+                        />
+                      </span>
+                    </span>
+                    <span
+                      className="chapter-number"
+                    >
+                      Chapter 
+                      <span
+                        className="chapter-section"
+                        data-chapter-section="4"
+                      >
+                        4
+                      </span>
+                       -
+                    </span>
+                    <span
+                      className="chapter-title"
+                    >
+                       
+                      Forces and Newton's Law of Motion
+                    </span>
+                  </a>
+                </div>
+              </div>
+              <div
+                aria-expanded={null}
+                aria-hidden={true}
+                className="panel-collapse collapse"
+                id={undefined}
+                role="tabpanel"
+              >
+                <div
+                  className="panel-body"
+                >
+                  <div
+                    className="section"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
                       />
                     </span>
-                  </span>
-                  <span
-                    className="chapter-number"
-                  >
-                    Chapter 
                     <span
                       className="chapter-section"
                       data-chapter-section="4"
                     >
                       4
                     </span>
-                     -
-                  </span>
-                  <span
-                    className="chapter-title"
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Introduction
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    Forces and Newton's Law of Motion
-                  </span>
-                </a>
-              </div>
-            </div>
-            <div
-              aria-expanded={null}
-              aria-hidden={true}
-              className="panel-collapse collapse"
-              id={undefined}
-              role="tabpanel"
-            >
-              <div
-                className="panel-body"
-              >
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="4.1"
+                    >
+                      4.1
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Force
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="4"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="4.2"
+                    >
+                      4.2
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Newton’s First Law of Motion: Inertia
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    4
-                  </span>
-                  <span
-                    className="-section-title"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="4.3"
+                    >
+                      4.3
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Newton’s Second Law of Motion
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    Introduction
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="4.1"
-                  >
-                    4.1
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Force
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="4.2"
-                  >
-                    4.2
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Newton’s First Law of Motion: Inertia
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="4.3"
-                  >
-                    4.3
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Newton’s Second Law of Motion
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="4.4"
-                  >
-                    4.4
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Newton’s Third Law of Motion
-                  </span>
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="4.4"
+                    >
+                      4.4
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Newton’s Third Law of Motion
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="panel-group"
-          expanded={false}
-          role="tablist"
-        >
           <div
-            className="panel panel-default"
-            id={null}
+            className="panel-group"
+            expanded={false}
+            role="tablist"
           >
             <div
-              className="panel-heading"
+              className="panel panel-default"
+              id={null}
             >
               <div
-                className="chapter-heading panel-title"
-                data-chapter-section={5}
+                className="panel-heading"
               >
-                <a
-                  aria-controls={undefined}
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="collapsed"
-                  href={undefined}
-                  onClick={[Function]}
-                  role="tab"
+                <div
+                  className="chapter-heading panel-title"
+                  data-chapter-section={5}
                 >
-                  <span
-                    className="chapter-checkbox"
+                  <a
+                    aria-controls={undefined}
+                    aria-expanded={false}
+                    aria-selected={false}
+                    className="collapsed"
+                    href={undefined}
+                    onClick={[Function]}
+                    role="tab"
                   >
                     <span
-                      className="tri-state-checkbox unchecked"
-                      onClick={[Function]}
-                      tabIndex={1}
+                      className="chapter-checkbox"
                     >
-                      <i
-                        className="tutor-icon fa fa-square-o clickable"
+                      <span
+                        className="tri-state-checkbox unchecked"
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "cursor": "pointer",
+                        tabIndex={1}
+                      >
+                        <i
+                          className="tutor-icon fa fa-square-o clickable"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "cursor": "pointer",
+                            }
                           }
-                        }
-                        type="square-o"
+                          type="square-o"
+                        />
+                      </span>
+                    </span>
+                    <span
+                      className="chapter-number"
+                    >
+                      Chapter 
+                      <span
+                        className="chapter-section"
+                        data-chapter-section="5"
+                      >
+                        5
+                      </span>
+                       -
+                    </span>
+                    <span
+                      className="chapter-title"
+                    >
+                       
+                      Motion in Two Dimensions
+                    </span>
+                  </a>
+                </div>
+              </div>
+              <div
+                aria-expanded={null}
+                aria-hidden={true}
+                className="panel-collapse collapse"
+                id={undefined}
+                role="tabpanel"
+              >
+                <div
+                  className="panel-body"
+                >
+                  <div
+                    className="section"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
                       />
                     </span>
-                  </span>
-                  <span
-                    className="chapter-number"
-                  >
-                    Chapter 
                     <span
                       className="chapter-section"
                       data-chapter-section="5"
                     >
                       5
                     </span>
-                     -
-                  </span>
-                  <span
-                    className="chapter-title"
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Introduction
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    Motion in Two Dimensions
-                  </span>
-                </a>
-              </div>
-            </div>
-            <div
-              aria-expanded={null}
-              aria-hidden={true}
-              className="panel-collapse collapse"
-              id={undefined}
-              role="tabpanel"
-            >
-              <div
-                className="panel-body"
-              >
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="5.1"
+                    >
+                      5.1
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Vector Addition and Subtraction: Graphical Methods
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="5"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="5.2"
+                    >
+                      5.2
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Vector Addition and Subtraction: Analytical Methods
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    5
-                  </span>
-                  <span
-                    className="-section-title"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="5.3"
+                    >
+                      5.3
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Projectile Motion
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    Introduction
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="5.4"
+                    >
+                      5.4
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Inclined Planes
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="5.1"
-                  >
-                    5.1
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Vector Addition and Subtraction: Graphical Methods
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="5.2"
-                  >
-                    5.2
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Vector Addition and Subtraction: Analytical Methods
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="5.3"
-                  >
-                    5.3
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Projectile Motion
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="5.4"
-                  >
-                    5.4
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Inclined Planes
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="5.5"
-                  >
-                    5.5
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Simple Harmonic Motion
-                  </span>
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="5.5"
+                    >
+                      5.5
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Simple Harmonic Motion
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="panel-group"
-          expanded={false}
-          role="tablist"
-        >
           <div
-            className="panel panel-default"
-            id={null}
+            className="panel-group"
+            expanded={false}
+            role="tablist"
           >
             <div
-              className="panel-heading"
+              className="panel panel-default"
+              id={null}
             >
               <div
-                className="chapter-heading panel-title"
-                data-chapter-section={6}
+                className="panel-heading"
               >
-                <a
-                  aria-controls={undefined}
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="collapsed"
-                  href={undefined}
-                  onClick={[Function]}
-                  role="tab"
+                <div
+                  className="chapter-heading panel-title"
+                  data-chapter-section={6}
                 >
-                  <span
-                    className="chapter-checkbox"
+                  <a
+                    aria-controls={undefined}
+                    aria-expanded={false}
+                    aria-selected={false}
+                    className="collapsed"
+                    href={undefined}
+                    onClick={[Function]}
+                    role="tab"
                   >
                     <span
-                      className="tri-state-checkbox unchecked"
-                      onClick={[Function]}
-                      tabIndex={1}
+                      className="chapter-checkbox"
                     >
-                      <i
-                        className="tutor-icon fa fa-square-o clickable"
+                      <span
+                        className="tri-state-checkbox unchecked"
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "cursor": "pointer",
+                        tabIndex={1}
+                      >
+                        <i
+                          className="tutor-icon fa fa-square-o clickable"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "cursor": "pointer",
+                            }
                           }
-                        }
-                        type="square-o"
+                          type="square-o"
+                        />
+                      </span>
+                    </span>
+                    <span
+                      className="chapter-number"
+                    >
+                      Chapter 
+                      <span
+                        className="chapter-section"
+                        data-chapter-section="6"
+                      >
+                        6
+                      </span>
+                       -
+                    </span>
+                    <span
+                      className="chapter-title"
+                    >
+                       
+                      Circular and Rotational Motion
+                    </span>
+                  </a>
+                </div>
+              </div>
+              <div
+                aria-expanded={null}
+                aria-hidden={true}
+                className="panel-collapse collapse"
+                id={undefined}
+                role="tabpanel"
+              >
+                <div
+                  className="panel-body"
+                >
+                  <div
+                    className="section"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
                       />
                     </span>
-                  </span>
-                  <span
-                    className="chapter-number"
-                  >
-                    Chapter 
                     <span
                       className="chapter-section"
                       data-chapter-section="6"
                     >
                       6
                     </span>
-                     -
-                  </span>
-                  <span
-                    className="chapter-title"
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Introduction
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    Circular and Rotational Motion
-                  </span>
-                </a>
-              </div>
-            </div>
-            <div
-              aria-expanded={null}
-              aria-hidden={true}
-              className="panel-collapse collapse"
-              id={undefined}
-              role="tabpanel"
-            >
-              <div
-                className="panel-body"
-              >
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="6.1"
+                    >
+                      6.1
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Angle of Rotation and Angular Velocity
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="6"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="6.2"
+                    >
+                      6.2
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Uniform Circular Motion
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    6
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Introduction
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="6.1"
-                  >
-                    6.1
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Angle of Rotation and Angular Velocity
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="6.2"
-                  >
-                    6.2
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Uniform Circular Motion
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="6.3"
-                  >
-                    6.3
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Rotational Motion
-                  </span>
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="6.3"
+                    >
+                      6.3
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Rotational Motion
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="panel-group"
-          expanded={false}
-          role="tablist"
-        >
           <div
-            className="panel panel-default"
-            id={null}
+            className="panel-group"
+            expanded={false}
+            role="tablist"
           >
             <div
-              className="panel-heading"
+              className="panel panel-default"
+              id={null}
             >
               <div
-                className="chapter-heading panel-title"
-                data-chapter-section={7}
+                className="panel-heading"
               >
-                <a
-                  aria-controls={undefined}
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="collapsed"
-                  href={undefined}
-                  onClick={[Function]}
-                  role="tab"
+                <div
+                  className="chapter-heading panel-title"
+                  data-chapter-section={7}
                 >
-                  <span
-                    className="chapter-checkbox"
+                  <a
+                    aria-controls={undefined}
+                    aria-expanded={false}
+                    aria-selected={false}
+                    className="collapsed"
+                    href={undefined}
+                    onClick={[Function]}
+                    role="tab"
                   >
                     <span
-                      className="tri-state-checkbox unchecked"
-                      onClick={[Function]}
-                      tabIndex={1}
+                      className="chapter-checkbox"
                     >
-                      <i
-                        className="tutor-icon fa fa-square-o clickable"
+                      <span
+                        className="tri-state-checkbox unchecked"
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "cursor": "pointer",
+                        tabIndex={1}
+                      >
+                        <i
+                          className="tutor-icon fa fa-square-o clickable"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "cursor": "pointer",
+                            }
                           }
-                        }
-                        type="square-o"
+                          type="square-o"
+                        />
+                      </span>
+                    </span>
+                    <span
+                      className="chapter-number"
+                    >
+                      Chapter 
+                      <span
+                        className="chapter-section"
+                        data-chapter-section="7"
+                      >
+                        7
+                      </span>
+                       -
+                    </span>
+                    <span
+                      className="chapter-title"
+                    >
+                       
+                      Newton's Law of Gravitation
+                    </span>
+                  </a>
+                </div>
+              </div>
+              <div
+                aria-expanded={null}
+                aria-hidden={true}
+                className="panel-collapse collapse"
+                id={undefined}
+                role="tabpanel"
+              >
+                <div
+                  className="panel-body"
+                >
+                  <div
+                    className="section"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
                       />
                     </span>
-                  </span>
-                  <span
-                    className="chapter-number"
-                  >
-                    Chapter 
                     <span
                       className="chapter-section"
                       data-chapter-section="7"
                     >
                       7
                     </span>
-                     -
-                  </span>
-                  <span
-                    className="chapter-title"
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Introduction
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    Newton's Law of Gravitation
-                  </span>
-                </a>
-              </div>
-            </div>
-            <div
-              aria-expanded={null}
-              aria-hidden={true}
-              className="panel-collapse collapse"
-              id={undefined}
-              role="tabpanel"
-            >
-              <div
-                className="panel-body"
-              >
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="7.1"
+                    >
+                      7.1
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Kepler’s Laws of Planetary Motion
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="7"
-                  >
-                    7
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Introduction
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="7.1"
-                  >
-                    7.1
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Kepler’s Laws of Planetary Motion
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="7.2"
-                  >
-                    7.2
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Newton’s Law of Universal Gravitation and Einstein’s Theory of General Relativity
-                  </span>
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="7.2"
+                    >
+                      7.2
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Newton’s Law of Universal Gravitation and Einstein’s Theory of General Relativity
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="panel-group"
-          expanded={false}
-          role="tablist"
-        >
           <div
-            className="panel panel-default"
-            id={null}
+            className="panel-group"
+            expanded={false}
+            role="tablist"
           >
             <div
-              className="panel-heading"
+              className="panel panel-default"
+              id={null}
             >
               <div
-                className="chapter-heading panel-title"
-                data-chapter-section={8}
+                className="panel-heading"
               >
-                <a
-                  aria-controls={undefined}
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="collapsed"
-                  href={undefined}
-                  onClick={[Function]}
-                  role="tab"
+                <div
+                  className="chapter-heading panel-title"
+                  data-chapter-section={8}
                 >
-                  <span
-                    className="chapter-checkbox"
+                  <a
+                    aria-controls={undefined}
+                    aria-expanded={false}
+                    aria-selected={false}
+                    className="collapsed"
+                    href={undefined}
+                    onClick={[Function]}
+                    role="tab"
                   >
                     <span
-                      className="tri-state-checkbox unchecked"
-                      onClick={[Function]}
-                      tabIndex={1}
+                      className="chapter-checkbox"
                     >
-                      <i
-                        className="tutor-icon fa fa-square-o clickable"
+                      <span
+                        className="tri-state-checkbox unchecked"
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "cursor": "pointer",
+                        tabIndex={1}
+                      >
+                        <i
+                          className="tutor-icon fa fa-square-o clickable"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "cursor": "pointer",
+                            }
                           }
-                        }
-                        type="square-o"
+                          type="square-o"
+                        />
+                      </span>
+                    </span>
+                    <span
+                      className="chapter-number"
+                    >
+                      Chapter 
+                      <span
+                        className="chapter-section"
+                        data-chapter-section="8"
+                      >
+                        8
+                      </span>
+                       -
+                    </span>
+                    <span
+                      className="chapter-title"
+                    >
+                       
+                      Momentum
+                    </span>
+                  </a>
+                </div>
+              </div>
+              <div
+                aria-expanded={null}
+                aria-hidden={true}
+                className="panel-collapse collapse"
+                id={undefined}
+                role="tabpanel"
+              >
+                <div
+                  className="panel-body"
+                >
+                  <div
+                    className="section"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
                       />
                     </span>
-                  </span>
-                  <span
-                    className="chapter-number"
-                  >
-                    Chapter 
                     <span
                       className="chapter-section"
                       data-chapter-section="8"
                     >
                       8
                     </span>
-                     -
-                  </span>
-                  <span
-                    className="chapter-title"
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Introduction
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    Momentum
-                  </span>
-                </a>
-              </div>
-            </div>
-            <div
-              aria-expanded={null}
-              aria-hidden={true}
-              className="panel-collapse collapse"
-              id={undefined}
-              role="tabpanel"
-            >
-              <div
-                className="panel-body"
-              >
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="8.1"
+                    >
+                      8.1
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Linear Momentum, Force, and Impulse
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="8"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="8.2"
+                    >
+                      8.2
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Conservation of Momentum
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    8
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Introduction
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="8.1"
-                  >
-                    8.1
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Linear Momentum, Force, and Impulse
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="8.2"
-                  >
-                    8.2
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Conservation of Momentum
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="8.3"
-                  >
-                    8.3
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Elastic and Inelastic Collisions
-                  </span>
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="8.3"
+                    >
+                      8.3
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Elastic and Inelastic Collisions
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="panel-group"
-          expanded={false}
-          role="tablist"
-        >
           <div
-            className="panel panel-default"
-            id={null}
+            className="panel-group"
+            expanded={false}
+            role="tablist"
           >
             <div
-              className="panel-heading"
+              className="panel panel-default"
+              id={null}
             >
               <div
-                className="chapter-heading panel-title"
-                data-chapter-section={9}
+                className="panel-heading"
               >
-                <a
-                  aria-controls={undefined}
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="collapsed"
-                  href={undefined}
-                  onClick={[Function]}
-                  role="tab"
+                <div
+                  className="chapter-heading panel-title"
+                  data-chapter-section={9}
                 >
-                  <span
-                    className="chapter-checkbox"
+                  <a
+                    aria-controls={undefined}
+                    aria-expanded={false}
+                    aria-selected={false}
+                    className="collapsed"
+                    href={undefined}
+                    onClick={[Function]}
+                    role="tab"
                   >
                     <span
-                      className="tri-state-checkbox unchecked"
-                      onClick={[Function]}
-                      tabIndex={1}
+                      className="chapter-checkbox"
                     >
-                      <i
-                        className="tutor-icon fa fa-square-o clickable"
+                      <span
+                        className="tri-state-checkbox unchecked"
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "cursor": "pointer",
+                        tabIndex={1}
+                      >
+                        <i
+                          className="tutor-icon fa fa-square-o clickable"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "cursor": "pointer",
+                            }
                           }
-                        }
-                        type="square-o"
+                          type="square-o"
+                        />
+                      </span>
+                    </span>
+                    <span
+                      className="chapter-number"
+                    >
+                      Chapter 
+                      <span
+                        className="chapter-section"
+                        data-chapter-section="9"
+                      >
+                        9
+                      </span>
+                       -
+                    </span>
+                    <span
+                      className="chapter-title"
+                    >
+                       
+                      Work, Energy, and Simple Machines
+                    </span>
+                  </a>
+                </div>
+              </div>
+              <div
+                aria-expanded={null}
+                aria-hidden={true}
+                className="panel-collapse collapse"
+                id={undefined}
+                role="tabpanel"
+              >
+                <div
+                  className="panel-body"
+                >
+                  <div
+                    className="section"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
                       />
                     </span>
-                  </span>
-                  <span
-                    className="chapter-number"
-                  >
-                    Chapter 
                     <span
                       className="chapter-section"
                       data-chapter-section="9"
                     >
                       9
                     </span>
-                     -
-                  </span>
-                  <span
-                    className="chapter-title"
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Introduction
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    Work, Energy, and Simple Machines
-                  </span>
-                </a>
-              </div>
-            </div>
-            <div
-              aria-expanded={null}
-              aria-hidden={true}
-              className="panel-collapse collapse"
-              id={undefined}
-              role="tabpanel"
-            >
-              <div
-                className="panel-body"
-              >
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="9.1"
+                    >
+                      9.1
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Work, Power, and the Work–Energy Theorem
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="9"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="9.2"
+                    >
+                      9.2
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Mechanical Energy and the Conservation of Energy
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    9
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Introduction
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="9.1"
-                  >
-                    9.1
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Work, Power, and the Work–Energy Theorem
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="9.2"
-                  >
-                    9.2
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Mechanical Energy and the Conservation of Energy
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="9.3"
-                  >
-                    9.3
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Simple Machines
-                  </span>
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="9.3"
+                    >
+                      9.3
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Simple Machines
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="panel-group"
-          expanded={false}
-          role="tablist"
-        >
           <div
-            className="panel panel-default"
-            id={null}
+            className="panel-group"
+            expanded={false}
+            role="tablist"
           >
             <div
-              className="panel-heading"
+              className="panel panel-default"
+              id={null}
             >
               <div
-                className="chapter-heading panel-title"
-                data-chapter-section={10}
+                className="panel-heading"
               >
-                <a
-                  aria-controls={undefined}
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="collapsed"
-                  href={undefined}
-                  onClick={[Function]}
-                  role="tab"
+                <div
+                  className="chapter-heading panel-title"
+                  data-chapter-section={10}
                 >
-                  <span
-                    className="chapter-checkbox"
+                  <a
+                    aria-controls={undefined}
+                    aria-expanded={false}
+                    aria-selected={false}
+                    className="collapsed"
+                    href={undefined}
+                    onClick={[Function]}
+                    role="tab"
                   >
                     <span
-                      className="tri-state-checkbox unchecked"
-                      onClick={[Function]}
-                      tabIndex={1}
+                      className="chapter-checkbox"
                     >
-                      <i
-                        className="tutor-icon fa fa-square-o clickable"
+                      <span
+                        className="tri-state-checkbox unchecked"
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "cursor": "pointer",
+                        tabIndex={1}
+                      >
+                        <i
+                          className="tutor-icon fa fa-square-o clickable"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "cursor": "pointer",
+                            }
                           }
-                        }
-                        type="square-o"
+                          type="square-o"
+                        />
+                      </span>
+                    </span>
+                    <span
+                      className="chapter-number"
+                    >
+                      Chapter 
+                      <span
+                        className="chapter-section"
+                        data-chapter-section="10"
+                      >
+                        10
+                      </span>
+                       -
+                    </span>
+                    <span
+                      className="chapter-title"
+                    >
+                       
+                      Special Relativity
+                    </span>
+                  </a>
+                </div>
+              </div>
+              <div
+                aria-expanded={null}
+                aria-hidden={true}
+                className="panel-collapse collapse"
+                id={undefined}
+                role="tabpanel"
+              >
+                <div
+                  className="panel-body"
+                >
+                  <div
+                    className="section"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
                       />
                     </span>
-                  </span>
-                  <span
-                    className="chapter-number"
-                  >
-                    Chapter 
                     <span
                       className="chapter-section"
                       data-chapter-section="10"
                     >
                       10
                     </span>
-                     -
-                  </span>
-                  <span
-                    className="chapter-title"
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Introduction
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                     
-                    Special Relativity
-                  </span>
-                </a>
-              </div>
-            </div>
-            <div
-              aria-expanded={null}
-              aria-hidden={true}
-              className="panel-collapse collapse"
-              id={undefined}
-              role="tabpanel"
-            >
-              <div
-                className="panel-body"
-              >
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="10.1"
+                    >
+                      10.1
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Postulates of Special Relativity
+                    </span>
+                  </div>
+                  <div
+                    className="section"
+                    onClick={[Function]}
                   >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="10"
-                  >
-                    10
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Introduction
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="10.1"
-                  >
-                    10.1
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Postulates of Special Relativity
-                  </span>
-                </div>
-                <div
-                  className="section"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="section-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      readOnly={true}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="chapter-section"
-                    data-chapter-section="10.2"
-                  >
-                    10.2
-                  </span>
-                  <span
-                    className="-section-title"
-                  >
-                     
-                    Consequences of Special Relativity
-                  </span>
+                    <span
+                      className="section-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        readOnly={true}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="chapter-section"
+                      data-chapter-section="10.2"
+                    >
+                      10.2
+                    </span>
+                    <span
+                      className="-section-title"
+                    >
+                       
+                      Consequences of Special Relativity
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1892,19 +1897,19 @@ exports[`Select Topics matches snapshot 1`] = `
         </div>
       </div>
     </div>
-  </div>
-  <div
-    className="panel-footer"
-  >
-    <button
-      aria-role="close"
-      className="btn btn-default"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
+    <div
+      className="panel-footer"
     >
-      Cancel
-    </button>
+      <button
+        aria-role="close"
+        className="btn btn-default"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Cancel
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/tutor/specs/components/task-plan/homework/__snapshots__/add-exercises.spec.cjsx.snap
+++ b/tutor/specs/components/task-plan/homework/__snapshots__/add-exercises.spec.cjsx.snap
@@ -81,8 +81,18 @@ exports[`choose exercises component matches snapshot 1`] = `
             />
           </div>
           <span>
-            Tutor Selections
+            OpenStax Tutor Selections
           </span>
+          <button
+            aria-describedby="homework-selections-popover"
+            className="btn btn-link"
+            disabled={false}
+            id="homework-selections-trigger"
+            onClick={[Function]}
+            type="button"
+          >
+            What are these?
+          </button>
         </div>
         <div
           className="tutor-added-later"

--- a/tutor/src/components/course-calendar/month.cjsx
+++ b/tutor/src/components/course-calendar/month.cjsx
@@ -259,7 +259,7 @@ CourseMonth = React.createClass
     <TourRegion
       className={calendarClassName}
       id="teacher-calendar"
-      otherTours={['teacher-calendar-super']}
+      otherTours={['teacher-calendar-super', 'reading-published']}
       courseId={courseId}
     >
 

--- a/tutor/src/components/course-calendar/month.cjsx
+++ b/tutor/src/components/course-calendar/month.cjsx
@@ -259,7 +259,7 @@ CourseMonth = React.createClass
     <TourRegion
       className={calendarClassName}
       id="teacher-calendar"
-      otherTours={['teacher-calendar-super', 'reading-published']}
+      otherTours={['teacher-calendar-super', 'reading-published', 'homework-published']}
       courseId={courseId}
     >
 

--- a/tutor/src/components/questions/exercises-display.cjsx
+++ b/tutor/src/components/questions/exercises-display.cjsx
@@ -43,7 +43,7 @@ ExercisesDisplay = React.createClass
     ecosystemId: React.PropTypes.string.isRequired
 
   getInitialState: -> {
-    filter: ''
+    filter: 'reading'
     showingCardsFromDetailsView: false
   }
   componentWillMount:   -> ExerciseStore.on('change',  @update)

--- a/tutor/src/components/task-plan/homework/choose-exercises.cjsx
+++ b/tutor/src/components/task-plan/homework/choose-exercises.cjsx
@@ -8,7 +8,6 @@ AddExercises    = require './add-exercises'
 ReviewExercises = require './review-exercises'
 SelectTopics    = require '../select-topics'
 {ScrollToMixin} = require 'shared'
-{ default: TourRegion } = require '../../tours/region'
 
 {ExerciseActions} = require '../../../flux/exercise'
 
@@ -57,18 +56,17 @@ ChooseExercises = React.createClass
 
     <div className='homework-plan-exercise-select-topics'>
 
-      <TourRegion id={"add-homework-choose-sections"} courseId={courseId}>
-        <SelectTopics
-          primary={primaryBtn}
-          onSectionChange={@onSectionChange}
-          header={<span key='hd'>Add Questions</span>}
-          courseId={courseId}
-          ecosystemId={ecosystemId}
-          planId={planId}
-          selected={selected}
-          cancel={cancel}
-          hide={hide} />
-      </TourRegion>
+      <SelectTopics
+        primary={primaryBtn}
+        onSectionChange={@onSectionChange}
+        header={<span key='hd'>Add Questions</span>}
+        type="homework"
+        courseId={courseId}
+        ecosystemId={ecosystemId}
+        planId={planId}
+        selected={selected}
+        cancel={cancel}
+        hide={hide} />
 
       {<AddExercises
         hide={hide}

--- a/tutor/src/components/task-plan/homework/exercise-controls.cjsx
+++ b/tutor/src/components/task-plan/homework/exercise-controls.cjsx
@@ -7,6 +7,7 @@ Sectionizer = require '../../exercises/sectionizer'
 Icon        = require '../../icon'
 
 { default: TourAnchor } = require '../../tours/anchor'
+{ default: SelectionsTooltip } = require './selections-tooltip'
 
 {TaskPlanStore, TaskPlanActions} = require '../../../flux/task-plan'
 
@@ -117,7 +118,8 @@ ExerciseControls = React.createClass
             <h2>{numTutor}</h2>
             {@renderIncreaseButton()}
           </div>
-          <span>Tutor Selections</span>
+          <span>OpenStax Tutor Selections</span>
+          <SelectionsTooltip/>
         </TourAnchor>
 
         {@renderExplanation()}

--- a/tutor/src/components/task-plan/homework/exercises-table.cjsx
+++ b/tutor/src/components/task-plan/homework/exercises-table.cjsx
@@ -9,6 +9,8 @@ _     = require 'underscore'
 LoadingExercises       = require './loading-exercises-mixin'
 ChapterSection         = require '../chapter-section'
 
+{ default: TourRegion } = require '../../tours/region'
+
 ExerciseTable = React.createClass
 
   mixins: [LoadingExercises]
@@ -74,7 +76,13 @@ ExerciseTable = React.createClass
     if (hasTeks)
       teksHead = <td>TEKS</td>
 
-    <table className="exercise-table">
+    <TourRegion
+      tag="table"
+      delay=4000
+      className="exercise-table"
+      id={"add-homework-review-sections"}
+      courseId={@props.courseId}
+    >
       <thead>
         <tr>
           <td></td>
@@ -89,7 +97,7 @@ ExerciseTable = React.createClass
         {_.map(exerciseIds, (exerciseId, index) => @renderExerciseRow(exerciseId, index, hasTeks))}
         {_.times(tutorSelection, (index) => @renderTutorRow(index, hasTeks))}
       </tbody>
-    </table>
+    </TourRegion>
 
 
 module.exports = ExerciseTable

--- a/tutor/src/components/task-plan/homework/selections-tooltip.jsx
+++ b/tutor/src/components/task-plan/homework/selections-tooltip.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { OverlayTrigger, Button, Popover } from 'react-bootstrap';
+
+export default class SelectionsTooltip extends React.PureComponent {
+
+  render() {
+    return (
+      <OverlayTrigger
+        trigger="click"
+        placement="bottom"
+        overlay={<Popover id="homework-selections-popover">
+          <p>These are questions selected by OpenStax Tutor's machine learning algorithms, using knowledge about each student's performance.</p>
+          <p>Questions are drawn from the Question Library, accessible from your dashboard.</p>
+        </Popover>}
+        rootClose={true}>
+        <Button bsStyle="link" id="homework-selections-trigger">
+          What are these?
+        </Button>
+      </OverlayTrigger>
+    );
+  }
+}

--- a/tutor/src/components/task-plan/index.cjsx
+++ b/tutor/src/components/task-plan/index.cjsx
@@ -59,6 +59,7 @@ EventShell = React.createClass
 PlanBuilder = ({ id, courseId, body: Body, type }) ->
   <TourRegion
     id={"#{type}-assignment-editor"}
+    otherTours={["#{type}-assignment-editor-super"]}
     courseId={courseId}
   >
     <Body id={id} courseId={courseId} />

--- a/tutor/src/components/task-plan/reading.cjsx
+++ b/tutor/src/components/task-plan/reading.cjsx
@@ -114,22 +114,18 @@ ChooseReadings = React.createClass
         disabled={@props.selected?.length is 0}
         onClick={@hide}>Add Readings
       </BS.Button>
-    <TourRegion
-      className="reading-plan-select-topics"
-      id={"add-reading-choose-sections"}
+
+    <SelectTopics
+      primary={primary}
+      onSectionChange={Fn.empty}
+      header={header}
+      type="reading"
       courseId={@props.courseId}
-    >
-      <SelectTopics
-        primary={primary}
-        onSectionChange={Fn.empty}
-        header={header}
-        courseId={@props.courseId}
-        ecosystemId={@props.ecosystemId}
-        planId={@props.planId}
-        selected={@props.selected}
-        cancel={@props.cancel}
-        hide={@hide} />
-    </TourRegion>
+      ecosystemId={@props.ecosystemId}
+      planId={@props.planId}
+      selected={@props.selected}
+      cancel={@props.cancel}
+      hide={@hide} />
 
 ReadingPlan = React.createClass
   displayName: 'ReadingPlan'

--- a/tutor/src/components/task-plan/reading.cjsx
+++ b/tutor/src/components/task-plan/reading.cjsx
@@ -13,6 +13,7 @@ ChapterSection = require './chapter-section'
 PlanMixin = require './plan-mixin'
 LoadableItem = require '../loadable-item'
 TaskPlanBuilder = require './builder'
+{ default: NoQuestionsTooltip } = require './reading/no-questions-tooltip'
 Fn = require '../../helpers/function'
 { default: TourRegion } = require '../tours/region'
 
@@ -206,6 +207,7 @@ ReadingPlan = React.createClass
                 ecosystemId={ecosystemId}
                 selected={topics}/>
               {addReadingsButton}
+              <NoQuestionsTooltip/>
               {readingsRequired}
             </BS.Col>
           </BS.Row>

--- a/tutor/src/components/task-plan/reading/no-questions-tooltip.jsx
+++ b/tutor/src/components/task-plan/reading/no-questions-tooltip.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { OverlayTrigger, Button, Popover } from 'react-bootstrap';
+
+export default class NoQuestionsTooltip extends React.PureComponent {
+
+  render() {
+    return (
+      <OverlayTrigger
+        trigger="click"
+        placement="top"
+        overlay={<Popover id="reading-no-questions-popover">
+          <p>Reading assignments are built by OpenStax Tutor. Readings include book content, 3 personalized questions per section, and 3 spaced practice questions per assignment.</p>
+          <p>Questions are drawn from the Question Library, which you can get to from your dashboard. Remember — if you plan to exclude questions, do so before publishing.</p>
+        </Popover>}
+        rootClose={true}>
+        <Button bsStyle="link">
+          Why can't I see the questions for this assignment?
+        </Button>
+      </OverlayTrigger>
+    );
+  }
+}

--- a/tutor/src/components/task-plan/select-topics.cjsx
+++ b/tutor/src/components/task-plan/select-topics.cjsx
@@ -9,6 +9,8 @@ LoadableItem = require '../loadable-item'
 SectionsChooser = require '../sections-chooser'
 LoadableItem = require '../loadable-item'
 
+{ default: TourRegion } = require '../tours/region'
+
 SelectTopics = React.createClass
   displayName: 'SelectTopics'
   propTypes:
@@ -30,27 +32,33 @@ SelectTopics = React.createClass
     @props.onSectionChange?(sectionIds)
 
   renderDialog: ->
-    {courseId, planId, selected, hide, header, primary, cancel, ecosystemId} = @props
+    {courseId, planId, selected, hide, header, primary, cancel, ecosystemId, type} = @props
 
-    <Dialog
-      className='select-topics'
-      header={header}
-      primary={primary}
-      confirmMsg='You will lose unsaved changes if you continue.'
-      cancel='Cancel'
-      isChanged={_.constant(@hasChanged())}
-      onCancel={cancel}>
+    <TourRegion
+      className={"#{type}-plan-select-topics"}
+      id={"add-#{type}-choose-sections"}
+      courseId={courseId}
+    >
+      <Dialog
+        className='select-topics'
+        header={header}
+        primary={primary}
+        confirmMsg='You will lose unsaved changes if you continue.'
+        cancel='Cancel'
+        isChanged={_.constant(@hasChanged())}
+        onCancel={cancel}>
 
-      <div className='select-chapters' data-ecosystem-id={ecosystemId}>
-        <SectionsChooser
-          ecosystemId={ecosystemId}
-          chapters={TocStore.get(ecosystemId)}
-          selectedSectionIds={TaskPlanStore.getTopics(planId)}
-          onSelectionChange={@onSectionChange}
-        />
-      </div>
+        <div className='select-chapters' data-ecosystem-id={ecosystemId}>
+          <SectionsChooser
+            ecosystemId={ecosystemId}
+            chapters={TocStore.get(ecosystemId)}
+            selectedSectionIds={TaskPlanStore.getTopics(planId)}
+            onSelectionChange={@onSectionChange}
+          />
+        </div>
 
-    </Dialog>
+      </Dialog>
+    </TourRegion>
 
   render: ->
 

--- a/tutor/src/components/tours/conductor.jsx
+++ b/tutor/src/components/tours/conductor.jsx
@@ -21,7 +21,6 @@ export default class TourConductor extends React.PureComponent {
   constructor(props) {
     super(props);
     this.tourContext = new TourContext({ isEnabled: true });
-    window.tourContext = this.tourContext;
   }
 
   componentWillReceiveProps(nextProps) {

--- a/tutor/src/components/tours/conductor.jsx
+++ b/tutor/src/components/tours/conductor.jsx
@@ -21,6 +21,7 @@ export default class TourConductor extends React.PureComponent {
   constructor(props) {
     super(props);
     this.tourContext = new TourContext({ isEnabled: true });
+    window.tourContext = this.tourContext;
   }
 
   componentWillReceiveProps(nextProps) {

--- a/tutor/src/components/tours/custom/centered-no-hole-wheel.jsx
+++ b/tutor/src/components/tours/custom/centered-no-hole-wheel.jsx
@@ -1,0 +1,24 @@
+import React                  from 'react';
+
+import { omit }               from 'lodash';
+
+import CenteredWheel          from './centered-wheel';
+
+export default class CenteredNoHoleWheel extends React.PureComponent {
+
+  render () {
+    const step = this.props.step;
+    // close hole
+    step.style.hole = {
+      maxWidth: 0,
+      maxHeight: 0
+    };
+
+    return (
+      <CenteredWheel
+        {...omit(this.props, 'step')}
+        step={step}
+      />
+    );
+  }
+}

--- a/tutor/src/components/tours/custom/centered-wheel.jsx
+++ b/tutor/src/components/tours/custom/centered-wheel.jsx
@@ -14,7 +14,7 @@ export default class CenteredWheel extends React.PureComponent {
   }
 
   setupWrapperClasses() {
-    this.joyrideEl = ReactDOM.findDOMNode(this.props.step.ride.joyrideRef);
+    this.joyrideEl = ReactDOM.findDOMNode(this.props.step.joyrideRef);
     if (this.joyrideEl) {
       this.joyrideEl.classList.add(`${this.className}-wrapper`, this.wrapperClassName);
     }

--- a/tutor/src/components/tours/custom/common.jsx
+++ b/tutor/src/components/tours/custom/common.jsx
@@ -39,12 +39,10 @@ function bindClickHandler(handlers) {
     if (el.className.indexOf('joyride-') === 0) {
       forEach(handlers, (handler, name) => {
         if (dataType === name) {
-          handled = true;
-
           clickEvent.preventDefault();
           clickEvent.stopPropagation();
 
-          handler(clickEvent);
+          handled = handler(clickEvent) || handled;
         }
       });
     }

--- a/tutor/src/components/tours/custom/common.jsx
+++ b/tutor/src/components/tours/custom/common.jsx
@@ -50,7 +50,7 @@ function bindClickHandler(handlers) {
     }
 
     if (!handled) {
-      this.props.step.ride.joyrideRef.onClickTooltip(clickEvent);
+      this.props.step.joyrideRef.onClickTooltip(clickEvent);
     }
 
   });

--- a/tutor/src/components/tours/custom/force-scroll-on-mount.jsx
+++ b/tutor/src/components/tours/custom/force-scroll-on-mount.jsx
@@ -1,0 +1,38 @@
+import React        from 'react';
+
+import { omit }               from 'lodash';
+
+import { Tooltip }  from 'react-joyride';
+
+export default class ForceScrollOnMount extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    // force top position
+    const { joyrideRef } = this.props.step;
+    joyrideRef.props.steps[joyrideRef.state.index].position = 'top';
+  }
+
+  render () {
+    const step = this.props.step;
+    // close hole
+    step.style.hole = {
+      maxWidth: 0,
+      maxHeight: 0
+    };
+    // hide arrow
+    step.style.arrow = {
+      display: 'none'
+    };
+
+    const adjustedYPos = this.props.yPos + step.joyrideRef.getElementDimensions().height;
+
+    return (
+      <Tooltip
+        {...omit(this.props, 'step', 'yPos')}
+        step={step}
+        yPos={adjustedYPos}
+      />
+    );
+  }
+}

--- a/tutor/src/components/tours/custom/how-to-use-ql.jsx
+++ b/tutor/src/components/tours/custom/how-to-use-ql.jsx
@@ -22,12 +22,12 @@ export default class HowToUseQL extends React.PureComponent {
           <ColumnContent>
             <Column className="machine-learning">
               <p>
-                <TutorBeta/> adds personalized and spaced practice questions to your assignments
+                OpenStax Tutor Beta adds personalized and spaced practice questions to your assignments
               </p>
             </Column>
             <Column className="question-details">
               <p>
-                You can view all questions <TutorBeta/> might use in the Question Library
+                You can view all questions OpenStax Tutor Beta might use in the Question Library
               </p>
             </Column>
             <Column className="exclude-question">

--- a/tutor/src/components/tours/custom/how-we-build-your-reading.jsx
+++ b/tutor/src/components/tours/custom/how-we-build-your-reading.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {
+  ValueProp,
+  ColumnContent,
+  Column
+} from './common';
+import SuperTrainingWheel from './super-training-wheel';
+
+import TutorLink from '../../link'
+
+export default class HowWeBuildYourReading extends React.PureComponent {
+
+  render () {
+    console.info(this.props)
+    return (
+      <SuperTrainingWheel {...this.props}>
+        <ValueProp className="build-reading">
+          <h1 className="heading">
+            How we build your reading assignment
+          </h1>
+          <h2 className="sub-heading">
+            You select the chapters and sections, we do the rest.
+          </h2>
+          <ColumnContent>
+            <Column className="machine-learning">
+              <p>
+                Select what you want your students to read, and OpenStax Tutor Beta picks the questions for you
+              </p>
+            </Column>
+            <Column className="exclude-question">
+              <p>
+                You can manage questions in the<br/>
+                <TutorLink to='viewQuestionsLibrary' params={{courseId: 'CHANGME'}}>
+                  Question Library
+                </TutorLink> before you publish your assignment
+              </p>
+            </Column>
+          </ColumnContent>
+        </ValueProp>
+      </SuperTrainingWheel>
+    );
+  }
+}

--- a/tutor/src/components/tours/custom/how-we-build-your-reading.jsx
+++ b/tutor/src/components/tours/custom/how-we-build-your-reading.jsx
@@ -11,7 +11,7 @@ import TutorLink from '../../link'
 export default class HowWeBuildYourReading extends React.PureComponent {
 
   render () {
-    const { courseId } = this.props.step.ride.region
+    const { courseId } = this.props.step.region
 
     return (
       <SuperTrainingWheel {...this.props}>

--- a/tutor/src/components/tours/custom/how-we-build-your-reading.jsx
+++ b/tutor/src/components/tours/custom/how-we-build-your-reading.jsx
@@ -7,12 +7,11 @@ import {
 import SuperTrainingWheel from './super-training-wheel';
 
 import TutorLink from '../../link'
-import Router from '../../../helpers/router'
 
 export default class HowWeBuildYourReading extends React.PureComponent {
 
   render () {
-    const { courseId } = Router.currentParams()
+    const { courseId } = this.props.step.ride.region
 
     return (
       <SuperTrainingWheel {...this.props}>

--- a/tutor/src/components/tours/custom/how-we-build-your-reading.jsx
+++ b/tutor/src/components/tours/custom/how-we-build-your-reading.jsx
@@ -7,11 +7,13 @@ import {
 import SuperTrainingWheel from './super-training-wheel';
 
 import TutorLink from '../../link'
+import Router from '../../../helpers/router'
 
 export default class HowWeBuildYourReading extends React.PureComponent {
 
   render () {
-    console.info(this.props)
+    const { courseId } = Router.currentParams()
+
     return (
       <SuperTrainingWheel {...this.props}>
         <ValueProp className="build-reading">
@@ -30,7 +32,7 @@ export default class HowWeBuildYourReading extends React.PureComponent {
             <Column className="exclude-question">
               <p>
                 You can manage questions in the<br/>
-                <TutorLink to='viewQuestionsLibrary' params={{courseId: 'CHANGME'}}>
+                <TutorLink to='viewQuestionsLibrary' params={{courseId}}>
                   Question Library
                 </TutorLink> before you publish your assignment
               </p>

--- a/tutor/src/components/tours/custom/index.js
+++ b/tutor/src/components/tours/custom/index.js
@@ -6,6 +6,7 @@ import QuestionLibraryPageTips  from './question-library-page-tips';
 import CenteredWheel            from './centered-wheel';
 import CenteredNoHoleWheel      from './centered-no-hole-wheel';
 import HowWeBuildYourReading    from './how-we-build-your-reading';
+import ForceScrollOnMount       from './force-scroll-on-mount';
 
 export default {
   HowToUseQL,
@@ -15,5 +16,6 @@ export default {
   QuestionLibraryPageTips,
   CenteredWheel,
   CenteredNoHoleWheel,
-  HowWeBuildYourReading
+  HowWeBuildYourReading,
+  ForceScrollOnMount
 };

--- a/tutor/src/components/tours/custom/index.js
+++ b/tutor/src/components/tours/custom/index.js
@@ -4,6 +4,7 @@ import ValueProp                from './value-prop';
 import DashboardPageTips        from './dashboard-page-tips';
 import QuestionLibraryPageTips  from './question-library-page-tips';
 import CenteredWheel            from './centered-wheel';
+import HowWeBuildYourReading    from './how-we-build-your-reading';
 
 export default {
   HowToUseQL,
@@ -11,5 +12,6 @@ export default {
   ValueProp,
   DashboardPageTips,
   QuestionLibraryPageTips,
-  CenteredWheel
+  CenteredWheel,
+  HowWeBuildYourReading
 };

--- a/tutor/src/components/tours/custom/index.js
+++ b/tutor/src/components/tours/custom/index.js
@@ -4,6 +4,7 @@ import ValueProp                from './value-prop';
 import DashboardPageTips        from './dashboard-page-tips';
 import QuestionLibraryPageTips  from './question-library-page-tips';
 import CenteredWheel            from './centered-wheel';
+import CenteredNoHoleWheel      from './centered-no-hole-wheel';
 import HowWeBuildYourReading    from './how-we-build-your-reading';
 
 export default {
@@ -13,5 +14,6 @@ export default {
   DashboardPageTips,
   QuestionLibraryPageTips,
   CenteredWheel,
+  CenteredNoHoleWheel,
   HowWeBuildYourReading
 };

--- a/tutor/src/components/tours/custom/super-training-wheel.jsx
+++ b/tutor/src/components/tours/custom/super-training-wheel.jsx
@@ -16,14 +16,14 @@ export default class SuperTrainingWheel extends React.PureComponent {
   handleClick = bindClickHandler.call(this, {close: this.triggerNext.bind(this)});
 
   triggerNext() {
-    this.props.step.ride.joyrideRef.next();
+    this.props.step.joyrideRef.next();
   }
 
   render () {
     const step = this.props.step;
     const buttons = (
-      this.props.step.ride.joyrideRef &&
-      this.props.step.ride.joyrideRef.props.steps.length < 3
+      this.props.step.joyrideRef &&
+      this.props.step.joyrideRef.props.steps.length < 3
     )? { primary: 'Continue' } : {};
     const className = classnames(this.className,  this.props.className);
 

--- a/tutor/src/components/tours/custom/super-training-wheel.jsx
+++ b/tutor/src/components/tours/custom/super-training-wheel.jsx
@@ -5,7 +5,7 @@ import { action }             from 'mobx';
 import { defaultsDeep, omit } from 'lodash';
 import classnames             from 'classnames';
 
-import CenteredWheel          from './centered-wheel';
+import CenteredNoHoleWheel    from './centered-no-hole-wheel';
 import { bindClickHandler }   from './common';
 
 export default class SuperTrainingWheel extends React.PureComponent {
@@ -30,17 +30,11 @@ export default class SuperTrainingWheel extends React.PureComponent {
     step.text = this.props.children;
     step.isFixed = true;
 
-    // close hole
-    step.style.hole = {
-      maxWidth: 0,
-      maxHeight: 0
-    };
-
     defaultsDeep(step.style, this.props.style);
     defaultsDeep(buttons, this.props.buttons);
 
     return (
-      <CenteredWheel
+      <CenteredNoHoleWheel
         {...omit(this.props, 'style', 'buttons')}
         showOverlay={true}
         className={className}

--- a/tutor/src/components/tours/custom/super-training-wheel.jsx
+++ b/tutor/src/components/tours/custom/super-training-wheel.jsx
@@ -16,15 +16,17 @@ export default class SuperTrainingWheel extends React.PureComponent {
   handleClick = bindClickHandler.call(this, {close: this.triggerNext.bind(this)});
 
   triggerNext() {
-    this.props.step.joyrideRef.next();
+    if (this.props.step.step.tour.autoplay) {
+      this.props.step.joyrideRef.next();
+      return true;      
+    }
+
+    return false;
   }
 
   render () {
-    const step = this.props.step;
-    const buttons = (
-      this.props.step.joyrideRef &&
-      this.props.step.joyrideRef.props.steps.length < 3
-    )? { primary: 'Continue' } : {};
+    const { step } = this.props;
+    const buttons = step.step.tour.autoplay? { primary: 'Continue' } : {};
     const className = classnames(this.className,  this.props.className);
 
     step.text = this.props.children;

--- a/tutor/src/components/tours/custom/tips-now-or-later.jsx
+++ b/tutor/src/components/tours/custom/tips-now-or-later.jsx
@@ -28,6 +28,7 @@ export default class TipsNowOrLater extends React.PureComponent {
       action: 'finished'
     });
     this.props.tourContext.playTriggeredTours();
+    return true;
   }
 
   render () {

--- a/tutor/src/components/tours/custom/tips-now-or-later.jsx
+++ b/tutor/src/components/tours/custom/tips-now-or-later.jsx
@@ -23,7 +23,7 @@ export default class TipsNowOrLater extends React.PureComponent {
   handleClick = bindClickHandler.call(this, {next: this.triggerPageTips.bind(this)});
 
   triggerPageTips() {
-    this.props.step.ride.joyrideRef.props.callback({
+    this.props.step.joyrideRef.props.callback({
       type: 'finished',
       action: 'finished'
     });

--- a/tutor/src/models/course.js
+++ b/tutor/src/models/course.js
@@ -108,27 +108,7 @@ export default class Course extends BaseModel {
   }
 
   @computed get taskPlans() {
-    if (this.isTeacher) {
-      return TeacherTaskPlans.forCourseId(this.id).values();
-    }
-
-    return [];
-  }
-
-  @computed get hasReadingPublishing() {
-    if (this.isTeacher) {
-      return some(this.taskPlans, {is_publishing: true, type: 'reading'});
-    }
-
-    return false;
-  }
-
-  @computed get hasHomeworkPublishing() {
-    if (this.isTeacher) {
-      return some(this.taskPlans, {is_publishing: true, type: 'homework'});
-    }
-
-    return false;
+    return TeacherTaskPlans.forCourseId(this.id);
   }
 
   @computed get tourAudienceTags() {
@@ -136,11 +116,11 @@ export default class Course extends BaseModel {
     if (this.isTeacher) {
       tags.push(this.is_preview ? 'teacher-preview' : 'teacher');
 
-      if (this.hasReadingPublishing) {
+      if (this.taskPlans.reading.hasPublishing) {
         tags.push('teacher-reading-published');
       }
 
-      if (this.hasHomeworkPublishing) {
+      if (this.taskPlans.homework.hasPublishing) {
         tags.push('teacher-homework-published');
       }
     }

--- a/tutor/src/models/course.js
+++ b/tutor/src/models/course.js
@@ -115,9 +115,17 @@ export default class Course extends BaseModel {
     return [];
   }
 
-  @computed get hasPublishing() {
+  @computed get hasReadingPublishing() {
     if (this.isTeacher) {
-      return some(this.taskPlans, 'is_publishing');
+      return some(this.taskPlans, {is_publishing: true, type: 'reading'});
+    }
+
+    return false;
+  }
+
+  @computed get hasHomeworkPublishing() {
+    if (this.isTeacher) {
+      return some(this.taskPlans, {is_publishing: true, type: 'homework'});
     }
 
     return false;
@@ -128,8 +136,12 @@ export default class Course extends BaseModel {
     if (this.isTeacher) {
       tags.push(this.is_preview ? 'teacher-preview' : 'teacher');
 
-      if (this.is_preview && this.hasPublishing) {
-        tags.push('teacher-preview-published');
+      if (this.hasReadingPublishing) {
+        tags.push('teacher-reading-published');
+      }
+
+      if (this.hasHomeworkPublishing) {
+        tags.push('teacher-homework-published');
       }
     }
     if (this.isStudent) { tags.push('student'); }

--- a/tutor/src/models/course.js
+++ b/tutor/src/models/course.js
@@ -2,12 +2,13 @@ import {
   BaseModel, identifiedBy, field, identifier, hasMany,
 } from './base';
 import { computed, action } from 'mobx';
-import { first, sortBy, find, get, endsWith, capitalize } from 'lodash';
+import { first, sortBy, find, get, endsWith, capitalize, some } from 'lodash';
 import { UiSettings } from 'shared';
 import Period  from './course/period';
 import Role    from './course/role';
 import Student from './course/student';
 import CourseInformation from './course/information';
+import TeacherTaskPlans   from './teacher-task-plans';
 import TimeHelper from '../helpers/time';
 import { TimeStore } from '../flux/time';
 import moment from 'moment-timezone';
@@ -106,10 +107,30 @@ export default class Course extends BaseModel {
     return !!find(this.roles, 'isTeacher');
   }
 
+  @computed get taskPlans() {
+    if (this.isTeacher) {
+      return TeacherTaskPlans.forCourseId(this.id).values();
+    }
+
+    return [];
+  }
+
+  @computed get hasPublishing() {
+    if (this.isTeacher) {
+      return some(this.taskPlans, 'is_publishing');
+    }
+
+    return false;
+  }
+
   @computed get tourAudienceTags() {
     let tags = [];
     if (this.isTeacher) {
       tags.push(this.is_preview ? 'teacher-preview' : 'teacher');
+
+      if (this.is_preview && this.hasPublishing) {
+        tags.push('teacher-preview-published');
+      }
     }
     if (this.isStudent) { tags.push('student'); }
     return tags;

--- a/tutor/src/models/teacher-task-plans.js
+++ b/tutor/src/models/teacher-task-plans.js
@@ -34,6 +34,21 @@ class CourseTaskPlans extends Map {
     return filter(this.array, plan => !plan.is_deleting);
   }
 
+  @computed get isPublishing() {
+    return this.where(plan => plan.is_publishing);
+  }
+
+  @computed get hasPublishing() {
+    return this.isPublishing.any;
+  }
+
+  @computed get reading() {
+    return this.where(plan => plan.type === 'reading');
+  }
+
+  @computed get homework() {
+    return this.where(plan => plan.type === 'homework');
+  }
 }
 
 

--- a/tutor/src/models/tour/region.js
+++ b/tutor/src/models/tour/region.js
@@ -14,7 +14,7 @@ export default class TourRegion extends BaseModel {
   @field({ type: 'array' }) otherTours;
 
   @computed get tour_ids() {
-    return this.otherTours.concat( [this.id] );
+    return this.otherTours.reverse().concat( [this.id] ).reverse();
   }
 
   @computed get domSelector() {

--- a/tutor/src/models/tour/region.js
+++ b/tutor/src/models/tour/region.js
@@ -1,7 +1,6 @@
 import {
   BaseModel, identifiedBy, field, identifier, computed,
 } from '../base';
-import { concat } from 'lodash';
 
 // TourRegion
 // Wraps an area of the screen, maps it's id to a given set of audience tags
@@ -15,7 +14,7 @@ export default class TourRegion extends BaseModel {
   @field({ type: 'array' }) otherTours;
 
   @computed get tour_ids() {
-    return concat( [this.id], this.otherTours.peek() );
+    return this.otherTours.concat( [this.id] );
   }
 
   @computed get domSelector() {

--- a/tutor/src/models/tour/region.js
+++ b/tutor/src/models/tour/region.js
@@ -14,6 +14,9 @@ export default class TourRegion extends BaseModel {
   @field({ type: 'array' }) otherTours;
 
   @computed get tour_ids() {
+    // this seems convoluted, but this makes it so that `tour_ids` will react
+    // to `otherTours` updates.  see https://github.com/openstax/tutor-js/pull/1726#discussion_r122459935
+    // for more details.
     return this.otherTours.reverse().concat( [this.id] ).reverse();
   }
 

--- a/tutor/src/models/tour/ride.js
+++ b/tutor/src/models/tour/ride.js
@@ -102,7 +102,8 @@ export default class TourRide extends BaseModel {
 
     if (step.customComponent && CustomComponents[step.customComponent]) {
       props.StepComponent = CustomComponents[step.customComponent];
-      props.ride = this;
+      props.joyrideRef = this.joyrideRef;
+      props.region = this.region;
     }
 
     return extend(props, {

--- a/tutor/src/models/tour/step.js
+++ b/tutor/src/models/tour/step.js
@@ -31,7 +31,6 @@ export default class TourStep extends BaseModel {
   @field position;
   @field is_fixed;
   @field anchor_id;
-  @field supersize;
   @field customComponent;
   @field({ type: 'object' }) action;
 

--- a/tutor/src/tours/add-homework.json
+++ b/tutor/src/tours/add-homework.json
@@ -70,4 +70,17 @@
       }
     }
   ]
+}, {
+  "id": "homework-published",
+  "group_id": "homework",
+  "audience_tags": [
+    "teacher-homework-published"
+  ],
+  "steps": [
+    {
+      "title": "Congratulations!",
+      "body": "You just published your first homework assignment. Now, find the homework on your calendar and:\n\n* Get a direct link for your learning management system\n* Edit or delete the assignment\n* View student completion and performance metrics, once students complete it.",
+      "customComponent": "CenteredNoHoleWheel"
+    }
+  ]
 }]

--- a/tutor/src/tours/add-homework.json
+++ b/tutor/src/tours/add-homework.json
@@ -12,7 +12,7 @@
     },
     {
       "title": "Build a homework",
-      "body": "Ready to make a homework assignment? Fill in this form and click “select problems.”"
+      "body": "Ready to make a homework assignment? Fill in this form and click \"Select Problems.\""
     }
 
   ]
@@ -26,7 +26,7 @@
   "steps": [
     {
       "title": "First, select a chapter",
-      "body": "Select a chapter you want to assign, then scroll down and click “show problems.” Uncheck any sections you don’t want to cover."
+      "body": "Select a chapter you want to assign, then scroll down and click \"Show Problems.\" Uncheck any sections you don't want to cover."
     }
   ]
 }, {
@@ -39,14 +39,14 @@
   "steps": [
     {
       "title": "Personalized questions",
-      "body": "OpenStax Tutor generates questions using machine learning algorithms that study a student’s performance. You can allow up to four, but no fewer than two personalized questions per homework assignment.",
+      "body": " OpenStax Tutor selects questions using machine learning algorithms, using knowledge about each student's performance. You can allow up to four, but no fewer than two personalized questions per homework assignment.",
       "position": "bottom",
       "anchor_id": "tutor-selections",
       "action": {
         "id": "reposition"
       }
     }, {
-      "body":  ":best-practices: Don’t forget—exclude questions you don’t want your students to get before you publish an assignment. Questions can’t be removed after it’s published.",
+      "body":  ":best-practices: Don't forget — exclude questions you don't want your students to get *before* you publish an assignment. Questions can't be removed after it's published.",
       "position": "bottom",
       "anchor_id": "tutor-selections",
       "action": {
@@ -54,7 +54,7 @@
       }
     }, {
       "title": "How OpenStax Tutor selects questions",
-      "body": "Based on sections you assign and student performance, OpenStax Tutor selects questions that will help students improve their understanding of [the section or topic, depending on how we’re using those terms].",
+      "body": "Based on sections you assign and student performance, OpenStax Tutor selects questions that will help students improve their understanding of the material you assign.",
       "position": "bottom",
       "anchor_id": "tutor-selections",
       "action": {
@@ -62,12 +62,26 @@
       }
     }, {
       "title": "Add questions",
-      "body": "To add a homework question, hover over the question and click “Add question.”",
-      "position": "bottom",
-      "anchor_id": "exercise_preview",
+      "body": "To add a homework question, hover over the question and click \"Add question.\"",
+      "position": "right",
+      "anchor_id": "exercise-preview",
       "action": {
-        "id": "reposition"
+        "id": "hover-exercise"
       }
+    }
+  ]
+}, {
+  "id": "add-homework-review-sections",
+  "group_id": "homework",
+  "audience_tags": [
+    "teacher",
+    "teacher-preview"
+  ],
+  "steps": [
+    {
+      "title": "Publish",
+      "body": "To schedule this Homework, click Publish. Don't forget -- questions can't be added or removed once it's published.",
+      "anchor_id": "builder-save-button"
     }
   ]
 }, {

--- a/tutor/src/tours/add-homework.json
+++ b/tutor/src/tours/add-homework.json
@@ -39,7 +39,7 @@
   "steps": [
     {
       "title": "Personalized questions",
-      "body": " OpenStax Tutor selects questions using machine learning algorithms, using knowledge about each student's performance. You can allow up to four, but no fewer than two personalized questions per homework assignment.",
+      "body": "OpenStax Tutor selects questions using machine learning algorithms, using knowledge about each student's performance. You can allow up to four, but no fewer than two personalized questions per homework assignment.",
       "position": "bottom",
       "anchor_id": "tutor-selections",
       "action": {

--- a/tutor/src/tours/add-reading.json
+++ b/tutor/src/tours/add-reading.json
@@ -67,4 +67,17 @@
       "anchor_id": "builder-save-button"
     }
   ]
+}, {
+  "id": "reading-published",
+  "group_id": "reading",
+  "audience_tags": [
+    "teacher-preview-published"
+  ],
+  "steps": [
+    {
+      "title": "Congratulations!",
+      "body": "You just published your first reading assignment. Now, find the reading on your calendar and:\n\n* Get a direct link for your learning management system\n* Edit or delete the assignment\n* View student completion and performance metrics, once students complete it.",
+      "customComponent": "CenteredNoHoleWheel"
+    }
+  ]
 }]

--- a/tutor/src/tours/add-reading.json
+++ b/tutor/src/tours/add-reading.json
@@ -1,4 +1,24 @@
-[{
+[
+{
+  "id": "reading-assignment-editor-super",
+  "autoplay": true,
+  "standalone": true,
+  "audience_tags": [
+    "teacher-preview"
+  ],
+  "steps": [
+    {
+      "customComponent": "HowWeBuildYourReading"
+    }, {
+      "body": "More about reading assignments in our \"Page Tips\"",
+      "anchor_id": "menu-option-page-tips",
+      "action": {
+        "id": "open-support-menu"
+      },
+      "position": "left"
+    }
+  ]
+}, {
   "id": "reading-assignment-editor",
   "group_id": "reading",
   "audience_tags": [
@@ -13,7 +33,7 @@
       "body": ":best-practices: Make reading assignments due before you cover the topic in class to help your students prepare."
     }, {
       "title": "Build a reading assignment",
-      "body":  "Ready to make a reading assignment? Fill in this form and click “Add readings.”"
+      "body":  "Ready to make a reading assignment? Fill in this form and click \"Add readings.\""
     }
   ]
 }, {
@@ -26,7 +46,7 @@
   "steps": [
     {
       "title": "First, select a chapter",
-      "body": "Select a chapter you want to assign, then scroll down and click “show problems.” Uncheck any sections you don’t want to cover."
+      "body": "Select a chapter you want to assign, then scroll down and click \"Add Readings.\" Uncheck any sections you don’t want to cover."
     }
   ]
 }, {

--- a/tutor/src/tours/add-reading.json
+++ b/tutor/src/tours/add-reading.json
@@ -71,7 +71,7 @@
   "id": "reading-published",
   "group_id": "reading",
   "audience_tags": [
-    "teacher-preview-published"
+    "teacher-reading-published"
   ],
   "steps": [
     {

--- a/tutor/src/tours/question-library.json
+++ b/tutor/src/tours/question-library.json
@@ -44,7 +44,8 @@
   "steps": [
     {
       "title": "How OpenStax Tutor uses questions",
-      "body": "When you assign a reading or homework, OpenStax Tutor will add personalized and spaced practice questions."
+      "body": "When you assign a reading or homework, OpenStax Tutor will add personalized and spaced practice questions.",
+      "customComponent": "ForceScrollOnMount"
     }, {
       "title": "Reading vs Homework",
       "body": "Click \"Reading\" to view questions reserved for reading assignments. To view questions you can assign as homework, click \"Homework.\"",


### PR DESCRIPTION
## [Reading training wheels](https://trello.com/c/EDmfqj7a/586-pri-1-for-june-29-add-a-reading-training-wheels)

- [x] super training wheel
- [x] post-publish wheel
- [x] fix some reading wheel content
- [x] contextual help why no questions

![screen shot 2017-06-16 at 3 49 28 am](https://user-images.githubusercontent.com/2483873/27219494-828e98ce-5247-11e7-9ae3-df01cf6416e4.png)
![screen shot 2017-06-16 at 3 49 35 am](https://user-images.githubusercontent.com/2483873/27219500-85adda4c-5247-11e7-8148-961ee3986b5f.png)
![screen shot 2017-06-16 at 3 48 47 am](https://user-images.githubusercontent.com/2483873/27219513-8e644c84-5247-11e7-8287-99d661ecf067.png)
![screen shot 2017-06-16 at 3 48 56 am](https://user-images.githubusercontent.com/2483873/27219516-909a413e-5247-11e7-8a1e-bbd7902cde84.png)


## [Homework training wheels](https://trello.com/c/XtVZad60/585-pri-1-for-june-29-add-homework-training-wheels)

- [x] post-publish wheel
- [x] fix some homework wheel content
- [x] exercise wheel should show
- [x] publish button wheel should show
- [x] contextual help on tutor selections

![screen shot 2017-06-16 at 3 46 08 am](https://user-images.githubusercontent.com/2483873/27219535-9e993d3a-5247-11e7-88c9-9c61eea996d0.png)
![screen shot 2017-06-16 at 3 47 42 am](https://user-images.githubusercontent.com/2483873/27219540-a2aba80e-5247-11e7-93c7-1c299126d60a.png)
![screen shot 2017-06-16 at 3 47 57 am](https://user-images.githubusercontent.com/2483873/27219543-a4916c8a-5247-11e7-9320-84a6b02b58fb.png)
![screen shot 2017-06-16 at 3 48 13 am](https://user-images.githubusercontent.com/2483873/27219544-a6fc052a-5247-11e7-9dab-ae8a306629d5.png)



## [Question Library Wheels](https://trello.com/c/9akksdAB/582-pri-1-for-june-29-question-library-changes-training-wheels)
- [x] in copy, "beta" must be first-letter capitalized and in regular text same as other text: "OpenStax Tutor Beta" This is a logo/branding priority.
- [x] When part of "Page tips" tour, super training wheel Continue button should be "Next 1/2" since it is now part of a group of training wheels.
It's "Continue" when seen for first time outside page tips tour.
- [x] When in page tips tour, I clicked "Show Questions" and page did not auto scroll down to questions. User left with just shade, but nothing else until manually scrolling down. (see screenshot).
- [x] Reading questions are still not selected by default (this may be on another card?)

![screen shot 2017-06-16 at 6 45 59 am](https://user-images.githubusercontent.com/2483873/27225408-92dfef58-525f-11e7-8447-9677a4362ff3.png)
![screen shot 2017-06-16 at 6 46 07 am](https://user-images.githubusercontent.com/2483873/27225410-95a47466-525f-11e7-8458-cf337253f092.png)
![screen shot 2017-06-16 at 6 46 24 am](https://user-images.githubusercontent.com/2483873/27225413-99c0e19c-525f-11e7-9c41-11a5e741e231.png)
![screen shot 2017-06-16 at 6 46 29 am](https://user-images.githubusercontent.com/2483873/27225415-9c298fce-525f-11e7-94fd-34647faf09a7.png)



## Other
- [x] computed tour ids update if `otherTours` is updated
- [x] Section chooser wheel waiting until after "loading" screen to display
