### PR TITLE
Fix weird top margin and scroll to linked annotation

### DIFF
--- a/tutor/resources/styles/components/annotations/summary-page.scss
+++ b/tutor/resources/styles/components/annotations/summary-page.scss
@@ -45,10 +45,14 @@
     }
 
     .annotation-card {
+      padding-bottom: 3rem;
+    }
+
+    .annotation-body {
       background-color: $tutor-white;
       display: flex;
       flex-direction: column;
-      margin-bottom: 3rem;
+
       padding: 3rem;
       width: 100%;
       break-inside: avoid;

--- a/tutor/specs/components/__snapshots__/annotations.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/annotations.spec.jsx.snap
@@ -151,107 +151,115 @@ exports[`Annotations renders and matches snapshot 1`] = `
                 className="annotation-card"
               >
                 <div
-                  className="annotation-content"
+                  className="annotation-body"
                 >
-                  <blockquote
-                    className="selected-text"
-                  >
-                    ng world, elements are found in different proportions, and some elements common to living organisms are relatively rare on the earth as a whole, as shown in See Table. For examp
-                  </blockquote>
                   <div
-                    className="plain-text"
+                    className="annotation-content"
                   >
-                    ee
+                    <blockquote
+                      className="selected-text"
+                    >
+                      ng world, elements are found in different proportions, and some elements common to living organisms are relatively rare on the earth as a whole, as shown in See Table. For examp
+                    </blockquote>
+                    <div
+                      className="plain-text"
+                    >
+                      ee
+                    </div>
                   </div>
-                </div>
-                <div
-                  className="controls"
-                >
-                  <button
-                    onClick={[Function]}
-                    title="Edit"
+                  <div
+                    className="controls"
                   >
-                    <i
-                      className="tutor-icon fa fa-edit"
-                      role="presentation"
-                      type="edit"
-                    />
-                  </button>
-                  <button
-                    onClick={[Function]}
-                    title="View in book"
-                  >
-                    <i
-                      className="tutor-icon fa fa-external-link"
-                      role="presentation"
-                      type="external-link"
-                    />
-                  </button>
-                  <button
-                    onClick={[Function]}
-                    title="Delete"
-                  >
-                    <i
-                      className="tutor-icon fa fa-trash"
-                      role="presentation"
-                      type="trash"
-                    />
-                  </button>
+                    <button
+                      onClick={[Function]}
+                      title="Edit"
+                    >
+                      <i
+                        className="tutor-icon fa fa-edit"
+                        role="presentation"
+                        type="edit"
+                      />
+                    </button>
+                    <button
+                      onClick={[Function]}
+                      title="View in book"
+                    >
+                      <i
+                        className="tutor-icon fa fa-external-link"
+                        role="presentation"
+                        type="external-link"
+                      />
+                    </button>
+                    <button
+                      onClick={[Function]}
+                      title="Delete"
+                    >
+                      <i
+                        className="tutor-icon fa fa-trash"
+                        role="presentation"
+                        type="trash"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
               <div
                 className="annotation-card"
               >
                 <div
-                  className="annotation-content"
+                  className="annotation-body"
                 >
-                  <blockquote
-                    className="selected-text"
+                  <div
+                    className="annotation-content"
                   >
-                    Hydrogen (H)
+                    <blockquote
+                      className="selected-text"
+                    >
+                      Hydrogen (H)
                 10%
                 trace
                 0.1%
-                  </blockquote>
-                  <div
-                    className="plain-text"
-                  >
-                    
+                    </blockquote>
+                    <div
+                      className="plain-text"
+                    >
+                      
+                    </div>
                   </div>
-                </div>
-                <div
-                  className="controls"
-                >
-                  <button
-                    onClick={[Function]}
-                    title="Edit"
+                  <div
+                    className="controls"
                   >
-                    <i
-                      className="tutor-icon fa fa-edit"
-                      role="presentation"
-                      type="edit"
-                    />
-                  </button>
-                  <button
-                    onClick={[Function]}
-                    title="View in book"
-                  >
-                    <i
-                      className="tutor-icon fa fa-external-link"
-                      role="presentation"
-                      type="external-link"
-                    />
-                  </button>
-                  <button
-                    onClick={[Function]}
-                    title="Delete"
-                  >
-                    <i
-                      className="tutor-icon fa fa-trash"
-                      role="presentation"
-                      type="trash"
-                    />
-                  </button>
+                    <button
+                      onClick={[Function]}
+                      title="Edit"
+                    >
+                      <i
+                        className="tutor-icon fa fa-edit"
+                        role="presentation"
+                        type="edit"
+                      />
+                    </button>
+                    <button
+                      onClick={[Function]}
+                      title="View in book"
+                    >
+                      <i
+                        className="tutor-icon fa fa-external-link"
+                        role="presentation"
+                        type="external-link"
+                      />
+                    </button>
+                    <button
+                      onClick={[Function]}
+                      title="Delete"
+                    >
+                      <i
+                        className="tutor-icon fa fa-trash"
+                        role="presentation"
+                        type="trash"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/tutor/specs/components/annotations.spec.jsx
+++ b/tutor/specs/components/annotations.spec.jsx
@@ -5,8 +5,10 @@ import AnnotationsMap from '../../src/models/annotations';
 import User from '../../src/models/user';
 import Page from '../../api/pages/be8818d0-2dba-4bf3-859a-737c25fb2c99@20.json';
 import ANNOTATIONS from '../../api/annotations.json';
+import Router from '../../src/helpers/router';
 
 jest.mock('../../src/models/feature_flags', () => ({ is_highlighting_allowed: true }));
+jest.mock('../../src/helpers/router');
 jest.mock('../../src/models/user');
 
 describe('Annotations', () => {
@@ -15,6 +17,7 @@ describe('Annotations', () => {
 
   beforeEach(function() {
     Courses = bootstrapCoursesList();
+    Router.currentQuery.mockReturnValue({});
     Courses.get(1).appearance_code = 'college_biology';
     body = window.document.body;
     annotations = new AnnotationsMap();
@@ -68,4 +71,15 @@ describe('Annotations', () => {
     expect(comp.toJSON()).toMatchSnapshot();
     comp.unmount();
   });
+
+  it('scrolls to linked annotation', () => {
+    const highlight = annotations.keys()[0];
+    Router.currentQuery.mockReturnValue({ highlight });
+    const widget = mount(<AnnotationWidget {...props} />);
+    expect(widget.instance().scrollToPendingAnnotation).not.toBeUndefined();
+    widget.instance().scrollToAnnotation = jest.fn();
+    widget.instance().scrollToPendingAnnotation();
+    expect(widget.instance().scrollToAnnotation).toHaveBeenCalled();
+  });
+
 });

--- a/tutor/src/components/annotations/annotation-card.jsx
+++ b/tutor/src/components/annotations/annotation-card.jsx
@@ -98,34 +98,36 @@ export default class AnnotationCard extends React.Component {
 
     return (
       <div className="annotation-card">
-        <div className="annotation-content">
-          <blockquote className="selected-text">
-            {annotation.selection.content}
-          </blockquote>
-          {this.editing ? (
-            <EditBox
-              text={annotation.text}
-              dismiss={this.stopEditing}
-              save={this.saveAnnotation}
-            />
-          ) : (
-            <div className="plain-text">
-              {annotation.text}
-            </div>
-          )}
-        </div>
-        <div className="controls">
-          {!this.editing && <button title="Edit" onClick={this.startEditing}><Icon type="edit" /></button>}
+        <div className="annotation-body">
+          <div className="annotation-content">
+            <blockquote className="selected-text">
+              {annotation.selection.content}
+            </blockquote>
+            {this.editing ? (
+               <EditBox
+                 text={annotation.text}
+                 dismiss={this.stopEditing}
+                 save={this.saveAnnotation}
+               />
+            ) : (
+               <div className="plain-text">
+                 {annotation.text}
+               </div>
+            )}
+          </div>
+          <div className="controls">
+            {!this.editing && <button title="Edit" onClick={this.startEditing}><Icon type="edit" /></button>}
 
-          <button title="View in book" onClick={this.openPage}><Icon type="external-link" /></button>
-          <SuretyGuard
-            title="Are you sure you want to delete this note?"
-            message="If you delete this note, your work cannot be recovered."
-            okButtonLabel="Delete"
-            onConfirm={this.doDelete}
-          >
-            <button title="Delete"><Icon type="trash" /></button>
-          </SuretyGuard>
+            <button title="View in book" onClick={this.openPage}><Icon type="external-link" /></button>
+            <SuretyGuard
+              title="Are you sure you want to delete this note?"
+              message="If you delete this note, your work cannot be recovered."
+              okButtonLabel="Delete"
+              onConfirm={this.doDelete}
+            >
+              <button title="Delete"><Icon type="trash" /></button>
+            </SuretyGuard>
+          </div>
         </div>
       </div>
     );

--- a/tutor/src/components/annotations/annotation-card.jsx
+++ b/tutor/src/components/annotations/annotation-card.jsx
@@ -89,7 +89,7 @@ export default class AnnotationCard extends React.Component {
     if (section) {
       url += `.${section}`;
     }
-    url += `#highlight-${id}`;
+    url += `?highlight=${id}`;
     window.open(url, '_blank');
   }
 

