### PR TITLE
Highlight fixes for loading and positioning

### DIFF
--- a/tutor/src/components/annotations/sidebar-buttons.jsx
+++ b/tutor/src/components/annotations/sidebar-buttons.jsx
@@ -26,6 +26,7 @@ export default class SidebarButtons extends React.Component {
     } = this.props;
 
     if (disabled) { return null; }
+    const wTop = window.pageYOffset;
 
     return (
       <div>
@@ -37,7 +38,7 @@ export default class SidebarButtons extends React.Component {
                 cn('sidebar-button', { active: note === activeAnnotation })
               }
               style={{
-                top: get(note.selection, 'bounds.top', 0) - parentRect.top,
+                top: get(note.selection, 'bounds.top', 0) - parentRect.top + wTop,
                 position: 'absolute',
               }}
               alt="View annotation"

--- a/tutor/src/components/annotations/summary-page.jsx
+++ b/tutor/src/components/annotations/summary-page.jsx
@@ -69,7 +69,7 @@ export default class AnnotationSummaryPage extends React.Component {
     return (
       <div className="summary-page">
         <div className="annotations">
-          <h3>No annotations have been created yet</h3>
+          <h3>No notes have been created yet</h3>
         </div>
       </div>
     );

--- a/tutor/src/helpers/dom.coffee
+++ b/tutor/src/helpers/dom.coffee
@@ -6,6 +6,14 @@ module.exports = {
     method = el.matches or el.mozMatchesSelector or el.msMatchesSelector or el.oMatchesSelector or el.webkitMatchesSelector
     method?.call(el, selector)
 
+  isParent: (parent, child, options = { matchSame: true }) ->
+    return false unless parent and child
+    return true if options.matchSame and parent is child
+    node = child.parentNode
+    while node
+      return true if node is parent
+      node = node.parentNode
+    return false
 
   closest: (el, selector) ->
     return null unless el

--- a/tutor/src/models/annotations/annotation.js
+++ b/tutor/src/models/annotations/annotation.js
@@ -100,17 +100,8 @@ export default class Annotation extends BaseModel {
     return this.listing.destroy(this);
   }
 
-  // get style() {
-  //   const rect = this.selection.restore();
-  //   console.log(rect)
-  //   return {
-  //     top: rect.top - this.parentRect.top,
-  //     position: 'absolute',
-  //   }
-  // }
-
   isSiblingOfElement(el) {
-    if (!el) { return; }
+    if (!el) { return false; }
     if (el === this.referenceElement) { return true; }
     let node = el.parentNode;
     while (node != null) {

--- a/tutor/src/models/annotations/hypothesis.js
+++ b/tutor/src/models/annotations/hypothesis.js
@@ -3,7 +3,7 @@ import {
 } from '../base';
 import axios from 'axios';
 import { action, observable, computed } from 'mobx';
-import { isEmpty, defaultsDeep } from 'lodash';
+import { isEmpty, defaultsDeep, find } from 'lodash';
 import { Logging } from 'shared';
 import { AppActions } from '../../flux/app';
 
@@ -61,10 +61,10 @@ class Hypothesis extends BaseModel {
         return this.performRequest({
           service: 'profile?authority=openstax.org',
         }).then((response) => {
-          this.userInfo = response.groups[0];
+          this.userInfo = find(response.groups, { public: false });
           return this.fetchAllAnnotations();
         });
-      }
+      } else { return this; }
     });
   }
 
@@ -108,6 +108,7 @@ class Hypothesis extends BaseModel {
     });
     const promiseBody = (resolve) => {
       fetchASet().then((response) => {
+
         if (response.rows.length > 0) {
           rows = rows.concat(response.rows);
           promiseBody(resolve);


### PR DESCRIPTION
Fixes bugs where:
 * We were only loading public annotations, not the ones from the users's group
 *. Annotations were being saved with an incorrect reference element, causing them to appear randomly placed after save
