### PR TITLE
Fix bug with period selection on LMS courses

### DIFF
--- a/tutor/specs/components/__snapshots__/enroll.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/enroll.spec.jsx.snap
@@ -205,9 +205,9 @@ exports[`Student Enrollment select periods matches snapshot 1`] = `
             >
               You are joining
             </p>
-            <h3>
+            <h4>
               My Grand Course
-            </h3>
+            </h4>
           </div>
           <p>
             Please select the section you are a member of
@@ -281,9 +281,9 @@ exports[`Student Enrollment submits with student id when form is clicked 1`] = `
             >
               You are joining
             </p>
-            <h3>
+            <h4>
               
-            </h3>
+            </h4>
           </div>
           <div
             className="sub-title"

--- a/tutor/specs/components/enroll.spec.jsx
+++ b/tutor/specs/components/enroll.spec.jsx
@@ -47,7 +47,8 @@ describe('Student Enrollment', () => {
 
   describe('select periods', () => {
     beforeEach(() => {
-      enrollment.enrollment_code = 'cc3c6ff9-83d8-4375-94be-8c7ae3024938';
+      enrollment.enrollment_code = enrollment.originalEnrollmentCode = 'cc3c6ff9-83d8-4375-94be-8c7ae3024938';
+
       enrollment.onEnrollmentCreate({ data: { name: 'My Grand Course', periods: [
         { name: 'Period #1', enrollment_code: '1234' }, { name: 'Period #2', enrollment_code: '4321' },
       ] } });
@@ -63,7 +64,7 @@ describe('Student Enrollment', () => {
       expect(enroll).toHaveRendered('SelectPeriod');
       enroll.find('.choice').last().simulate('click');
       enroll.find('.btn-primary').simulate('click');
-      expect(enrollment.enrollment_code).toEqual('4321');
+      expect(enrollment.pendingEnrollmentCode).toEqual('4321');
       expect(enrollment.onSubmitPeriod).toHaveBeenCalled();
     });
   });

--- a/tutor/specs/models/courses/enroll.spec.js
+++ b/tutor/specs/models/courses/enroll.spec.js
@@ -63,7 +63,7 @@ describe('Course Enrollment', function() {
     expect(comp.text()).toContain('this enrollment link isn’t valid');
 
     enroll.to.is_lms_enabled = false;
-    enroll.enrollment_code = 'e1e1a822-0985-4b54-b5ab-f0963d98c494';
+    enroll.originalEnrollmentCode = 'e1e1a822-0985-4b54-b5ab-f0963d98c494';
     enroll.courseToJoin = { is_lms_enabled: false };
     expect(enroll.isFromLms).toBe(true);
     expect(enroll.courseIsLmsEnabled).toBe(false);

--- a/tutor/src/components/enroll.jsx
+++ b/tutor/src/components/enroll.jsx
@@ -35,7 +35,7 @@ export default class CourseEnroll extends React.PureComponent {
   enrollment = this.props.enrollment ||
     new Enroll({ enrollment_code: this.enrollmentCode, router: this.context.router });
 
-  componentDidMount() {
+  componentWillMount() {
     this.enrollment.create();
   }
 

--- a/tutor/src/components/enroll/select-periods.js
+++ b/tutor/src/components/enroll/select-periods.js
@@ -18,7 +18,7 @@ export default class SelectPeriod extends React.PureComponent {
         <Modal.Body>
           <div className="title">
             <p className="joining">You are joining</p>
-            <h3>{course.name}</h3>
+            <h4>{course.name}</h4>
           </div>
           <p>Please select the section you are a member of</p>
           <Listing>
@@ -26,8 +26,8 @@ export default class SelectPeriod extends React.PureComponent {
               <Choice key={pr.enrollment_code}
                 record={pr}
                 onClick={enrollment.selectPeriod}
-                active={pr.enrollment_code == enrollment.enrollment_code}
-                >
+                active={pr.enrollment_code == enrollment.pendingEnrollmentCode}
+              >
                 {pr.name}
               </Choice>
             ))}
@@ -35,7 +35,7 @@ export default class SelectPeriod extends React.PureComponent {
         </Modal.Body>
         <Modal.Footer>
           <Button
-            disabled={enrollment.needsPeriodSelection}
+            disabled={!enrollment.periodIsSelected}
             bsStyle="primary"
             className="btn btn-success" onClick={enrollment.onSubmitPeriod}>
             Continue

--- a/tutor/src/components/enroll/student-id.jsx
+++ b/tutor/src/components/enroll/student-id.jsx
@@ -8,7 +8,7 @@ export default function StudentIDForm({ enrollment }) {
       <Modal.Body>
         <div className="title">
           <p className="joining">You are joining</p>
-          <h3>{enrollment.courseName}</h3>
+          <h4>{enrollment.courseName}</h4>
         </div>
 
         <div className="sub-title">Enter your school-issued student ID number *</div>


### PR DESCRIPTION
Previously the period selection would disappear as soon as
a period was clicked and then it would either do a LMS enroll
or a course period one depending on the time of the request