### PR TITLE
Add labels to progress labels for screen readers

### DIFF
--- a/tutor/resources/styles/components/performance-forecast/index.less
+++ b/tutor/resources/styles/components/performance-forecast/index.less
@@ -54,6 +54,10 @@
     .chapter {
       .performance-forecast-section();
       .heading  { #fonts > .sans(1.8rem, 1.8rem); }
+      .btn {
+        padding: 0;
+        margin: 8px 0;
+      }
       .progress { height: 1.2rem; }
       .amount-worked {
         .justify-content(flex-start);

--- a/tutor/resources/styles/components/performance-forecast/section-mixin.less
+++ b/tutor/resources/styles/components/performance-forecast/section-mixin.less
@@ -51,6 +51,7 @@
 
   .progress {
     height: 0.8rem;
+    margin: 8px;
     .performance-forecast-colors();
   }
 

--- a/tutor/resources/styles/components/student-dashboard/progress-guide.less
+++ b/tutor/resources/styles/components/student-dashboard/progress-guide.less
@@ -35,6 +35,12 @@
       margin: 0;
     }
 
+    .btn {
+      padding: 0.5rem;
+      margin: 0.5rem 0;
+
+    }
+
     .guide-key {
       margin: 10px 0;
       .performance-forecast-key();

--- a/tutor/src/components/performance-forecast/progress-bar.cjsx
+++ b/tutor/src/components/performance-forecast/progress-bar.cjsx
@@ -14,35 +14,39 @@ module.exports = React.createClass
     section:  React.PropTypes.object.isRequired
     canPractice: React.PropTypes.bool
     courseId:    React.PropTypes.string.isRequired
+    ariaLabel:   React.PropTypes.string
 
   getDefaultProps: ->
     id: _.uniqueId('progress-bar-tooltip-')
     canPractice: false
-
-  getTip: (props) ->
-    'Click to practice' unless props.isDisabled
+    ariaLabel:   ''
 
   render: ->
-    {section, canPractice, courseId, id} = @props
+    {section, canPractice, courseId, id, ariaLabel} = @props
     {page_ids} = section
 
     bar = if PerformanceForecast.Helpers.canDisplayForecast(section.clue)
       percent = Math.round(Number(section.clue.most_likely) * 100)
       value_interpretation = if percent >= 80 then 'high' else (if percent >= 30 then 'medium' else 'low')
       # always show at least 5% of bar, otherwise it just looks empty
-      <BS.ProgressBar className={value_interpretation} now={Math.max(percent, 5)} />
+      <BS.ProgressBar
+        aria-label={"Practice - #{ariaLabel}"}
+        className={value_interpretation}
+        now={Math.max(percent, 5)}
+      />
     else
-      <div className="no-data">
-        {if canPractice then 'Practice more to get forecast' else 'Not enough exercises completed'}
+      msg = if canPractice then 'Practice more to get forecast' else 'Not enough exercises completed'
+      <div className="no-data" aria-label={"#{msg} - #{ariaLabel}"}>
+        {msg}
       </div>
 
     if canPractice
       <Practice
         courseId={courseId}
         page_ids={page_ids}>
-        <ButtonWithTip id={id} block getTip={@getTip} role='link'>
+        <BS.Button id={id} block role='link'>
           {bar}
-        </ButtonWithTip>
+        </BS.Button>
       </Practice>
     else
       bar

--- a/tutor/src/components/performance-forecast/section.cjsx
+++ b/tutor/src/components/performance-forecast/section.cjsx
@@ -27,10 +27,15 @@ module.exports = React.createClass
         <span className='number'>
           {@sectionFormat(section.chapter_section)}
         </span>
-        <span className='title' title={section.title}>{section.title}</span>
+        <span className='title' title={section.title}>
+            {section.title}
+          </span>
       </h4>
 
-      <ProgressBar {...@props} />
+      <ProgressBar
+        {...@props}
+        ariaLabel={"#{@sectionFormat(section.chapter_section)} #{section.title}"}
+      />
       <Statistics
       courseId={@props.courseId}
       roleId={@props.roleId}


### PR DESCRIPTION
And also adjust margin / padding to make it cleaner.

![screen shot 2017-08-15 at 5 21 00 pm](https://user-images.githubusercontent.com/79566/29339066-1efa08ea-81de-11e7-944d-6c2680a45a4c.png)
![screen shot 2017-08-15 at 5 21 15 pm](https://user-images.githubusercontent.com/79566/29339078-2a56a8a6-81de-11e7-8756-a98eb448095a.png)
