### PR TITLE
update enrollment URL

### DIFF
--- a/tutor/src/routes.coffee
+++ b/tutor/src/routes.coffee
@@ -92,7 +92,7 @@ getStudentPreview = ->
 
 ROUTES = [
   { pattern: '/dashboard',              name: 'myCourses',                renderer: getMyCourses }
-  { pattern: '/enroll/:enrollmentCode', name: 'createEnrollmentChange',   renderer: getCreateEnrollmentChange }
+  { pattern: '/enroll/start/:enrollmentCode', name: 'createEnrollmentChange',   renderer: getCreateEnrollmentChange }
   { pattern: '/new-course/:sourceId?',  name: 'createNewCourse',          renderer: getCreateCourse  }
   {
     pattern: '/qa',                     name: 'QADashboard',              renderer: getQADashboard


### PR DESCRIPTION
Needs to be merged in conjunction with https://github.com/openstax/tutor-server/pull/1474

The BE now handles the first stage /enroll/:code so it can display a splash screen

It then redirects to the FE at this url