### PR TITLE
browser warning modal for payments

### DIFF
--- a/tutor/src/components/accessibility-statement.jsx
+++ b/tutor/src/components/accessibility-statement.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Router from '../helpers/router';
-import CourseBranding from './branding/course'
+import CourseBranding from './branding/course';
 import BackButton from './buttons/back-button';
 import { Grid, Table } from 'react-bootstrap';
 

--- a/tutor/src/components/browser-warning-modal/index.jsx
+++ b/tutor/src/components/browser-warning-modal/index.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { map, includes } from 'lodash';
+import browser from 'detect-browser';
+
+import WarningModal from '../warning-modal';
+
+const EXCLUDED_BROWSERS = ['ie'];
+
+const BROWSERS_AND_LINKS = [{
+  name: 'Chrome',
+  link: 'https://www.google.com/chrome/browser/desktop/index.html',
+}, {
+  name: 'Firefox',
+  link: 'https://www.mozilla.org/en-US/firefox/new/',
+}, {
+  name: 'Safari',
+  link: 'https://support.apple.com/en_GB/downloads/safari',
+}, {
+  name: 'Microsoft Edge',
+  link: 'https://www.microsoft.com/en-us/windows/microsoft-edge',
+}];
+
+const isBrowserExcluded = () => ( includes(EXCLUDED_BROWSERS, browser.name) )
+
+const getConnector = (browserIndex) => {
+  let connector = ', ';
+
+  if (browserIndex === BROWSERS_AND_LINKS.length - 2) {
+    connector = ' or ';
+  }
+
+  if (browserIndex === BROWSERS_AND_LINKS.length - 1) {
+    connector = '.';
+  }
+
+  return connector;
+}
+
+const BrowserWarning = (props) => {
+  return (
+    <WarningModal
+      title="We're sorry, your browser isn't supported."
+    >
+      <p>
+        You can't pay for OpenStax Tutor using this browser.
+        We recommend using a recent version of 
+        {map(BROWSERS_AND_LINKS, (browser, index) => {
+          const connector = getConnector(index);
+
+          return (
+            <span> <a
+                href={browser.link}
+                target='_blank'
+                key={`browser-${browser.name}-link`}
+              >
+                {browser.name}
+              </a>
+              {connector}
+            </span>
+          );
+        })}
+      </p>
+      <p>
+        Please launch Tutor in a new, supported browser.
+      </p>
+    </WarningModal>
+  );
+}
+
+export {
+  BrowserWarning as default,
+  isBrowserExcluded
+}

--- a/tutor/src/components/browser-warning-modal/index.jsx
+++ b/tutor/src/components/browser-warning-modal/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { map, includes } from 'lodash';
 import browser from 'detect-browser';
 
+import CourseBranding from '../branding/course';
 import WarningModal from '../warning-modal';
 
 const EXCLUDED_BROWSERS = ['ie'];
@@ -42,7 +43,7 @@ const BrowserWarning = (props) => {
       title="We're sorry, your browser isn't supported."
     >
       <p>
-        You can't pay for OpenStax Tutor using this browser.
+        You can't pay for <CourseBranding /> using this browser.
         We recommend using a recent version of 
         {map(BROWSERS_AND_LINKS, (browser, index) => {
           const connector = getConnector(index);

--- a/tutor/src/components/navbar/student-pay-now-btn.jsx
+++ b/tutor/src/components/navbar/student-pay-now-btn.jsx
@@ -6,6 +6,7 @@ import { computed, action, observable } from 'mobx';
 import PaymentsModal from '../payments/modal';
 import Payments from '../../models/payments';
 import Courses from '../../models/courses-map';
+import BrowserWarning, { isBrowserExcluded } from '../browser-warning-modal';
 import Icon from '../icon';
 
 const FREE_TRIAL_MESSAGE = `
@@ -44,6 +45,12 @@ export default class StudentPayNowBtn extends React.PureComponent {
 
   renderModal() {
     if (this.isShowingModal) {
+
+      if (isBrowserExcluded()) {
+        return <BrowserWarning />;
+      }
+
+
       return (
         <PaymentsModal
           onPaymentComplete={this.onComplete}


### PR DESCRIPTION
https://trello.com/c/gfKbpURS/521-change-request-user-taken-to-different-page-when-unsupported-browser-is-detected-in-payments

![screen shot 2017-12-04 at 5 27 27 am](https://user-images.githubusercontent.com/2483873/33550554-fea8527c-d8b3-11e7-9365-b9490b9c20ce.png)
