### PR TITLE
Move teachers notifications bar back where it belongs 

### DIFF
--- a/tutor/specs/components/__snapshots__/course-page.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/course-page.spec.jsx.snap
@@ -50,6 +50,9 @@ exports[`Course Page renders and matches snapshot 2`] = `
         This is a subtitle
       </div>
     </div>
+    <h1>
+      This is a test notice
+    </h1>
     <div
       className="controls-wrapper"
     >

--- a/tutor/specs/components/course-page.spec.jsx
+++ b/tutor/specs/components/course-page.spec.jsx
@@ -27,6 +27,7 @@ describe('Course Page', () => {
       <CoursePage
         {...props}
         title={<Title />}
+        notices={<h1>This is a test notice</h1>}
         subtitle="This is a subtitle"
         controls={<button>Click Me</button>}
       >

--- a/tutor/src/components/course-calendar/index.jsx
+++ b/tutor/src/components/course-calendar/index.jsx
@@ -182,15 +182,16 @@ export default class TeacherTaskPlanListing extends React.PureComponent {
         subtitle={course.termFull}
         course={course}
         controls={this.renderCourseCalendarHeader(courseId, hasPeriods)}
+        notices={
+          <NotificationsBar
+            course={course}
+            role={course.primaryRole}
+            callbacks={NotificationHelpers.buildCallbackHandlers(this)}
+          />
+        }
       >
-        <NotificationsBar
-          course={course}
-          role={course.primaryRole}
-          callbacks={NotificationHelpers.buildCallbackHandlers(this)}
-        />
         <TermsModal />
         <CourseNagModal ux={this.ux} />
-
         <CourseCalendar {...calendarProps} />
       </CoursePage>
     );

--- a/tutor/src/components/course-page.jsx
+++ b/tutor/src/components/course-page.jsx
@@ -12,6 +12,7 @@ export default class CoursePage extends React.PureComponent {
     children: React.PropTypes.node.isRequired,
     controls: React.PropTypes.node,
     title: React.PropTypes.node,
+    notices: React.PropTypes.node,
     subtitle: React.PropTypes.node,
     className: React.PropTypes.string,
   }
@@ -43,6 +44,7 @@ export default class CoursePage extends React.PureComponent {
       >
         <header>
           {this.renderTitle()}
+          {this.props.notices}
           {this.renderControls()}
         </header>
         <div className="body-wrapper">


### PR DESCRIPTION
before:
<img width="1180" alt="screen shot 2017-10-13 at 12 30 13 pm" src="https://user-images.githubusercontent.com/79566/31558420-5ef286d6-b012-11e7-8351-4fe23cf08394.png">


after:
<img width="1181" alt="screen shot 2017-10-13 at 12 29 27 pm" src="https://user-images.githubusercontent.com/79566/31558421-5f0bf8dc-b012-11e7-95cf-cb633523531e.png">
