### PR TITLE
update a11y extension so it loads same version as mathjax

### DIFF
--- a/shared/src/helpers/mathjax.coffee
+++ b/shared/src/helpers/mathjax.coffee
@@ -64,7 +64,7 @@ startMathJax = ->
     window.MathJax.Hub.Configured()
 
   if window.MathJax?.Hub
-    window.MathJax.Ajax.config.path["a11y"] = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/extensions/a11y"
+    window.MathJax.Ajax.config.path["a11y"] = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/#{window.MathJax.version}/extensions/a11y"
     window.MathJax.Hub.Config(MATHJAX_CONFIG)
     # Does not seem to work when passed to Config
     window.MathJax.Hub.processSectionDelay = 0


### PR DESCRIPTION
Goes along with BE https://github.com/openstax/tutor-server/pull/1534