### PR TITLE
Fix personalized icon on student value prop modal

### DIFF
--- a/tutor/resources/styles/components/tours/value-prop.less
+++ b/tutor/resources/styles/components/tours/value-prop.less
@@ -103,11 +103,7 @@
     &.welcome-to-tutor {
       .column {
         &.spaced       { .tutor-background-image("value-prop/spaced-practice.svg"); }
-        &.personalized {
-          .tutor-background-image("value-prop/personalized.svg");
-          background-size: auto 120px;
-          background-position: center -15px;
-        }
+        &.personalized { .tutor-background-image("value-prop/personalized.svg");    }
         &.low-cost     {
           .tutor-background-image("value-prop/low-cost.svg");
           background-size: 100px auto;


### PR DESCRIPTION
Not sure why it was added but was making it look funky

Before:
![screen shot 2017-08-01 at 5 02 30 pm](https://user-images.githubusercontent.com/79566/28849116-42273058-76db-11e7-98ce-7c10a2b7c962.png)


After:
![screen shot 2017-08-01 at 5 02 16 pm](https://user-images.githubusercontent.com/79566/28849117-42395f08-76db-11e7-8168-06892f590cb5.png)
