### PR TITLE
Fix double loading tasks when enrolling

### DIFF
--- a/shared/src/api/index.coffee
+++ b/shared/src/api/index.coffee
@@ -150,7 +150,7 @@ class APIHandlerBase
 
   # send can now be used separately without initializing routes
   send: (requestConfig, routeOptions, args...) ->
-    return if @records.isPending(requestConfig)
+    return Promise.reject('already-in-progress') if @records.isPending(requestConfig)
 
     requestInfo = pick(routeOptions, 'subject', 'topic', 'action')
     requestInfo = guessInfoFromConfig(requestConfig) if isEmpty(requestInfo)

--- a/tutor/specs/models/student-tasks.spec.jsx
+++ b/tutor/specs/models/student-tasks.spec.jsx
@@ -39,24 +39,6 @@ describe('Student Tasks Model', () => {
     ]);
   });
 
-  it('polls for updates', () => {
-    const tasks = StudentTasks.forCourseId(1);
-    tasks.fetch = jest.fn(() => Promise.resolve({}));
-    tasks.pollForUpdates({ expectedCount: 42 });
-    expect(tasks.fetch).toHaveBeenCalled();
-    expect(tasks._updatesPoller).not.toBeNull();
-    jest.runAllTimers();
-    expect(tasks.fetch).toHaveBeenCalledTimes(2);
-    times(41, (i) => tasks.set(i, {}));
-    jest.runAllTimers();
-    expect(tasks.fetch).toHaveBeenCalledTimes(3);
-    tasks.set(42, {});
-    expect(tasks.array).toHaveLength(42);
-    jest.runAllTimers();
-    expect(tasks.fetch).toHaveBeenCalledTimes(3);
-    expect(tasks._updatesPoller).toBeNull();
-  });
-
   it('#upcomingEvents', () => {
     const tasks = StudentTasks.forCourseId(1);
     const task = tasks.array[0];

--- a/tutor/src/models/course/enroll.js
+++ b/tutor/src/models/course/enroll.js
@@ -154,11 +154,6 @@ export default class CourseEnrollment extends BaseModel {
   fetchCourses() {
     this.isLoadingCourses = true;
     User.refreshCourses().then(() => {
-      const assignments_count = get(this, 'to.period.assignments_count', 0);
-      if (assignments_count) {
-        const tasks = StudentTasks.forCourseId(this.courseId);
-        tasks.pollForUpdates({ expectedCount: assignments_count });
-      }
       this.isLoadingCourses = false;
       this.isComplete = true;
     });

--- a/tutor/src/models/student-tasks.js
+++ b/tutor/src/models/student-tasks.js
@@ -49,23 +49,6 @@ export class CourseStudentTasks extends Map {
     return Boolean(this.array.length == 0 && this._updatesPoller);
   }
 
-  @action
-  pollForUpdates({ expectedCount }) {
-    if (this._updatesPoller){ return; }
-    let attempts = 0;
-    this._updatesPoller = () => {
-      attempts += 1;
-      if (attempts < MAX_POLLING_ATTEMPTS && this.array.length < expectedCount) {
-        this.fetch().then(() => {
-          setTimeout(this._updatesPoller, POLL_SECONDS * 1000);
-        });
-      } else {
-        this._updatesPoller = null;
-      }
-    };
-    this._updatesPoller();
-  }
-
   // note: the response also contains limited course and role information but they're currently unused
   onLoaded({ data: { tasks, research_surveys } }) {
     this.researchSurveys = research_surveys ? new ResearchSurveys(research_surveys) : null;


### PR DESCRIPTION
Initially the enrollment code would poll for tasks, but then later we also added polling anytime the student dashboard is displayed.  

Which caused double loads and occasionally an error when the action-adapter noticed the same api request and returned undefined instead of a Promise