### PR TITLE
action active menu

### DIFF
--- a/tutor/resources/styles/components/top-nav-bar/drop-down-menu.scss
+++ b/tutor/resources/styles/components/top-nav-bar/drop-down-menu.scss
@@ -75,8 +75,11 @@
       }
     }
 
-    .divider:last-child {
-      display: none;
+    .divider {
+      &:first-child,
+      &:last-child {
+        display: none;
+      }
     }
 
   }

--- a/tutor/resources/styles/components/top-nav-bar/drop-down-menu.scss
+++ b/tutor/resources/styles/components/top-nav-bar/drop-down-menu.scss
@@ -23,20 +23,28 @@
     min-width: calc(100% + 15px);
     right: -15px;
 
-    > li > a {
-      color: inherit;
-      height: auto;
-      line-height: 2;
-      padding: 15 20px;
-
-      &:hover,
-      &:active {
-        background-color: $tutor-neutral-lighter;
-        color: $tutor-neutral-darker;
+    > li {
+      > a {
+        color: inherit;
+        height: auto;
+        line-height: 2;
+        padding: 15 20px;
+  
+        &:hover {
+          background-color: $tutor-neutral-lighter;
+          color: $tutor-neutral-darker;
+        }
+  
+        form input[type="submit"] {
+          line-height: inherit;
+        }
       }
 
-      form input[type="submit"] {
-        line-height: inherit;
+      &.active {
+        > a {
+          background-color: $tutor-neutral-lighter;
+          color: $tutor-neutral-darker;
+        }
       }
     }
 

--- a/tutor/specs/components/navbar/__snapshots__/actions_menu.spec.jsx.snap
+++ b/tutor/specs/components/navbar/__snapshots__/actions_menu.spec.jsx.snap
@@ -87,6 +87,7 @@ exports[`Student Navbar Component has actions menu that matches snapshot 1`] = `
       </a>
     </li>
     <li
+      className=""
       role="presentation"
     >
       <a
@@ -240,6 +241,7 @@ exports[`Teacher Navbar Component has actions menu that matches snapshot 1`] = `
       </a>
     </li>
     <li
+      className=""
       role="presentation"
     >
       <a

--- a/tutor/specs/components/navbar/actions_menu.spec.jsx
+++ b/tutor/specs/components/navbar/actions_menu.spec.jsx
@@ -30,12 +30,12 @@ const testWithRole = roleType =>
     });
 
     it('should have link to browse the book', () => {
-      const menu = shallow(<UserActionsMenu {...props} />);
+      const menu = mount(<Wrapper _wrapped_component={UserActionsMenu}  {...props} />);
       expect(menu).toHaveRendered('BrowseBookMenuItem');
     });
 
     it('should have performance forecast menu', () => {
-      const menu = shallow(<UserActionsMenu {...props} />);
+      const menu = mount(<Wrapper _wrapped_component={UserActionsMenu}  {...props} />);
       expect(menu).toHaveRendered('[data-name="viewPerformanceGuide"]');
     });
   };


### PR DESCRIPTION
![screen shot 2018-01-05 at 2 21 35 pm](https://user-images.githubusercontent.com/2483873/34626959-5c72b242-f224-11e7-83e7-6b4882711ef9.png)

![screen shot 2018-01-05 at 4 40 23 pm](https://user-images.githubusercontent.com/2483873/34631687-3334dd48-f237-11e7-8855-8aa963f848e9.png)


## Before

![screen shot 2018-01-05 at 4 38 41 pm](https://user-images.githubusercontent.com/2483873/34631690-34b84240-f237-11e7-8ad6-445042bef466.png)

  


**note** seems like we should be able to use the `match` prop being passed into a `Route`'s children, but that doesn't seem to be updating with each route change
  