### PR TITLE
FE hi-pri fixes

### DIFF
--- a/shared/src/factories/link.cjsx
+++ b/shared/src/factories/link.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 {Link} = require 'react-router-dom'
-concat    = require 'lodash/concat'
-
+concat = require 'lodash/concat'
+qs = require 'qs'
 {filterProps} = require '../helpers/react'
 filterPropsBase = filterProps
 
@@ -27,7 +27,8 @@ make = (router, name = 'OpenStax') ->
 
       to =
         pathname: pathname or to
-        query: query
+      if query
+        to.search = qs.stringify(query)
 
       # TODO see about isActive
       <Link to={to} {...filterProps(@props)} />

--- a/tutor/api/user/courses/1.json
+++ b/tutor/api/user/courses/1.json
@@ -5,6 +5,11 @@
   "ecosystem_id": "1",
   "is_concept_coach": false,
   "is_college": false,
+  "roles": [{
+    "id": "1",
+    "type": "teacher",
+    "joined_at": "2016-02-03T01:10:10.125Z"
+  }],
   "periods": [{
     "id": "1",
     "name" : "1st",

--- a/tutor/resources/styles/components/payments.less
+++ b/tutor/resources/styles/components/payments.less
@@ -109,3 +109,9 @@
     }
   }
 }
+
+.payments-panel {
+  .error-message {
+    padding: 20px;
+  }
+}

--- a/tutor/resources/styles/components/task-plan/index.less
+++ b/tutor/resources/styles/components/task-plan/index.less
@@ -10,6 +10,7 @@
 @import './teacher-task-plans-listing';
 @import './controls';
 
