### PR TITLE
update mobx-decorated-models to version without babel-runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7649,9 +7649,9 @@
       "integrity": "sha1-qmcUWb7e39mIDJSIiaP2K84JJ5w="
     },
     "mobx-decorated-models": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/mobx-decorated-models/-/mobx-decorated-models-0.7.1.tgz",
-      "integrity": "sha512-2Cp0E9fM+JiGP8hhZhIefHoALSCjmqCj2x9+PqOUIZHkbOkJwyfMPbkSTVRwLW8DWXcDXLZiMAWbfrD61ad8EQ=="
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/mobx-decorated-models/-/mobx-decorated-models-0.7.3.tgz",
+      "integrity": "sha512-yG5JDMXeZsEw0f1ppW9hO9Tsz+CjAVLWD9Zs4kINxMnmleYJfFKwJ+/LVGTXrGaobjs6WJXW53mzK5NMlyxhGQ=="
     },
     "mobx-react": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "mime-types": "2.1.14",
     "minimatch": "3.0.3",
     "mobx": "3.2.2",
-    "mobx-decorated-models": "0.7.1",
+    "mobx-decorated-models": "0.7.3",
     "mobx-react": "4.2.2",
     "moment": "2.17.1",
     "moment-timezone": "0.5.11",


### PR DESCRIPTION
Fixes build error: `ERROR in tutor.min.js from UglifyJs`