### PR TITLE
Tasks may be undefined if they're not loaded yet

### DIFF
--- a/tutor/specs/models/courses/onboarding/student-course.spec.js
+++ b/tutor/specs/models/courses/onboarding/student-course.spec.js
@@ -50,11 +50,13 @@ describe('Full Course Onboarding', () => {
 
   it('#onPaymentComplete', () => {
     ux.course.needsPayment = true;
+    ux.course.studentTasks = { fetch: jest.fn() };
     ux.payNow();
     ux.course.userStudentRecord = {
       markPaid: jest.fn(),
     };
     ux.onPaymentComplete();
+    expect(ux.course.studentTasks.fetch).toHaveBeenCalled();
     expect(ux.course.userStudentRecord.markPaid).toHaveBeenCalled();
   });
 

--- a/tutor/src/components/student-dashboard/this-week-panel.jsx
+++ b/tutor/src/components/student-dashboard/this-week-panel.jsx
@@ -17,7 +17,8 @@ export default class ThisWeekPanel extends React.PureComponent {
   render() {
     const { courseId } = this.props;
     const startAt = moment(TimeStore.getNow()).startOf('isoweek');
-    const events  = StudentTasks.get(this.props.courseId).weeklyEventsForDay(startAt);
+    const tasks = StudentTasks.get(this.props.courseId);
+    const events = tasks ? tasks.weeklyEventsForDay(startAt) : [];
 
     if (!events.length) { return <EmptyPanel courseId={courseId} message='No assignments this week' />; }
 

--- a/tutor/src/components/student-dashboard/upcoming-panel.jsx
+++ b/tutor/src/components/student-dashboard/upcoming-panel.jsx
@@ -18,7 +18,8 @@ export default class UpcomingPanel extends React.PureComponent {
   render() {
     const { courseId } = this.props;
     const startAt = moment(TimeStore.getNow()).startOf('isoweek').add(1, 'week');
-    const events  = StudentTasks.get(courseId).upcomingEvents(startAt);
+    const tasks = StudentTasks.get(this.props.courseId);
+    const events  = tasks ? tasks.upcomingEvents(startAt) : [];
 
     if (isEmpty(events)) {
       return <EmptyPanel courseId={courseId} message='No upcoming assignments' />;

--- a/tutor/src/models/course/onboarding/student-course.js
+++ b/tutor/src/models/course/onboarding/student-course.js
@@ -70,6 +70,8 @@ export default class StudentCourseOnboarding extends BaseOnboarding {
   @action.bound
   onPaymentComplete() {
     this.displayPayment = false;
+    // fetch tasks since they could not be fetched while student was in unpaid status
+    this.course.studentTasks.fetch();
     this.course.userStudentRecord.markPaid();
   }
 


### PR DESCRIPTION
When a past-due student loads the dashboard we can't load the tasks since the BE will raise 403.

That means the dashboard may be task-less after a student pays.  