### PR TITLE
Reload browser window when an error occurs

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-addons-css-transition-group": "15.4.2",
     "react-addons-pure-render-mixin": "15.4.2",
     "react-addons-test-utils": "15.4.2",
-    "react-async-component": "github:nathanstitt/react-async-component#retry-on-err",
+    "react-async-component": "^1.0.2",
     "react-bootstrap": "0.31.3",
     "react-calendar": "1.1.0",
     "react-container-dimensions": "1.3.2",

--- a/tutor/specs/components/error-monitoring/__snapshots__/async-load-error.spec.jsx.snap
+++ b/tutor/specs/components/error-monitoring/__snapshots__/async-load-error.spec.jsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AsyncLoadErrors Component renders and matches snapshot if page is reloaded 1`] = `
+<div
+  className="invalid-page"
+>
+  <div
+    className="ox-colored-stripe"
+  >
+    <div
+      className="orange"
+    />
+    <div
+      className="blue"
+    />
+    <div
+      className="red"
+    />
+    <div
+      className="yellow"
+    />
+    <div
+      className="teal"
+    />
+  </div>
+  <h1>
+    Uh-oh, the page failed to load
+  </h1>
+  <p>
+    Error: SOMETHING FAILED!
+  </p>
+  <button
+    className="btn btn-primary"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    Retry
+  </button>
+</div>
+`;

--- a/tutor/specs/components/error-monitoring/async-load-error.spec.jsx
+++ b/tutor/specs/components/error-monitoring/async-load-error.spec.jsx
@@ -1,0 +1,32 @@
+import AsyncLoadErrors from '../../../src/components/error-monitoring/async-load-error';
+import { SnapShot } from '../helpers/component-testing';
+import { isReloaded, reloadOnce, forceReload } from '../../../src/helpers/reload';
+jest.mock('../../../src/helpers/reload');
+
+describe('AsyncLoadErrors Component', function() {
+  let props;
+  beforeEach(() => {
+    props = { error: new Error('SOMETHING FAILED!') };
+  });
+
+  it('does not render if page isnt reloaded', () => {
+    const err = mount(<AsyncLoadErrors {...props} />);
+    expect(reloadOnce).toHaveBeenCalled();
+    expect(err.html()).toBeNull();
+  });
+
+  it('renders and matches snapshot if page is reloaded', () => {
+    isReloaded.mockImplementation(() => true);
+    const err = mount(<AsyncLoadErrors {...props} />);
+    expect(err.html()).not.toBeNull();
+    expect(SnapShot.create(<AsyncLoadErrors {...props} />)).toMatchSnapshot();
+  });
+
+  it('forces a reload when clicked', () => {
+    isReloaded.mockImplementation(() => true);
+    const err = mount(<AsyncLoadErrors {...props} />);
+    err.find('Button').simulate('click');
+    expect(forceReload).toHaveBeenCalled();
+  });
+
+});

--- a/tutor/specs/helpers/reload.spec.js
+++ b/tutor/specs/helpers/reload.spec.js
@@ -1,0 +1,38 @@
+import { isReloaded, reloadOnce, forceReload } from '../../src/helpers/reload';
+
+
+describe('Reloading window', () => {
+  beforeEach(() => {
+    Object.defineProperties(window.location, {
+      search: {
+        writable: true,
+        value: '',
+      },
+      reload: {
+        writable: true,
+        value: jest.fn(),
+      },
+    });
+  });
+
+  it('detects if page is reloaded', () => {
+    expect(isReloaded()).toEqual(false);
+
+    window.location.search = '?foo&reloaded';
+    expect(isReloaded()).toEqual(true);
+  });
+
+  it('reloads page once', () => {
+    expect(isReloaded()).toEqual(false);
+    reloadOnce();
+    expect(isReloaded()).toEqual(true);
+  });
+
+  it('can force a page reload', () => {
+    expect(isReloaded()).toEqual(false);
+    forceReload();
+    expect(isReloaded()).toEqual(false); // force reload doesn't change the search, it just reloads
+    expect(window.location.reload).toHaveBeenCalledWith(true); // true == no-cache
+  });
+
+});

--- a/tutor/specs/helpers/reload.spec.js
+++ b/tutor/specs/helpers/reload.spec.js
@@ -12,6 +12,14 @@ describe('Reloading window', () => {
         writable: true,
         value: jest.fn(),
       },
+      href: {
+        writable: true,
+        value: 'https://tutor.org/dashboard',
+      },
+    });
+    Object.defineProperty(window.history, 'pushState', {
+      writable: true,
+      value: jest.fn(),
     });
   });
 
@@ -25,14 +33,22 @@ describe('Reloading window', () => {
   it('reloads page once', () => {
     expect(isReloaded()).toEqual(false);
     reloadOnce();
-    expect(isReloaded()).toEqual(true);
+    expect(window.history.pushState).toHaveBeenCalledWith('', '', `${window.location.href}?reloaded`);
+    expect(window.location.reload).toHaveBeenCalledWith(true); // true == no-cache
+  });
+
+  it('retains existing query params', () => {
+    window.location.href = 'http://openstax.org/test?test=true';
+    reloadOnce();
+    expect(window.history.pushState).toHaveBeenCalledWith('', '', 'http://openstax.org/test?test=true&reloaded');
+    expect(window.location.reload).toHaveBeenCalledWith(true);
   });
 
   it('can force a page reload', () => {
     expect(isReloaded()).toEqual(false);
     forceReload();
     expect(isReloaded()).toEqual(false); // force reload doesn't change the search, it just reloads
-    expect(window.location.reload).toHaveBeenCalledWith(true); // true == no-cache
+    expect(window.location.reload).toHaveBeenCalledWith(true);
   });
 
 });

--- a/tutor/src/components/error-monitoring/async-load-error.jsx
+++ b/tutor/src/components/error-monitoring/async-load-error.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Button } from 'react-bootstrap';
+import OXColoredStripe from 'shared/src/components/ox-colored-stripe';
+import { isReloaded, reloadOnce, forceReload } from '../../helpers/reload';
+
+export default class AsyncLoadError extends React.PureComponent {
+
+  static propTypes = {
+    error: React.PropTypes.object.isRequired,
+  }
+
+  componentWillMount() {
+    reloadOnce();
+  }
+
+  render() {
+    if (!isReloaded()) { return null; }
+
+    return (
+      <div className="invalid-page">
+        <OXColoredStripe />
+        <h1>
+          Uh-oh, the page failed to load
+        </h1>
+        <p>{String(this.props.error)}</p>
+        <Button bsStyle="primary" onClick={forceReload}>Retry</Button>
+      </div>
+    );
+  }
+
+}

--- a/tutor/src/components/error-monitoring/handlers.cjsx
+++ b/tutor/src/components/error-monitoring/handlers.cjsx
@@ -9,7 +9,7 @@ Dialog      = require '../tutor-dialog'
 TutorRouter = require '../../helpers/router'
 TimeHelper  = require '../../helpers/time'
 ServerErrorMessage = require './server-error-message'
-
+{reloadOnce} = require '../../helpers/reload'
 {AppStore}    = require '../../flux/app'
 {default: Courses} = require '../../models/courses-map'
 
@@ -25,12 +25,11 @@ getCurrentCourse = ->
   {courseId} = TutorRouter.currentParams()
   if courseId then Courses.get(courseId) else {}
 
-reloadOnce = ->
+reloadOnceIfShouldReload = ->
   navigation = AppStore.errorNavigation()
   return if isEmpty navigation
   if navigation.shouldReload
-    join = if window.location.search then '&' else '?'
-    window.location.href = window.location.href + join + 'reloaded'
+    reloadOnce()
   else if navigation.href
     window.location.href = navigation.href
 
@@ -119,8 +118,8 @@ ERROR_HANDLERS =
     buttons: [
       <BS.Button key='ok' onClick={-> Dialog.hide()} bsStyle='primary'>OK</BS.Button>
     ]
-    onOk: reloadOnce
-    onCancel: reloadOnce
+    onOk: reloadOnceIfShouldReload
+    onCancel: reloadOnceIfShouldReload
 
 
 module.exports = {

--- a/tutor/src/components/error-monitoring/index.cjsx
+++ b/tutor/src/components/error-monitoring/index.cjsx
@@ -4,7 +4,7 @@ BS = require 'react-bootstrap'
 isEmpty = require 'lodash/isEmpty'
 
 ErrorHandlers = require './handlers'
-
+{ isReloaded } = require '../../helpers/reload';
 {AppStore, AppActions} = require '../../flux/app'
 
 Dialog = require '../tutor-dialog'
@@ -23,7 +23,7 @@ module.exports = React.createClass
   bindUpdate: ->
     error = AppStore.getError()
 
-    return unless error and -1 is window.location.search.indexOf('reloaded')
+    return unless error and not isReloaded()
     dialogAttrs = ErrorHandlers.forError(error, @context)
 
     Dialog.show( dialogAttrs ).then(dialogAttrs.onOk, dialogAttrs.onCancel)

--- a/tutor/src/helpers/async-component.js
+++ b/tutor/src/helpers/async-component.js
@@ -1,20 +1,7 @@
 import React from 'react';
-import { Button } from 'react-bootstrap';
 import { asyncComponent as asyncLoader } from 'react-async-component';
-import OXColoredStripe from 'shared/src/components/ox-colored-stripe';
+import ErrorComponent from '../components/error-monitoring/async-load-error';
 import LoadingComponent from '../components/loading-screen';
-
-const ErrorComponent = ({ error, retry }) => (
-  <div className="invalid-page">
-    <OXColoredStripe />
-    <h1>
-      Uh-oh, the page failed to load
-    </h1>
-    <p>{String(error)}</p>
-    <Button bsStyle="primary" onClick={retry}>Retry</Button>
-  </div>
-);
-
 
 export function asyncComponent(resolve) {
   return asyncLoader({

--- a/tutor/src/helpers/reload.js
+++ b/tutor/src/helpers/reload.js
@@ -1,0 +1,14 @@
+export function isReloaded() {
+  return -1 !== window.location.search.indexOf('reloaded');
+}
+
+export function reloadOnce() {
+  if (!isReloaded()) {
+    const join = window.location.search ? '&' : '?';
+    window.location.search = `${window.location.search}${join}reloaded`;
+  }
+}
+
+export function forceReload() {
+  window.location.reload(true);
+}

--- a/tutor/src/helpers/reload.js
+++ b/tutor/src/helpers/reload.js
@@ -1,14 +1,16 @@
+const RELOADED_FLAG = 'reloaded';
+
 export function isReloaded() {
-  return -1 !== window.location.search.indexOf('reloaded');
+  return -1 !== window.location.search.indexOf(RELOADED_FLAG);
 }
 
 export function reloadOnce() {
-  if (!isReloaded()) {
-    const join = window.location.search ? '&' : '?';
-    window.location.search = `${window.location.search}${join}reloaded`;
-  }
+  if (isReloaded()) { return; }
+  const join = window.location.href.indexOf('?') == -1 ? '?' : '&';
+  window.history.pushState('', '', `${window.location.href}${join}${RELOADED_FLAG}`);
+  forceReload();
 }
 
 export function forceReload() {
-  window.location.reload(true);
+  window.location.reload(true); // true == no-cache
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5851,9 +5851,9 @@ react-addons-test-utils@15.4.2:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-"react-async-component@github:nathanstitt/react-async-component#retry-on-err":
+react-async-component@^1.0.2:
   version "1.0.2"
-  resolved "https://codeload.github.com/nathanstitt/react-async-component/tar.gz/80c276a4b121c050db08c991b8704f2cb02edbb1"
+  resolved "https://registry.yarnpkg.com/react-async-component/-/react-async-component-1.0.2.tgz#b041722bf7734a95c51dc9fc2f28ec9e918e9659"
 
 react-autobind@^1.0:
   version "1.0.6"


### PR DESCRIPTION
When I force a load failure by typing gibberish in a scores import it reloads once then displays:


![screen shot 2018-02-13 at 1 35 11 pm](https://user-images.githubusercontent.com/79566/36169750-bc239564-10c2-11e8-9660-e4869bcb24b7.png)
