### PR TITLE
initial student scores work, missing weights and modal details, as we…

### DIFF
--- a/tutor/specs/components/navbar/__snapshots__/actions_menu.spec.jsx.snap
+++ b/tutor/specs/components/navbar/__snapshots__/actions_menu.spec.jsx.snap
@@ -110,6 +110,28 @@ exports[`Student Navbar Component has actions menu that matches snapshot 1`] = `
       </a>
     </li>
     <li
+      className="viewScores"
+      role="presentation"
+      style={undefined}
+    >
+      <a
+        data-name="viewScores"
+        href="/course/1/scores"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="menuitem"
+        tabIndex="-1"
+      >
+        <div
+          className="tour-anchor"
+          data-tour-anchor-id="menu-option-viewScores"
+          id="menu-option-viewScores"
+        >
+          Scores
+        </div>
+      </a>
+    </li>
+    <li
       className="viewPerformanceGuide"
       role="presentation"
       style={undefined}

--- a/tutor/specs/models/user/__snapshots__/menu.spec.js.snap
+++ b/tutor/specs/models/user/__snapshots__/menu.spec.js.snap
@@ -24,6 +24,13 @@ Array [
     },
   },
   Object {
+    "label": "Scores",
+    "name": "viewScores",
+    "params": Object {
+      "courseId": "1",
+    },
+  },
+  Object {
     "label": "Performance Forecast",
     "name": "viewPerformanceGuide",
     "params": Object {

--- a/tutor/specs/screens/scores-report/homework-cell.spec.jsx
+++ b/tutor/specs/screens/scores-report/homework-cell.spec.jsx
@@ -9,9 +9,10 @@ describe('Student Scores Homework Cell', function() {
   let props;
   let scores;
   let task;
+  let period;
 
   beforeEach(() => {
-    scores = bootstrapScores().scores;
+    ({ scores, period } = bootstrapScores());
     task = scores.getTask(18);
     props = {
       courseId: '1',
@@ -22,6 +23,7 @@ describe('Student Scores Homework Cell', function() {
         role: 1,
       },
       task,
+      period,
     };
   });
 

--- a/tutor/specs/screens/scores-report/index.spec.jsx
+++ b/tutor/specs/screens/scores-report/index.spec.jsx
@@ -27,6 +27,8 @@ describe('Scores Report', function() {
     ({ course, period } = bootstrapScores());
     props = {
       params: { courseId: course.id },
+      course,
+      period,
     };
   });
 

--- a/tutor/specs/screens/scores-report/reading-cell.spec.jsx
+++ b/tutor/specs/screens/scores-report/reading-cell.spec.jsx
@@ -8,9 +8,10 @@ describe('Student Scores Report Reading Cell', function() {
   let task;
   let props;
   let scores;
+  let period;
 
   beforeEach(function() {
-    ({ scores } = bootstrapScores());
+    ({ scores, period } = bootstrapScores());
     task = scores.getTask(2);
     props = {
       courseId: '1',
@@ -21,6 +22,7 @@ describe('Student Scores Report Reading Cell', function() {
         role: 1,
       },
       task,
+      period,
     };
   });
 

--- a/tutor/src/models/user/menu.js
+++ b/tutor/src/models/user/menu.js
@@ -23,6 +23,12 @@ const ROUTES = {
     label: 'Browse the Book',
     isAllowed(course) { return !!course; },
   },
+  studentScores: {
+    label: 'Scores',
+    roles: {
+      student: 'viewScores',
+    },
+  },
   guide: {
     label: 'Performance Forecast',
     isAllowed(course) { return get(course, 'is_concept_coach') !== true; },

--- a/tutor/src/screens/scores-report/assignment-header.jsx
+++ b/tutor/src/screens/scores-report/assignment-header.jsx
@@ -103,6 +103,21 @@ const AssignmentSortingHeader = (props) => {
   );
 };
 
+const TeacherAssignmentHeaderRow = function(props) {
+  const { heading } = props;
+
+  if (!props.period.course.isTeacher) {
+    return null;
+  }
+
+  return (<div className="header-row overview-row">
+      <AverageLabel {...props} heading={heading} />
+      <ReviewLink {...props} heading={heading} />
+    </div>
+  );
+
+}
+
 const AssignmentHeader = function(props) {
   const { period: { data_headings }, isConceptCoach, periodIndex, courseId, sort, onSort, columnIndex, width, ux } = props;
   const heading = data_headings[columnIndex];
@@ -127,10 +142,7 @@ const AssignmentHeader = function(props) {
       <div className="header-row">
         <AssignmentSortingHeader {...props} heading={heading} />
       </div>
-      <div className="header-row overview-row">
-        <AverageLabel {...props} heading={heading} />
-        <ReviewLink {...props} heading={heading} />
-      </div>
+      <TeacherAssignmentHeaderRow {...props} heading={heading} />
     </div>
   );
 };

--- a/tutor/src/screens/scores-report/export-controls.jsx
+++ b/tutor/src/screens/scores-report/export-controls.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Export from './export';
+import LmsPush from './lms-push';
+import Course from '../../models/course';
+
+export default class ScoresReportExportControls extends React.PureComponent {
+
+  static propTypes = {
+    course: React.PropTypes.instanceOf(Course).isRequired,
+  }
+
+  render() {
+    if (!this.props.course.isTeacher) {
+      return null;
+    }
+
+    return (
+      <div>
+        <LmsPush course={this.props.course} />
+        <Export course={this.props.course} />
+      </div>
+    );
+  }
+}

--- a/tutor/src/screens/scores-report/homework-cell.jsx
+++ b/tutor/src/screens/scores-report/homework-cell.jsx
@@ -109,18 +109,30 @@ export default class HomeworkCell extends React.PureComponent {
     );
   }
 
-  render() {
+  renderLateWork() {
     const { task, columnIndex } = this.props;
+
+
+    if (!this.props.period.course.isTeacher) {
+      return null;
+    }
+
+    return (<LateWork
+        task={task}
+        onMouseOver={this.show}
+        onMouseLeave={this.hide}
+        columnIndex={columnIndex}
+      />
+    );
+  }
+
+  render() {
 
     return (
       <div className="scores-cell">
         <HomeworkScore {...this.props} />
         {this.renderPopover()}
-        <LateWork
-          onMouseOver={this.show}
-          onMouseLeave={this.hide}
-          task={task}
-          columnIndex={columnIndex} />
+        {this.renderLateWork()}
       </div>
     );
   }

--- a/tutor/src/screens/scores-report/index.jsx
+++ b/tutor/src/screens/scores-report/index.jsx
@@ -8,9 +8,8 @@ import ScoresTable from './table';
 import TableFilters from './table-filters';
 import NoPeriods from '../../components/no-periods';
 import Courses from '../../models/courses-map';
-import Export from './export';
-import LmsPush from './lms-push';
-import CoursePeriodsNav from '../../components/course-periods-nav';
+import ScoresReportExportControls from './export-controls';
+import ScoresReportNav from './nav';
 import TourRegion from '../../components/tours/region';
 import LoadingScreen from '../../components/loading-screen';
 import './styles.scss';
@@ -32,6 +31,10 @@ export default class StudentScores extends React.PureComponent {
     return this.course.scores.periods.get(
       this.course.periods.active[this.periodIndex].id
     );
+  }
+
+  @computed get title() {
+    return (this.course.isTeacher && 'Student Scores') || 'Scores';
   }
 
   @observable sortIndex;
@@ -85,8 +88,7 @@ export default class StudentScores extends React.PureComponent {
       <div className="controls">
         <TableFilters displayAs={this.displayAs} changeDisplayAs={this.changeDisplayAs} />
         <div className="spacer" />
-        <LmsPush course={this.course} />
-        <Export course={this.course} />
+        <ScoresReportExportControls course={this.course}/>
       </div>
     );
   }
@@ -106,7 +108,7 @@ export default class StudentScores extends React.PureComponent {
     return (
       <CoursePage
         course={this.course}
-        title="Student Scores"
+        title={this.title}
         className="course-scores-report"
         controls={this.renderControls()}
         fullWidthChildren={<TourRegion
@@ -126,9 +128,9 @@ export default class StudentScores extends React.PureComponent {
           </ContainerDimensions>
         </TourRegion>}
       >
-        <CoursePeriodsNav
+        <ScoresReportNav
+          course={this.course}
           handleSelect={this.selectPeriod}
-          courseId={this.course.id}
           afterTabsItem={this.renderAfterTabsItem()}
         />
       </CoursePage>

--- a/tutor/src/screens/scores-report/nav.jsx
+++ b/tutor/src/screens/scores-report/nav.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import CoursePeriodsNav from '../../components/course-periods-nav';
+import Course from '../../models/course';
+
+import { keys, pick } from 'lodash';
+
+const COURSE_PERIODS_NAV_PROPS = keys(CoursePeriodsNav.propTypes);
+
+export default class ScoresReportNav extends React.PureComponent {
+
+  static propTypes = {
+    course: React.PropTypes.instanceOf(Course).isRequired,
+  }
+
+  render() {
+    if (!this.props.course.isTeacher) {
+      return null;
+    }
+
+    return (
+      <CoursePeriodsNav
+        {...pick(this.props, COURSE_PERIODS_NAV_PROPS)}
+        courseId={this.props.course.id}
+      />
+    );
+  }
+}

--- a/tutor/src/screens/scores-report/overall-header.jsx
+++ b/tutor/src/screens/scores-report/overall-header.jsx
@@ -17,6 +17,8 @@ const AveragesToggle = observer(({ ux }) => (
 
 const OverallHeader = observer(({ ux, period }) => {
 
+  const viewWeightsLabel = (period.course.isTeacher && 'Set weights') || 'View weights';
+
   return (
     <div className={cn('header-cell-wrapper', 'overall-average', { 'is-expanded': ux.isAveragesExpanded })}>
       <SetWeights ux={ux} />
@@ -24,7 +26,7 @@ const OverallHeader = observer(({ ux, period }) => {
         <AveragesToggle ux={ux} />
         <div className="avg">
           <b>Averages</b>
-          <a className="set-weights" onClick={ux.weights.onSetClick}>Set weights</a>
+          <a className="set-weights" onClick={ux.weights.onSetClick}>{viewWeightsLabel}</a>
         </div>
       </div>
       <div className="header-row labels">

--- a/tutor/src/screens/scores-report/overall-header.jsx
+++ b/tutor/src/screens/scores-report/overall-header.jsx
@@ -5,6 +5,7 @@ import { asPercent } from '../../helpers/string';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react';
 import SetWeights from './set-weights-modal';
+import ViewWeights from './view-weights-modal';
 
 const AveragesToggle = observer(({ ux }) => (
   <Icon
@@ -18,10 +19,30 @@ const AveragesToggle = observer(({ ux }) => (
 const OverallHeader = observer(({ ux, period }) => {
 
   const viewWeightsLabel = (period.course.isTeacher && 'Set weights') || 'View weights';
+  let overviewHeaderRow = null;
+  let weightsModal = <ViewWeights ux={ux} />
+
+  if (period.course.isTeacher) {
+    overviewHeaderRow = (
+      <div className="header-row values overview-row">
+        <div>{asPercent(period.overall_course_average)}%</div>
+        <div className="homework">
+          <div>{asPercent(period.overall_homework_score)}%</div>
+          <div>{asPercent(period.overall_homework_progress)}%</div>
+        </div>
+        <div className="reading">
+          <div>{asPercent(period.overall_reading_score)}%</div>
+          <div>{asPercent(period.overall_reading_progress)}%</div>
+        </div>
+      </div>
+    );
+
+    weightsModal = <SetWeights ux={ux} />
+  }
 
   return (
     <div className={cn('header-cell-wrapper', 'overall-average', { 'is-expanded': ux.isAveragesExpanded })}>
-      <SetWeights ux={ux} />
+      {weightsModal}
       <div className="overall-header-cell">
         <AveragesToggle ux={ux} />
         <div className="avg">
@@ -45,17 +66,7 @@ const OverallHeader = observer(({ ux, period }) => {
           <div>Progress</div>
         </div>
       </div>
-      <div className="header-row values overview-row">
-        <div>{asPercent(period.overall_course_average)}%</div>
-        <div className="homework">
-          <div>{asPercent(period.overall_homework_score)}%</div>
-          <div>{asPercent(period.overall_homework_progress)}%</div>
-        </div>
-        <div className="reading">
-          <div>{asPercent(period.overall_reading_score)}%</div>
-          <div>{asPercent(period.overall_reading_progress)}%</div>
-        </div>
-      </div>
+      {overviewHeaderRow}
     </div>
   );
 });

--- a/tutor/src/screens/scores-report/reading-cell.jsx
+++ b/tutor/src/screens/scores-report/reading-cell.jsx
@@ -40,6 +40,28 @@ export default class ReadingCell extends React.PureComponent {
     return ReactDOM.findDOMNode(this.refs.pieChart);
   }
 
+  renderReviewLink() {
+    const { task, period } = this.props;
+
+    if (!period.course.isTeacher) {
+      return null;
+    }
+
+    return (
+      <div className="row">
+        <div>
+          <TutorLink
+            to="viewTaskStep"
+            data-assignment-type={`${task.type}`}
+            params={{ courseId, id: task.id, stepIndex: 1 }}
+          >
+            Review
+          </TutorLink>
+        </div>
+      </div>
+    );
+  }
+
   renderPopover() {
     const { task, courseId, period_id } = this.props;
     if (!task.isStarted) { return null; }
@@ -61,17 +83,7 @@ export default class ReadingCell extends React.PureComponent {
                 Completed {TH.getHumanCompletedPercent(task)}
               </div>
             </div>
-            <div className="row">
-              <div>
-                <TutorLink
-                  to="viewTaskStep"
-                  data-assignment-type={`${task.type}`}
-                  params={{ courseId, id: task.id, stepIndex: 1 }}
-                >
-                  Review
-                </TutorLink>
-              </div>
-            </div>
+            {this.renderReviewLink()}
           </div>
         </Popover>
       </Overlay>

--- a/tutor/src/screens/scores-report/reading-cell.jsx
+++ b/tutor/src/screens/scores-report/reading-cell.jsx
@@ -77,8 +77,26 @@ export default class ReadingCell extends React.PureComponent {
       </Overlay>
     );
   }
+
+  renderLateWork() {
+    const { task, columnIndex } = this.props;
+
+
+    if (!this.props.period.course.isTeacher) {
+      return null;
+    }
+
+    return (<LateWork
+        task={task}
+        onMouseOver={this.show}
+        onMouseLeave={this.hide}
+        columnIndex={columnIndex}
+      />
+    );
+  }
+
   render() {
-    const { task, isConceptCoach, columnIndex, period_id } = this.props;
+    const { task, isConceptCoach, period_id } = this.props;
 
     return (
       <div className="scores-cell">
@@ -92,11 +110,7 @@ export default class ReadingCell extends React.PureComponent {
             value={TH.getCompletedPercent(task)}
             isLate={TH.isDue(task)} />
         </div>
-        <LateWork
-          task={task}
-          onMouseOver={this.show}
-          onMouseLeave={this.hide}
-          columnIndex={columnIndex} />
+        {this.renderLateWork()}
       </div>
     );
   }

--- a/tutor/src/screens/scores-report/reading-cell.jsx
+++ b/tutor/src/screens/scores-report/reading-cell.jsx
@@ -41,7 +41,7 @@ export default class ReadingCell extends React.PureComponent {
   }
 
   renderReviewLink() {
-    const { task, period } = this.props;
+    const { task, courseId, period } = this.props;
 
     if (!period.course.isTeacher) {
       return null;

--- a/tutor/src/screens/scores-report/styles/set-weights-modal.scss
+++ b/tutor/src/screens/scores-report/styles/set-weights-modal.scss
@@ -17,6 +17,11 @@
     }
   }
 
+  .header {
+    text-align: right;
+    @include tutor-sans-light-font(14px);
+  }
+
   .weight {
     display: flex;
     align-items: center;

--- a/tutor/src/screens/scores-report/table.jsx
+++ b/tutor/src/screens/scores-report/table.jsx
@@ -89,6 +89,49 @@ export default class ScoresTable extends React.PureComponent {
     );
   }
 
+  renderLeftColumnGroup() {
+    const { ux, courseId, students, props: { period } } = this;
+
+    if (!period.course.isTeacher) {
+      return (
+        <ColumnGroup fixed={true}>
+          <Column
+            fixed={true}
+            width={ux.averagesWidth}
+            flexGrow={0}
+            allowCellsRecycling={true}
+            isResizable={false}
+            cell={<OverallCell ux={ux} students={students} />}
+            header={<OverallHeader ux={ux} {...this.props} />}
+          />
+        </ColumnGroup>
+      );
+    }
+
+    return (
+      <ColumnGroup fixed={true}>
+        <Column
+          fixed={true}
+          width={COLUMN_WIDTH}
+          flexGrow={0}
+          allowCellsRecycling={true}
+          isResizable={false}
+          cell={<NameCell {...this.props} {...{ students, courseId }} />}
+          header={<NameHeader {...this.props} />}
+        />
+        <Column
+          fixed={true}
+          width={ux.averagesWidth}
+          flexGrow={0}
+          allowCellsRecycling={true}
+          isResizable={false}
+          cell={<OverallCell ux={ux} students={students} />}
+          header={<OverallHeader ux={ux} {...this.props} />}
+        />
+      </ColumnGroup>
+    );
+  }
+
   render() {
     const { ux, courseId, students, props: { period } } = this;
     const width = COLUMN_WIDTH;
@@ -106,26 +149,7 @@ export default class ScoresTable extends React.PureComponent {
         rowsCount={students.length}
         insetScrollbarX={true}
       >
-        <ColumnGroup fixed={true}>
-          <Column
-            fixed={true}
-            width={COLUMN_WIDTH}
-            flexGrow={0}
-            allowCellsRecycling={true}
-            isResizable={false}
-            cell={<NameCell {...this.props} {...{ students, courseId }} />}
-            header={<NameHeader {...this.props} />}
-          />
-          <Column
-            fixed={true}
-            width={ux.averagesWidth}
-            flexGrow={0}
-            allowCellsRecycling={true}
-            isResizable={false}
-            cell={<OverallCell ux={ux} students={students} />}
-            header={<OverallHeader ux={ux} {...this.props} />}
-          />
-        </ColumnGroup>
+        {this.renderLeftColumnGroup()}
         <ColumnGroup>
           {range(0, period.numAssignments).map((columnIndex) =>
             <Column

--- a/tutor/src/screens/scores-report/view-weights-modal.jsx
+++ b/tutor/src/screens/scores-report/view-weights-modal.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { observer, PropTypes as MobxPropTypes } from 'mobx-react';
+import cn from 'classnames';
+import { Modal, Button } from 'react-bootstrap';
+
+@observer
+export default class SetWeightsModal extends React.Component {
+
+  static propTypes = {
+    ux: MobxPropTypes.observableObject,
+  }
+
+  render() {
+    const { ux: { weights } } = this.props;
+    if (!weights.isSetting) { return null; }
+
+    return (
+      <Modal
+        show={true}
+        backdrop="static"
+        className="set-weights view-weights"
+      >
+        <Modal.Header closeButton>
+          How your instructor adds up your work
+        </Modal.Header>
+        <Modal.Body
+          className={
+            cn({'page-loading loadable is-loading': true})
+          }
+        >
+          <p className="header">Counts for</p>
+          <label className="weight">
+            <div>Homework scores</div>
+            <div>
+              {weights.homework_scores}%
+            </div>
+          </label>
+          <label className="weight">
+            <div>Homework progress</div>
+            <div>
+              {weights.homework_progress}%
+            </div>
+          </label>
+          <label className="weight">
+            <div>Reading scores</div>
+            <div>
+              {weights.reading_scores}%
+            </div>
+          </label>
+          <label className="weight">
+            <div>Reading progress</div>
+            <div>
+              {weights.reading_progress}%
+            </div>
+          </label>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            onClick={weights.onCancelClick}
+            className={'btn-outline-secondary'}
+          >Close</Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}


### PR DESCRIPTION
…ll as styling details

- [x] Student will have a new page that includes the instructor scores table
- [x] All styling will remain consistent w/instructor scores page
- [x] Only the student's data will populate the table
- [x] Student name/id column will be removed
- [x] No late work (orange triangle) will be indicated
- [x] No export option
- [x] Remove "Scores displayed on the due date . . . " text
- [x] The page will have a link in the Menu dropdown menu called "Scores"; NOTE POSITION IN MOCKUP
- [x] weights modal updates
- [ ] fix some stylings

https://trello.com/c/04Xk18sV/1089-change-request-add-score-report-for-students-in-tutor