### PR TITLE
stop scrolling if element has been deleted

### DIFF
--- a/tutor/src/helpers/scroll-to.js
+++ b/tutor/src/helpers/scroll-to.js
@@ -115,6 +115,7 @@ export default class ScrollTo {
 
   scrollToElement(el, options ) {
     if (options == null) { options = {}; }
+    if (!el.parentElement) { return Promise.resolve(); } // the element has been deleted
     const win       = this.windowImpl;
     const endPos    = this._desiredTopPosition(el, options);
 


### PR DESCRIPTION
Fixes a bug with annotations where the page will scroll to top
if an annotation is created and immediately deleted while it's scrolling