### PR TITLE
Import headers from pattern-library, style student dashboard using them

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "moment-timezone": "0.5.11",
     "object-hash": "1.1.7",
     "path-to-regexp": "1.7.0",
+    "pattern-library": "github:openstax/pattern-library#v0.6.0",
     "phantomjs-prebuilt": "^2.1.16",
     "pluralize": "3.1.0",
     "promise-loader": "1.0.0",

--- a/tutor/resources/styles/components/tabs.scss
+++ b/tutor/resources/styles/components/tabs.scss
@@ -3,7 +3,7 @@ $tutor-tabs-horizontal-padding: 15px;
 .tutor-tabs {
   display: flex;
   border-bottom: 1px solid $nav-tabs-border-color;
-
+  min-height: $tutor-tab-height;
   > .nav-tabs {
     background: none;
     display: flex;

--- a/tutor/resources/styles/components/top-nav-bar.scss
+++ b/tutor/resources/styles/components/top-nav-bar.scss
@@ -1,6 +1,3 @@
-$tutor-navbar-height: 60px;
-$tutor-navbar-padding-horizontal: 4rem;
-
 // the $navbar-XX vars are bootstrap defaults
 
 .tutor-top-navbar {

--- a/tutor/resources/styles/global/externals.scss
+++ b/tutor/resources/styles/global/externals.scss
@@ -2,4 +2,4 @@
 @import '~fixed-data-table-2/dist/fixed-data-table.css';
 @import '~font-awesome/scss/font-awesome';
 @import './tutor-bootstrap';
-@import '~pattern-library/core/pattern-library';
+@import '~pattern-library/core/pattern-library/headers';

--- a/tutor/resources/styles/global/externals.scss
+++ b/tutor/resources/styles/global/externals.scss
@@ -2,3 +2,4 @@
 @import '~fixed-data-table-2/dist/fixed-data-table.css';
 @import '~font-awesome/scss/font-awesome';
 @import './tutor-bootstrap';
+@import '~pattern-library/core/pattern-library';

--- a/tutor/resources/styles/global/scaffold.scss
+++ b/tutor/resources/styles/global/scaffold.scss
@@ -4,8 +4,9 @@ html {
 
 body {
   padding-top: 60px; // For the top navbar
-  padding-bottom: 50px;
-  background: $tutor-white;
+  padding-bottom: 0px;
+  background: ui-color(white);
+  margin: 0;
   @media print {
     padding: 0;
   }

--- a/tutor/resources/styles/variables.scss
+++ b/tutor/resources/styles/variables.scss
@@ -6,6 +6,11 @@
 $tutor-task-width: 1000px;
 $tutor-max-panel-width: 1200px;
 
+$tutor-navbar-height: 60px;
+$tutor-navbar-padding-horizontal: 4rem;
+
+$tutor-tab-height: 45px;
+
 $tutor-panel-padding-vertical: 50px;
 $tutor-card-body-padding-vertical: 20px;
 $tutor-card-body-padding-horizontal: 140px;

--- a/tutor/src/screens/screen-styles.scss
+++ b/tutor/src/screens/screen-styles.scss
@@ -9,5 +9,6 @@ $fa-font-path: '~font-awesome/fonts';
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins";
 @import '~shared/resources/styles/mixins/index';
 @import '~shared/resources/styles/variables/index';
+@import '~pattern-library/core/pattern-library/headers';
 @import '../../resources/styles/mixins';
 @import '../../resources/styles/global/typography';

--- a/tutor/src/screens/student-dashboard/progress-guide.cjsx
+++ b/tutor/src/screens/student-dashboard/progress-guide.cjsx
@@ -59,7 +59,7 @@ ProgressGuidePanels = React.createClass
     )
 
   renderEmpty: (sections) ->
-    <div className='progress-guide empty'>
+    <div className='progress-guide panel empty'>
       <div className='actions-box'>
         <h1 className='panel-title'>Performance Forecast</h1>
           <p>
@@ -84,7 +84,7 @@ ProgressGuidePanels = React.createClass
     recent = PerformanceForecast.Helpers.recentSections(sections)
     return @renderEmpty(sections) if _.isEmpty(recent)
 
-    <div className='progress-guide'>
+    <div className='progress-guide panel'>
       <div className='actions-box'>
 
         <ProgressGuide sections={recent} {...@props} />

--- a/tutor/src/screens/student-dashboard/styles/dashboard.scss
+++ b/tutor/src/screens/student-dashboard/styles/dashboard.scss
@@ -1,5 +1,7 @@
 .student-dashboard {
   $small-height-breakpoint: 600px;
+  background-color: ui-color(page-bg);
+  min-height: calc(100vh - #{$tutor-navbar-height});
   .container {
     margin-top: 2rem;
   }

--- a/tutor/src/screens/student-dashboard/styles/progress-guide.scss
+++ b/tutor/src/screens/student-dashboard/styles/progress-guide.scss
@@ -3,6 +3,10 @@
 
 .student-dashboard {
   .progress-guide {
+    &.panel {
+      margin-top: $tutor-tab-height - 1px; // shift up to meet bottom-border of tabs
+    }
+
     .section {
       @include performance-forecast-section();
       text-align: left;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4951,7 +4951,7 @@ node-pre-gyp@^0.6.39:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-sass@4.7.2:
+node-sass@4.7.2, node-sass@^4.7.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.7.2.tgz#9366778ba1469eb01438a9e8592f4262bcb6794e"
   dependencies:
@@ -5282,6 +5282,12 @@ path-type@^1.0.0:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+"pattern-library@github:openstax/pattern-library#v0.6.0":
+  version "0.6.0"
+  resolved "https://codeload.github.com/openstax/pattern-library/tar.gz/2c81a8816e649b8ab34dfd77aa3263ec9dfc8f58"
+  dependencies:
+    node-sass "^4.7.2"
 
 pbkdf2@^3.0.3:
   version "3.0.14"


### PR DESCRIPTION
@Fredasaurus as we discussed this sets the BG color for student dashboard to light grey.  I added the "panel" style to performance forecast so it is white with shadow.  Should Browse the book also receive that?

![screen shot 2018-02-12 at 1 08 25 pm](https://user-images.githubusercontent.com/79566/36114531-dc01365c-0ff5-11e8-87b8-23494ae29178.png)
