### PR TITLE
Updated copy (needs more changes)

### DIFF
--- a/tutor/src/components/scores/lms-push.jsx
+++ b/tutor/src/components/scores/lms-push.jsx
@@ -25,7 +25,7 @@ export default class LmsPush extends React.PureComponent {
 
   @computed get message() {
     if (this.lmsPush.isPending) {
-      return <span className="busy">Sending to LMS…</span>;
+      return <span className="busy">Sending course averages to LMS…</span>;
     }
     return <span>Last sent to LMS: {this.lmsPush.lastPushedAt}</span>;
   }


### PR DESCRIPTION
Per mockup: http://4tk3oi.axshare.com/tutor_scores_paired_new_tabs_toolbar_dashboard_sty_2.html#choose_settings_tab=lms&CSUM=1
Nathan, I believe this may need more changes than I'm capable of doing: 
1.  Default scores send state is now "Send course averages to LMS" (instead of "Last sent to LMS: Never") The "Last sent to LMS: Date, Time" message appears only after you click the button the first time, per the mockup.
2. Default export scores state is now "Export all scores as spreadsheet" (instead of "Last exported: Never"). Once you click the button the first time, that changes to "Last exported: Date, Time" per the mockup)