### PR TITLE
set a background color on all pinned headers and footers

### DIFF
--- a/tutor/resources/styles/components/pinned-header-footer-card.scss
+++ b/tutor/resources/styles/components/pinned-header-footer-card.scss
@@ -1,0 +1,6 @@
+.pinned-header,
+.pinned-footer {
+   background-color: $tutor-neutral-lightest;
+}
+
+@import './pinned-header-footer-card/sections';

--- a/tutor/resources/styles/components/task-teacher-review/breadcrumbs.scss
+++ b/tutor/resources/styles/components/task-teacher-review/breadcrumbs.scss
@@ -1,7 +1,3 @@
-.pinned-header {
-  background-color: $tutor-neutral-lightest;
-}
-
 .task-title {
   display: inline-block;
   line-height: $icon-size-lg;

--- a/tutor/resources/styles/tutor.scss
+++ b/tutor/resources/styles/tutor.scss
@@ -41,7 +41,7 @@
 @import './components/ox-fancy-loader';
 @import './components/related-content-link';
 @import './components/paging-navigation';
-@import './components/pinned-header-footer-card/sections';
+@import './components/pinned-header-footer-card';
 @import './components/enrollment-student-id';
 @import './components/dialog';
 @import './components/tutor-input';


### PR DESCRIPTION
In #2036, it only was set on the review header but those css classes are also used
on student homeworks

before:
![screen shot 2018-02-06 at 10 20 18 am](https://user-images.githubusercontent.com/79566/35870469-5a61d94e-0b27-11e8-8e92-a4f9f17d46b4.png)



after:
![screen shot 2018-02-06 at 10 18 57 am](https://user-images.githubusercontent.com/79566/35870402-30f4f668-0b27-11e8-8ba5-a18419e82eed.png)
