### PR TITLE
fix enrollment/student-id/refunds modal on small screens

### DIFF
--- a/tutor/resources/styles/components/enrollment-student-id.less
+++ b/tutor/resources/styles/components/enrollment-student-id.less
@@ -3,7 +3,7 @@
 .modal.course-enroll,
 .modal.change-student-id {
 
-  padding-top: 120px;
+  overflow: scroll;
 
   .modal-title,
   .modal-body,

--- a/tutor/resources/styles/components/payments.less
+++ b/tutor/resources/styles/components/payments.less
@@ -45,8 +45,10 @@
 // TODO - make this a mixin or standard style once UX finishes style guide
 .modal.refund {
   @spacing: 40px;
-  top: 130px;
+  overflow: scroll;
+
   .modal-dialog {
+    margin-top: 130px;
     width: 500px;
   }
   .modal-content {


### PR DESCRIPTION
The modal was positioned too low, and didn't allow scrolling