### PR TITLE
UX fixes for student scores

### DIFF
--- a/tutor/resources/styles/components/modals.scss
+++ b/tutor/resources/styles/components/modals.scss
@@ -21,10 +21,10 @@
 
   .modal-footer {
     padding: 0 $modal-padding $modal-padding $modal-padding;
-    text-align: left;
     border-top: 0;
+    display: flex;
     button {
-      height: 50px;
+      @include button(); // openstax pattern-library
     }
   }
 

--- a/tutor/resources/styles/components/modals.scss
+++ b/tutor/resources/styles/components/modals.scss
@@ -1,6 +1,6 @@
 .modal {
   $header-padding: 35px;
-  $modal-padding: 50px;
+  $modal-padding: 30px;
 
   .modal-content {
     border-radius: 0;

--- a/tutor/src/screens/scores-report/assignment-header.jsx
+++ b/tutor/src/screens/scores-report/assignment-header.jsx
@@ -34,19 +34,21 @@ const AverageLabel = (props) => {
       </span>
     );
   } if (props.heading.type === 'external') {
-    const p = props.heading.completion_rate;
-    const percent = (() => {
-      switch (false) {
-        case (!(p < 1) || !(p > 0.99)): return 99; // Don't round to 100% when it's not 100%!
-        case (!(p > 0) || !(p < 0.01)): return 1; // Don't round to 0% when it's not 0%!
-        case (!(p > 1)): return 100; // Don't let it go over 100%!
-        default: return Math.round(p * 100);
-      }
-    })();
+    const p = props.heading.average_progress;
+    let percent;
+    if (p < 1 && p > 0.99) {
+      percent = 99; // Don't round to 100% when it's not 100%!
+    } else if (p > 0 && p < 0.01) {
+      percent = 1; // Don't round to 0% when it's not 0%!
+    } else if (p > 1) {
+      percent = 100; // Don't let it go over 100%!
+    } else {
+      percent = Math.round(p * 100);
+    }
 
     return (
       <span className="click-rate">
-        {percent} % have clicked link
+        {percent}% have clicked link
       </span>
     );
   } else {
@@ -111,9 +113,9 @@ const TeacherAssignmentHeaderRow = function(props) {
   }
 
   return (<div className="header-row overview-row">
-      <AverageLabel {...props} heading={heading} />
-      <ReviewLink {...props} heading={heading} />
-    </div>
+    <AverageLabel {...props} heading={heading} />
+    <ReviewLink {...props} heading={heading} />
+  </div>
   );
 
 }

--- a/tutor/src/screens/scores-report/external-cell.jsx
+++ b/tutor/src/screens/scores-report/external-cell.jsx
@@ -13,11 +13,19 @@ export default class ExternalCell extends React.PureComponent {
   static propTypes = {
     className: React.PropTypes.string,
     courseId: React.PropTypes.string.isRequired,
+    period: React.PropTypes.object.isRequired,
     task: React.PropTypes.shape({
       id: React.PropTypes.number,
       type: React.PropTypes.string,
       status: React.PropTypes.string,
     }).isRequired,
+  }
+
+  renderLateIcon() {
+    if (this.props.period.course.isTeacher) {
+      return <LateIcon {...this.props} />;
+    }
+    return null;
   }
 
   renderLink({ message }) {
@@ -30,7 +38,7 @@ export default class ExternalCell extends React.PureComponent {
         <span>
           {message}
         </span>
-        <LateIcon {...this.props} />
+        {this.renderLateIcon()}
       </TutorLink>
     );
   }

--- a/tutor/src/screens/scores-report/ux.js
+++ b/tutor/src/screens/scores-report/ux.js
@@ -71,16 +71,17 @@ export default class ScoresReportUX {
   }
 
   @computed get headerHeight() {
-    return (this.period.course.isTeacher && 180) || 140;
+    return (this.course.isTeacher && 180) || 140;
   }
 
   @computed get windowHeightPadding() {
-    return (this.period.course.isTeacher && (WINDOW_HEIGHT_PADDING + 95)) || WINDOW_HEIGHT_PADDING;
+    return (this.course.isTeacher && (WINDOW_HEIGHT_PADDING + 95)) || WINDOW_HEIGHT_PADDING;
   }
 
   @computed get tableWidth() {
+    const extraCol = this.course.isTeacher ? 1 : 0;
     const desiredWidth = this.averagesWidth +
-      (this.COLUMN_WIDTH * (this.period.numAssignments + 1));
+      (this.COLUMN_WIDTH * (this.period.numAssignments + extraCol));
     return Math.min(
       desiredWidth, (this.windowSize.width - PADDING)
     );


### PR DESCRIPTION
* Use pattern library buttons styles on weights modal
* Fix overly wide table for students
* Don't render late icon for student's external assignments

![screen shot 2018-02-19 at 1 09 13 pm](https://user-images.githubusercontent.com/79566/36393691-39a33f1e-1576-11e8-9c16-a8449db808e6.png)

![screen shot 2018-02-19 at 1 08 59 pm](https://user-images.githubusercontent.com/79566/36393692-39b3bae2-1576-11e8-944b-0dc59d6a9b2b.png)

![screen shot 2018-02-19 at 1 12 06 pm](https://user-images.githubusercontent.com/79566/36393756-85a9d7e2-1576-11e8-929c-e6c46734ac12.png)
