### PR TITLE
move delete button to left, display preview regardless of state

### DIFF
--- a/tutor/specs/components/task-plan/footer/preview-button.spec.jsx
+++ b/tutor/specs/components/task-plan/footer/preview-button.spec.jsx
@@ -13,17 +13,13 @@ describe('Task Plan Builder: Preview button', () => {
     };
   });
 
-  it('renders when plan is new and not waiting', () => {
+  it('renders when plan hw or reading', () => {
     const btn = shallow(<Preview {...props} />);
-    expect(btn.html()).not.toBeNull();
-    btn.setProps({ isWaiting: true });
-    expect(btn.html()).toBeNull();
-    btn.setProps({ isWaiting: false, isNew: false });
-    expect(btn.html()).toBeNull();
-    btn.setProps({ isWaiting: false, isNew: true });
     expect(btn.html()).not.toBeNull();
     btn.setProps({ planType: 'external' });
     expect(btn.html()).toBeNull();
+    btn.setProps({ planType: 'homework' });
+    expect(btn.html()).not.toBeNull();
   });
 
   it('matches snapshot', function() {

--- a/tutor/src/components/task-plan/footer/delete-link.jsx
+++ b/tutor/src/components/task-plan/footer/delete-link.jsx
@@ -31,9 +31,10 @@ export default class DeleteLink extends React.PureComponent {
           className="delete-link pull-right"
           isWaiting={this.props.isWaiting}
           isFailed={this.props.isFailed}
-          waitingText="Deleting…">
+          waitingText="Deleting…"
+        >
           <Icon type="trash" />
-          Delete Assignment
+          Delete
         </AsyncButton>
       </SuretyGuard>
     );

--- a/tutor/src/components/task-plan/footer/index.jsx
+++ b/tutor/src/components/task-plan/footer/index.jsx
@@ -119,10 +119,6 @@ export default class PlanFooter extends React.PureComponent {
             isEditable={this.state.isEditable}
             getBackToCalendarParams={this.props.getBackToCalendarParams} />
         </TourAnchor>
-        <HelpTooltip isPublished={isPublished} />
-
-        <div className="spacer" />
-
         <TourAnchor id="builder-delete-button">
           <DeleteLink
             isNew={TaskPlanStore.isNew(id)}
@@ -132,6 +128,11 @@ export default class PlanFooter extends React.PureComponent {
             isWaiting={TaskPlanStore.isDeleting(id)}
             isPublished={isPublished} />
         </TourAnchor>
+
+        <HelpTooltip isPublished={isPublished} />
+
+        <div className="spacer" />
+
         <PreviewButton
           planType={TaskPlanStore.get(id).type}
           isWaiting={isWaiting}

--- a/tutor/src/components/task-plan/footer/preview-button.jsx
+++ b/tutor/src/components/task-plan/footer/preview-button.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { includes } from 'lodash';
 import { observer } from 'mobx-react';
-import { observable, action } from 'mobx';
 
-import BuilderPopup from "../../student-preview/builder-popup";
+import BuilderPopup from '../../student-preview/builder-popup';
 
 const VALID_PLAN_TYPES = ['reading', 'homework'];
 
@@ -20,10 +19,7 @@ export default class PreviewButton extends React.PureComponent {
   render() {
     const { planType } = this.props;
 
-    if (!this.props.isNew ||
-        this.props.isWaiting ||
-        !includes(VALID_PLAN_TYPES, planType)
-    ) { return null; }
+    if (!includes(VALID_PLAN_TYPES, planType)) { return null; }
 
     return (
       <BuilderPopup courseId={this.props.courseId} planType={planType} />


### PR DESCRIPTION

https://trello.com/c/EyuSyVu4/771-j29-bug-faux-student-preview-not-available-on-published-assignments

![screen shot 2017-06-21 at 9 48 08 am](https://user-images.githubusercontent.com/79566/27390522-1ce50b60-5667-11e7-9f24-b38f6c73e9ef.png)