### PR TITLE
Fix keyboard navigation on menus

### DIFF
--- a/tutor/resources/styles/components/top-nav-bar.scss
+++ b/tutor/resources/styles/components/top-nav-bar.scss
@@ -61,14 +61,6 @@ $tutor-navbar-padding-horizontal: 4rem;
     width: 1200px;
   }
 
-  #student-preview-link {
-    display: flex;
-    flex: 1;
-    align-items: center;
-    align-self: stretch;
-    @include top-nav-action();
-  }
-
   @include make-shy-animate();
 
   a {
@@ -130,9 +122,7 @@ $tutor-navbar-padding-horizontal: 4rem;
       .tutor-icon { margin-left: 0.5rem; }
     }
   }
-  .student-preview-link {
-    @include top-nav-action();
-  }
+
   .student-pay-now {
     display: flex;
     align-items: center;

--- a/tutor/specs/components/__snapshots__/app.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/app.spec.jsx.snap
@@ -46,7 +46,7 @@ exports[`main Tutor App renders and matches snapshot 1`] = `
                 role="button"
               >
                 <div
-                  ariaLabelledby="support-menu"
+                  aria-labelledby="support-menu"
                   className="tour-anchor"
                   data-tour-anchor-id="support-menu-button"
                   id="support-menu-button"

--- a/tutor/specs/components/__snapshots__/app.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/app.spec.jsx.snap
@@ -45,28 +45,35 @@ exports[`main Tutor App renders and matches snapshot 1`] = `
                 onKeyDown={[Function]}
                 role="button"
               >
-                <i
-                  className="tutor-icon fa fa-question-circle"
-                  role="presentation"
-                  type="question-circle"
-                />
-                <span
-                  className="control-label"
-                  title="Page tips and support"
+                <div
+                  ariaLabelledby="support-menu"
+                  className="tour-anchor"
+                  data-tour-anchor-id="support-menu-button"
+                  id="support-menu-button"
+                  onSelect={[Function]}
                 >
-                  Help
-                </span>
-                <i
-                  className="tutor-icon fa fa-angle-down toggle"
-                  role="presentation"
-                  type="angle-down"
-                />
+                  <i
+                    className="tutor-icon fa fa-question-circle"
+                    role="presentation"
+                    type="question-circle"
+                  />
+                  <span
+                    className="control-label"
+                    title="Page tips and support"
+                  >
+                    Help
+                  </span>
+                  <i
+                    className="tutor-icon fa fa-angle-down toggle"
+                    role="presentation"
+                    type="angle-down"
+                  />
+                </div>
               </a>
               <ul
-                className="tour-anchor dropdown-menu dropdown-menu-right"
-                data-tour-anchor-id="support-menu-button"
-                id="support-menu-button"
-                onSelect={[Function]}
+                aria-labelledby="support-menu"
+                className="dropdown-menu dropdown-menu-right dropdown-menu"
+                role="menu"
               >
                 <li
                   className="-help-link"
@@ -200,10 +207,16 @@ exports[`main Tutor App renders and matches snapshot 1`] = `
               >
                 <li
                   className="logout"
+                  role="presentation"
+                  style={undefined}
                 >
                   <a
                     href="#"
+                    label="Log out"
                     onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
                   >
                     <form
                       acceptCharset="UTF-8"

--- a/tutor/specs/components/navbar/__snapshots__/actions_menu.spec.jsx.snap
+++ b/tutor/specs/components/navbar/__snapshots__/actions_menu.spec.jsx.snap
@@ -89,12 +89,15 @@ exports[`Student Navbar Component has actions menu that matches snapshot 1`] = `
     <li
       className=""
       role="presentation"
+      style={undefined}
     >
       <a
-        className="view-reference-guide"
         href="/books/1"
+        name="browseBook"
         onClick={[Function]}
-        tabIndex={0}
+        onKeyDown={[Function]}
+        role="menuitem"
+        tabIndex="-1"
         target="_blank"
       >
         <div
@@ -243,12 +246,15 @@ exports[`Teacher Navbar Component has actions menu that matches snapshot 1`] = `
     <li
       className=""
       role="presentation"
+      style={undefined}
     >
       <a
-        className="view-reference-guide"
         href="/books/1"
+        name="browseBook"
         onClick={[Function]}
-        tabIndex={0}
+        onKeyDown={[Function]}
+        role="menuitem"
+        tabIndex="-1"
         target="_blank"
       >
         <div

--- a/tutor/specs/components/navbar/__snapshots__/index.spec.jsx.snap
+++ b/tutor/specs/components/navbar/__snapshots__/index.spec.jsx.snap
@@ -37,7 +37,7 @@ exports[`Main navbar renders and matches snapshot 1`] = `
           role="button"
         >
           <div
-            ariaLabelledby="support-menu"
+            aria-labelledby="support-menu"
             className="tour-anchor"
             data-tour-anchor-id="support-menu-button"
             id="support-menu-button"

--- a/tutor/specs/components/navbar/__snapshots__/index.spec.jsx.snap
+++ b/tutor/specs/components/navbar/__snapshots__/index.spec.jsx.snap
@@ -36,28 +36,35 @@ exports[`Main navbar renders and matches snapshot 1`] = `
           onKeyDown={[Function]}
           role="button"
         >
-          <i
-            className="tutor-icon fa fa-question-circle"
-            role="presentation"
-            type="question-circle"
-          />
-          <span
-            className="control-label"
-            title="Page tips and support"
+          <div
+            ariaLabelledby="support-menu"
+            className="tour-anchor"
+            data-tour-anchor-id="support-menu-button"
+            id="support-menu-button"
+            onSelect={[Function]}
           >
-            Help
-          </span>
-          <i
-            className="tutor-icon fa fa-angle-down toggle"
-            role="presentation"
-            type="angle-down"
-          />
+            <i
+              className="tutor-icon fa fa-question-circle"
+              role="presentation"
+              type="question-circle"
+            />
+            <span
+              className="control-label"
+              title="Page tips and support"
+            >
+              Help
+            </span>
+            <i
+              className="tutor-icon fa fa-angle-down toggle"
+              role="presentation"
+              type="angle-down"
+            />
+          </div>
         </a>
         <ul
-          className="tour-anchor dropdown-menu dropdown-menu-right"
-          data-tour-anchor-id="support-menu-button"
-          id="support-menu-button"
-          onSelect={[Function]}
+          aria-labelledby="support-menu"
+          className="dropdown-menu dropdown-menu-right dropdown-menu"
+          role="menu"
         >
           <li
             className="-help-link"
@@ -122,10 +129,16 @@ exports[`Main navbar renders and matches snapshot 1`] = `
         >
           <li
             className="logout"
+            role="presentation"
+            style={undefined}
           >
             <a
               href="#"
+              label="Log out"
               onClick={[Function]}
+              onKeyDown={[Function]}
+              role="menuitem"
+              tabIndex="-1"
             >
               <form
                 acceptCharset="UTF-8"

--- a/tutor/specs/components/navbar/__snapshots__/support-menu.spec.jsx.snap
+++ b/tutor/specs/components/navbar/__snapshots__/support-menu.spec.jsx.snap
@@ -14,28 +14,35 @@ exports[`Support Menu renders and matches snapshot 1`] = `
     onKeyDown={[Function]}
     role="button"
   >
-    <i
-      className="tutor-icon fa fa-question-circle"
-      role="presentation"
-      type="question-circle"
-    />
-    <span
-      className="control-label"
-      title="Page tips and support"
+    <div
+      ariaLabelledby="support-menu"
+      className="tour-anchor"
+      data-tour-anchor-id="support-menu-button"
+      id="support-menu-button"
+      onSelect={[Function]}
     >
-      Help
-    </span>
-    <i
-      className="tutor-icon fa fa-angle-down toggle"
-      role="presentation"
-      type="angle-down"
-    />
+      <i
+        className="tutor-icon fa fa-question-circle"
+        role="presentation"
+        type="question-circle"
+      />
+      <span
+        className="control-label"
+        title="Page tips and support"
+      >
+        Help
+      </span>
+      <i
+        className="tutor-icon fa fa-angle-down toggle"
+        role="presentation"
+        type="angle-down"
+      />
+    </div>
   </a>
   <ul
-    className="tour-anchor dropdown-menu dropdown-menu-right"
-    data-tour-anchor-id="support-menu-button"
-    id="support-menu-button"
-    onSelect={[Function]}
+    aria-labelledby="support-menu"
+    className="dropdown-menu dropdown-menu-right dropdown-menu"
+    role="menu"
   >
     <li
       className="page-tips"
@@ -111,28 +118,35 @@ exports[`Support Menu renders support links when in a course for student 1`] = `
     onKeyDown={[Function]}
     role="button"
   >
-    <i
-      className="tutor-icon fa fa-question-circle"
-      role="presentation"
-      type="question-circle"
-    />
-    <span
-      className="control-label"
-      title="Page tips and support"
+    <div
+      ariaLabelledby="support-menu"
+      className="tour-anchor"
+      data-tour-anchor-id="support-menu-button"
+      id="support-menu-button"
+      onSelect={[Function]}
     >
-      Help
-    </span>
-    <i
-      className="tutor-icon fa fa-angle-down toggle"
-      role="presentation"
-      type="angle-down"
-    />
+      <i
+        className="tutor-icon fa fa-question-circle"
+        role="presentation"
+        type="question-circle"
+      />
+      <span
+        className="control-label"
+        title="Page tips and support"
+      >
+        Help
+      </span>
+      <i
+        className="tutor-icon fa fa-angle-down toggle"
+        role="presentation"
+        type="angle-down"
+      />
+    </div>
   </a>
   <ul
-    className="tour-anchor dropdown-menu dropdown-menu-right"
-    data-tour-anchor-id="support-menu-button"
-    id="support-menu-button"
-    onSelect={[Function]}
+    aria-labelledby="support-menu"
+    className="dropdown-menu dropdown-menu-right dropdown-menu"
+    role="menu"
   >
     <li
       className="-help-link"
@@ -209,28 +223,35 @@ exports[`Support Menu renders support links when in a course for teacher 1`] = `
     onKeyDown={[Function]}
     role="button"
   >
-    <i
-      className="tutor-icon fa fa-question-circle"
-      role="presentation"
-      type="question-circle"
-    />
-    <span
-      className="control-label"
-      title="Page tips and support"
+    <div
+      ariaLabelledby="support-menu"
+      className="tour-anchor"
+      data-tour-anchor-id="support-menu-button"
+      id="support-menu-button"
+      onSelect={[Function]}
     >
-      Help
-    </span>
-    <i
-      className="tutor-icon fa fa-angle-down toggle"
-      role="presentation"
-      type="angle-down"
-    />
+      <i
+        className="tutor-icon fa fa-question-circle"
+        role="presentation"
+        type="question-circle"
+      />
+      <span
+        className="control-label"
+        title="Page tips and support"
+      >
+        Help
+      </span>
+      <i
+        className="tutor-icon fa fa-angle-down toggle"
+        role="presentation"
+        type="angle-down"
+      />
+    </div>
   </a>
   <ul
-    className="tour-anchor dropdown-menu dropdown-menu-right"
-    data-tour-anchor-id="support-menu-button"
-    id="support-menu-button"
-    onSelect={[Function]}
+    aria-labelledby="support-menu"
+    className="dropdown-menu dropdown-menu-right dropdown-menu"
+    role="menu"
   >
     <li
       className="-help-link"

--- a/tutor/specs/components/navbar/__snapshots__/support-menu.spec.jsx.snap
+++ b/tutor/specs/components/navbar/__snapshots__/support-menu.spec.jsx.snap
@@ -15,7 +15,7 @@ exports[`Support Menu renders and matches snapshot 1`] = `
     role="button"
   >
     <div
-      ariaLabelledby="support-menu"
+      aria-labelledby="support-menu"
       className="tour-anchor"
       data-tour-anchor-id="support-menu-button"
       id="support-menu-button"
@@ -119,7 +119,7 @@ exports[`Support Menu renders support links when in a course for student 1`] = `
     role="button"
   >
     <div
-      ariaLabelledby="support-menu"
+      aria-labelledby="support-menu"
       className="tour-anchor"
       data-tour-anchor-id="support-menu-button"
       id="support-menu-button"
@@ -224,7 +224,7 @@ exports[`Support Menu renders support links when in a course for teacher 1`] = `
     role="button"
   >
     <div
-      ariaLabelledby="support-menu"
+      aria-labelledby="support-menu"
       className="tour-anchor"
       data-tour-anchor-id="support-menu-button"
       id="support-menu-button"

--- a/tutor/specs/components/navbar/account_link.spec.js
+++ b/tutor/specs/components/navbar/account_link.spec.js
@@ -13,6 +13,6 @@ describe('Account Link', function() {
   it('renders link with profile url and target set to _blank', function() {
     User.profile_url = 'a.test.url';
     const link = shallow(<Link />);
-    expect(link).toHaveRendered('a[target="_blank"][href="a.test.url"]');
+    expect(link).toHaveRendered('[href="a.test.url"][target="_blank"]');
   });
 });

--- a/tutor/specs/components/navbar/support-menu.spec.jsx
+++ b/tutor/specs/components/navbar/support-menu.spec.jsx
@@ -24,15 +24,8 @@ describe('Support Menu', () => {
     region = new TourRegion({ id: 'foo', courseId: '2', otherTours: ['teacher-calendar'] });
     context.openRegion(region);
     expect(context.hasTriggeredTour).toBe(true);
-    expect(context.hasTriggeredTour).toBe(true);
     expect(menu).toHaveRendered('.page-tips');
-  });
-
-  it('renders and matches snapshot', () => {
-    context.openRegion(region);
-    expect(SnapShot.create(
-      <Wrapper _wrapped_component={SupportMenu} courseId="2" tourContext={context} />).toJSON()
-    ).toMatchSnapshot();
+    menu.unmount();
   });
 
   it('calls chat when clicked', () => {
@@ -40,6 +33,7 @@ describe('Support Menu', () => {
     const menu = mount(<SupportMenu courseId="2" tourContext={context} />);
     menu.find('.chat.enabled a').simulate('click');
     expect(Chat.start).toHaveBeenCalled();
+    menu.unmount();
   });
 
   it('renders support links when in a course for student', () => {
@@ -50,6 +44,13 @@ describe('Support Menu', () => {
 
   it('renders support links when in a course for teacher', () => {
     courses.get('2').appearance_code = 'college_biology';
+    expect(SnapShot.create(
+      <Wrapper _wrapped_component={SupportMenu} courseId="2" tourContext={context} />).toJSON()
+    ).toMatchSnapshot();
+  });
+
+  it('renders and matches snapshot', () => {
+    context.openRegion(region);
     expect(SnapShot.create(
       <Wrapper _wrapped_component={SupportMenu} courseId="2" tourContext={context} />).toJSON()
     ).toMatchSnapshot();

--- a/tutor/src/components/navbar/account-link.jsx
+++ b/tutor/src/components/navbar/account-link.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { MenuItem } from 'react-bootstrap';
 import User from '../../models/user';
 import { observer } from 'mobx-react';
 
@@ -14,11 +14,9 @@ export default class AccountLink extends React.PureComponent {
     const { profile_url } = User;
     if (!profile_url) { return null; }
     return (
-      <li role="presentation">
-        <a href={profile_url} target="_blank">
-          My Account
-        </a>
-      </li>
+      <MenuItem {...this.props} href={profile_url} target="_blank">
+        My Account
+      </MenuItem>
     );
   }
 }

--- a/tutor/src/components/navbar/actions-menu.jsx
+++ b/tutor/src/components/navbar/actions-menu.jsx
@@ -2,15 +2,13 @@ import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 import TutorRouter from '../../helpers/router'
 import { Route } from 'react-router';
-
 import {  partial, flatMap, get, isEmpty, omit } from 'lodash';
 import classnames from 'classnames';
 import { observer } from 'mobx-react';
 import { autobind } from 'core-decorators';
 import Icon from '../icon';
-
+import NewTabLink from '../new-tab-link';
 import TourAnchor from '../tours/anchor';
-import BrowseTheBook from '../buttons/browse-the-book';
 import Router from '../../helpers/router';
 import User from '../../models/user';
 import UserMenu from '../../models/user/menu';
@@ -20,26 +18,32 @@ const RoutedMenuItem = (props) => {
   const { label, name, tourId, className, route } = props;
   const isActive = TutorRouter.isActive(route.name, route.params, route.options);
 
-  return (<Route path={props.href} exact>
-    <MenuItem
-      className={classnames(name, className, { 'active': isActive })}
-      data-name={name}
-      {...omit(props, ['label', 'name', 'tourId', 'className', 'route'])}
-    >
-      <TourAnchor id={tourId}>
-        {label}
-      </TourAnchor>
-    </MenuItem>
-  </Route>);
+  return (
+    <Route path={props.href} exact>
+      <MenuItem
+        className={classnames(name, className, { 'active': isActive })}
+        data-name={name}
+        {...omit(props, ['label', 'name', 'tourId', 'className', 'route'])}
+      >
+        <TourAnchor id={tourId}>
+          {label}
+        </TourAnchor>
+      </MenuItem>
+    </Route>
+  );
 }
 
-function BrowseBookMenuItem({ params: { courseId }, className, active, label }) {
+function BrowseBookMenuItem({ params: { courseId }, className, active, label, ...props }) {
   return (
-    <li role="presentation" className={classnames(className, { 'active': active })}>
-      <BrowseTheBook unstyled courseId={courseId}>
-        <TourAnchor id="menu-option-browse-book">{label}</TourAnchor>
-      </BrowseTheBook>
-    </li>
+      <MenuItem
+        {...props}
+        href={`/books/${courseId}`}
+        target="_blank"
+      >
+        <TourAnchor id="menu-option-browse-book">
+          Browse the Book
+        </TourAnchor>
+      </MenuItem>
   );
 }
 

--- a/tutor/src/components/navbar/logout.jsx
+++ b/tutor/src/components/navbar/logout.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { observer } from 'mobx-react';
+import { MenuItem } from 'react-bootstrap';
 
 import User from '../../models/user';
 
@@ -24,19 +25,18 @@ export default class LogoutLink extends React.PureComponent {
 
   render() {
     return (
-      <li className="logout">
-        <a href="#" onClick={this.onLinkClick}>
-          <form
-            acceptCharset="UTF-8"
-            action={this.props.isConceptCoach ? LOGOUT_URL_CC : LOGOUT_URL}
-            className="-logout-form"
-            method="post">
-            <input type="hidden" name="_method" value="delete" />
-            <input type="hidden" name="authenticity_token" value={User.csrf_token} />
-            <input type="submit" aria-label={this.props.label} value={this.props.label} />
-          </form>
-        </a>
-      </li>
+      <MenuItem className="logout" {...this.props} onClick={this.onLinkClick}>
+        <form
+          acceptCharset="UTF-8"
+          action={this.props.isConceptCoach ? LOGOUT_URL_CC : LOGOUT_URL}
+          className="-logout-form"
+          method="post"
+        >
+          <input type="hidden" name="_method" value="delete" />
+          <input type="hidden" name="authenticity_token" value={User.csrf_token} />
+          <input type="submit" aria-label={this.props.label} value={this.props.label} />
+        </form>
+      </MenuItem>
     );
   }
 }

--- a/tutor/src/components/navbar/student-previews-link.jsx
+++ b/tutor/src/components/navbar/student-previews-link.jsx
@@ -3,12 +3,12 @@ import User from '../../models/user';
 import TutorLink from '../link';
 import TourAnchor from '../tours/anchor';
 
-export default function StudentPreviewLinks({ courseId }) {
+export default function StudentPreviewLinks({ courseId, ...props }) {
 
   if( !courseId || !( User.isConfirmedFaculty || User.isUnverifiedInstructor ) ) { return null; }
 
   return (
-    <TourAnchor tag="li" id="student-preview-link">
+    <TourAnchor tag="li" id="student-preview-link" {...props}>
       <TutorLink
         className="student-preview-link"
         to='studentPreview'

--- a/tutor/src/components/navbar/support-document-link.jsx
+++ b/tutor/src/components/navbar/support-document-link.jsx
@@ -13,8 +13,9 @@ export default class SupportDocumentLink extends React.Component {
   }
 
   render() {
-    if (!this.props.courseId) { return null; }
-    const course = Courses.get(this.props.courseId);
+    const { courseId, ...props } = this.props;
+    const course = Courses.get(courseId);
+    if (!course) { return null; }
 
     let url, name;
     if (!course || course.isStudent) {
@@ -32,6 +33,7 @@ export default class SupportDocumentLink extends React.Component {
         className="support-document-link"
         target="_blank"
         href={url}
+        {...props}
       >
         <TourAnchor id="menu-support-document">
           {name}

--- a/tutor/src/components/navbar/support-menu.jsx
+++ b/tutor/src/components/navbar/support-menu.jsx
@@ -16,7 +16,7 @@ import Router from '../../helpers/router';
 import TutorLink from '../link';
 
 
-const StudentPreview = ({ courseId, ...props }, { router }) => {
+const StudentPreview = observer(({ courseId, ...props }, { router }) => {
   if( !courseId || !( User.isConfirmedFaculty || User.isUnverifiedInstructor ) ) { return null; }
   return (
     <MenuItem
@@ -30,14 +30,13 @@ const StudentPreview = ({ courseId, ...props }, { router }) => {
       </TourAnchor>
     </MenuItem>
   );
-
-}
+});
 
 StudentPreview.contextTypes = {
   router: React.PropTypes.object,
 }
 
-const PageTips = ({ courseId, onPlayClick, tourContext, ...props }) => {
+const PageTips = observer(({ courseId, onPlayClick, tourContext, ...props }) => {
   if (!get(tourContext, 'hasTriggeredTour', false)){ return null; }
   return (
     <MenuItem
@@ -50,7 +49,7 @@ const PageTips = ({ courseId, onPlayClick, tourContext, ...props }) => {
       </TourAnchor>
     </MenuItem>
   );
-}
+});
 
 
 
@@ -158,7 +157,7 @@ export default class SupportMenu extends React.PureComponent {
         >
           <TourAnchor
             id="support-menu-button"
-            ariaLabelledby="support-menu"
+            aria-labelledby="support-menu"
             onSelect={this.onSelect}
           >
             <Icon type="question-circle" />

--- a/tutor/src/components/navbar/support-menu.jsx
+++ b/tutor/src/components/navbar/support-menu.jsx
@@ -5,17 +5,63 @@ import { get } from 'lodash';
 import { action, computed } from 'mobx';
 import { observer, inject } from 'mobx-react';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
-
+import User from '../../models/user';
 import TourAnchor from '../tours/anchor';
 import Chat from '../../models/chat';
 import UserMenu from '../../models/user/menu';
 import Icon from '../icon';
 import SupportDocument from './support-document-link';
 import TourContext from '../../models/tour/context';
-import StudentPreviewLink from './student-previews-link';
+import Router from '../../helpers/router';
+import TutorLink from '../link';
 
+
+const StudentPreview = ({ courseId, ...props }, { router }) => {
+  if( !courseId || !( User.isConfirmedFaculty || User.isUnverifiedInstructor ) ) { return null; }
+  return (
+    <MenuItem
+      {...props}
+      onClick={() => {
+          router.history.push(Router.makePathname('studentPreview'))
+      }}
+    >
+      <TourAnchor id="student-preview-link">
+        <span className="control-label" title="See what students see">Student preview videos</span>
+      </TourAnchor>
+    </MenuItem>
+  );
+
+}
+
+StudentPreview.contextTypes = {
+  router: React.PropTypes.object,
+}
+
+const PageTips = ({ courseId, onPlayClick, tourContext, ...props }) => {
+  if (!get(tourContext, 'hasTriggeredTour', false)){ return null; }
+  return (
+    <MenuItem
+      className="page-tips"
+      {...props}
+      onSelect={onPlayClick}
+    >
+      <TourAnchor id="menu-option-page-tips">
+        Page Tips
+      </TourAnchor>
+    </MenuItem>
+  );
+}
+
+
+
+@inject((allStores, props) => ({ tourContext: ( props.tourContext || allStores.tourContext ) }))
 @observer
-class SupportMenuDropDown extends React.PureComponent {
+export default class SupportMenu extends React.PureComponent {
+  static propTypes = {
+    tourContext: React.PropTypes.instanceOf(TourContext),
+    courseId: React.PropTypes.string,
+  }
+
 
   static defaultProps = {
     bsRole: 'menu',
@@ -34,20 +80,6 @@ class SupportMenuDropDown extends React.PureComponent {
 
   componentDidMount() {
     Chat.setElementVisiblity(findDOMNode(this.chatEnabled), findDOMNode(this.chatDisabled));
-  }
-
-  renderPageTipsOption() {
-    if (!get(this.props, 'tourContext.hasTriggeredTour', false)){ return null; }
-    return (
-      <MenuItem
-        className="page-tips"
-        onSelect={this.onPlayTourClick}
-      >
-        <TourAnchor id="menu-option-page-tips">
-          Page Tips
-        </TourAnchor>
-      </MenuItem>
-    );
   }
 
   renderChat() {
@@ -98,67 +130,22 @@ class SupportMenuDropDown extends React.PureComponent {
     return `/accessibility-statement/${this.props.courseId || ''}`;
   }
 
-  render() {
+  renderF() {
     const { open, onClose, rootCloseEvent, courseId } = this.props;
 
-    const menu = (
-      <TourAnchor
-        tag="ul"
-        bsRole="menu"
-        id="support-menu-button"
-        ariaLabelledby="support-menu"
-        onSelect={this.onSelect}
-        className="dropdown-menu dropdown-menu-right"
-      >
-
-        {this.renderPageTipsOption()}
-        <MenuItem
-          key="nav-help-link"
-          className="-help-link"
-          target="_blank"
-          onSelect={this.onSelect}
-          href={UserMenu.helpLinkForCourseId(courseId)}
-        >
-          <span>Help Articles</span>
-        </MenuItem>
-        <StudentPreviewLink  courseId={courseId} />
-        <SupportDocument courseId={courseId} />
-
-        <MenuItem
-          key="nav-keyboard-shortcuts"
-          className="-help-link"
-          onSelect={this.onSelect}
-          href={this.accessibilityLink}
-          onClick={this.goToAccessibility}
-        >
-          <span>Accessibility Statement</span>
-        </MenuItem>
-        {this.renderChat()}
-      </TourAnchor>
-    );
     return (
       <RootCloseWrapper noWrap
         onRootClose={onClose}
         disabled={!open}
         event={rootCloseEvent}
       >
-        {menu}
       </RootCloseWrapper>
     );
   }
 
-}
-
-
-@inject((allStores, props) => ({ tourContext: ( props.tourContext || allStores.tourContext ) }))
-@observer
-export default class SupportMenu extends React.PureComponent {
-  static propTypes = {
-    tourContext: React.PropTypes.instanceOf(TourContext),
-    courseId: React.PropTypes.string,
-  }
-
   render() {
+    const { open, onClose, rootCloseEvent, courseId } = this.props;
+
     return (
       <Dropdown
         id="support-menu"
@@ -169,13 +156,44 @@ export default class SupportMenu extends React.PureComponent {
           useAnchor={true}
           noCaret
         >
-          <Icon type="question-circle" />
-          <span title="Page tips and support" className="control-label">Help</span>
-          <Icon type="angle-down" className="toggle" />
+          <TourAnchor
+            id="support-menu-button"
+            ariaLabelledby="support-menu"
+            onSelect={this.onSelect}
+          >
+            <Icon type="question-circle" />
+            <span title="Page tips and support" className="control-label">Help</span>
+            <Icon type="angle-down" className="toggle" />
+          </TourAnchor>
         </Dropdown.Toggle>
-        <SupportMenuDropDown {...this.props} />
+        <Dropdown.Menu
+          className="dropdown-menu dropdown-menu-right"
+        >
+          <PageTips onPlayClick={this.onPlayTourClick} {...this.props} />
+          <MenuItem
+            key="nav-help-link"
+            className="-help-link"
+            target="_blank"
+            onSelect={this.onSelect}
+            href={UserMenu.helpLinkForCourseId(courseId)}
+          >
+            <span>Help Articles</span>
+          </MenuItem>
+          <StudentPreview courseId={courseId} {...this.props} />
+          <SupportDocument courseId={courseId} />
+          <MenuItem
+            key="nav-keyboard-shortcuts"
+            className="-help-link"
+            onSelect={this.onSelect}
+            href={this.accessibilityLink}
+            onClick={this.goToAccessibility}
+          >
+            <span>Accessibility Statement</span>
+          </MenuItem>
+          {this.renderChat()}
+        </Dropdown.Menu>
       </Dropdown>
     );
-
   }
+
 }

--- a/tutor/src/components/navbar/user-menu.jsx
+++ b/tutor/src/components/navbar/user-menu.jsx
@@ -9,7 +9,6 @@ export default class UserMenu extends React.Component {
 
 
   render() {
-
     return (
       <Dropdown
         id="user-menu"

--- a/tutor/src/components/tours/anchor.jsx
+++ b/tutor/src/components/tours/anchor.jsx
@@ -44,7 +44,7 @@ export default class TourAnchor extends React.PureComponent {
       className: cn('tour-anchor', className),
       'data-tour-anchor-id': this.props.id,
       ref: ref => (this.wrapperEl = ref),
-    }, ReactHelpers.filterProps(otherProps)), this.props.children);
+    }, otherProps), this.props.children);
   }
 
 }

--- a/tutor/src/components/tours/anchor.jsx
+++ b/tutor/src/components/tours/anchor.jsx
@@ -44,7 +44,7 @@ export default class TourAnchor extends React.PureComponent {
       className: cn('tour-anchor', className),
       'data-tour-anchor-id': this.props.id,
       ref: ref => (this.wrapperEl = ref),
-    }, otherProps), this.props.children);
+    }, ReactHelpers.filterProps(otherProps)), this.props.children);
   }
 
 }


### PR DESCRIPTION
One user visible change is that we can no longer wrap the entire menu in a tour region.  Doing so makes the menu stop passing the keyboard handlers down to the MenuItems.

This moves the tour regional that highlighted the help menu from the menu itself to the menu controls at the top.  Basically from this:
![screen shot 2018-02-01 at 12 41 26 pm](https://user-images.githubusercontent.com/79566/35696482-3c99bd9c-074d-11e8-8de0-3c79566d8e6c.png)



to this:
![screen shot 2018-02-01 at 12 10 31 pm](https://user-images.githubusercontent.com/79566/35696447-1c459462-074d-11e8-8153-b3e7b55dbf04.png)
