### PR TITLE
Fix `Cannot set property 'time_zone' of undefined`

### DIFF
--- a/tutor/src/components/task-plan/builder/tasking-date-times.cjsx
+++ b/tutor/src/components/task-plan/builder/tasking-date-times.cjsx
@@ -40,6 +40,7 @@ TaskingDateTimes = React.createClass
     model = if period then period else Courses.get(courseId)
     _.assign(model, timeChange)
     model.save()
+    @forceUpdate()
 
   isSetting: ->
     {courseId} = @props
@@ -56,9 +57,12 @@ TaskingDateTimes = React.createClass
     TaskingActions.updateTime(id, period?.serialize(), type, value)
 
   render: ->
-    {isVisibleToStudents, isEditable, period, id, termStart, termEnd} = @props
+    {isVisibleToStudents, isEditable, period, courseId, id, termStart, termEnd} = @props
     period = period.serialize() if period
     commonDateTimesProps = _.pick @props, 'required', 'currentLocale', 'taskingIdentifier'
+
+    model = if period then period else Courses.get(courseId)
+    { default_open_time, default_due_time } = model
 
     defaults = TaskingStore.getDefaultsForTasking(id, period)
     {open_time, open_date, due_time, due_date} = TaskingStore._getTaskingFor(id, period)
@@ -103,7 +107,7 @@ TaskingDateTimes = React.createClass
         setTime={_.partial(@setTime, 'open')}
         value={ openDate }
         defaultValue={open_time or defaults.open_time}
-        defaultTime={defaults.open_time}
+        defaultTime={default_open_time}
         setDefaultTime={@setDefaultTime}
         timeLabel='default_open_time'
         isSetting={@isSetting}
@@ -119,7 +123,7 @@ TaskingDateTimes = React.createClass
         setTime={_.partial(@setTime, 'due')}
         value={due_date}
         defaultValue={due_time or defaults.due_time}
-        defaultTime={defaults.due_time}
+        defaultTime={default_due_time}
         setDefaultTime={@setDefaultTime}
         timeLabel='default_due_time'
         isSetting={@isSetting}

--- a/tutor/src/components/task-plan/builder/tasking-date-times.cjsx
+++ b/tutor/src/components/task-plan/builder/tasking-date-times.cjsx
@@ -37,8 +37,8 @@ TaskingDateTimes = React.createClass
 
   setDefaultTime: (timeChange) ->
     {courseId, period} = @props
-    model = if period then Courses.get(courseId) else period
-    model.time_zone = timeChange
+    model = if period then period else Courses.get(courseId)
+    _.assign(model, timeChange)
     model.save()
 
   isSetting: ->

--- a/tutor/src/models/course.js
+++ b/tutor/src/models/course.js
@@ -27,6 +27,7 @@ import ReferenceBook from './reference-book';
 
 const ROLE_PRIORITY = [ 'guest', 'student', 'teacher', 'admin' ];
 const DASHBOARD_VIEW_COUNT_KEY = 'DBVC';
+const SAVEABLE_ATTRS = ['name', 'is_lms_enabled', 'time_zone', 'default_open_time', 'default_due_time'];
 
 @identifiedBy('course')
 export default class Course extends BaseModel {
@@ -253,6 +254,6 @@ export default class Course extends BaseModel {
   // called by API
   fetch() { }
   save() {
-    return { id: this.id, data: pick(this, 'name', 'is_lms_enabled', 'time_zone') };
+    return { id: this.id, data: pick(this, SAVEABLE_ATTRS) };
   }
 }


### PR DESCRIPTION
When the time is changed in the task plan builder, a "Set as default" link appears. However clicking it causes a `Cannot set property 'time_zone' of undefined` error and the time default is not saved.


  