### PR TITLE
Fix cancel button on payments modal that's selected from pay-now-or-later

### DIFF
--- a/tutor/specs/components/onboarding/__snapshots__/make-payment.spec.jsx.snap
+++ b/tutor/specs/components/onboarding/__snapshots__/make-payment.spec.jsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`make payment modal renders and matches snapshot 1`] = `
+<div
+  className="onboarding-nag make-payment"
+>
+  <div
+    className="payments-panel"
+  >
+    <div
+      className="payments-wrapper"
+    />
+  </div>
+</div>
+`;

--- a/tutor/specs/components/onboarding/make-payment.spec.jsx
+++ b/tutor/specs/components/onboarding/make-payment.spec.jsx
@@ -1,0 +1,27 @@
+import { Wrapper, SnapShot } from '../helpers/component-testing';
+import MakePayment from '../../../src/components/onboarding/make-payment';
+import { STUDENT_COURSE_ONE_MODEL } from '../../courses-test-data';
+import Course from '../../../src/models/course';
+import Student from '../../../src/models/course/onboarding/student-course';
+import { isFunction } from 'lodash';
+
+describe('make payment modal', () => {
+  let ux;
+  beforeEach(() => {
+    ux = new Student(new Course(STUDENT_COURSE_ONE_MODEL));
+  });
+
+  it('renders and matches snapshot', () => {
+    expect(SnapShot.create(
+      <Wrapper _wrapped_component={MakePayment} ux={ux} />).toJSON()
+    ).toMatchSnapshot();
+  });
+
+  it('calls onCancel', () => {
+    const modal = shallow(<MakePayment ux={ux} />);
+    const payments = modal.find('PaymentsPanel');
+    const onCancel = payments.props().onCancel;
+    expect(onCancel).toBe(ux.onPayLater);
+    expect(isFunction(onCancel)).toBe(true);
+  });
+});

--- a/tutor/src/components/onboarding/make-payment.jsx
+++ b/tutor/src/components/onboarding/make-payment.jsx
@@ -18,7 +18,7 @@ export default class MakePayment extends React.PureComponent {
 
     return (
       <OnboardingNag className="make-payment">
-        <PaymentsPanel onCancel={ux.payLater} onPaymentComplete={ux.onPaymentComplete} course={ux.course} />
+        <PaymentsPanel onCancel={ux.onPayLater} onPaymentComplete={ux.onPaymentComplete} course={ux.course} />
       </OnboardingNag>
     );
   }


### PR DESCRIPTION
Before it was non-functional because the `ux.payLater` method was renamed to `onPayLater` at some point ☹️ 