### PR TITLE
Don't display "free trial" message for free courses

### DIFF
--- a/tutor/specs/models/courses/onboarding/student-course.spec.js
+++ b/tutor/specs/models/courses/onboarding/student-course.spec.js
@@ -27,6 +27,8 @@ describe('Full Course Onboarding', () => {
 
   it('#nagComponent', () => {
     expect(ux.course.needsPayment).toBeUndefined();
+    expect(ux.nagComponent).toBeNull();
+    ux.course.does_cost = true
     expect(ux.nagComponent).toBe(Nags.payDisabled);
     Payments.config.is_enabled = true;
     ux.course.needsPayment = true;

--- a/tutor/src/models/course/onboarding/student-course.js
+++ b/tutor/src/models/course/onboarding/student-course.js
@@ -16,7 +16,7 @@ export default class StudentCourseOnboarding extends BaseOnboarding {
 
   get nagComponent() {
     if (this.displayPayment) { return Nags.makePayment; }
-    if (!Payments.config.is_enabled){
+    if (!Payments.config.is_enabled && this.course.does_cost){
       if (!UiSettings.get(TRIAL_ACKNOWLEDGED, this.course.id)) {
         return Nags.payDisabled;
       }


### PR DESCRIPTION
Note this changes default trigger of tooltip to include `hover` - UX would prefer that and react-bootstrap now supports multiple triggers

![screen shot 2017-07-26 at 11 50 57 am](https://user-images.githubusercontent.com/79566/28633219-b46cc5f2-71f8-11e7-8e16-a101bd2de10c.png)
