### PR TITLE
Remove deleted plans from the teacher task plan map

### DIFF
--- a/tutor/specs/models/teacher-task-plans.spec.js
+++ b/tutor/specs/models/teacher-task-plans.spec.js
@@ -1,6 +1,7 @@
 import TeacherTaskPlans from '../../src/models/teacher-task-plans';
 import { autorun } from 'mobx';
 import { map } from 'lodash';
+import { TaskPlanStore } from '../../src/flux/task-plan';
 
 const COURSE_ID = '123';
 
@@ -27,7 +28,18 @@ describe('Teacher Task Plans', function() {
         { id: '2', hello: 'world', steps: [] },
       ] } }, [ { courseId: COURSE_ID } ]);
     TeacherTaskPlans.get(COURSE_ID).get(1).is_deleting = true;
-    expect(TeacherTaskPlans.get(COURSE_ID).active).toHaveLength(1);
+    expect(TeacherTaskPlans.get(COURSE_ID).active.array).toHaveLength(1);
+  });
+
+  it('removes deleted plans when flux deletes', () => {
+    TeacherTaskPlans.onLoaded(
+      { data: { plans: [ { id: '211', hello: 'world', steps: [] } ] } },
+      [ { courseId: COURSE_ID } ]
+    );
+    expect(TeacherTaskPlans.get(COURSE_ID).get(211)).not.toBeUndefined();
+    TaskPlanStore.emit('deleted', 211);
+    expect(TeacherTaskPlans.get(COURSE_ID).get(211)).toBeUndefined();
+    expect(TeacherTaskPlans.get(COURSE_ID).array).toHaveLength(0);
   });
 
   it('can store a cloned plan', () => {

--- a/tutor/src/components/course-calendar/month.cjsx
+++ b/tutor/src/components/course-calendar/month.cjsx
@@ -243,7 +243,7 @@ CourseMonth = React.createClass
       'with-sidebar-open': @state.showingSideBar
     )
 
-    plansList = TeacherTaskPlans.forCourseId(courseId).array
+    plansList = TeacherTaskPlans.forCourseId(courseId).active.array
     if plansList?
       plans = <CourseDuration
         referenceDate={moment(TimeStore.getNow())}

--- a/tutor/src/flux/task-plan.coffee
+++ b/tutor/src/flux/task-plan.coffee
@@ -103,6 +103,9 @@ TaskPlanConfig =
 
   FAILED: -> # used by API
 
+  _deleted: (result, id, args...) ->
+    @emit('deleted', id, result)
+
   # Returns copies of the given property names from settings
   # Copies are returned so that the store can be reset
   _getClonedSettings: (id, names...) ->

--- a/tutor/src/models/teacher-task-plans.js
+++ b/tutor/src/models/teacher-task-plans.js
@@ -4,6 +4,13 @@ import { filter } from 'lodash';
 import Map from './map';
 import TaskPlan from './teacher-task-plan';
 import moment from 'moment';
+import { TaskPlanStore } from '../flux/task-plan';
+
+let TaskPlans;
+
+TaskPlanStore.on('deleted', (planId) => {
+  TaskPlans.forEach((plans) => plans.delete(planId));
+});
 
 class CourseTaskPlans extends Map {
 
@@ -32,7 +39,7 @@ class CourseTaskPlans extends Map {
   }
 
   @computed get active() {
-    return filter(this.array, plan => !plan.is_deleting);
+    return this.where(plan => plan.is_deleting !== true);
   }
 
   @computed get isPublishing() {
@@ -75,5 +82,5 @@ class TeacherTaskPlans extends Map {
 
 }
 
-const taskPlans = new TeacherTaskPlans();
-export default taskPlans;
+TaskPlans = new TeacherTaskPlans();
+export default TaskPlans;


### PR DESCRIPTION
Two issues:
 * We weren't filtering them out when displaying on calendar
 * We were relying on the server to reply back with the 'is_deleted' flag,
   but it does not, instead they're just not included.