### PR TITLE
Don't call annotate when highlight button is clicked

### DIFF
--- a/tutor/resources/styles/components/annotations/annotation.scss
+++ b/tutor/resources/styles/components/annotations/annotation.scss
@@ -27,7 +27,7 @@
       align-items: center;
       justify-content: center;
     }
-    .annotate {
+    .highlight {
       svg {
         width: 30px;
         height: 30px;
@@ -41,7 +41,7 @@
         svg path { fill: $tutor-black; }
       }
     }
-    .comment {
+    .annotate {
       border-right: thin solid $tutor-neutral-light;
       color: $tutor-neutral-darker;
       &:hover {

--- a/tutor/src/components/annotations/inline-controls.jsx
+++ b/tutor/src/components/annotations/inline-controls.jsx
@@ -5,9 +5,9 @@ import HighlightIcon from './highlight-icon';
 const InlineControls = ({ style, annotate, highlight }) => (
   style ? (
     <div className="widget arrow-box" style={style}>
-      <Icon className="comment" type="comment" alt="annotate" onClick={annotate} />
-      <button className="annotate" onClick={annotate}>
-        <HighlightIcon role="button" alt="highlight" onClick={highlight} />
+      <Icon className="annotate" type="comment" alt="annotate" onClick={annotate} />
+      <button className="highlight" onClick={highlight}>
+        <HighlightIcon role="button" alt="highlight" />
       </button>
     </div>
   ) : null


### PR DESCRIPTION
Somehow the onClick handler's were transposed ☹️ 