### PR TITLE
Fix cloning a course

### DIFF
--- a/tutor/specs/models/courses/builder-ux.spec.js
+++ b/tutor/specs/models/courses/builder-ux.spec.js
@@ -53,6 +53,14 @@ describe('Course Builder UX Model', () => {
     expect(ux.newCourse.save).toHaveBeenCalled();
   }
 
+  it('sets cloned course when sourceId is present', () => {
+    Router.currentParams.mockReturnValue({ sourceId: '2' });
+    courses.get('2').name = 'CLONE ME';
+    ux = new CourseBuilderUX();
+    expect(ux.newCourse.cloned_from_id).toEqual('2');
+    expect(ux.newCourse.name).toEqual('CLONE ME');
+  });
+
   it('calculates first stage', () => {
     expect(ux.firstStageIndex).toEqual(0);
     Router.currentParams.mockReturnValue({ sourceId: '1' });
@@ -97,6 +105,5 @@ describe('Course Builder UX Model', () => {
       expect(ux.router.transitionTo).toHaveBeenCalledWith('/course/42/cc/help?showIntro=true');
     });
   });
-
 
 });

--- a/tutor/specs/models/courses/builder-ux.spec.js
+++ b/tutor/specs/models/courses/builder-ux.spec.js
@@ -17,24 +17,6 @@ describe('Course Builder UX Model', () => {
     ux = new CourseBuilderUX();
   });
 
