### PR TITLE
remove happy pack

### DIFF
--- a/configs/webpack/base.coffee
+++ b/configs/webpack/base.coffee
@@ -3,27 +3,17 @@ path = require 'path'
 _ = require 'lodash'
 webpack = require 'webpack'
 UglifyJsPlugin = require 'uglifyjs-webpack-plugin'
-HappyPack = require 'happypack'
-happyThreadPool = HappyPack.ThreadPool(size: 8);
 
-HAPPY_LOADERS =
+LOADERS =
   babel:  'babel-loader'
   coffee: 'coffee-loader'
   cjsx:   'coffee-jsx-loader'
-
-STYLE_LOADERS =
   file:   'file-loader?name=[name].[ext]'
   url:    'url-loader?limit=30000&name=[name]-[hash].[ext]'
   style:  'style-loader'
   css:    'css-loader?minimize=true'
   less:   'less-loader'
   scss:   'fast-sass-loader'
-
-LOADERS = _.mapValues(HAPPY_LOADERS, (loader, name) -> "happypack/loader?id=#{name}")
-
-HAPPY_PACK_PLUGINS = _.map(HAPPY_LOADERS, (loader, name) ->
-  new HappyPack(id: name, threadPool: happyThreadPool, loaders: [ loader ], debug: true)
-)
 
 RESOLVABLES =
   js:     { test: /\.js$/,     use: LOADERS.babel,  exclude: /node_modules/ }
@@ -32,17 +22,17 @@ RESOLVABLES =
   cjsx:   { test: /\.cjsx$/,   use: LOADERS.cjsx,   exclude: /node_modules/ }
 
 STATICS =
-  image: { test: /\.(png|jpg|svg|gif)/,    use: [ STYLE_LOADERS.file ] }
-  font:  { test: /\.(woff|woff2|eot|ttf)/, use: [ STYLE_LOADERS.url  ] }
+  image: { test: /\.(png|jpg|svg|gif)/,    use: [ LOADERS.file ] }
+  font:  { test: /\.(woff|woff2|eot|ttf)/, use: [ LOADERS.url  ] }
 
 BASE_BUILD =
   js:     RESOLVABLES.js
   jsx:    RESOLVABLES.jsx
   coffee: RESOLVABLES.coffee
   cjsx:   RESOLVABLES.cjsx
-  css:  { test: /\.css$/,  use: STYLE_LOADERS.css }
-  less: { test: /\.less$/, use: [ STYLE_LOADERS.style, STYLE_LOADERS.css, STYLE_LOADERS.less ] }
-  scss: { test: /\.scss$/, use: [ STYLE_LOADERS.style, STYLE_LOADERS.css, STYLE_LOADERS.scss ] }
+  css:  { test: /\.css$/,  use: LOADERS.css }
+  less: { test: /\.less$/, use: [ LOADERS.style, LOADERS.css, LOADERS.less ] }
+  scss: { test: /\.scss$/, use: [ LOADERS.style, LOADERS.css, LOADERS.scss ] }
 
 DEV_LOADERS = ['react-hot-loader/webpack']
 
@@ -52,7 +42,6 @@ BASE_DEV_LOADER_RULES = _.map(BASE_BUILD, (loaderConfig, type) ->
   config.use = loaderConfig.use
   config
 )
-
 
 BASE_BUILD_LOADERS = _.values(BASE_BUILD)
 
@@ -73,9 +62,6 @@ BASE_CONFIG =
       /\/sinon\.js/
     ]
     rules: _.values(STATICS)
-  plugins: [
-    HAPPY_PACK_PLUGINS...
-  ]
 
 
 mergeWebpackConfigs = ->

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "fixed-data-table-2": "github:openstax/fixed-data-table-2#trying-scroll-thing",
     "flux-react": "3.0.0",
     "font-awesome": "4.7.0",
-    "happypack": "^4.0.0",
     "history": "4.5.1",
     "htmlparser2": "3.9.2",
     "interpolate": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,10 +249,6 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
-async@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.0.tgz#2796642723573859565633fc6274444bee2f8ce3"
-
 async@1.x, async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -3216,15 +3212,6 @@ handlebars@^4.0.1, handlebars@^4.0.3:
   optionalDependencies:
     uglify-js "^2.6"
 
-happypack@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/happypack/-/happypack-4.0.0.tgz#de1770d472dab33e3f31782a3edb4e77cc658631"
-  dependencies:
-    async "1.5.0"
-    json-stringify-safe "5.0.1"
-    loader-utils "1.1.0"
-    serialize-error "^2.1.0"
-
 har-schema@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
@@ -4210,7 +4197,7 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -4381,7 +4368,7 @@ loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@1.1.0, loader-utils@^1.0.1, loader-utils@^1.1.0:
+loader-utils@^1.0.1, loader-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
   dependencies:
@@ -6513,10 +6500,6 @@ send@0.16.1:
     on-finished "~2.3.0"
     range-parser "~1.2.0"
     statuses "~1.3.1"
-
-serialize-error@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
 
 serialize-javascript@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
It was running out of memory on production.  Will try to re-introduce as part of an upgrade to webpack in the future

I'm hopeful that web pack 4 is supposed to be faster / use less resources