### PR TITLE
Redirect already enrolled students to their course when using enroll link

### DIFF
--- a/tutor/specs/components/enroll.spec.jsx
+++ b/tutor/specs/components/enroll.spec.jsx
@@ -5,6 +5,9 @@ import Enroll from '../../src/components/enroll';
 import EnzymeContext from './helpers/enzyme-context';
 import Router from '../../src/helpers/router';
 import EnrollModel from '../../src/models/course/enroll';
+jest.mock('../../src/models/user', () => ({
+  refreshCourses: jest.fn(() => Promise.resolve()),
+}));
 jest.mock('../../src/helpers/router');
 
 describe('Student Enrollment', () => {
@@ -39,6 +42,19 @@ describe('Student Enrollment', () => {
     expect(enrollment.router.history.push).toHaveBeenCalledWith('/courses');
   });
 
+  it('forwards to your course if already a member', (done) => {
+    enrollment.api.errors = { already_enrolled: { data: { course_name: 'My Course' } } };
+    const enroll = mount(<Enroll enrollment={enrollment} />, context);
+    expect(enroll).toHaveRendered('OXFancyLoader');
+    enrollment.isComplete = true;
+    enroll.update();
+    setTimeout(() => {
+      //console.log(enroll.debug());
+      expect(enroll).toHaveRendered('Redirect');
+      enroll.unmount();
+      done();
+    }, 100);
+  });
 
   it('displays an invalid message', () => {
     enrollment.api.errors = { invalid_enrollment_code: true };

--- a/tutor/src/models/course/enroll.js
+++ b/tutor/src/models/course/enroll.js
@@ -50,6 +50,11 @@ export default class CourseEnrollment extends BaseModel {
       return this.renderComponent('invalidTeacher');
     } else if (this.isInvalid) {
       return this.renderComponent('invalidCode');
+    } else if (this.isComplete) {
+      if (this.courseId)
+        return <Redirect to={Router.makePathname('dashboard', { courseId: this.courseId })} />;
+      else
+        return <Redirect to={Router.makePathname('myCourses')} />;
     } else if (!isEmpty(this.api.errors)) {
       if (this.api.errors.dropped_student) {
         return this.renderComponent('droppedStudent');
@@ -60,11 +65,6 @@ export default class CourseEnrollment extends BaseModel {
       }
     } else if (this.needsPeriodSelection) {
       return this.renderComponent('selectPeriod');
-    } else if (this.isComplete) {
-      if (this.courseId)
-        return <Redirect to={Router.makePathname('dashboard', { courseId: this.courseId })} />;
-      else
-        return <Redirect to={Router.makePathname('myCourses')} />;
     } else {
       return this.renderComponent('studentIDForm');
     }

--- a/tutor/src/models/course/enroll.js
+++ b/tutor/src/models/course/enroll.js
@@ -9,6 +9,7 @@ import S from '../../helpers/string';
 import Router from '../../../src/helpers/router';
 import User from '../user';
 import StudentTasks from '../student-tasks';
+import Courses from '../courses-map';
 import Activity from '../../../src/components/ox-fancy-loader';
 
 import Enroll from '../../../src/components/enroll';
@@ -51,10 +52,13 @@ export default class CourseEnrollment extends BaseModel {
     } else if (this.isInvalid) {
       return this.renderComponent('invalidCode');
     } else if (this.isComplete) {
-      if (this.courseId)
+      if (this.courseId) {
         return <Redirect to={Router.makePathname('dashboard', { courseId: this.courseId })} />;
-      else
+      } else {
+        // the BE says we're registered but we didn't find the course
+        // most likely because they're coming from LMS or have a non-standard enrollment
         return <Redirect to={Router.makePathname('myCourses')} />;
+      }
     } else if (!isEmpty(this.api.errors)) {
       if (this.api.errors.dropped_student) {
         return this.renderComponent('droppedStudent');
@@ -119,8 +123,16 @@ export default class CourseEnrollment extends BaseModel {
     return get(this, 'to.course.name', '');
   }
 
+  @computed get course() {
+    return Courses.array.find(c =>
+      c.periods.find(p =>
+        p.enrollment_code == this.enrollment_code
+      )
+    );
+  }
+
   @computed get courseId() {
-    return get(this, 'to.course.id', '');
+    return get(this, 'to.course.id', this.course ? this.course.id : '');
   }
 
   @computed get isPending() {


### PR DESCRIPTION
render already enrolled redirect before errors; otherwise we'd render the generic error message because the error check came before the redirect