### PR TITLE
Fix "orig. due date" popover on plan clone

### DIFF
--- a/tutor/src/helpers/task-plan.js
+++ b/tutor/src/helpers/task-plan.js
@@ -32,7 +32,7 @@ export default {
 
 
   earliestDueDate(plan) {
-    const dates = map(get(plan, 'x.tasking_plans'), 'due_at');
+    const dates = map(get(plan, 'tasking_plans'), 'due_at');
     return first(dates.sort()) || '';
   },
 


### PR DESCRIPTION
Before:
<img width="481" alt="screen shot 2018-01-30 at 9 02 52 pm" src="https://user-images.githubusercontent.com/79566/35603043-f377cf20-0600-11e8-9257-25de54f0be12.png">


After:
<img width="510" alt="screen shot 2018-01-30 at 9 02 12 pm" src="https://user-images.githubusercontent.com/79566/35603040-edf1f148-0600-11e8-8632-95827f55991f.png">
