### PR TITLE
flexbox bug; use height vs min-height

### DIFF
--- a/tutor/resources/styles/components/top-nav-bar.scss
+++ b/tutor/resources/styles/components/top-nav-bar.scss
@@ -89,7 +89,7 @@ $tutor-navbar-padding-horizontal: 4rem;
 
   .right-side-controls {
     display: flex;
-    min-height: 100%;
+    height: 100%;
     > * {
       margin-left: 20px;
       @media screen and (min-width: $screen-md-min ) {


### PR DESCRIPTION
For Firefox and probably IE

Before:
![screen shot 2017-12-07 at 5 10 12 pm](https://user-images.githubusercontent.com/79566/33743219-833bb7a8-db71-11e7-8d91-957720071f96.png)


After:

![screen shot 2017-12-07 at 5 08 45 pm](https://user-images.githubusercontent.com/79566/33743214-76d61daa-db71-11e7-95df-15356986b233.png)
