### PR TITLE
Fix changing dates on teacher task plans mini-editor

### DIFF
--- a/tutor/src/components/task-plan/builder/tasking-date-times.cjsx
+++ b/tutor/src/components/task-plan/builder/tasking-date-times.cjsx
@@ -7,6 +7,7 @@ moment = require 'moment-timezone'
 TimeHelper  = require '../../../helpers/time'
 {default: Courses} = require '../../../models/courses-map'
 {TaskingActions, TaskingStore} = require '../../../flux/tasking'
+BindStoreMixin     = require '../../bind-store-mixin'
 
 Icon = require '../../icon'
 DateTime = require './date-time'
@@ -25,6 +26,12 @@ TaskingDateTimes = React.createClass
 
   getDefaultProps: ->
     bsSizes: { sm: 8, md: 9 }
+
+  mixins: [BindStoreMixin]
+  bindStore: TaskingStore
+  bindEvent: ->
+    type = if @props.period then @props.period.id else 'all'
+    "taskings.#{@props.id}.#{type}.changed"
 
   getError: ->
     return false unless @refs?.due?.hasValidInputs() and @refs?.open?.hasValidInputs()

--- a/tutor/src/components/task-plan/builder/tasking-date-times.cjsx
+++ b/tutor/src/components/task-plan/builder/tasking-date-times.cjsx
@@ -7,7 +7,6 @@ moment = require 'moment-timezone'
 TimeHelper  = require '../../../helpers/time'
 {default: Courses} = require '../../../models/courses-map'
 {TaskingActions, TaskingStore} = require '../../../flux/tasking'
-BindStoreMixin     = require '../../bind-store-mixin'
 
 Icon = require '../../icon'
 DateTime = require './date-time'

--- a/tutor/src/components/task-plan/builder/tasking-date-times.cjsx
+++ b/tutor/src/components/task-plan/builder/tasking-date-times.cjsx
@@ -27,12 +27,6 @@ TaskingDateTimes = React.createClass
   getDefaultProps: ->
     bsSizes: { sm: 8, md: 9 }
 
-  mixins: [BindStoreMixin]
-  bindStore: TaskingStore
-  bindEvent: ->
-    type = if @props.period then @props.period.id else 'all'
-    "taskings.#{@props.id}.#{type}.changed"
-
   getError: ->
     return false unless @refs?.due?.hasValidInputs() and @refs?.open?.hasValidInputs()
 

--- a/tutor/src/components/task-plan/mini-editor/editor.cjsx
+++ b/tutor/src/components/task-plan/mini-editor/editor.cjsx
@@ -53,6 +53,7 @@ TaskPlanMiniEditor = React.createClass
 
     taskings = TaskingStore.getChanged(id)
     Courses.get(@props.courseId).taskPlans.get(id).taskings = taskings
+    TaskPlanActions.replaceTaskings(id, taskings)
 
   setTitle: (title) ->
     {id} = @props


### PR DESCRIPTION
On the full builder the main component will re-render and
ripple down to the times.  However the mini-editor is mobx
powered and doesn't bind to the store