### PR TITLE
step completion should submit answer_id and free_response

### DIFF
--- a/tutor/src/api/index.coffee
+++ b/tutor/src/api/index.coffee
@@ -18,7 +18,7 @@ PerformanceForecast = require '../flux/performance-forecast'
 
 {TaskActions} = require '../flux/task'
 {TaskPanelActions} = require '../flux/task-panel'
-{TaskStepActions} = require '../flux/task-step'
+{TaskStepActions, TaskStepStore} = require '../flux/task-step'
 {TaskPlanActions, TaskPlanStore} = require '../flux/task-plan'
 
 {PastTaskPlansActions} = require '../flux/past-task-plans'
@@ -139,7 +139,11 @@ startAPI = ->
       TaskStepActions.loadedNoPersonalized(args...)
       true
   )
-  connectModify(TaskActions, pattern: 'steps/{id}/completed', trigger: 'completeStep', onSuccess: 'stepCompleted')
+  connectModify(TaskActions, pattern: 'steps/{id}/completed', trigger: 'completeStep', onSuccess: 'stepCompleted',
+    data: (id) ->
+      step = TaskStepStore.get(id)
+      pick(step, ['free_response', 'answer_id'])
+  )
 
   connectUpdate(TaskStepActions, pattern: 'steps/{id}', trigger: 'setFreeResponseAnswer',
     data: (id, freeResponse) ->


### PR DESCRIPTION
https://trello.com/c/qfjqBsAa/1285-change-request-change-mark-exercises-as-completed-api-so-the-selected-answer-is-transmitted-in-the-same-api-call-that-an-exercis

uses openstax/tutor-server#1664