### PR TITLE
course id needs to be passed in as props so that support menu re-rend…

### DIFF
--- a/tutor/specs/components/navbar/__snapshots__/support-menu.spec.jsx.snap
+++ b/tutor/specs/components/navbar/__snapshots__/support-menu.spec.jsx.snap
@@ -82,7 +82,7 @@ exports[`Support Menu renders and matches snapshot 1`] = `
       style={undefined}
     >
       <a
-        href="/accessibility-statement/"
+        href="/accessibility-statement/2"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="menuitem"

--- a/tutor/specs/components/navbar/support-menu.spec.jsx
+++ b/tutor/specs/components/navbar/support-menu.spec.jsx
@@ -5,17 +5,13 @@ import { bootstrapCoursesList } from '../../courses-test-data';
 import TourRegion from '../../../src/models/tour/region';
 import TourContext from '../../../src/models/tour/context';
 import Chat from '../../../src/models/chat';
-import Router from '../../../src/helpers/router';
 jest.mock('../../../src/models/chat');
-
-jest.mock('../../../src/helpers/router');
 
 describe('Support Menu', () => {
   let context;
   let region;
   let courses;
   beforeEach(() => {
-    Router.currentParams.mockReturnValue({});
     Chat.isEnabled = false;
     context = new TourContext({ isEnabled: true });
     region = new TourRegion({ id: 'teacher-calendar', courseId: '2' });
@@ -47,15 +43,13 @@ describe('Support Menu', () => {
   });
 
   it('renders support links when in a course for student', () => {
-    Router.currentParams.mockReturnValue({ courseId: '1' });
     expect(SnapShot.create(
-      <Wrapper _wrapped_component={SupportMenu} courseId="2" tourContext={context} />).toJSON()
+      <Wrapper _wrapped_component={SupportMenu} courseId="1" tourContext={context} />).toJSON()
     ).toMatchSnapshot();
   });
 
   it('renders support links when in a course for teacher', () => {
     courses.get('2').appearance_code = 'college_biology';
-    Router.currentParams.mockReturnValue({ courseId: '2' });
     expect(SnapShot.create(
       <Wrapper _wrapped_component={SupportMenu} courseId="2" tourContext={context} />).toJSON()
     ).toMatchSnapshot();

--- a/tutor/src/components/navbar/index.jsx
+++ b/tutor/src/components/navbar/index.jsx
@@ -28,7 +28,7 @@ function DefaultNavBar({ params }) {
         </div>
         <CenterControls params={params} />
         <div className="right-side-controls">
-          <SupportMenu />
+          <SupportMenu         courseId={courseId} />
           <StudentPayNowBtn    courseId={courseId} />
           <ActionsMenu         courseId={courseId} />
           <PreviewAddCourseBtn courseId={courseId} />

--- a/tutor/src/components/navbar/support-menu.jsx
+++ b/tutor/src/components/navbar/support-menu.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { findDOMNode } from 'react-dom';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 import { get } from 'lodash';
-import { action } from 'mobx';
+import { action, computed } from 'mobx';
 import { observer, inject } from 'mobx-react';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 
@@ -12,7 +12,6 @@ import UserMenu from '../../models/user/menu';
 import Icon from '../icon';
 import SupportDocument from './support-document-link';
 import TourContext from '../../models/tour/context';
-import Router from '../../helpers/router';
 import StudentPreviewLink from './student-previews-link';
 
 @observer
@@ -94,9 +93,9 @@ class SupportMenuDropDown extends React.PureComponent {
     this.context.router.history.push(this.accessibilityLink);
   }
 
+  @computed
   get accessibilityLink() {
-    const { courseId } = Router.currentParams();
-    return `/accessibility-statement/${courseId || ''}`;
+    return `/accessibility-statement/${this.props.courseId || ''}`;
   }
 
   render() {

--- a/tutor/src/components/navbar/support-menu.jsx
+++ b/tutor/src/components/navbar/support-menu.jsx
@@ -100,8 +100,7 @@ class SupportMenuDropDown extends React.PureComponent {
   }
 
   render() {
-    const { open, onClose, rootCloseEvent } = this.props;
-    const { courseId } = Router.currentParams();
+    const { open, onClose, rootCloseEvent, courseId } = this.props;
 
     const menu = (
       <TourAnchor


### PR DESCRIPTION
…ers on course id change

https://trello.com/c/bzcXD536/1194-bug-student-onboarding-tour-help-menu-training-wheel-not-displaying?menu=filter&filter=label:priority1-high,label:none

If the page load is at `course/:courseId`, tour was rendering, but if you went to my courses and then to a course dashboard, the support menu was not re-rendering, so the tour was not bring registered.