### PR TITLE
Fine tune logic for the "course access has moved" tip

### DIFF
--- a/tutor/specs/models/course.spec.js
+++ b/tutor/specs/models/course.spec.js
@@ -46,15 +46,17 @@ describe('Course Model', () => {
     expect(Courses.get(1).tourAudienceTags).toEqual(['student']);
     const teacher = Courses.get(2);
     expect(teacher.tourAudienceTags).toEqual(['teacher', 'teacher-settings-roster-split']);
+
     teacher.is_preview = true;
     expect(teacher.tourAudienceTags).toEqual(['teacher-preview']);
     const course = Courses.get(3);
-    expect(course.tourAudienceTags).toEqual(['teacher', 'teacher-settings-roster-split', 'student']);
+    expect(course.tourAudienceTags).toEqual(['teacher', 'student']);
     course.is_preview = false;
     expect(course.isTeacher).toEqual(true);
     course.taskPlans.set('1', { id: 1, type: 'reading', is_publishing: true, isPublishing: true });
     expect(course.taskPlans.reading.hasPublishing).toEqual(true);
-    expect(course.tourAudienceTags).toEqual(['teacher', 'teacher-settings-roster-split', 'teacher-reading-published', 'student' ]);
+    expect(course.tourAudienceTags).toEqual(['teacher', 'teacher-reading-published', 'student' ]);
+
   });
 
 
@@ -62,6 +64,7 @@ describe('Course Model', () => {
     expect(Courses.get(1).primaryRole.type).to.equal('student');
     expect(Courses.get(2).primaryRole.type).to.equal('teacher');
     expect(Courses.get(3).primaryRole.type).to.equal('teacher');
+    expect(Courses.get(1).primaryRole.joinedAgo('days')).toEqual(7);
   });
 
   it('sunsets cc courses', () => {

--- a/tutor/src/models/course.js
+++ b/tutor/src/models/course.js
@@ -184,7 +184,7 @@ export default class Course extends BaseModel {
     if (this.isTeacher) {
       tags.push(this.is_preview ? 'teacher-preview' : 'teacher');
       if (!this.is_preview) {
-        if (this.isBeforeTerm('fall', 2017)) {
+        if (this.notifyAboutRosterSplit) {
           tags.push('teacher-settings-roster-split');
         }
         if (this.taskPlans.reading.hasPublishing) {
@@ -197,6 +197,16 @@ export default class Course extends BaseModel {
     }
     if (this.isStudent) { tags.push('student'); }
     return tags;
+  }
+
+  // remove after 2018 spring semester
+  @computed get notifyAboutRosterSplit() {
+    return Boolean(
+      !this.is_preview &&
+      this.primaryRole.joinedAgo('days') > 7 &&
+      find(this.map.nonPreview.teaching.array,
+           c => c != this && c.isBeforeTerm('winter', 2017))
+    );
   }
 
   isBeforeTerm(term, year) {

--- a/tutor/src/models/course/offerings/offering.js
+++ b/tutor/src/models/course/offerings/offering.js
@@ -10,7 +10,7 @@ import Term from './term';
 export default class Offering extends BaseModel {
 
   @readonly static possibleTerms = [
-    'winter', 'sprint', 'summer', 'fall',
+    'spring', 'summer', 'fall', 'winter',
   ];
 
   @identifier id;

--- a/tutor/src/models/course/role.js
+++ b/tutor/src/models/course/role.js
@@ -2,6 +2,8 @@ import {
   BaseModel, identifiedBy, field, identifier,
 } from '../base';
 import { computed } from 'mobx';
+import moment from 'moment';
+import { TimeStore } from '../../flux/time';
 
 @identifiedBy('course/role')
 export default class CourseRole extends BaseModel {
@@ -16,5 +18,9 @@ export default class CourseRole extends BaseModel {
 
   @computed get isTeacher() {
     return this.type == 'teacher';
+  }
+
+  joinedAgo(terms = 'days') {
+    return moment(TimeStore.getNow()).diff(this.joined_at, terms);
   }
 }


### PR DESCRIPTION
Before it would show on any course that was fall 2017. 

It now is displayed if the user has created or joined a course in the last 7 days,  and they have courses they're teaching for fall 2017
