### PR TITLE
figures float better, use relative top positioning instead of margin …

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -12,6 +12,10 @@
     margin: 0 0 2.4rem 0;
   }
 
+  section {
+    clear: both;
+  }
+
   blockquote {
     @include tutor-serif-font(1.75rem, 190%);
     font-style: italic;

--- a/tutor/resources/styles/book-content/note.scss
+++ b/tutor/resources/styles/book-content/note.scss
@@ -3,7 +3,7 @@ $feature-title-is-element: '[data-has-label=true][data-label=""]';
 $tutor-note-title-element: '[data-type=title]:first-child';
 
 $tutor-note-margin-horizontal: 38px;
-$tutor-note-margin-vertical: 71px;
+$tutor-note-margin-vertical: 48px;
 %tutor-empty-rules { }
 
 
@@ -151,13 +151,14 @@ $tutor-note-margin-vertical: 71px;
 
 %tutor-all-note-rules {
   background: $tutor-neutral-lightest;
-  margin: $tutor-note-margin-vertical 0 32px 0;
+  margin: 0 0 71px 0;
   clear: both;
   border-top: solid 8px $tutor-neutral-lighter;
   border-bottom: solid 8px $tutor-neutral-lighter;
   padding: $tutor-note-padding;
   width: 100%;
   position: relative;
+  top: $tutor-note-margin-vertical;
 
   .exercise[data-type=exercise] .solution {
     // undo general hiding of solutions
@@ -204,7 +205,7 @@ $tutor-book-note-selector: '
     @extend %tutor-all-note-rules;
 
     .grasp-check {
-      margin: $tutor-note-margin-vertical 0 32px 0;
+      margin: 0 0 71px 0;
       padding: $tutor-note-padding-vertical 0;
       border-top: solid 8px $tutor-secondary;
       border-bottom: none;
@@ -249,6 +250,11 @@ $tutor-book-note-selector: '
       content: attr(data-label);
     }
 
+    #{$tutor-book-note-selector} {
+      @include tutor-book-label-style() {
+        top: auto;
+      };
+    }
   }
 
 }

--- a/tutor/resources/styles/mixins.scss
+++ b/tutor/resources/styles/mixins.scss
@@ -257,6 +257,15 @@ $tutor-shadow-types: (
     text-align: left;
     padding: 0;
     float: left;
+
+    + figure {
+      float: none;
+    }
+
+    > figure + figure {
+      float: left;
+    }
+
     img {
       max-width: 100%;
       border: 1px solid $border-color;


### PR DESCRIPTION
…since top margins dont work nicely with floats

https://trello.com/c/Oo4ALQx9/1278-bug-spacing-between-or-around-text-is-missing


# Before

![screen shot 2018-02-09 at 2 14 39 pm](https://user-images.githubusercontent.com/2483873/36048077-a1c41382-0da3-11e8-83aa-dca3d4314103.png)
![screen shot 2018-02-09 at 2 14 34 pm](https://user-images.githubusercontent.com/2483873/36048078-a1d4bb10-0da3-11e8-9629-aae1123f1869.png)


# After
![screen shot 2018-02-09 at 2 05 02 pm](https://user-images.githubusercontent.com/2483873/36047936-301844ba-0da3-11e8-966f-a3f69f9c8c68.png)

![screen shot 2018-02-09 at 2 10 26 pm](https://user-images.githubusercontent.com/2483873/36047933-2fd6e056-0da3-11e8-8440-fbe5c77f243a.png)