+
 .task-plan {
   .panel-default {
     border: none;
@@ -17,6 +18,13 @@
 
   .panel-heading {
     border-bottom: none;
+    height: 50px;
+    display: flex;
+    align-items: center;
+    button.close {
+      top: 0;
+      transistion: opacity 0.3s;
+    }
   }
 
   .select-topics {

--- a/tutor/specs/components/__snapshots__/enroll.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/enroll.spec.jsx.snap
@@ -35,7 +35,7 @@ exports[`Student Enrollment blocks teacher enrollment 1`] = `
           <p>
             Contact 
             <a
-              href="mailto:support@openstaxtutor.org"
+              href="mailto:support@openstax.org"
             >
               Support
             </a>

--- a/tutor/specs/components/__snapshots__/my-courses.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/my-courses.spec.jsx.snap
@@ -1,0 +1,191 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`My Courses Component matches snapshot 1`] = `
+<div
+  className="my-courses"
+  data-tour-region-id="my-courses"
+>
+  <div
+    className="my-courses-current"
+  >
+    <div
+      className="container"
+    >
+      <div
+        className="my-courses-title row"
+      >
+        <div
+          className="col-md-12"
+        >
+          <h1>
+            Current Courses
+          </h1>
+        </div>
+      </div>
+      <div
+        className="my-courses-section my-courses-current-section row"
+      >
+        <div
+          className="col-md-3 col-sm-6 col-xs-12"
+        >
+          <div
+            className="my-courses-item-wrapper"
+          >
+            <div
+              className="my-courses-item"
+              data-appearance="testing"
+              data-book-title="Testing"
+              data-course-course-type="tutor"
+              data-course-id="2"
+              data-is-preview={false}
+              data-is-teacher={true}
+              data-term="Spring 2017"
+              data-title="Local Test Course Two"
+            >
+              <div
+                className="my-courses-item-title"
+              >
+                <a
+                  href="/course/2"
+                  onClick={[Function]}
+                >
+                  Local Test Course Two
+                </a>
+              </div>
+              <div
+                className="my-courses-item-details"
+                data-has-controls={false}
+              >
+                <a
+                  href="/course/2"
+                  onClick={[Function]}
+                >
+                  <p
+                    className="course-branding my-courses-item-brand"
+                    data-is-beta={true}
+                  >
+                    OpenStax Tutor
+                  </p>
+                  <p
+                    className="my-courses-item-term"
+                  >
+                    Spring
+                     
+                    2017
+                  </p>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="col-md-3 col-sm-6 col-xs-12"
+        >
+          <div
+            className="my-courses-item-wrapper"
+          >
+            <div
+              className="my-courses-item"
+              data-appearance="testing"
+              data-book-title="Testing"
+              data-course-course-type="tutor"
+              data-course-id="1"
+              data-is-preview={false}
+              data-is-teacher={false}
+              data-term="Spring 2017"
+              data-title="Local Test Course One"
+            >
+              <div
+                className="my-courses-item-title"
+              >
+                <a
+                  href="/course/1"
+                  onClick={[Function]}
+                >
+                  Local Test Course One
+                </a>
+              </div>
+              <div
+                className="my-courses-item-details"
+                data-has-controls={false}
+              >
+                <a
+                  href="/course/1"
+                  onClick={[Function]}
+                >
+                  <p
+                    className="course-branding my-courses-item-brand"
+                    data-is-beta={true}
+                  >
+                    OpenStax Tutor
+                  </p>
+                  <p
+                    className="my-courses-item-term"
+                  >
+                    Spring
+                     
+                    2017
+                  </p>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="col-md-3 col-sm-6 col-xs-12"
+        >
+          <div
+            className="my-courses-item-wrapper"
+          >
+            <div
+              className="my-courses-item"
+              data-appearance="testing"
+              data-book-title="Testing"
+              data-course-course-type="tutor"
+              data-course-id="3"
+              data-is-preview={false}
+              data-is-teacher={true}
+              data-term="Spring 2017"
+              data-title="Local Test Course Three"
+            >
+              <div
+                className="my-courses-item-title"
+              >
+                <a
+                  href="/course/3"
+                  onClick={[Function]}
+                >
+                  Local Test Course Three
+                </a>
+              </div>
+              <div
+                className="my-courses-item-details"
+                data-has-controls={false}
+              >
+                <a
+                  href="/course/3"
+                  onClick={[Function]}
+                >
+                  <p
+                    className="course-branding my-courses-item-brand"
+                    data-is-beta={true}
+                  >
+                    OpenStax Tutor
+                  </p>
+                  <p
+                    className="my-courses-item-term"
+                  >
+                    Spring
+                     
+                    2017
+                  </p>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/tutor/specs/components/change-student-id.spec.jsx
+++ b/tutor/specs/components/change-student-id.spec.jsx
@@ -10,7 +10,7 @@ describe('Change Student ID', () => {
   let params, courses, context;
 
   beforeEach(() => {
-    context = EnzymeContext.build()
+    context = EnzymeContext.build();
     params = { courseId: '1' };
     courses = bootstrapCoursesList();
     Router.currentParams.mockReturnValue(params);
@@ -22,13 +22,14 @@ describe('Change Student ID', () => {
   });
 
   it('updates student id when edited', () => {
-    const form = mount(<ChangeStudentId />, context);
     const course = courses.get(params.courseId);
-    course.userStudentRecord.save = jest.fn(() => Promise.resolve({}));
+    course.userStudentRecord.saveOwnStudentId = jest.fn(() => Promise.resolve({}));
+    const form = mount(<ChangeStudentId />, context);
     form.find('input').get(0).value = '4252';
     form.find('.btn-primary').simulate('click');
     expect(course.userStudentRecord.student_identifier).toEqual('4252');
-    expect(course.userStudentRecord.save).toHaveBeenCalled();
+    expect(course.userStudentRecord.saveOwnStudentId).toHaveBeenCalled();
+    form.unmount();
   });
 
   it('navigates to dashboard when clicked', () => {

--- a/tutor/specs/components/my-courses.spec.jsx
+++ b/tutor/specs/components/my-courses.spec.jsx
@@ -21,18 +21,29 @@ describe('My Courses Component', function() {
     User.self_reported_role = '';
   });
 
-  it('renders the listing', function() {
+  it('matches snapshot', function() {
+    const component = SnapShot.create(
+      <Wrapper _wrapped_component={CourseListing} noReference />
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+    component.unmount();
+  });
+
+  it('renders the listing sorted', function() {
     const wrapper = mount(<CourseListing />, EnzymeContext.withDnD());
     for (let i = 0; i < MASTER_COURSES_LIST.length; i++) {
       const course = MASTER_COURSES_LIST[i];
       expect(wrapper).toHaveRendered(`.my-courses [data-course-id='${course.id}']`);
     }
+    wrapper.unmount();
   });
 
   it('renders the listing without archived courses', function() {
     Courses.bootstrap(flatten([MASTER_COURSES_LIST, STUDENT_ARCHIVED_COURSE]), { clear: true });
     const wrapper = shallow(<CourseListing />, EnzymeContext.withDnD());
     expect(wrapper).not.toHaveRendered(`CourseLink[courseId='${STUDENT_ARCHIVED_COURSE.id}']`);
+    wrapper.unmount();
   });
 
   it('renders add course action if user is teacher', function() {
@@ -40,6 +51,7 @@ describe('My Courses Component', function() {
     const wrapper = mount(<CourseListing />, EnzymeContext.withDnD());
     expect(User.isConfirmedFaculty).toBeTruthy();
     expect(wrapper).toHaveRendered('.my-courses-add-zone');
+    wrapper.unmount();
   });
 
   it('renders controls for course if user is teacher of course', function() {
@@ -51,6 +63,7 @@ describe('My Courses Component', function() {
         expect(wrapper).toHaveRendered(`[data-course-id='${course.id}'] .my-courses-item-controls`);
       }
     }
+    wrapper.unmount();
   });
 
   it('does not render controls for course if user is student of course', function() {
@@ -62,6 +75,7 @@ describe('My Courses Component', function() {
         expect(wrapper).not.toHaveRendered(`[data-course-id='${course.id}'] .my-courses-item-controls`);
       }
     }
+    wrapper.unmount();
   });
 
   it('renders past courses in past courses listing', function() {
@@ -103,6 +117,7 @@ describe('My Courses Component', function() {
     User.self_reported_role = 'instructor';
     const wrapper = shallow(<CourseListing />, EnzymeContext.withDnD());
     expect(wrapper).toHaveRendered('PendingVerification');
+    wrapper.unmount();
   });
 
   it('displays popover help for verified instructor without courses', () => {
@@ -110,5 +125,6 @@ describe('My Courses Component', function() {
     loadTeacherUser();
     const wrapper = mount(<CourseListing />, EnzymeContext.withDnD());
     expect(wrapper).toHaveRendered('[data-tour-anchor-id="create-course-zone"]');
+    wrapper.unmount();
   });
 });

--- a/tutor/specs/components/new-course/__snapshots__/course-numbers.spec.jsx.snap
+++ b/tutor/specs/components/new-course/__snapshots__/course-numbers.spec.jsx.snap
@@ -137,7 +137,7 @@ exports[`CreateCourse: entering details updates values when edited 1`] = `
     sections
      is not supported. Need more? 
     <a
-      href="mailto:support@openstaxtutor.org"
+      href="mailto:support@openstax.org"
     >
       Contact Support
     </a>

--- a/tutor/specs/components/questions/__snapshots__/dashboard.spec.cjsx.snap
+++ b/tutor/specs/components/questions/__snapshots__/dashboard.spec.cjsx.snap
@@ -18,7 +18,7 @@ exports[`Questions Dashboard Component matches snapshot 1`] = `
         </h2>
         <a
           className="btn btn-default"
-          href="/"
+          href="/course/1"
           onClick={[Function]}
         >
           Back to Dashboard

--- a/tutor/specs/courses-test-data.coffee
+++ b/tutor/specs/courses-test-data.coffee
@@ -17,9 +17,11 @@ STUDENT_COURSE_ONE_MODEL = {
   ends_at: moment().add(1, 'month').format(),
   webview_url: 'http://cnx.org/',
   salesforce_book_name: 'a book title',
-  roles: [
-    { "id": "1", "type": "student" }
-  ],
+  roles: [{
+    id: "1",
+    type: "student",
+    joined_at: moment().subtract(1, 'week').format()
+  }],
   students: [
     {
        role_id: "1", student_identifier: '1234', uuid: "06fc16fc-70f5-4db1-a61d-b0f496cf3cd4"
@@ -47,11 +49,11 @@ TEACHER_COURSE_TWO_MODEL = {
     id: "1", name : "1st", enrollment_url: "http://test/period/1", default_open_time: "07:01",
     default_due_time: "12:00", is_archived: false
   }]
-  roles: [
-    {
-      "type": "teacher"
-    }
-  ]
+  roles: [{
+    id: "1",
+    type: "teacher",
+    joined_at: moment().subtract(2, 'week').format()
+  }]
 }
 
 TEACHER_AND_STUDENT_COURSE_THREE_MODEL = {
@@ -66,14 +68,22 @@ TEACHER_AND_STUDENT_COURSE_THREE_MODEL = {
   term: 'Spring'
   starts_at: moment().subtract(1, 'month').format(),
   ends_at: moment().add(1, 'month').format(),
-  roles: [
+  roles: [{
+    id: "1",
+    type: "student",
+    joined_at: moment().subtract(1, 'week').format()
+  }, {
+    id: "2",
+    type: "teacher",
+    joined_at: moment().subtract(1, 'week').format()
+  }]
+  students: [
     {
-      type: 'student'
-    }
-    {
-      type: 'teacher'
+       role_id: "1", student_identifier: '1234', uuid: "06fc16fc-70f5-4db1-a61d-b0f496cf3cd4"
+       is_paid: false, is_comped: false, is_active: true, first_name: 'Test', last_name: 'Tester',
     }
   ]
+
 }
 
 STUDENT_ARCHIVED_COURSE = {
@@ -90,7 +100,11 @@ STUDENT_ARCHIVED_COURSE = {
   ends_at: moment().add(1, 'month').format(),
   webview_url: 'http://cnx.org/',
   salesforce_book_name: 'a book title',
-  roles: []
+  roles: [{
+    id: "1",
+    type: "student",
+    joined_at: moment().subtract(1, 'week').format()
+  }]
 }
 
 TEACHER_PAST_COURSE = {
@@ -107,11 +121,11 @@ TEACHER_PAST_COURSE = {
   ends_at: moment().subtract(1, 'month').format(),
   webview_url: 'http://cnx.org/',
   salesforce_book_name: 'a book title',
-  roles: [
-    {
-      type: 'teacher'
-    }
-  ]
+  roles: [{
+    id: "1",
+    type: "teacher",
+    joined_at: moment().subtract(1, 'week').format()
+  }]
 }
 
 STUDENT_PAST_COURSE = {
@@ -128,11 +142,11 @@ STUDENT_PAST_COURSE = {
   ends_at: moment().subtract(1, 'month').format(),
   webview_url: 'http://cnx.org/',
   salesforce_book_name: 'a book title',
-  roles: [
-    {
-      type: 'teacher'
-    }
-  ]
+  roles: [{
+    id: "1",
+    type: "student",
+    joined_at: moment().subtract(1, 'week').format()
+  }]
 }
 
 MASTER_COURSES_LIST = [

--- a/tutor/specs/models/course.spec.js
+++ b/tutor/specs/models/course.spec.js
@@ -6,18 +6,10 @@ import PH from '../../src/helpers/period';
 import { autorun } from 'mobx';
 import { bootstrapCoursesList } from '../courses-test-data';
 
-import { observable, extendObservable, computed } from 'mobx';
-
 import COURSE from '../../api/courses/1.json';
 
-import TeacherTaskPlans from '../../src/models/course/task-plans';
 jest.mock('shared/src/model/ui-settings');
-// jest.mock('../../src/models/course/task-plans', () => ({
-//   forCourseId: jest.fn(() => ({
-//     reading:  { hasPublishing: false },
-//     homework: { hasPublishing: false },
-//   })),
-// }));
+
 describe('Course Model', () => {
 
   beforeEach(() => bootstrapCoursesList());
@@ -59,7 +51,9 @@ describe('Course Model', () => {
     const course = Courses.get(3);
     expect(course.tourAudienceTags).toEqual(['teacher', 'student']);
     course.is_preview = false;
-    course.taskPlans.set('1', { id: 1, type: 'reading', is_publishing: true });
+    expect(course.isTeacher).toEqual(true);
+    course.taskPlans.set('1', { id: 1, type: 'reading', is_publishing: true, isPublishing: true });
+    expect(course.taskPlans.reading.hasPublishing).toEqual(true);
     expect(course.tourAudienceTags).toEqual(['teacher', 'teacher-reading-published', 'student' ]);
   });
 
@@ -127,4 +121,5 @@ describe('Course Model', () => {
     expect(PH.sort).toHaveBeenCalledTimes(3);
     expect(sortedSpy).toHaveBeenCalledTimes(2);
   });
+
 });

--- a/tutor/specs/models/course.spec.js
+++ b/tutor/specs/models/course.spec.js
@@ -3,8 +3,6 @@ import Courses from '../../src/models/courses-map';
 import Course from '../../src/models/course';
 import PH from '../../src/helpers/period';
 
-//jest.mock('../../src/helpers/period');
-
 import { autorun } from 'mobx';
 import { bootstrapCoursesList } from '../courses-test-data';
 
@@ -14,12 +12,12 @@ import COURSE from '../../api/courses/1.json';
 
 import TeacherTaskPlans from '../../src/models/course/task-plans';
 jest.mock('shared/src/model/ui-settings');
-jest.mock('../../src/models/course/task-plans', () => ({
-  forCourseId: jest.fn(() => ({
-    reading:  { hasPublishing: false },
-    homework: { hasPublishing: false },
-  })),
-}));
+// jest.mock('../../src/models/course/task-plans', () => ({
+//   forCourseId: jest.fn(() => ({
+//     reading:  { hasPublishing: false },
+//     homework: { hasPublishing: false },
+//   })),
+// }));
 describe('Course Model', () => {
 
   beforeEach(() => bootstrapCoursesList());
@@ -55,18 +53,14 @@ describe('Course Model', () => {
   it('calculates audience tags', () => {
     expect(Courses.get(1).tourAudienceTags).toEqual(['student']);
     const teacher = Courses.get(2);
-    // expect(teacher.tourAudienceTags).toEqual(['teacher']);
-    // teacher.is_preview = true;
-    // expect(teacher.tourAudienceTags).toEqual(['teacher-preview']);
-    // const course = Courses.get(3);
-    // expect(course.tourAudienceTags).toEqual(['teacher', 'student']);
-    // course.is_preview = false;
-
-    // TeacherTaskPlans.forCourseId.mockImplementation(() => ({
-    //   reading: { hasPublishing: true },
-    //   homework: { hasPublishing: false },
-    // }));
-    // expect(course.tourAudienceTags).toEqual(['teacher', 'teacher-reading-published', 'student' ]);
+    expect(teacher.tourAudienceTags).toEqual(['teacher']);
+    teacher.is_preview = true;
+    expect(teacher.tourAudienceTags).toEqual(['teacher-preview']);
+    const course = Courses.get(3);
+    expect(course.tourAudienceTags).toEqual(['teacher', 'student']);
+    course.is_preview = false;
+    course.taskPlans.set('1', { id: 1, type: 'reading', is_publishing: true });
+    expect(course.tourAudienceTags).toEqual(['teacher', 'teacher-reading-published', 'student' ]);
   });
 
 

--- a/tutor/specs/models/courses/onboarding/base.spec.js
+++ b/tutor/specs/models/courses/onboarding/base.spec.js
@@ -13,8 +13,9 @@ describe('Course Onboarding base class', () => {
   });
 
   it('#courseIsNaggable', () => {
+    ux.course.roles[0].joined_at = moment().subtract(1, 'hours');
     expect(ux.courseIsNaggable).toBe(false);
-    ux.course.primaryRole.joined_at = moment().subtract(4, 'hours').subtract(1, 'second');
+    ux.course.roles[0].joined_at = moment().subtract(4, 'hours').subtract(1, 'second');
     expect(ux.courseIsNaggable).toBe(true);
     ux.course.ends_at = moment().subtract(1, 'day');
     expect(ux.courseIsNaggable).toBe(false);

--- a/tutor/specs/models/courses/scores.spec.js
+++ b/tutor/specs/models/courses/scores.spec.js
@@ -115,6 +115,11 @@ describe('scores store', function() {
     expect(period.overall_average_score).closeTo(0.2222, 0.0001);
   });
 
+  it('can get task by id', () => {
+    const task = Courses.get(COURSE_ID).scores.getTask('17');
+    expect(task.id).toEqual(COMPLETED_TASK_ID);
+  });
+
   it('resets properties after a rejection', function() {
     let task = gT(PARTIALLY_WORKED_LATE_TASK_ID);
 

--- a/tutor/src/api/index.coffee
+++ b/tutor/src/api/index.coffee
@@ -192,6 +192,7 @@ startAPI = ->
       end_at: endAt
   )
 
+  connectModelUpdate(Student, 'saveOwnStudentId', pattern: 'user/courses/{course.id}/student', onSuccess: 'onApiRequestComplete')
   connectModelUpdate(Student, 'saveStudentId', pattern: 'students/{id}', onSuccess: 'onApiRequestComplete')
   connectModelUpdate(Student, 'savePeriod', pattern: 'students/{id}', onSuccess: 'onApiRequestComplete')
   connectModelDelete(Student, 'drop', pattern: 'students/{id}', onSuccess: 'onApiRequestComplete' )

--- a/tutor/src/components/book-content-mixin.cjsx
+++ b/tutor/src/components/book-content-mixin.cjsx
@@ -99,7 +99,7 @@ LinkContentMixin =
     mediaCNXId = @getCnxIdOfHref(link.getAttribute('href')) or @props.cnxId or @getCnxId?()
     previewNode = document.createElement('span')
     previewNode.classList.add('media-preview-wrapper')
-    link.parentNode.replaceChild(previewNode, link)
+    link.parentNode?.replaceChild(previewNode, link)
 
     mediaProps =
       mediaId: mediaId
@@ -237,7 +237,7 @@ sizeImage = ->
   aspectRatio = @naturalWidth / @naturalHeight
 
   # let wide, square, and almost square figures be natural.
-  if aspectRatio > 0.9 or figure.parentNode.dataset.orient is 'horizontal'
+  if aspectRatio > 0.9 or figure.parentNode?.dataset.orient is 'horizontal'
     figure.classList.add('tutor-ui-horizontal-img')
     if @naturalWidth > 450 and figure.parentNode?.nodeName isnt 'FIGURE'
       figure.classList.add('full-width')

--- a/tutor/src/components/book-content-mixin.cjsx
+++ b/tutor/src/components/book-content-mixin.cjsx
@@ -170,7 +170,7 @@ ReadingContentMixin =
     @updateCanonicalLink()
 
   updateCanonicalLink: ->
-    cnxId = @props.cnxId or @getCnxId?()
+    cnxId = @props.cnxId or @getCnxId?() or ''
     # leave versioning out of canonical link
     canonicalCNXId = _.first(cnxId.split('@'))
     {courseId} = Router.currentParams()

--- a/tutor/src/components/change-student-id.jsx
+++ b/tutor/src/components/change-student-id.jsx
@@ -33,7 +33,7 @@ export default class ChangeStudentId extends React.PureComponent {
   @action.bound
   onSubmit() {
     this.student.student_identifier = this.input.value;
-    this.student.save().then(this.onSaved);
+    this.student.saveOwnStudentId().then(this.onSaved);
   }
 
   @action.bound

--- a/tutor/src/components/course-roster/index.jsx
+++ b/tutor/src/components/course-roster/index.jsx
@@ -92,38 +92,32 @@ export default class CourseRoster extends React.PureComponent {
         course={course}
         controls={this.renderControls(course)}
       >
-        <TourRegion
-          id="course-settings"
-          otherTours={['course-settings-preview']}
-          courseId={course.id}
-        >
-          <div className="settings-section teachers">
-            <TeacherRoster course={course} />
-          </div>
+        <div className="settings-section teachers">
+          <TeacherRoster course={course} />
+        </div>
 
-          <div className="roster">
-            <div className="settings-section periods">
-              <Tabs ref="tabs" tabs={map(periods, 'name')} onSelect={this.onTabSelection}>
-                <AddPeriodLink show={false} course={course} />
-                <ViewArchivedPeriods course={course} onComplete={this.selectPreviousPeriod} />
-              </Tabs>
-              <div className="active-period">
-                <div className="period-edit-controls">
-                  <span className="spacer" />
-                  <RenamePeriodLink course={course} period={activePeriod} />
-                  <DeletePeriodLink
-                    course={course}
-                    period={activePeriod}
-                    onDelete={this.selectPreviousPeriod} />
-                </div>
-
-                <StudentRoster period={activePeriod} />
-
-                <DroppedRoster course={course} />
+        <div className="roster">
+          <div className="settings-section periods">
+            <Tabs ref="tabs" tabs={map(periods, 'name')} onSelect={this.onTabSelection}>
+              <AddPeriodLink show={false} course={course} />
+              <ViewArchivedPeriods course={course} onComplete={this.selectPreviousPeriod} />
+            </Tabs>
+            <div className="active-period">
+              <div className="period-edit-controls">
+                <span className="spacer" />
+                <RenamePeriodLink course={course} period={activePeriod} />
+                <DeletePeriodLink
+                  course={course}
+                  period={activePeriod}
+                  onDelete={this.selectPreviousPeriod} />
               </div>
+
+              <StudentRoster period={activePeriod} />
+
+              <DroppedRoster course={course} />
             </div>
           </div>
-        </TourRegion>
+        </div>
       </CoursePage>
     );
   }

--- a/tutor/src/components/exercises/details.cjsx
+++ b/tutor/src/components/exercises/details.cjsx
@@ -110,6 +110,7 @@ ExerciseDetails = React.createClass
           isBackwardEnabled={moves.prev}
           onForwardNavigation={@onNext}
           onBackwardNavigation={@onPrev}
+          scrollOnNavigation={false}
         >
           <ExercisePreview
             className='exercise-card'

--- a/tutor/src/components/paging-navigation.jsx
+++ b/tutor/src/components/paging-navigation.jsx
@@ -6,7 +6,7 @@ import Icon from './icon';
 import Arrow from './icons/arrow';
 import { observable, action } from 'mobx';
 import { observer } from 'mobx-react';
-
+import ScrollTo from '../helpers/scroll-to';
 const KEYBINDING_SCOPE  = 'page-navigation';
 
 @observer
@@ -22,6 +22,7 @@ export default class PagingNavigation extends React.PureComponent {
     forwardHref:          React.PropTypes.string,
     backwardHref:         React.PropTypes.string,
     enableKeys:           React.PropTypes.bool,
+    scrollOnNavigation:   React.PropTypes.bool,
     titles:               React.PropTypes.shape({
       next:     React.PropTypes.string,
       current:  React.PropTypes.string,
@@ -33,6 +34,7 @@ export default class PagingNavigation extends React.PureComponent {
   }
 
   static defaultProps = {
+    scrollOnNavigation: true,
     enableKeys: true,
     forwardHref: '#',
     backwardHref: '#',
@@ -45,6 +47,7 @@ export default class PagingNavigation extends React.PureComponent {
 
   @observable activeNav;
   @observable pendingTimeOut;
+  scrollTo = new ScrollTo();
 
   componentWillMount() {
     if (this.props.enableKeys) { this.enableKeys(); }
@@ -109,10 +112,13 @@ export default class PagingNavigation extends React.PureComponent {
     }
   }
 
+  @action.bound
   clickHandler(action, href, ev) {
     ev.preventDefault();
     if (isFunction(action)) { action(href); }
-    window.scrollTo(0,0);
+    if (this.props.scrollOnNavigation) {
+      this.scrollTo.scrollToTop();
+    }
   }
 
   renderPrev() {

--- a/tutor/src/components/plan-stats/progress.jsx
+++ b/tutor/src/components/plan-stats/progress.jsx
@@ -1,9 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * DS207: Consider shorter variations of null checks
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { map, partial } from 'lodash';
@@ -20,20 +14,7 @@ export default class Progress extends React.PureComponent {
     activeSection: React.PropTypes.string,
   }
 
-  _calculatePercent(num, total) {
-    return Math.round((num / total) * 100);
-  }
-
-  calculatePercent(data, correctOrIncorrect) {
-    if (correctOrIncorrect == null) { correctOrIncorrect = 'correct'; }
-    const count = correctOrIncorrect + '_count';
-
-    const total_count = data.correct_count + data.incorrect_count;
-    return total_count ? this._calculatePercent(data[count], total_count) : 0;
-  }
-
   renderPercentBar(data, type, percent, correctOrIncorrect) {
-    let correct;
     let classes = 'reading-progress-bar';
     classes += ` progress-bar-${correctOrIncorrect}`;
     if (!percent) { classes += ' no-progress'; }
@@ -55,16 +36,15 @@ export default class Progress extends React.PureComponent {
   renderPercentBars() {
     const { data, type } = this.props;
 
-    const percents = {
-      correct: this.calculatePercent(data, 'correct'),
-      incorrect: this.calculatePercent(data, 'incorrect'),
-    };
-
-    // make sure percents add up to 100
-    if ((percents.incorrect + percents.correct) > 100) {
+    const total_count = data.correct_count + data.incorrect_count;
+    const correct = total_count ? Math.round((data.correct_count / total_count) * 100) : 0;
+    const percents = {};
+    if (correct >=5) {
+      percents.correct = correct;
+    }
+    if (correct < 95) {
       percents.incorrect = 100 - percents.correct;
     }
-
     return map(percents, partial(this.renderPercentBar, data, type));
   }
 

--- a/tutor/src/components/questions/sections-chooser.cjsx
+++ b/tutor/src/components/questions/sections-chooser.cjsx
@@ -36,8 +36,9 @@ QLSectionsChooser = React.createClass
       <div className="header">
         <div className="wrapper">
           <h2>Question Library</h2>
+
           <BackButton fallbackLink={
-            text: 'Back to Dashboard', to: 'viewTeacherDashBoard', params: {courseId: @props.courseId}
+            text: 'Back to Dashboard', to: 'dashboard', params: {courseId: @props.courseId}
           }/>
         </div>
       </div>

--- a/tutor/src/components/task-plan/plan-mixin.cjsx
+++ b/tutor/src/components/task-plan/plan-mixin.cjsx
@@ -144,25 +144,18 @@ PlanMixin =
   # TODO move to helper type thing.
   getBackToCalendarParams: ->
     {id, courseId} = @props
-    calendarRoute = 'calendarByDate'
     dueAt = TaskingStore.getFirstDueDate(id) or @context.router.getCurrentQuery().due_at
     if dueAt?
       date = dueAt
     else
       date = TimeStore.getNow()
-
     date = moment(date).format(CALENDAR_DATE_FORMAT)
-
-    unless TaskPlanStore.isNew(id) or TaskPlanStore.isPublishing(id) or TaskPlanStore.isDeleteRequested(id)
-      calendarRoute = 'calendarViewPlanStats'
-      planId = id
-
-    to: calendarRoute
-    params: {courseId, date, planId}
+    {courseId, date}
 
   goBackToCalendar: ->
-    {to, params} = @getBackToCalendarParams()
-    @context.router.history.push(Router.makePathname(to, params))
+    @context.router.history.push(
+      Router.makePathname('calendarByDate', @getBackToCalendarParams())
+    )
 
   builderHeader: (type, label = 'Assignment') ->
     {id} = @props

--- a/tutor/src/components/task/index.cjsx
+++ b/tutor/src/components/task/index.cjsx
@@ -197,10 +197,8 @@ Task = React.createClass
 
     @scrollToTop() unless @_isSameStep({id}, {currentStep: stepKey})
 
-    if silent
-      @context.router.replaceWith(Router.makePathname('viewTaskStep', params))
-    else
-      @context.router.history.push(Router.makePathname('viewTaskStep', params))
+    action = if silent then 'replace' else 'push'
+    @context.router.history[action](Router.makePathname('viewTaskStep', params))
 
     true
 

--- a/tutor/src/components/task/viewing-as-student-name.cjsx
+++ b/tutor/src/components/task/viewing-as-student-name.cjsx
@@ -18,7 +18,8 @@ ViewingAsStudentName = React.createClass
 
   getStudentState: (props) ->
     {courseId, taskId} = props or @props
-    Courses.get(courseId).scores.getTask(taskId).student
+    task = Courses.get(courseId).scores.getTask(taskId)
+    if task then { student: task.student } else {}
 
   updateStudent: (props) ->
     props ?= @props
@@ -27,10 +28,9 @@ ViewingAsStudentName = React.createClass
   componentWillMount: ->
     {courseId, taskId} = @props
     {student} = @state
-
-    unless student?
-      ScoresStore.once('change', @updateStudent)
-      ScoresActions.load(courseId)
+    scores = Courses.get(courseId).scores
+    unless student? or scores.api.hasBeenFetched
+      scores.fetch().then(=> @updateStudent())
 
   componentWillReceiveProps: (nextProps) ->
     @updateStudent(nextProps)
@@ -38,7 +38,6 @@ ViewingAsStudentName = React.createClass
   render: ->
     {className} = @props
     studentName = null
-
     className = classnames className, 'task-student'
     {student} = @state
 

--- a/tutor/src/flux/transition.coffee
+++ b/tutor/src/flux/transition.coffee
@@ -37,7 +37,8 @@ TransitionStore = flux.createStore
     @_local
 
   exports:
-    getPrevious: (current = window.location.pathname) ->
+    getPrevious: (current) ->
+      current = window.document?.location unless current
       for path in @_local by -1
         if path isnt current
           return {path, name: DestinationHelper.destinationFromPath(path)}

--- a/tutor/src/helpers/policies/utils.coffee
+++ b/tutor/src/helpers/policies/utils.coffee
@@ -2,8 +2,8 @@ _ = require 'underscore'
 
 policies = require './policies'
 {TaskStore} = require '../../flux/task'
-User = require('../../models/user').default
-
+{default: Courses} = require '../../models/courses-map'
+Router = require '../router'
 DEFAULT = 'default'
 
 utils =
@@ -13,7 +13,10 @@ utils =
 
     state
 
-  _role: -> User.viewing_course_role
+  _role: ->
+    { courseId } = Router.currentParams()
+    course = Courses.get(courseId)
+    if course then course.primaryRole.type else 'unknown'
 
   _checkQuestionFormat: (task, step, panel) ->
     # assuming 1 question right now

--- a/tutor/src/models/course.js
+++ b/tutor/src/models/course.js
@@ -74,6 +74,10 @@ export default class Course extends BaseModel {
     this.map = map;
   }
 
+  @computed get sortKey() {
+    return this.primaryRole.joined_at;
+  }
+
   @computed get num_enrolled_students() {
     return sumBy(this.periods, 'num_enrolled_students');
   }

--- a/tutor/src/models/course/scores.js
+++ b/tutor/src/models/course/scores.js
@@ -70,11 +70,12 @@ export default class CourseScores extends BaseModel {
   }
 
   getTask(taskId) {
+    const id = Number(taskId);
     const periods = this.periods.values();
     for(let p=0; p < periods.length; p+=1) {
       const period = periods[p];
       for(let i=0; i < period.students.length; i +=1 ){
-        const task = find(period.students[i].data, { id: taskId });
+        const task = find(period.students[i].data, { id });
         if (task) return task;
       }
     }

--- a/tutor/src/models/course/student.js
+++ b/tutor/src/models/course/student.js
@@ -90,5 +90,8 @@ export default class CourseStudent extends BaseModel {
   saveStudentId() {
     return { id: this.id, data: pick(this, 'student_identifier') };
   }
+  saveOwnStudentId() {
+    return { id: this.id, data: pick(this, 'student_identifier') };
+  }
 
 }

--- a/tutor/src/models/course/task-plans.js
+++ b/tutor/src/models/course/task-plans.js
@@ -1,4 +1,5 @@
 import { computed, observable, action } from 'mobx';
+import { find } from 'lodash';
 import Map from '../map';
 import TaskPlan from '../task-plan/teacher';
 
@@ -52,11 +53,11 @@ export default class CourseTaskPlans extends Map {
   }
 
   @computed get isPublishing() {
-    return this.where(plan => plan.is_publishing);
+    return this.where(plan => plan.isPublishing);
   }
 
   @computed get hasPublishing() {
-    return this.isPublishing.any;
+    return Boolean(find(this.array, 'isPublishing'));
   }
 
   @computed get reading() {

--- a/tutor/src/models/courses-map.js
+++ b/tutor/src/models/courses-map.js
@@ -1,17 +1,14 @@
 import Map from './map';
 import { computed, action } from 'mobx';
 import Course from './course';
-import { once, isEmpty } from 'lodash';
-//
-// function onCourseSave(courseData) {
-//   coursesMap.get(courseData.id).update(courseData);
-// }
-//
-// function onLoaded(courseData) {
-//   courseData.forEach(cd => coursesMap.set(String(cd.id), new Course(cd, this)));
-// }
-//
+import { isEmpty, sortBy } from 'lodash';
+
 class CoursesMap extends Map {
+
+  // override array in Map to return a sorted list
+  @computed get array() {
+    return sortBy(this.values(), 'sortKey');
+  }
 
   @computed get active() {
     return this.where(c => c.is_active);

--- a/tutor/src/models/payments.js
+++ b/tutor/src/models/payments.js
@@ -116,7 +116,7 @@ export default class Payments extends BaseModel {
     return extend({}, this.options, {
       product_uuid: Payments.config.product_uuid,
       purchaser_account_uuid: User.account_uuid,
-      product_end_date: course.ends_at,
+      product_end_date: new Date(course.ends_at),
       product_instance_uuid: course.userStudentRecord.uuid,
       course_uuid: course.uuid,
     });

--- a/tutor/src/models/user/menu.js
+++ b/tutor/src/models/user/menu.js
@@ -123,7 +123,7 @@ const TUTOR_CONTACT = 'http://openstax.force.com/support/?cu=1&fs=ContactUs&l=en
 const CONCEPT_COACH_HELP = 'http://openstax.force.com/support?l=en_US&c=Products%3AConcept_Coach';
 const CONCEPT_COACH_CONTACT = 'http://openstax.force.com/support/?cu=1&fs=ContactUs&l=en_US&c=Products%3AConcept_Coach';
 
-const SUPPORT_EMAIL = 'support@openstaxtutor.org';
+const SUPPORT_EMAIL = 'support@openstax.org';
 
 function getRouteByRole(routeName, menuRole) {
   if (!ROUTES[routeName].roles) { return routeName; }


### PR DESCRIPTION
Fixes:
 * [x] Teacher viewing student tasks
 * [x] Remove "Page tips" option from roster since there was no page tips on that page
 * [x] Remove stray "0" that appeared at end of progress bars on quick look metrics when they were 100% correct
 * [x] Fix updating student id
 * [x] homework breadcrumb navigation
 * [x] don't scroll to top when paging navigation used in QL
 * [x] back button on QL
 * [x] sort my course by join date