### PR TITLE
Fix html in step titles

### DIFF
--- a/tutor/resources/styles/variables/tutor-bootstrap.scss
+++ b/tutor/resources/styles/variables/tutor-bootstrap.scss
@@ -623,9 +623,9 @@ $popover-background: $tutor-white;
 // //** Modal footer border color
 // $modal-footer-border-color:   $modal-header-border-color;
 
-// $modal-lg:                    900px;
-// $modal-md:                    600px;
-// $modal-sm:                    300px;
+$modal-lg:                    670px;
+$modal-md:                    570px;
+$modal-sm:                    470px;
 
 
 // //== Alerts

--- a/tutor/specs/flux/step-title.spec.js
+++ b/tutor/specs/flux/step-title.spec.js
@@ -1,0 +1,16 @@
+import { StepTitleActions, StepTitleStore } from '../../src/flux/step-title';
+
+const STEP_ID = 'step-id-1-1';
+
+describe('StepTitle', () => {
+
+
+  it('parses step title with math', () => {
+    const html = `<p>Which of the following quantities are of the same order of magnitude?</p>↵↵<ol>↵  <li>↵<span data-math="5">5</span> and <span data-math="50">50</span>↵</li>↵  <li>↵<span data-math="400">400</span> and <span data-math="500">500</span>↵</li>↵  <li>↵<span data-math="500">500</span> and <span data-math="500">500</span>↵</li>↵  <li>↵<span data-math="2 \times 10^2">2 \times 10^2</span> and <span data-math="3 \times 10^2">3 \times 10^2</span>↵</li>↵</ol>↵`;
+    StepTitleActions.parseExercise(STEP_ID, html);
+
+    const title = StepTitleStore.getTitleForCrumb({ id: STEP_ID });
+    expect(title).toEqual('Which of the following quantities are of the same order of magnitude?↵↵↵  ↵5 and 50↵↵  ↵400 and 500↵↵  ↵500 and 500↵↵  ↵2 	i…');
+  });
+
+});

--- a/tutor/src/flux/step-title.coffee
+++ b/tutor/src/flux/step-title.coffee
@@ -137,9 +137,10 @@ StepTitleConfig =
           lastPart.data = grabTruncatedText(lastPart.data, start)
           truncatedExercise[truncatedExercise.length - 1] = lastPart
         else
-          truncatedExercise.push({data: '...', type: 'text'})
+          truncatedExercise.push({data: '…', type: 'text'})
 
-      text = htmlparser.DomUtils.getOuterHTML(truncatedExercise)
+      text = htmlparser.DomUtils.getText(truncatedExercise)
+      text = text.slice(0, TEXT_LENGTH - 1) + '…' if text.length >= TEXT_LENGTH
 
     actions.loaded(id, text)
     actions.loadedMetaData(id)


### PR DESCRIPTION
Previously if a task step had math in it's `stem_html` that would cause us to parse the title incorrectly and we'd display math in the task step title and it's "Continue to .." text link.