### PR TITLE
Fix hard-source/happy-pack build

### DIFF
--- a/bin/serve
+++ b/bin/serve
@@ -7,4 +7,4 @@ bin/checkinputs "$@"
 export OX_PROJECT=$1
 echo Serving: $OX_PROJECT
 
-$(npm bin)/webpack-dev-server --debug --progress --config webpack.config.js
+node --max_old_space_size=2048 $(npm bin)/webpack-dev-server --debug --progress --config webpack.config.js

--- a/configs/webpack/base.coffee
+++ b/configs/webpack/base.coffee
@@ -43,7 +43,7 @@ BASE_BUILD =
   coffee: RESOLVABLES.coffee
   cjsx:   RESOLVABLES.cjsx
   css:  { test: /\.css$/,  use: ExtractTextPlugin.extract([ STYLE_LOADERS.css ]) }
-  less: { test: /\.less$/, use: ExtractTextPlugin.extract([ STYLE_LOADERS.css, LOADERS.less ]) }
+  less: { test: /\.less$/, use: ExtractTextPlugin.extract([ STYLE_LOADERS.css, STYLE_LOADERS.less ]) }
   scss: { test: /\.scss$/, use: ExtractTextPlugin.extract([ STYLE_LOADERS.css, STYLE_LOADERS.scss ]) }
 
 DEV_LOADERS = ['react-hot-loader/webpack']

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint-cjsx": "./bin/lint-cjsx-files.sh",
     "validate": "./bin/validate-console-messages.sh",
     "prestart": "npm run validate",
-    "start": "./bin/tdd"
+    "start": "./bin/tdd",
+    "clear-build-cache": "rm -r ./tutor/node_modules/.cache/hard-source"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps memory up to 2gb from node's default of 1
Removes styles from happy-pack
adds a command to clear cache for when hard-source is messed up