### PR TITLE
spiffy up performance forecast styles

### DIFF
--- a/tutor/resources/styles/components/performance-forecast/index.less
+++ b/tutor/resources/styles/components/performance-forecast/index.less
@@ -16,8 +16,8 @@
     }
   }
 
-  background: none;
-  box-shadow: none;
+  &:extend(.container);
+  .tutor-shadow(pop);
 
   .guide-container {
     min-width: 340px;
@@ -38,14 +38,21 @@
     text-align: center;
   }
 
+  .no-data {
+    #fonts > .sans(1.2rem);
+    font-weight: 300;
+    color: @tutor-neutral-lite;
+    margin: 0.5rem 0;
+  }
+
   .chapter-panel {
     .performance-forecast-panel();
-
+    .align-items(flex-start);
     // specific styles to apply to the chapter progress
     .chapter {
       .performance-forecast-section();
       .heading  { #fonts > .sans(1.8rem, 1.8rem); }
-      .progress { height: 1rem; }
+      .progress { height: 1.2rem; }
       .amount-worked {
         .justify-content(flex-start);
         font-size: 1.3rem;
@@ -55,7 +62,10 @@
       }
     }
 
-    .section { .performance-forecast-section(); }
+    .section {
+      .performance-forecast-section();
+      margin-bottom: 2rem;
+    }
 
     &.weaker {
       .metric {

--- a/tutor/resources/styles/components/performance-forecast/responsive.less
+++ b/tutor/resources/styles/components/performance-forecast/responsive.less
@@ -23,6 +23,7 @@
       .make-xs-column(12);
       .make-md-column(4);
       .make-lg-column(3);
+      min-height: 7rem;
       // when the screen is the "sm" size the chapter panel needs to be 100% width so it expands above the sections.
       // But the bar shouldn't be any longer than the sections bars.
       @media (max-width: @screen-sm-max) and (min-width: @screen-sm-min){
@@ -51,6 +52,7 @@
         .make-xs-column(12);
         .make-sm-column(6);
         .make-lg-column(4);
+        min-height: 5.5rem;
       }
     }
   }

--- a/tutor/resources/styles/components/performance-forecast/section-mixin.less
+++ b/tutor/resources/styles/components/performance-forecast/section-mixin.less
@@ -8,6 +8,9 @@
 }
 
 .performance-forecast-section() {
+  .flex-display();
+  .flex-direction(column);
+  .justify-content(space-between);
 
   #fonts > .sans(1.4rem, 1.4rem);
 

--- a/tutor/src/components/performance-forecast/progress-bar.cjsx
+++ b/tutor/src/components/performance-forecast/progress-bar.cjsx
@@ -32,9 +32,9 @@ module.exports = React.createClass
       # always show at least 5% of bar, otherwise it just looks empty
       <BS.ProgressBar className={value_interpretation} now={Math.max(percent, 5)} />
     else
-      <span className="no-data">
+      <div className="no-data">
         {if canPractice then 'Practice more to get forecast' else 'Not enough exercises completed'}
-      </span>
+      </div>
 
     if canPractice
       <Practice


### PR DESCRIPTION
https://trello.com/c/MeDZreE7/745-bug-all-text-in-performance-forecast-both-on-the-page-and-in-the-right-rail-on-the-student-dashboard-need-more-padding

From:
![screen shot 2017-06-16 at 11 27 13 am](https://user-images.githubusercontent.com/79566/27235540-c93520c4-5286-11e7-8946-3690f59744dd.png)






![screen shot 2017-06-16 at 11 25 34 am](https://user-images.githubusercontent.com/79566/27235462-8ea5c71a-5286-11e7-8367-60d23ccd6156.png)