### PR TITLE
Unsubscribe from updates when unmounted

### DIFF
--- a/tutor/src/components/task-plan/footer/index.jsx
+++ b/tutor/src/components/task-plan/footer/index.jsx
@@ -40,12 +40,17 @@ export default class PlanFooter extends React.PureComponent {
     };
   }
 
+  componentWillUnmount() {
+    PlanHelper.unsubscribeFromPublishing(this.props.id, this.checkPublishingStatus);
+  }
+
   componentWillMount() {
     const plan = TaskPlanStore.get(this.props.id);
     const publishState = PlanHelper.subscribeToPublishing(plan, this.checkPublishingStatus);
     this.setState({ publishing: publishState.isPublishing });
   }
 
+  @action.bound
   checkPublishingStatus(published) {
     const planId = this.props.id;
     if (published.for === planId) {
@@ -54,7 +59,7 @@ export default class PlanFooter extends React.PureComponent {
 
       this.setState(planStatus);
       if (PlanPublishStore.isDone(planId)) {
-        PlanPublishStore.removeAllListeners(`progress.${planId}.*`, this.checkPublishingStatus);
+        PlanHelper.unsubscribeFromPublishing(planId, this.checkPublishingStatus);
         TaskPlanActions.load(planId);
       }
     }

--- a/tutor/src/helpers/plan.coffee
+++ b/tutor/src/helpers/plan.coffee
@@ -13,6 +13,9 @@ PlanHelper =
     PlanPublishActions.startChecking(id, jobId)
     PlanPublishStore.on("progress.#{id}.*", callback) if callback? and _.isFunction(callback)
 
+  unsubscribeFromPublishing: (planId, callback) ->
+    PlanPublishStore.removeAllListeners("progress.#{planId}.*", callback) if callback? and _.isFunction(callback)
+
   subscribeToPublishing: (plan, callback) ->
     {jobId, id} = PlanPublishStore._getIds(plan)
     isPublishing = PlanHelper.isPublishing(plan) or false


### PR DESCRIPTION
Was causing JS errors and causing the task plan emit to stop mid-delivery, which in turn would cause plans to stay as "Publishing.." on the calendar forever