-  function advanceToName() {
-    expect(ux.stage).toEqual('offering');
-    expect(ux.canGoBackward).toBe(false);
-    expect(ux.canGoForward).toBe(false);
-    ux.newCourse.offering = mockOffering;
-    Offerings.get.mockReturnValue(mockOffering);
-    expect(ux.canGoForward).toBe(true);
-
-    ux.goForward();
-    expect(ux.canGoBackward).toBe(true);
-    expect(ux.stage).toEqual('term');
-    expect(ux.canGoForward).toBe(false);
-    ux.newCourse.term = { year: 2018 };
-    expect(ux.canGoForward).toBe(true);
-
-    ux.goForward();
-    expect(ux.stage).toEqual('name');
-  }
 
   function advanceToSave() {
     ux.goForward();
@@ -68,13 +50,68 @@ describe('Course Builder UX Model', () => {
     expect(ux.firstStageIndex).toEqual(1);
   });
 
-  it('can advance through specs for a cloned course', () => {
-    advanceToName();
+  it('can advance through steps for new course', () => {
+    expect(ux.stage).toEqual('offering');
+    expect(ux.canGoBackward).toBe(false);
+    expect(ux.canGoForward).toBe(false);
+    ux.newCourse.offering = mockOffering;
+    Offerings.get.mockReturnValue(mockOffering);
+    expect(ux.canGoForward).toBe(true);
+
+    ux.goForward();
+    expect(ux.canGoBackward).toBe(true);
+    expect(ux.stage).toEqual('term');
+    expect(ux.canGoForward).toBe(false);
+    ux.newCourse.term = { year: 2018 };
+    expect(ux.canGoForward).toBe(true);
+
+    ux.goForward();
+
+    expect(ux.stage).toEqual('new_or_copy');
+    expect(ux.canGoForward).toBe(true);
+    ux.goForward();
+    expect(ux.stage).toEqual('name');
     expect(ux.newCourse.name).toEqual(mockOffering.title);
-    expect(ux.newCourse.num_sections).toEqual(courses.get(2).periods.length);
-    expect(ux.canGoForward).toBe(true); // fields are already set from clone
+
+    ux.goBackward();
+    expect(ux.stage).toEqual('new_or_copy');
+    ux.newCourse.new_or_copy = 'copy';
+    expect(ux.canGoForward).toBe(true);
+    ux.goForward();
+
+    const course = courses.get('2');
+
+    expect(ux.stage).toEqual('cloned_from_id');
+    expect(ux.canGoForward).toBe(false);
+    ux.source = course;
+
+    expect(ux.canGoForward).toBe(true);
+    ux.goForward();
+    expect(ux.stage).toEqual('name');
+    expect(ux.newCourse.name).toEqual(course.name);
+
+    expect(ux.newCourse.num_sections).toEqual(course.periods.length);
+    expect(ux.canGoForward).toBe(true);
     advanceToSave();
   });
+
+  it('can advance through steps for cloned course', () => {
+    const course = courses.get('2');
+    Router.currentParams.mockReturnValue({ sourceId: course.id });
+    ux = new CourseBuilderUX();
+    expect(ux.stage).toEqual('term');
+    expect(ux.canGoForward).toBe(false);
+    ux.newCourse.term = { year: 2018 };
+    expect(ux.canGoForward).toBe(true);
+    ux.goForward();
+    expect(ux.stage).toEqual('name'); // new_or_copy is skipped
+    expect(ux.canGoForward).toBe(true);
+    expect(ux.newCourse.name).toEqual(course.name);
+    expect(ux.newCourse.num_sections).toEqual(course.periods.length);
+    expect(ux.canGoForward).toBe(true);
+    advanceToSave();
+  });
+
 
   it('goes to dashboard after canceling', () => {
     ux.router = { transitionTo: jest.fn() };

--- a/tutor/specs/models/courses/create.spec.js
+++ b/tutor/specs/models/courses/create.spec.js
@@ -1,0 +1,66 @@
+import CourseCreate from '../../../src/models/course/create'
+import { bootstrapCoursesList } from '../../courses-test-data';
+import Offerings from '../../../src/models/course/offerings';
+import Router from '../../../src/helpers/router';
+import { extend, defer } from 'lodash';
+jest.mock('../../../src/helpers/router');
+jest.mock('../../../src/models/course/offerings', () => ({
+  get: jest.fn(() => undefined),
+}));
+
+describe('Course Builder UX Model', () => {
+  let creater;
+
+  beforeEach(() => {
+
+    creater = new CourseCreate({
+      name: 'TEST COURSE FOR TESTING',
+      estimated_student_count: 100,
+      offering_id: 1,
+      term: { year: 2018, term: 'spring' },
+    });
+
+  });
+
+  it('creates a course', () => {
+    expect(creater.cloned_from_id).toBe(false);
+    const saved = creater.save();
+    expect(saved.url).toEqual('/courses');
+    expect(saved.data).toEqual({
+      cloned_from_id: false,
+      copy_question_library: true,
+      estimated_student_count: 100,
+      is_college: true,
+      is_preview: false,
+      name: 'TEST COURSE FOR TESTING',
+      num_sections: 1,
+      offering_id: 1,
+      term: 'spring',
+      year: 2018,
+      time_zone: 'Central Time (US & Canada)',
+    });
+  });
+
+  it('clones a course', () => {
+    const course = bootstrapCoursesList().get('2');
+    creater.cloned_from = course;
+    expect(creater.cloned_from_id).toBe(course.id);
+    const saved = creater.save();
+    expect(saved.url).toEqual('/courses/2/clone');
+    expect(saved.data).toEqual({
+      cloned_from_id: course.id,
+      copy_question_library: true,
+      estimated_student_count: 100,
+      is_college: course.is_college,
+      is_preview: false,
+      name: course.name,
+      num_sections: course.periods.length,
+      offering_id: 1,
+      term: 'spring',
+      year: 2018,
+      time_zone: 'Central Time (US & Canada)',
+    });
+
+  });
+
+});

--- a/tutor/src/api/index.coffee
+++ b/tutor/src/api/index.coffee
@@ -234,6 +234,7 @@ startAPI = ->
   connectModelRead(Offerings.constructor, 'fetch', url: 'offerings', onSuccess: 'onLoaded')
 
   connectModelCreate(CourseCreate, 'save', onSuccess: 'onCreated')
+
   connectModelRead(TeacherTaskPlans.constructor, 'fetch',
     pattern: 'courses/{courseId}/dashboard',
     onSuccess: 'onLoaded'

--- a/tutor/src/models/course/builder-ux.js
+++ b/tutor/src/models/course/builder-ux.js
@@ -152,10 +152,10 @@ export default class CourseBuilderUX extends BaseModel {
 
   // skips
   skip_new_or_copy() {
-    return Boolean(this.offering || isEmpty(this.cloneSources));
+    return Boolean(this.source);
   }
 
   skip_cloned_from_id() {
-    return Boolean(this.offering);
+    return Boolean(this.newCourse.new_or_copy === 'new');
   }
 }

--- a/tutor/src/models/course/builder-ux.js
+++ b/tutor/src/models/course/builder-ux.js
@@ -34,8 +34,10 @@ export default class CourseBuilderUX extends BaseModel {
   constructor(router) {
     super();
     this.router = router;
+
     observe(this, 'source', ({ newValue: newSource }) => {
       if (newSource) {
+        this.newCourse.cloned_from = newSource;
         when(
           () => Offerings.get(newSource.offering_id),
           () => this.newCourse.offering = Offerings.get(newSource.offering_id),

--- a/tutor/src/models/course/create.js
+++ b/tutor/src/models/course/create.js
@@ -31,7 +31,9 @@ export default class CourseCreate extends BaseModel {
 
   set offering(offering) {
     this.offering_id = offering.id;
-    this.name = offering.title;
+    if (!this.name) {
+      this.name = offering.title;
+    }
   }
 
   @computed get cloned_from() {

--- a/tutor/src/models/course/create.js
+++ b/tutor/src/models/course/create.js
@@ -1,5 +1,5 @@
 import {
-  BaseModel, identifiedBy, field, belongsTo, computed,
+  BaseModel, identifiedBy, field, belongsTo, computed, session,
 } from '../base';
 import { observable } from 'mobx';
 import { extend, omit } from 'lodash';
@@ -17,7 +17,7 @@ export default class CourseCreate extends BaseModel {
   @field is_preview = false;
   @field is_college = true;
   @field time_zone = 'Central Time (US & Canada)';
-  @field new_or_copy = 'new';
+  @session new_or_copy = 'new';
   @field cloned_from_id = false;
   @field copy_question_library = true;
 
@@ -52,7 +52,7 @@ export default class CourseCreate extends BaseModel {
     });
     return {
       data,
-      url: this.new_or_copy === 'new' ? '/courses' : `/courses/${this.cloned_from_id}/clone`,
+      url: this.cloned_from_id ? `/courses/${this.cloned_from_id}/clone` : '/courses',
     };
   }
 


### PR DESCRIPTION
Cloning a course was broken because we weren't:

 * Setting the source course when sourceId was present on router params
 * Not using the cloned course endpoint when a clone course was set