### PR TITLE
Fix infinite recursion on task plan clone

### DIFF
--- a/tutor/src/models/jobs/task-plan-publish.js
+++ b/tutor/src/models/jobs/task-plan-publish.js
@@ -60,7 +60,7 @@ export default class TaskPlanPublish extends Job {
   }
 
   @computed get shouldPoll() {
-    return Boolean(this.plan && this.plan.publish_job_url);
+    return Boolean(this.plan && this.plan.is_publishing && this.plan.publish_job_url);
   }
 
   onPollComplete() {

--- a/tutor/src/models/teacher-task-plans.js
+++ b/tutor/src/models/teacher-task-plans.js
@@ -36,10 +36,10 @@ class CourseTaskPlans extends Map {
     } else {
       tp = new TaskPlan(planAttrs);
     }
-    if (oldId != planAttrs.id) {
+    this.set(planAttrs.id, tp);
+    if (oldId != tp.id) {
       this.delete(oldId);
     }
-    this.set(planAttrs.id, tp);
   }
 
   addClone(planAttrs) {

--- a/tutor/src/models/teacher-task-plans.js
+++ b/tutor/src/models/teacher-task-plans.js
@@ -1,4 +1,4 @@
-import { computed, observable } from 'mobx';
+import { computed, observable, action } from 'mobx';
 import Map from './map';
 import TaskPlan from './task-plan/teacher';
 import { TaskPlanStore } from '../flux/task-plan';
@@ -29,7 +29,7 @@ class CourseTaskPlans extends Map {
     return plan;
   }
 
-  onPlanSave(oldId, planAttrs) {
+  @action onPlanSave(oldId, planAttrs) {
     let tp = this.get(oldId);
     if (tp) {
       tp.update(planAttrs);


### PR DESCRIPTION
When they were cloned we removed them from the map and then re-inserted with the proper id.

Doing so caused the publish job listener to become unobserved and trigger a removal itself.