### PR TITLE
Render assignment link popover even if shareable_url is missing

### DIFF
--- a/tutor/specs/components/task-plan/lms-info.spec.jsx
+++ b/tutor/specs/components/task-plan/lms-info.spec.jsx
@@ -27,17 +27,22 @@ describe('LmsInfo Component', function() {
     const info = mount(<LmsInfoLink {...props} />);
     info.find('.get-link').simulate('click');
     expect(document.querySelector('.popover-title').textContent).toContain('No assignment link');
+    info.unmount();
   });
 
-  it('does not render when there are no stats', function() {
-    const info = shallow(<LmsInfoLink {...props} />);
-    expect(info.html()).toBeNull();
+  it('renders with message even when there is no url', function() {
+    TaskPlanStore.TaskPlanStatsStore.get.mockReturnValueOnce({});
+    props.plan.shareable_url = '';
+    const info = mount(<LmsInfoLink {...props} />);
+    expect(info.html()).not.toBeNull();
+    info.unmount();
   });
 
   it('renders with stats', () => {
     TaskPlanStore.TaskPlanStatsStore.get.mockReturnValueOnce({ shareable_url: 'foo' });
     const info = shallow(<LmsInfoLink {...props} />);
     expect(info).toHaveRendered('.get-link');
+    info.unmount();
   });
 
   it('displays popover when clicked', () => {
@@ -45,5 +50,6 @@ describe('LmsInfo Component', function() {
     const info = mount(<LmsInfoLink {...props} />);
     info.find('.get-link').simulate('click');
     expect(document.querySelector('.body input').value).toContain('foo');
+    info.unmount();
   });
 });

--- a/tutor/src/components/task-plan/lms-info.jsx
+++ b/tutor/src/components/task-plan/lms-info.jsx
@@ -73,7 +73,7 @@ export class LmsInfoLink extends React.PureComponent {
   @computed get url() {
     const l = window.location;
     const { shareable_url } = this.getStats();
-    return `${l.protocol}//${l.host}${shareable_url}`;
+    return shareable_url ? `${l.protocol}//${l.host}${shareable_url}` : null;
   }
 
   @computed get isPreview() {
@@ -81,7 +81,7 @@ export class LmsInfoLink extends React.PureComponent {
   }
 
   @computed get popOverBody() {
-    if (this.isPreview) {
+    if (this.isPreview || !this.url) {
       return (
         <div className="body">
           {this.props.plan.title}
@@ -137,7 +137,6 @@ export class LmsInfoLink extends React.PureComponent {
   }
 
   render() {
-    if (!this.getStats().shareable_url) { return null; }
 
     return (
       <div className="lms-info">


### PR DESCRIPTION
Some preview courses don't have this, but that's ok because the'll have a "NO URL IN PREVIEW" message
![screen shot 2017-06-30 at 2 49 36 pm](https://user-images.githubusercontent.com/79566/27751742-5ebe55ee-5da3-11e7-96a5-0a88de7dfb50.png)

