### PR TITLE
do not reposition when displaying preview vid tip

### DIFF
--- a/tutor/src/tours/teacher-calendar.json
+++ b/tutor/src/tours/teacher-calendar.json
@@ -77,7 +77,8 @@
       "title": "Help videos",
       "body": "View the student experience and other helpful videos here.",
       "anchor_id": "student-preview-link",
-      "position": "bottom-center"
+      "position": "bottom-center",
+      "is_fixed": true
     }, {
       "title": "Remember, this is a preview course",
       "body": "You're in a preview course with pre-populated data. When you're done exploring the preview course, here's where you can create a real course.",


### PR DESCRIPTION
Fixes this nastiness:

![screen shot 2017-06-21 at 10 01 48 am](https://user-images.githubusercontent.com/79566/27391123-abc230dc-5668-11e7-9b9d-8db595e14014.png)


