### PR TITLE
Fix fetching tasks on enrollment

### DIFF
--- a/tutor/specs/components/helpers/component-testing.coffee
+++ b/tutor/specs/components/helpers/component-testing.coffee
@@ -11,6 +11,7 @@ SnapShot = require 'react-test-renderer'
 { spyOnComponentMethod, stubComponentMethod } = require 'sinon-spy-react'
 {DragDropManager} = require 'dnd-core'
 TestBackend = require('react-dnd-test-backend').default
+{Provider} = require 'mobx-react'
 
 # No longer exists, needs further investigation if we're using it
 # ReactContext   = require('react/lib/ReactContext')
@@ -48,12 +49,13 @@ Wrapper = React.createClass
 
   render: ->
     location = { pathname: '/' }
-    props = _.omit(@props, '_wrapped_component')
+    props = _.omit(@props, '_wrapped_component', 'injected')
     props.ref = 'element' unless @props.noReference
-
+    body = React.createElement(@props._wrapped_component, props)
     React.createElement(ReactRouter, { history: createHistory.default( initialEntries: ['/dashboard'] ) },
-      React.createElement(@props._wrapped_component, props)
+      if @props.injected then React.createElement(Provider, @props.injected, body) else body
     )
+
 
 Testing = {
 

--- a/tutor/specs/models/courses/onboarding/student-course.spec.js
+++ b/tutor/specs/models/courses/onboarding/student-course.spec.js
@@ -87,7 +87,7 @@ describe('Full Course Onboarding', () => {
     expect(ux.course.studentTasks.fetch).not.toHaveBeenCalled();
     return ux.onPaymentComplete().then(() => {
       expect(ux.course.studentTasks.fetch).toHaveBeenCalledTimes(1);
-      expect(setTimeout).toHaveBeenCalledWith(ux.fetchTaskPeriodically, 60000);
+      expect(setTimeout).toHaveBeenCalledWith(ux.fetchTaskPeriodically, expect.any(Number));
       jest.runOnlyPendingTimers();
       expect(ux.course.studentTasks.fetch).toHaveBeenCalledTimes(2);
       ux.close();

--- a/tutor/specs/models/courses/onboarding/student-course.spec.js
+++ b/tutor/specs/models/courses/onboarding/student-course.spec.js
@@ -5,13 +5,14 @@ import CourseUX from '../../../../src/models/course/onboarding/student-course';
 import UiSettings from 'shared/model/ui-settings';
 import User from '../../../../src/models/user';
 import Payments from '../../../../src/models/payments';
-
+import StudentTasks from '../../../../src/models/student-tasks';
 jest.mock('shared/model/ui-settings', () => ({
   set: jest.fn(),
   get: jest.fn(),
 }));
 jest.mock('../../../../src/models/course');
-jest.mock('../../../../src/models/payments' );
+jest.mock('../../../../src/models/payments');
+
 jest.useFakeTimers();
 
 describe('Full Course Onboarding', () => {
@@ -21,10 +22,10 @@ describe('Full Course Onboarding', () => {
     UiSettings.get.mockImplementation(() => undefined);
     User.terms_signatures_needed = false;
     ux = new CourseUX(
-      new Course,
+      new Course({ id: 1 }),
       { tour: null },
     );
-    ux.course.studentTasks = { fetch: jest.fn(), };
+    ux.course.studentTasks = { fetch: jest.fn(() => Promise.resolve()) };
   });
 
   afterEach(() => {
@@ -55,7 +56,6 @@ describe('Full Course Onboarding', () => {
 
   it('#onPaymentComplete', () => {
     ux.course.needsPayment = true;
-    ux.course.studentTasks = { fetch: jest.fn() };
     ux.payNow();
     ux.course.userStudentRecord = {
       markPaid: jest.fn(),
@@ -85,16 +85,15 @@ describe('Full Course Onboarding', () => {
     expect(ux.paymentIsPastDue).toBe(true);
     ux.mount();
     expect(ux.course.studentTasks.fetch).not.toHaveBeenCalled();
-    ux.onPaymentComplete();
-    expect(setInterval).toHaveBeenCalled();
-    expect(ux.course.studentTasks.fetch).toHaveBeenCalledTimes(1);
-    expect(ux.refreshTasksTimer).not.toBeNull();
-    jest.runOnlyPendingTimers();
-    expect(ux.course.studentTasks.fetch).toHaveBeenCalledTimes(2);
-    ux.close();
-    expect(ux.refreshTasksTimer).toBeNull();
-    jest.runAllTimers();
-    expect(ux.course.studentTasks.fetch).toHaveBeenCalledTimes(2);
+    return ux.onPaymentComplete().then(() => {
+      expect(ux.course.studentTasks.fetch).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenCalledWith(ux.fetchTaskPeriodically, 60000);
+      jest.runOnlyPendingTimers();
+      expect(ux.course.studentTasks.fetch).toHaveBeenCalledTimes(2);
+      ux.close();
+      expect(ux.refreshTasksTimer).toBeNull();
+    });
+
   });
 
 });

--- a/tutor/specs/screens/student-dashboard/dashboard.spec.jsx
+++ b/tutor/specs/screens/student-dashboard/dashboard.spec.jsx
@@ -1,6 +1,7 @@
 import {React, SnapShot, Wrapper} from '../../components/helpers/component-testing';
 import Dashboard from '../../../src/screens/student-dashboard/dashboard';
 import StudentTasks from '../../../src/models/student-tasks';
+import ux from '../../../src/models/course/onboarding/student-course.js';
 import { bootstrapCoursesList } from '../../courses-test-data';
 import chronokinesis from 'chronokinesis';
 import moment from 'moment-timezone';
@@ -36,7 +37,11 @@ describe('Student Dashboard', () => {
   });
 
   it('matches snapshot', function() {
-    const component = SnapShot.create(<Wrapper _wrapped_component={Dashboard} {...props} />);
+    const ux = { isEmptyNewStudent: false };
+    const component = SnapShot.create(
+      <Wrapper injected={{ studentDashboardUX: ux }}
+        _wrapped_component={Dashboard} {...props} />
+    );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/tutor/src/models/student-tasks.js
+++ b/tutor/src/models/student-tasks.js
@@ -13,7 +13,6 @@ const POLL_SECONDS = 30;
 export class CourseStudentTasks extends Map {
   @readonly static Model = Task;
 
-  @observable _updatesPoller;
   @observable researchSurveys;
 
   constructor(courseId) {
@@ -43,10 +42,6 @@ export class CourseStudentTasks extends Map {
   // Returns events who's due date has not passed
   upcomingEvents(now = TimeStore.getNow()) {
     return sortBy(filter(this.array, event => event.due_at > now), 'due_at');
-  }
-
-  @computed get isFetchingInitialUpdates() {
-    return Boolean(this.array.length == 0 && this._updatesPoller);
   }
 
   // note: the response also contains limited course and role information but they're currently unused

--- a/tutor/src/screens/student-dashboard/empty-panel.jsx
+++ b/tutor/src/screens/student-dashboard/empty-panel.jsx
@@ -10,7 +10,7 @@ const EmptyPanel = inject('studentDashboardUX')(observer(({
   title,
 }) => {
 
-  if (studentDashboardUX.isEmptyNewStudent) {
+  if (studentDashboardUX && studentDashboardUX.isEmptyNewStudent) {
     return (
       <Panel className="empty" header={title}>
         <Icon type="spinner" spin /> Loading assignments for course
@@ -28,7 +28,7 @@ const EmptyPanel = inject('studentDashboardUX')(observer(({
 EmptyPanel.propTypes = {
   studentDashboardUX: React.PropTypes.shape({
     isEmptyNewStudent: React.PropTypes.bool,
-  }).isRequired,
+  }),
   message: React.PropTypes.string.isRequired,
   title: React.PropTypes.string,
 };

--- a/tutor/src/screens/student-dashboard/empty-panel.jsx
+++ b/tutor/src/screens/student-dashboard/empty-panel.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
-import { observer } from 'mobx-react';
+import { observer, inject } from 'mobx-react';
 import { Panel } from 'react-bootstrap';
 import StudentTasks from '../../models/student-tasks';
 import Icon from '../../components/icon';
 
-const EmptyPanel = observer(({ courseId, message, title }) => {
-  if (StudentTasks.get(courseId).isFetchingInitialUpdates) {
+const EmptyPanel = inject('studentDashboardUX')(observer(({
+  studentDashboardUX,
+  message,
+  title,
+}) => {
+
+  if (studentDashboardUX.isEmptyNewStudent) {
     return (
       <Panel className="empty" header={title}>
         <Icon type="spinner" spin /> Loading assignments for course
@@ -18,10 +23,12 @@ const EmptyPanel = observer(({ courseId, message, title }) => {
       {message}
     </Panel>
   );
-});
+}));
 
 EmptyPanel.propTypes = {
-  courseId: React.PropTypes.string.isRequired,
+  studentDashboardUX: React.PropTypes.shape({
+    isEmptyNewStudent: React.PropTypes.bool,
+  }).isRequired,
   message: React.PropTypes.string.isRequired,
   title: React.PropTypes.string,
 };

--- a/tutor/src/screens/student-dashboard/index.jsx
+++ b/tutor/src/screens/student-dashboard/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { observable, computed, action, observe } from 'mobx';
-import { observer, inject } from 'mobx-react';
+import { observer, inject, Provider } from 'mobx-react';
 import StudentDashboard from './dashboard';
 import CourseNagModal from '../../components/onboarding/course-nag';
 import TermsModal from '../../components/terms-modal';
@@ -59,11 +59,13 @@ export default class StudentDashboardShell extends React.PureComponent {
     if (this.ux.paymentIsPastDue) { return <CourseNagModal ux={this.ux} />; }
 
     return (
-      <div className="student-dashboard ">
-        <TermsModal />
-        <CourseNagModal ux={this.ux} />
-        <StudentDashboard params={params} courseId={courseId} />
-      </div>
+      <Provider studentDashboardUX={this.ux}>
+        <div className="student-dashboard ">
+          <TermsModal />
+          <CourseNagModal ux={this.ux} />
+          <StudentDashboard params={params} courseId={courseId} />
+        </div>
+      </Provider>
     );
   }
 }


### PR DESCRIPTION
Before it wouldn't immediately re-poll after the initial fetch until 4 hours had past 😿 

And the task spinner wasn't displaying while it loaded