### PR TITLE
Fix review metrics displaying wrong stats for periods

### DIFF
--- a/tutor/specs/models/course.spec.js
+++ b/tutor/specs/models/course.spec.js
@@ -109,13 +109,13 @@ describe('Course Model', () => {
     const sortedSpy = jest.fn(() => course.periods.sorted);
     autorun(sortedSpy);
 
-    expect(course.periods.sorted).toHaveLength(len);
+    expect(course.periods.sorted).toHaveLength(len - 2);
     expect(sortedSpy).toHaveBeenCalledTimes(1);
     expect(PH.sort).toHaveBeenCalledTimes(2);
 
     course.periods.pop();
     expect(course.periods.length).toEqual(len - 1);
-    expect(course.periods.sorted.length).toEqual(len - 1);
+    expect(course.periods.sorted.length).toEqual(len - 3);
 
     expect(PH.sort).toHaveBeenCalledTimes(3);
     expect(sortedSpy).toHaveBeenCalledTimes(2);

--- a/tutor/src/components/course-periods-nav.jsx
+++ b/tutor/src/components/course-periods-nav.jsx
@@ -27,9 +27,7 @@ export default class CoursePeriodsNav extends React.PureComponent {
   @observable tabIndex = this.props.initialActive;
 
   @computed get sortedPeriods() {
-    return PeriodHelper.sort(
-      Courses.get(this.props.courseId).periods.active
-    );
+    return Courses.get(this.props.courseId).periods.sorted;
   }
 
   @action.bound onTabSelection(tabIndex, ev) {

--- a/tutor/src/components/plan-stats/index.jsx
+++ b/tutor/src/components/plan-stats/index.jsx
@@ -11,7 +11,7 @@ import { ChaptersPerformance, PracticesPerformance } from './performances';
 import Courses from '../../models/courses-map';
 import TeacherTaskPlan from '../../models/task-plan/teacher';
 import LoadingScreen from '../loading-screen';
-import NoStudents from './no-students.jsx';
+import NoStudents from './no-students';
 
 @observer
 export default class Stats extends React.PureComponent {

--- a/tutor/src/components/plan-stats/index.jsx
+++ b/tutor/src/components/plan-stats/index.jsx
@@ -41,7 +41,7 @@ export default class Stats extends React.PureComponent {
   }
 
   @computed get period() {
-    return this.course.periods[this.currentPeriodIndex];
+    return this.course.periods.sorted[this.currentPeriodIndex];
   }
 
   @computed get stats() {

--- a/tutor/src/components/task-teacher-review/breadcrumbs.jsx
+++ b/tutor/src/components/task-teacher-review/breadcrumbs.jsx
@@ -14,7 +14,7 @@ export default class Breadcrumbs extends React.PureComponent {
 
   static propTypes = {
     taskPlan: React.PropTypes.instanceOf(TeacherTaskPlan).isRequired,
-    stats: React.PropTypes.instanceOf(Stats).isRequired,
+    stats: React.PropTypes.instanceOf(Stats),
     courseId: React.PropTypes.string.isRequired,
     currentStep: React.PropTypes.number,
     scrollToStep: React.PropTypes.func.isRequired,

--- a/tutor/src/components/task-teacher-review/index.jsx
+++ b/tutor/src/components/task-teacher-review/index.jsx
@@ -11,6 +11,8 @@ import Review from './review';
 import { PinnedHeaderFooterCard } from 'shared';
 import ScrollTo from '../../helpers/scroll-to';
 
+import NoStats from './no-stats';
+
 @observer
 export default class TaskTeacherReview extends React.Component {
   static propTypes = {
@@ -62,7 +64,6 @@ export default class TaskTeacherReview extends React.Component {
   }
 
   renderBreadcrumbs() {
-    if (!this.stats) { return null; }
     return (
       <Breadcrumbs
         stats={this.stats}
@@ -75,7 +76,12 @@ export default class TaskTeacherReview extends React.Component {
   }
 
   renderReviewPanel() {
-    if (!this.stats) { return null; }
+
+    if (!this.stats) {
+      return (
+        <NoStats taskPlan={this.taskPlan} header={this.renderBreadcrumbs()} course={this.course} period={this.period} />
+      );
+    }
     return (
       <Review
         goToStep={this.goToStep}

--- a/tutor/src/components/task-teacher-review/index.jsx
+++ b/tutor/src/components/task-teacher-review/index.jsx
@@ -40,7 +40,7 @@ export default class TaskTeacherReview extends React.Component {
     windowImpl: this.props.windowImpl,
   })
 
-  @observable period = first(this.course.periods);
+  @observable period = first(this.course.periods.sorted);
 
   @action.bound setPeriod(period) {
     this.period = period;
@@ -76,7 +76,6 @@ export default class TaskTeacherReview extends React.Component {
   }
 
   renderReviewPanel() {
-
     if (!this.stats) {
       return (
         <NoStats taskPlan={this.taskPlan} header={this.renderBreadcrumbs()} course={this.course} period={this.period} />

--- a/tutor/src/components/task-teacher-review/no-stats.jsx
+++ b/tutor/src/components/task-teacher-review/no-stats.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import NoStudents from '../plan-stats/no-students';
+import CGL from '../course-grouping-label';
+import LoadingScreen from '../loading-screen';
+import { PinnedHeaderFooterCard } from 'shared';
+
+const NoStats = ({ taskPlan, header, course, period }) => {
+  if (!taskPlan.analytics.api.hasBeenFetched) {
+    return <LoadingScreen />;
+  }
+
+  const body = period.hasEnrollments ? (
+    <p>
+      No activity has been recorded for this <CGL lowercase courseId={course.id} /> yet.  Once students start to work the assignment their activity wil appear.
+    </p>
+  ) : (
+    <NoStudents courseId={course.id} />
+  );
+
+  return (
+    <PinnedHeaderFooterCard
+      className="task-teacher-review no-stats"
+      fixedOffset={0}
+      header={header}
+      cardType="task"
+    >
+      <h1>No activity yet</h1>
+      {body}
+    </PinnedHeaderFooterCard>
+  );
+};
+
+
+export default NoStats;

--- a/tutor/src/models/course.js
+++ b/tutor/src/models/course.js
@@ -62,7 +62,7 @@ export default class Course extends BaseModel {
   @field year;
 
   @hasMany({ model: Period, inverseOf: 'course', extend: extendHasMany({
-    sorted()   { return PH.sort(this);                               },
+    sorted()   { return PH.sort(this.active);                        },
     archived() { return filter(this, period => !period.is_archived); },
     active()   { return filter(this, period => !period.is_archived); },
   }) }) periods;


### PR DESCRIPTION
The root bug was that the tabs were sorted and filtered out archived (as they should) but the stats were not. 

There also wasn't a loading or "no students" message on the stats page so it looked broken when viewing empty periods.