### PR TITLE
IE z-index fix for student enrollment and id change

### DIFF
--- a/tutor/resources/styles/components/enrollment-student-id.less
+++ b/tutor/resources/styles/components/enrollment-student-id.less
@@ -2,7 +2,7 @@
 // since they both share the same structure
 .modal.course-enroll,
 .modal.change-student-id {
-  z-index: -1;
+
   padding-top: 120px;
 
   .modal-title,


### PR DESCRIPTION
Was preventing IE from registering clicks in the modal.

Doesn't seem to be needed in other browsers, not sure why we had it set