### PR TITLE
Only show page tips menu option if there's manually triggered tours

### DIFF
--- a/tutor/specs/components/navbar/support-menu.spec.jsx
+++ b/tutor/specs/components/navbar/support-menu.spec.jsx
@@ -21,7 +21,7 @@ describe('Support Menu', () => {
     expect(menu).not.toHaveRendered('.page-tips');
     region = new TourRegion({ id: 'foo', courseId: '2', otherTours: ['teacher-calendar'] });
     context.openRegion(region);
-    expect(context.hasElgibleTour).toBe(true);
+    expect(context.hasTriggeredTour).toBe(true);
     expect(menu).toHaveRendered('.page-tips');
   });
 

--- a/tutor/src/components/navbar/support-menu.jsx
+++ b/tutor/src/components/navbar/support-menu.jsx
@@ -30,7 +30,7 @@ export default class SupportMenu extends React.PureComponent {
   }
 
   renderPageTipsOption() {
-    if (!get(this.props, 'tourContext.hasElgibleTour', false)){ return null; }
+    if (!get(this.props, 'tourContext.hasTriggeredTour', false)){ return null; }
     return (
       <MenuItem
         className="page-tips"

--- a/tutor/src/models/tour/context.js
+++ b/tutor/src/models/tour/context.js
@@ -117,12 +117,13 @@ export default class TourContext extends BaseModel {
   }
 
   @computed get needsPageTipsReminders() {
-    return this.hasElgibleTour && !find(this.elgibleTours, 'autoplay');
+    return this.hasTriggeredTour && !find(this.elgibleTours, 'autoplay');
   }
 
-  // same logic as above but uses find, which short-circuits after a match
-  @computed get hasElgibleTour() {
-    return !!find(this.allTours, (tour) => (!isEmpty(intersection(tour.audience_tags, this.audienceTags))));
+  @computed get hasTriggeredTour() {
+    return !!find(this.allTours, (tour) =>
+        !(tour.autoplay || isEmpty(intersection(tour.audience_tags, this.audienceTags)))
+    );
   }
 
   @computed get debugStatus() {
@@ -131,7 +132,7 @@ export default class TourContext extends BaseModel {
 
   @action playTriggeredTours() {
     this.elgibleTours.forEach((tour) => {
-      if (!tour.auto_display){ tour.play(); }
+      if (!tour.autoplay){ tour.play(); }
     });
   }
 

--- a/tutor/src/models/user.js
+++ b/tutor/src/models/user.js
@@ -58,7 +58,7 @@ export class User extends BaseModel {
   }
 
   resetTours() {
-    this.viewed_tour_ids.clear();
+    this.viewed_tour_stats.clear();
   }
 
   replayTour(tour) {


### PR DESCRIPTION
Previously it showed if there were any tours, which would also include auto play ones