--- a/tutor/src/components/annotations/annotation.jsx
+++ b/tutor/src/components/annotations/annotation.jsx
@@ -19,6 +19,7 @@ import InlineControls from './inline-controls';
 import WindowShade from './window-shade';
 import ScrollTo from '../../helpers/scroll-to';
 import TextHighlighter from './highlighter';
+import Router from '../../helpers/router';
 
 const highlighter = new TextHighlighter(document.body);
 
@@ -67,9 +68,10 @@ export default class AnnotationWidget extends React.Component {
     if (!this.course.canAnnotate) { return; }
 
     this.props.windowImpl.document.addEventListener('mouseup', this.onSelection);
+    const { highlight } = Router.currentQuery();
 
-    if (this.props.windowImpl.location.hash) {
-      this.setupPendingHighlightScroll(this.props.windowImpl.location.hash);
+    if (highlight) {
+      this.setupPendingHighlightScroll(highlight);
     }
 
     when(
@@ -119,18 +121,14 @@ export default class AnnotationWidget extends React.Component {
     return filter(User.annotations.array, { courseId: this.props.courseId });
   }
 
-  setupPendingHighlightScroll(windowHash) {
-    if (!windowHash) { return; }
-    const highlightMatch = windowHash.match(/highlight-(.*)/);
-    if (!highlightMatch) { return; }
+  setupPendingHighlightScroll(highlightId) {
     this.scrollToPendingAnnotation = () => {
-      const id = highlightMatch[1];
-      const annotation = User.annotations.get(id);
+      const annotation = User.annotations.get(highlightId);
       if (annotation) {
         highlighter.focus(annotation.elements);
         this.scrollToAnnotation(annotation);
       } else {
-        Logging.error(`Page attempted to scroll to annotation id '${id}' but it was not found`);
+        Logging.error(`Page attempted to scroll to annotation id '${highlightId}' but it was not found`);
       }
       this.scrollToPendingAnnotation = null;
     };


### PR DESCRIPTION
When an annotation from the summary is clicked it wasn't scrolled to because it was linked via the hash which was cleared for some reason.

Before:
![screen shot 2018-03-14 at 4 47 10 pm](https://user-images.githubusercontent.com/79566/37433606-8965fd7a-27aa-11e8-8e07-1eeaaca2303b.png)

After:
![screen shot 2018-03-14 at 4 45 48 pm](https://user-images.githubusercontent.com/79566/37433607-897df754-27aa-11e8-92c1-3cffd1c49627.png)