### PR TITLE
Initialize timezone from course; deal with blank ones

### DIFF
--- a/tutor/src/components/course-settings/timezone.jsx
+++ b/tutor/src/components/course-settings/timezone.jsx
@@ -55,7 +55,8 @@ class TimezonePreview extends React.PureComponent {
   }
 
   render() {
-    const { time, props: { timezone } } = this;
+    let { time, props: { timezone } } = this;
+    if (!timezone) { timezone = moment.tz.guess(); }
     const timePreview = time.tz(timezone).format('h:mm a');
 
     return (
@@ -133,7 +134,7 @@ export default class SetTimezone extends React.PureComponent {
 
   @observable showModal = false
   @observable invalid = false;
-  @observable course_timezone = '';
+  @observable course_timezone = this.props.course.time_zone;
 
   @action.bound open() {
     this.showModal = true;

--- a/tutor/src/helpers/time.coffee
+++ b/tutor/src/helpers/time.coffee
@@ -132,7 +132,7 @@ TimeHelper =
     timezone in _.values(TimeHelper.getTimezones())
 
   isCourseTimezone: (courseTimezone) ->
-    return false unless courseTimezone?
+    return false if _.isEmpty(courseTimezone)
 
     {offsets} = moment()._z or moment.tz(TimeHelper.getLocalTimezone())._z
     courseTimezoneOffsets = moment.tz(courseTimezone)._z.offsets


### PR DESCRIPTION
Fixes a bug where the course time zone picker would save a blank timezone if
it was saved without a selection being made