### PR TITLE
use flexbox to layout bubble and answer text

### DIFF
--- a/shared/resources/styles/components/question.scss
+++ b/shared/resources/styles/components/question.scss
@@ -71,17 +71,14 @@
           background-color: $openstax-neutral-lightest;
         }
       }
+      @include answer();
     }
 
-    .answer-content {
-      width: calc('100% - #{$openstax-answer-label-spacing}');
+    .answer-answer {
       margin-left: $openstax-answer-horizontal-spacing;
-      margin-top: 0.5 * $openstax-answer-horizontal-spacing;
-      @include answer-left-block();
     }
 
     .answer-letter {
-      @include answer-left-block();
       text-align: center;
     }
 
@@ -93,7 +90,6 @@
       margin: 0;
 
       transition: color $openstax-answer-transition;
-      @include answer();
     }
 
     // a selectable answer

--- a/shared/resources/styles/mixins/questions.scss
+++ b/shared/resources/styles/mixins/questions.scss
@@ -1,23 +1,13 @@
 @mixin openstax-bubble() {
   $diameter: $openstax-answer-bubble-size;
   $border-size: 2px;
-
   width: $diameter;
   height: $diameter;
-  line-height: $diameter * .90;
+  min-width: $diameter;
+  min-height: $diameter;
   border-radius: $diameter / 2;
   border-width: $border-size;
   border-style: solid;
-
-  &::after {
-    width: $diameter;
-    height: $diameter;
-    line-height: $diameter;
-    margin-left: -1 * $border-size;
-    margin-top: -1 * $border-size;
-    text-align: center;
-    display: inline-block;
-  }
 };
 
 @mixin answer-fa-icon() {
@@ -32,7 +22,7 @@
   @include openstax-bubble();
   border-color: lighten($openstax-answer-label-color, 15%);
   color: $openstax-answer-label-color-hover;
-
+  margin-top: $openstax-answer-bubble-size * .25;
   transition: color $openstax-answer-transition, border-color $openstax-answer-transition, background-color $openstax-answer-transition;
 };
 
@@ -50,7 +40,6 @@
   border-color: $openstax-wrong-answer-color;
   background-color: $openstax-wrong-answer-color;
   color: $openstax-white;
-
   &::after {
     @include answer-fa-icon();
     content: $fa-var-close;
@@ -73,12 +62,10 @@
   color: $openstax-correct-answer-color;
 }
 
-@mixin answer-left-block() {
-  display: block;
-  float: left;
-}
-
 @mixin answer() {
+  .answer-label {
+    display: flex;
+  }
   color: $openstax-answer-label-color;
   .answer-letter {
     @include answer-bubble();
@@ -130,6 +117,5 @@
     // http://caniuse.com/#feat=rem -- rem ignored in pseudo elements
     line-height: 1em;
     margin-top: 0.8rem;
-    @include answer-left-block();
   }
 }

--- a/tutor/resources/styles/components/task-step/all-steps.scss
+++ b/tutor/resources/styles/components/task-step/all-steps.scss
@@ -60,7 +60,8 @@
         padding: 20px 40px;
         width: 100%;
 
-        //@include tutor-book-note-style();
+        @include tutor-book-note-style();
+        @include book-content-interactives();
       }
     }
 


### PR DESCRIPTION
Otherwise long text wraps with the new button based bubbles.  It was fine with short (one-line) text which is apparently all I tested with ☹️ 

Before:
![screen shot 2018-01-02 at 4 46 30 pm](https://user-images.githubusercontent.com/79566/34503158-94227528-efdc-11e7-8c8e-fc38a2691192.png)

after
![screen shot 2018-01-02 at 4 44 13 pm](https://user-images.githubusercontent.com/79566/34503159-9436f638-efdc-11e7-8bd4-eef354f1edc9.png)