### PR TITLE
add student enrollment tour step as part of calendar tour

### DIFF
--- a/tutor/src/tours/teacher-calendar.json
+++ b/tutor/src/tours/teacher-calendar.json
@@ -66,6 +66,15 @@
         "id": "open-user-menu"
       }
     }, {
+      "title": "Student enrollment",
+      "body": "Find student access options in Course settings.",
+      "anchor_id": "menu-option-courseSettings",
+      "position": "left",
+      "is_fixed": true,
+      "action": {
+        "id": "open-user-menu"
+      }
+    }, {
       "title": "Browse the book",
       "body": "Review the OpenStax textbook here.",
       "anchor_id": "menu-option-browse-book",


### PR DESCRIPTION
https://trello.com/c/HfU9jb4V/1091-change-request-add-training-wheel-to-the-end-of-course-dashboard-page-tips-tour-pointing-to-course-settings-page-call-out-studen

![screen shot 2017-12-04 at 4 13 09 am](https://user-images.githubusercontent.com/2483873/33550579-128f0e66-d8b4-11e7-98bc-713334224e04.png)
