### PR TITLE
update links to point to new support site

### DIFF
--- a/tutor/specs/components/__snapshots__/app.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/app.spec.jsx.snap
@@ -74,7 +74,7 @@ exports[`main Tutor App renders and matches snapshot 1`] = `
                   style={undefined}
                 >
                   <a
-                    href="http://openstax.force.com/support?l=en_US&c=Products%3ATutor"
+                    href="https://openstax.secure.force.com/help"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     role="menuitem"

--- a/tutor/specs/components/course-settings/__snapshots__/student-access.spec.jsx.snap
+++ b/tutor/specs/components/course-settings/__snapshots__/student-access.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`Course Settings, student access can switch to links 1`] = `
     Choose how students access OpenStax Tutor. Access settings cannot be changed after students begin to enroll.
   </p>
   <a
-    href="http://openstax.force.com/support/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor/?q=LMS+integration&l=en_US&c=Products%3ATutor&fs=Search&pn=1"
+    href="https://openstax.secure.force.com/help/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor?"
     target="_blank"
   >
     <i
@@ -149,7 +149,7 @@ exports[`Course Settings, student access can switch to lms 1`] = `
     Choose how students access OpenStax Tutor. Access settings cannot be changed after students begin to enroll.
   </p>
   <a
-    href="http://openstax.force.com/support/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor/?q=LMS+integration&l=en_US&c=Products%3ATutor&fs=Search&pn=1"
+    href="https://openstax.secure.force.com/help/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor?"
     target="_blank"
   >
     <i
@@ -375,7 +375,7 @@ exports[`Course Settings, student access can switch to lms 1`] = `
               className="blackboard"
             >
               <a
-                href="http://openstax.force.com/support/articles/How_To/How-can-I-integrate-OpenStax-Tutor-with-Blackboard/?q=LMS+integration&l=en_US&c=Products%3ATutor&fs=Search&pn=1"
+                href="https://openstax.secure.force.com/help/articles/How_To/Integrating-OpenStax-Tutor-into-Blackboard-LMS"
                 target="_blank"
               >
                 <i
@@ -435,7 +435,7 @@ exports[`Course Settings, student access renders chooser when lms is enabled 1`]
     Choose how students access OpenStax Tutor. Access settings cannot be changed after students begin to enroll.
   </p>
   <a
-    href="http://openstax.force.com/support/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor/?q=LMS+integration&l=en_US&c=Products%3ATutor&fs=Search&pn=1"
+    href="https://openstax.secure.force.com/help/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor?"
     target="_blank"
   >
     <i

--- a/tutor/specs/components/course-settings/__snapshots__/student-access.spec.jsx.snap
+++ b/tutor/specs/components/course-settings/__snapshots__/student-access.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`Course Settings, student access can switch to links 1`] = `
     Choose how students access OpenStax Tutor. Access settings cannot be changed after students begin to enroll.
   </p>
   <a
-    href="https://openstax.secure.force.com/help/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor?"
+    href="https://openstax.secure.force.com/help/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor"
     target="_blank"
   >
     <i
@@ -149,7 +149,7 @@ exports[`Course Settings, student access can switch to lms 1`] = `
     Choose how students access OpenStax Tutor. Access settings cannot be changed after students begin to enroll.
   </p>
   <a
-    href="https://openstax.secure.force.com/help/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor?"
+    href="https://openstax.secure.force.com/help/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor"
     target="_blank"
   >
     <i
@@ -435,7 +435,7 @@ exports[`Course Settings, student access renders chooser when lms is enabled 1`]
     Choose how students access OpenStax Tutor. Access settings cannot be changed after students begin to enroll.
   </p>
   <a
-    href="https://openstax.secure.force.com/help/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor?"
+    href="https://openstax.secure.force.com/help/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor"
     target="_blank"
   >
     <i

--- a/tutor/specs/components/navbar/__snapshots__/index.spec.jsx.snap
+++ b/tutor/specs/components/navbar/__snapshots__/index.spec.jsx.snap
@@ -65,7 +65,7 @@ exports[`Main navbar renders and matches snapshot 1`] = `
             style={undefined}
           >
             <a
-              href="http://openstax.force.com/support?l=en_US&c=Products%3ATutor"
+              href="https://openstax.secure.force.com/help"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="menuitem"

--- a/tutor/specs/components/navbar/__snapshots__/support-menu.spec.jsx.snap
+++ b/tutor/specs/components/navbar/__snapshots__/support-menu.spec.jsx.snap
@@ -64,7 +64,7 @@ exports[`Support Menu renders and matches snapshot 1`] = `
       style={undefined}
     >
       <a
