### PR TITLE
Fix progress bars on stats

### DIFF
--- a/tutor/resources/styles/components/task-plan/task-plan-stats.scss
+++ b/tutor/resources/styles/components/task-plan/task-plan-stats.scss
@@ -79,7 +79,6 @@ $progress-on-hover-label-height: 24px;
   &-bar{
 
     position: relative;
-    margin-bottom: $progress-on-hover-label-height;
 
     &.no-progress {
       span {
@@ -95,24 +94,6 @@ $progress-on-hover-label-height: 24px;
       min-width:15px;
     }
 
-    &::after {
-      content: attr(type);
-      position: absolute;
-      bottom: -$progress-on-hover-label-height;
-      left: 50%;
-      width: 100px;
-      margin-left: -50px;
-      text-align: center;
-      color: $tutor-neutral;
-      @include opacity(0);
-      @include transition(opacity 1s);
-    }
-
-    &:hover {
-      &::after {
-        @include opacity(1);
-      }
-    }
   }
 
   &-delta {


### PR DESCRIPTION
The after label wasn't being displayed and the margin-bottom pushes the following
label down since it's floated

before:
![screen shot 2018-01-31 at 12 56 26 pm](https://user-images.githubusercontent.com/79566/35641679-7858e6c2-0686-11e8-90a9-581f4a80ab6a.png)

after:
![screen shot 2018-01-31 at 12 49 00 pm](https://user-images.githubusercontent.com/79566/35641680-7869e01c-0686-11e8-9261-23991efa6b99.png)
