### PR TITLE
Re-add "Pay Now" button

### DIFF
--- a/tutor/src/components/navbar/index.jsx
+++ b/tutor/src/components/navbar/index.jsx
@@ -30,6 +30,7 @@ export default function NavigationBar() {
         <div className="right-side-controls">
           <PreviewAddCourseBtn courseId={courseId} />
           <SupportMenu />
+          <StudentPayNowBtn    courseId={courseId} />
           <StudentPreviewLink  courseId={courseId} />
           <UserActionsMenu     courseId={courseId} />
         </div>


### PR DESCRIPTION
Looks like this was droppped inadvertently when it was renamed from "Get Access"