-        href="http://openstax.force.com/support?l=en_US&c=Products%3ATutor"
+        href="https://openstax.secure.force.com/help"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="menuitem"
@@ -140,7 +140,7 @@ exports[`Support Menu renders support links when in a course for student 1`] = `
       style={undefined}
     >
       <a
-        href="http://openstax.force.com/support?l=en_US&c=Products%3ATutor"
+        href="https://openstax.secure.force.com/help"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="menuitem"
@@ -238,7 +238,7 @@ exports[`Support Menu renders support links when in a course for teacher 1`] = `
       style={undefined}
     >
       <a
-        href="http://openstax.force.com/support?l=en_US&c=Products%3ATutor"
+        href="https://openstax.secure.force.com/help"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="menuitem"

--- a/tutor/specs/models/user/menu.spec.js
+++ b/tutor/specs/models/user/menu.spec.js
@@ -19,11 +19,7 @@ describe('Current User Store', function() {
   });
 
   it('computes help URL', () => {
-    expect(UserMenu.helpURL).toContain('Tutor');
-    expect(UserMenu.helpLinkForCourseId(1)).toContain('Tutor');
-    Courses.get(1).is_concept_coach = true;
-    expect(UserMenu.helpURL).toContain('Tutor');
-    expect(UserMenu.helpLinkForCourseId(1)).toContain('Coach');
+    expect(UserMenu.helpURL).toContain('help');
   });
 
   it('should return expected menu routes for courses', function() {

--- a/tutor/src/components/course-settings/lms-panel.jsx
+++ b/tutor/src/components/course-settings/lms-panel.jsx
@@ -11,7 +11,7 @@ import Icon from '../icon';
 
 const blackboard = ({ lms }) => (
   <div className="blackboard">
-    <a href="http://openstax.force.com/support/articles/How_To/How-can-I-integrate-OpenStax-Tutor-with-Blackboard/?q=LMS+integration&l=en_US&c=Products%3ATutor&fs=Search&pn=1" target="_blank">
+    <a href="https://openstax.secure.force.com/help/articles/How_To/Integrating-OpenStax-Tutor-into-Blackboard-LMS" target="_blank">
       <Icon type="info-circle" /> How do I integrate with Blackboard?
     </a>
     <CopyOnFocusInput label="URL" value={lms.launch_url} />
@@ -22,7 +22,7 @@ const blackboard = ({ lms }) => (
 
 const canvas = ({ lms }) => (
   <div className="canvas">
-    <a href="http://openstax.force.com/support/articles/How_To/How-can-I-integrate-OpenStax-Tutor-with-Canvas/?q=LMS+integration&l=en_US&c=Products%3ATutor&fs=Search&pn=1" target="_blank">
+    <a href="https://openstax.secure.force.com/help/articles/How_To/Integrating-OpenStax-Tutor-into-Canvas-LMS" target="_blank">
       <Icon type="info-circle" /> How do I integrate with Canvas?
     </a>
     <CopyOnFocusInput label="Consumer key" value={lms.key} />
@@ -33,7 +33,7 @@ const canvas = ({ lms }) => (
 
 const moodle = ({ lms }) => (
   <div className="moodle">
-    <a href="http://openstax.force.com/support/articles/How_To/How-can-I-integrate-OpenStax-Tutor-with-Moodle/?q=LMS+integration&l=en_US&c=Products%3ATutor&fs=Search&pn=1" target="_blank">
+    <a href="https://openstax.secure.force.com/help/articles/How_To/How-can-I-integrate-OpenStax-Tutor-with-Moodle" target="_blank">
       <Icon type="info-circle" /> How do I integrate with Moodle?
     </a>
     <CopyOnFocusInput label="Secure tool URL" value={lms.launch_url} />
@@ -44,7 +44,7 @@ const moodle = ({ lms }) => (
 
 const d2l = ({ lms }) => (
   <div className="d2l">
-    <a href="http://openstax.force.com/support/articles/FAQ/How-can-I-integrate-OpenStax-Tutor-with-Desire2Learn/?q=LMS+integration&l=en_US&c=Products%3ATutor&fs=Search&pn=1" target="_blank">
+    <a href="https://openstax.secure.force.com/help/articles/FAQ/How-can-I-integrate-OpenStax-Tutor-with-Desire2Learn" target="_blank">
       <Icon type="info-circle" /> How do I integrate with Desire2Learn?
     </a>
     <CopyOnFocusInput label="URL" value={lms.launch_url} />
@@ -55,7 +55,7 @@ const d2l = ({ lms }) => (
 
 const sakai = ({ lms }) => (
   <div className="sakai">
-    <a href="http://openstax.force.com/support/articles/FAQ/How-can-I-integrate-OpenStax-Tutor-with-Sakai/?q=LMS+integration&l=en_US&c=Products%3ATutor&fs=Search&pn=1" target="_blank">
+    <a href="https://openstax.secure.force.com/help/articles/FAQ/How-can-I-integrate-OpenStax-Tutor-with-Sakai" target="_blank">
       <Icon type="info-circle" /> How do I integrate with Sakai?
     </a>
     <CopyOnFocusInput label="Launch URL" value={lms.launch_url} />

--- a/tutor/src/components/course-settings/student-access.jsx
+++ b/tutor/src/components/course-settings/student-access.jsx
@@ -167,7 +167,7 @@ export default class StudentAccess extends React.PureComponent {
           Choose how students access OpenStax Tutor.
           Access settings cannot be changed after students begin to enroll.
         </p>
-        <a href="https://openstax.secure.force.com/help/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor?" target="_blank">
+        <a href="https://openstax.secure.force.com/help/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor" target="_blank">
           <Icon type="info-circle" /> Which option is right for my course?
         </a>
         <PanelGroup

--- a/tutor/src/components/course-settings/student-access.jsx
+++ b/tutor/src/components/course-settings/student-access.jsx
@@ -167,7 +167,7 @@ export default class StudentAccess extends React.PureComponent {
           Choose how students access OpenStax Tutor.
           Access settings cannot be changed after students begin to enroll.
         </p>
-        <a href="http://openstax.force.com/support/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor/?q=LMS+integration&l=en_US&c=Products%3ATutor&fs=Search&pn=1" target="_blank">
+        <a href="https://openstax.secure.force.com/help/articles/FAQ/What-is-the-difference-between-using-a-direct-link-and-using-LMS-integration-to-give-your-students-access-to-OpenStax-Tutor?" target="_blank">
           <Icon type="info-circle" /> Which option is right for my course?
         </a>
         <PanelGroup

--- a/tutor/src/components/my-courses/empty.jsx
+++ b/tutor/src/components/my-courses/empty.jsx
@@ -8,7 +8,7 @@ export default function EmptyCourses() {
         We cannot find an OpenStax course associated with your account.
       </p>
       <p className="lead">
-        <a target="_blank" href="https://openstax.secure.force.com/help/">
+        <a target="_blank" href="https://openstax.secure.force.com/help">
           Get help >
         </a>
       </p>

--- a/tutor/src/components/my-courses/empty.jsx
+++ b/tutor/src/components/my-courses/empty.jsx
@@ -1,13 +1,6 @@
 import React from 'react';
 import { Panel } from 'react-bootstrap';
 
-const FAQ_BASE = 'http://openstax.force.com/support/articles/FAQ/';
-const CC_STUDENT_HELP = 'Getting-Started-with-Concept-Coach-Guide-Students/?q=getting+started&l=en_US&c=Products%3AConcept_Coach&fs=Search&pn=1';
-const CC_FACULTY_HELP = 'Getting-Started-with-Concept-Coach-Guide-Teachers/?q=getting+started&l=en_US&c=Products%3AConcept_Coach&fs=Search&pn=1';
-const TUTOR_STUDENT_HELP = 'Getting-Started-with-Tutor-Guide-Students/?q=getting+started&l=en_US&c=Products%3ATutor&fs=Search&pn=1';
-const TUTOR_FACULTY_HELP = 'Getting-Started-with-Tutor-Guide-Teachers/?q=getting+started&l=en_US&c=Products%3ATutor&fs=Search&pn=1';
-
-
 export default function EmptyCourses() {
   return (
     <Panel className="-course-list-empty">
@@ -15,23 +8,8 @@ export default function EmptyCourses() {
         We cannot find an OpenStax course associated with your account.
       </p>
       <p className="lead">
-        <a target="_blank" href={`${FAQ_BASE}${CC_STUDENT_HELP}`}>
-          Concept Coach Students.  Get help >
-        </a>
-      </p>
-      <p className="lead">
-        <a target="_blank" href={`${FAQ_BASE}${CC_FACULTY_HELP}`}>
-          Concept Coach Faculty.  Get help >
-        </a>
-      </p>
-      <p className="lead">
-        <a target="_blank" href={`${FAQ_BASE}${TUTOR_STUDENT_HELP}`}>
-          Tutor Students.  Get help >
-        </a>
-      </p>
-      <p className="lead">
-        <a target="_blank" href={`${FAQ_BASE}${TUTOR_FACULTY_HELP}`}>
-          Tutor Instructors.  Get help >
+        <a target="_blank" href="https://openstax.secure.force.com/help/">
+          Get help >
         </a>
       </p>
     </Panel>

--- a/tutor/src/components/navbar/toasts/lms.jsx
+++ b/tutor/src/components/navbar/toasts/lms.jsx
@@ -13,10 +13,10 @@ import { downloadData, arrayToCSV } from '../../../helpers/download-data';
 
 const Troubleshoot = () => (
   <NewTabLink
-    to="http://openstax.force.com/support/articles/FAQ/How-do-I-send-student-scores-from-OpenStax-Tutor-to-my-learning-management-system/?q=lms+scores&l=en_US&c=Products%3ATutor&fs=Search&pn=1"
-  >
+    to="https://openstax.secure.force.com/help/articles/FAQ/How-do-I-send-student-scores-from-OpenStax-Tutor-to-my-learning-management-system"
+    >
     Troubleshoot sending scores to your LMS
-  </NewTabLink>
+    </NewTabLink>
 );
 
 @observer
@@ -156,7 +156,7 @@ const renderFailedToSend = (footer) => (
     <div>
       <p>
         <NewTabLink
-          to="http://4tk3oi.axshare.com/salesforce_support_page_results.html#choose_support_article=All&CSUM=1"
+          to="https://openstax.secure.force.com/help/articles/FAQ/How-do-I-send-student-scores-from-OpenStax-Tutor-to-my-learning-management-system"
         >
           send course averages to your LMS
         </NewTabLink>

--- a/tutor/src/components/payments/manage.jsx
+++ b/tutor/src/components/payments/manage.jsx
@@ -171,7 +171,7 @@ export default class ManagePayments extends React.PureComponent {
         <div className="footer">
           <NewTabLink
             className="refund-policy"
-            to="http://openstax.force.com/support/articles/FAQ/OpenStax-Tutor-Student-Refund-Policy/?q=refund&l=en_US&c=Products%3ATutor&fs=Search&pn=1"
+            to="https://openstax.secure.force.com/help/articles/FAQ/OpenStax-Tutor-Student-Refund-Policy"
           >
             Refund policy for OpenStax Tutor Beta courses
           </NewTabLink>

--- a/tutor/src/models/user/menu.js
+++ b/tutor/src/models/user/menu.js
@@ -115,11 +115,8 @@ const ROUTES = {
 
 };
 
-const TUTOR_HELP = 'http://openstax.force.com/support?l=en_US&c=Products%3ATutor';
-const TUTOR_CONTACT = 'http://openstax.force.com/support/?cu=1&fs=ContactUs&l=en_US&c=Products%3ATutor';
-const CONCEPT_COACH_HELP = 'http://openstax.force.com/support?l=en_US&c=Products%3AConcept_Coach';
-const CONCEPT_COACH_CONTACT = 'http://openstax.force.com/support/?cu=1&fs=ContactUs&l=en_US&c=Products%3AConcept_Coach';
-
+const TUTOR_HELP = 'https://openstax.secure.force.com/help';
+const TUTOR_CONTACT = 'https://openstax.org/contact';
 const SUPPORT_EMAIL = 'support@openstax.org';
 
 function getRouteByRole(routeName, menuRole) {
@@ -154,7 +151,7 @@ const UserMenu = observable({
     if (!courseId) { return this.helpURL; }
     const course = Courses.get(courseId);
     if (!course) { return this.helpURL; }
-    return course.is_concept_coach ? CONCEPT_COACH_HELP : TUTOR_HELP;
+    return TUTOR_HELP;
   },
 
   getRoutes(courseId) {


### PR DESCRIPTION
Removes the teacher/student/cc options from the no-courses-found page so it's now:
![screen shot 2018-01-09 at 1 16 44 pm](https://user-images.githubusercontent.com/79566/34738916-397069a0-f540-11e7-9c7a-d2534ba560d0.png)


