### PR TITLE
maintain aspect ratio of scaled images in reference book

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -73,7 +73,10 @@
       }
     }
 
-    img { width: 100%; }
+    img {
+      width: 100%;
+      height: auto;
+    }
 
     figcaption {
       border-bottom: 1px solid;


### PR DESCRIPTION
before:

![screen shot 2018-02-14 at 4 01 09 pm](https://user-images.githubusercontent.com/79566/36230592-87df8b08-11a0-11e8-858e-c6a0d8c130d7.png)


after:  Note that the Isaac Newton image looks too tall but that's it's correct height.

![screen shot 2018-02-14 at 3 59 11 pm](https://user-images.githubusercontent.com/79566/36230593-87f4cb12-11a0-11e8-8736-91d0b178c3d8.png)