### PR TITLE
Fix re-exporting default exports from JS

### DIFF
--- a/shared/src/helpers/task.js
+++ b/shared/src/helpers/task.js
@@ -254,4 +254,6 @@ const mapSteps = task =>
   )
 ;
 
-export { mapSteps };
+const TaskHelper = { mapSteps };
+
+export { mapSteps, TaskHelper };

--- a/shared/src/index.js
+++ b/shared/src/index.js
@@ -36,7 +36,7 @@ export ExerciseIdentifierLink from './components/exercise-identifier-link';
 export ExerciseHelpers from './model/exercise';
 export ExercisePreview from './components/exercise-preview';
 
-export TaskHelper from './helpers/task';
+export { TaskHelper } from './helpers/task';
 export StepHelpsHelper from './helpers/step-helps';
 export propHelpers from './helpers/props';
 export Logging from './helpers/logging';
@@ -54,5 +54,5 @@ export Question from './components/question';
 export RefreshButton from './components/buttons/refresh-button';
 export ResizeListenerMixin from './components/resize-listener-mixin';
 export SmartOverflow from './components/smart-overflow';
-export SpyMode from './components/spy-mode';
+export { default as SpyMode } from './components/spy-mode';
 export HandleBodyClassesMixin from './components/handle-body-classes-mixin';


### PR DESCRIPTION
These were exported as default but we were re-exporting a named export that didn't exist

I went through `shared/index` and verified that these are the only two JS exports that we're re-exporting.