### PR TITLE
tweak styles so they're identical in Firefox

### DIFF
--- a/tutor/src/screens/scores-report/styles/header.scss
+++ b/tutor/src/screens/scores-report/styles/header.scss
@@ -5,7 +5,7 @@
 
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: flex-start;
 
   .expanded-header-row {
     flex: 1;
@@ -35,13 +35,17 @@
   }
 
   &.student-names {
+    justify-content: flex-end;
+
     .header-row {
       font-weight: 500;
       white-space: nowrap;
       align-items: center;
 
+      border-top-width: 0 !important;
+
       .header-cell {
-        border-top:  $scores-thin-grey-border;
+        border-top: $scores-thick-grey-border;
         justify-content: start;
         padding-left: 8px;
         background-color: $tutor-neutral-cool;

--- a/tutor/src/screens/scores-report/styles/overall-cell.scss
+++ b/tutor/src/screens/scores-report/styles/overall-cell.scss
@@ -1,9 +1,6 @@
 .overall-average {
   flex: 1;
-
-  border-top-color: $tutor-neutral;
-  border-top-width: 5px;
-  border-top-style: solid;
+  border-top-width: 0;
 
   font-weight: normal;
   border-bottom: 0;
@@ -17,7 +14,9 @@
     display: flex;
     flex-direction: column;
     background-color: $scores-student-header-bg-color;
-    // flex-basis: $scores-group-row-height;
+    border-top-color: $tutor-neutral;
+    border-top-width: 5px;
+    border-top-style: solid;
 
     .tutor-icon {
       position: absolute;
@@ -61,7 +60,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      padding-bottom: 5px;
+      // padding-bottom: 5px;
       .set-weights {
         white-space: nowrap;
         font-size: 1.4rem;


### PR DESCRIPTION
Before Firefox would display as:
![screen shot 2018-02-15 at 2 41 17 pm](https://user-images.githubusercontent.com/79566/36279922-4f85af9e-125e-11e8-82b5-ee1b894b6a50.png)



Now it matches other browsers as:
![screen shot 2018-02-15 at 2 40 42 pm](https://user-images.githubusercontent.com/79566/36279925-5201bee8-125e-11e8-9598-8eebd300a585.png)
