### PR TITLE
Fix popover styles

### DIFF
--- a/tutor/resources/styles/global/popover.scss
+++ b/tutor/resources/styles/global/popover.scss
@@ -1,11 +1,3 @@
-// This is largely taken from bootstrap since they do not provide a mixin for popovers
-$popover-title-bg: $tutor-white;
-$popover-border-color: transparent;
-$popover-arrow-color: $tutor-white;
-$popover-arrow-outer-fallback-color: $tutor-neutral-light;
-$popover-arrow-outer-color: $tutor-neutral-light;
-$popover-background: $tutor-white;
-
 .popover-title {
    @include tutor-sans-font(1.75rem, 1.75rem);
 }

--- a/tutor/resources/styles/global/tooltip.scss
+++ b/tutor/resources/styles/global/tooltip.scss
@@ -1,12 +1,11 @@
-// this overrides the bad styles that are supplied by bootstrap material design (grey text on gray bg?)
-$tooltip-border-color: $tutor-info;
-$tooltip-color: $tutor-neutral-darker;
-$tooltip-arrow-color: $tutor-white;
-$tooltip-arrow-outer-fallback-color: $tutor-info;
-$tooltip-arrow-outer-color: $tutor-info;
 .tooltip {
   .tooltip-inner {
     color: $tutor-neutral-darker;
+    @include tutor-shadow(2);
   }
   .tooltip-arrow { display: block; }
+}
+
+.popover-title {
+  @include tutor-sans-font(1.75rem, 1.75rem);
 }

--- a/tutor/resources/styles/variables/tutor-bootstrap.scss
+++ b/tutor/resources/styles/variables/tutor-bootstrap.scss
@@ -514,6 +514,14 @@ $dropdown-link-active-bg:        $gray;
 // //
 // //##
 
+$tooltip-border-color: $tutor-info;
+$tooltip-color: $tutor-neutral-darker;
+$tooltip-arrow-color: $tutor-white;
+$tooltip-arrow-outer-fallback-color: $tutor-info;
+$tooltip-arrow-outer-color: $tutor-info;
+$tooltip-bg: $tutor-white;
+
+
 // //** Tooltip max width
 // $tooltip-max-width:           200px;
 // //** Tooltip text color
@@ -531,6 +539,13 @@ $dropdown-link-active-bg:        $gray;
 // //== Popovers
 // //
 // //##
+// This is largely taken from bootstrap since they do not provide a mixin for popovers
+$popover-title-bg: $tutor-white;
+$popover-border-color: transparent;
+$popover-arrow-color: $tutor-white;
+$popover-arrow-outer-fallback-color: $tutor-neutral-light;
+$popover-arrow-outer-color: $tutor-neutral-light;
+$popover-background: $tutor-white;
 
 // //** Popover body background color
 // $popover-bg:                          #fff;


### PR DESCRIPTION
This way the popover colors variables will be applied before bootstrap is read

Before:
<img width="699" alt="screen shot 2018-01-22 at 4 54 50 pm" src="https://user-images.githubusercontent.com/79566/35248785-0d71928e-ff95-11e7-8103-0135f037929a.png">



After:
<img width="808" alt="screen shot 2018-01-22 at 4 52 03 pm" src="https://user-images.githubusercontent.com/79566/35248786-0d7ff1ee-ff95-11e7-8aef-a294ba87c542.png">
