### PR TITLE
intros in reading content were not rendering when related_content does not exist

### DIFF
--- a/tutor/src/components/task-step/step-with-reading-content.cjsx
+++ b/tutor/src/components/task-step/step-with-reading-content.cjsx
@@ -40,16 +40,34 @@ ReadingStepContent = React.createClass
     </div>
 
   shouldOpenNewTab: -> true
+
+  getContentChapterSection: ->
+    {chapter_section, related_content} = TaskStepStore.get(@props.id)
+    (related_content && related_content[0]) || chapter_section || []
+
+  getContentChapter: ->
+    @getContentChapterSection()?[0]
+
+  getContentSection: ->
+    @getContentChapterSection()?[1]
+
+  getContentTitle: ->
+    {related_content} = TaskStepStore.get(@props.id)
+    related_content && related_content[0] && related_content[0].title # || look up by @getContentChapterSection()
+
   render: ->
     {id, stepType} = @props
 
-    {content_html, related_content} = TaskStepStore.get(id)
+    {content_html} = TaskStepStore.get(id)
     {courseId} = Router.currentParams()
 
     <div className="#{stepType}-step">
       <div className="#{stepType}-content" {...CourseData.getCourseDataProps(courseId)}>
 
-        <RelatedContent contentId={id} {...related_content?[0]} />
+        <RelatedContent contentId={id}
+          chapter_section={@getContentChapterSection()}
+          title={@getContentTitle()}
+        />
         <ArbitraryHtmlAndMath
           className='book-content'
           shouldExcludeFrame={@shouldExcludeFrame}
@@ -59,9 +77,9 @@ ReadingStepContent = React.createClass
       </div>
       <AnnotationWidget
         courseId={courseId}
-        chapter={related_content[0].chapter_section[0]}
-        section={related_content[0].chapter_section[1]}
-        title={related_content[0].title}
+        chapter={@getContentChapter()}
+        section={@getContentSection()}
+        title={@getContentTitle()}
         documentId={@getCnxId()}
         pageType={stepType}
       />


### PR DESCRIPTION
This case should be relatively rare and may only happen locally with old content/task steps.

# Before
![screen shot 2018-02-08 at 4 39 40 pm](https://user-images.githubusercontent.com/2483873/36002177-cc9540b4-0cee-11e8-8b48-d3eae837d0c7.png)

# After
![screen shot 2018-02-08 at 4 38 48 pm](https://user-images.githubusercontent.com/2483873/36002178-ccab2a64-0cee-11e8-8d7e-58047d481880.png)
