### PR TITLE
Only fast poll if the course has tasks available

### DIFF
--- a/tutor/specs/components/enroll.spec.jsx
+++ b/tutor/specs/components/enroll.spec.jsx
@@ -1,22 +1,27 @@
 import { SnapShot } from './helpers/component-testing';
-
+import Factory from '../factories';
 import Enroll from '../../src/components/enroll';
-
 import EnzymeContext from './helpers/enzyme-context';
 import Router from '../../src/helpers/router';
 import EnrollModel from '../../src/models/course/enroll';
-jest.mock('../../src/models/user', () => ({
-  refreshCourses: jest.fn(() => Promise.resolve()),
-}));
+
 jest.mock('../../src/helpers/router');
 
 describe('Student Enrollment', () => {
   let params, context, enrollment;
+  let coursesMap;
+  let fetchMock;
 
   beforeEach(() => {
-    params = { courseId: '1' };
+    coursesMap = Factory.coursesMap();
+    fetchMock = Promise.resolve();
+    coursesMap.fetch = jest.fn(() => fetchMock);
+    const course = coursesMap.array[0];
+    coursesMap.set(course.id, course);
+    params = { courseId: course.id };
+
     context = EnzymeContext.build();
-    enrollment = new EnrollModel({ enrollment_code: '1234', router: context.context.router });
+    enrollment = new EnrollModel({ courses: coursesMap, llment_code: '1234', router: context.context.router });
     enrollment.create = jest.fn();
     Router.currentParams.mockReturnValue(params);
     Router.makePathname = jest.fn((name) => name);
@@ -49,7 +54,6 @@ describe('Student Enrollment', () => {
     enrollment.isComplete = true;
     enroll.update();
     setTimeout(() => {
-      //console.log(enroll.debug());
       expect(enroll).toHaveRendered('Redirect');
       enroll.unmount();
       done();

--- a/tutor/specs/factories/index.js
+++ b/tutor/specs/factories/index.js
@@ -6,6 +6,7 @@ import Course from '../../src/models/course';
 import TutorExercise from '../../src/models/exercises/exercise';
 import Book from '../../src/models/reference-book';
 import TaskPlanStat from '../../src/models/task-plan/stats';
+import { CoursesMap } from '../../src/models/courses-map';
 import { EcosystemsMap, Ecosystem } from '../../src/models/ecosystems';
 import { ExercisesMap } from '../../src/models/exercises';
 import { ResearchSurvey } from '../../src/models/research-surveys/survey';
@@ -32,7 +33,14 @@ each({
   };
 });
 
-Factories.data = (...args) => FactoryBot.create(...args)
+Factories.data = (...args) => FactoryBot.create(...args);
+
+Factories.coursesMap = ({ count = 2, ...attrs } = {}) => {
+  const map = new CoursesMap();
+  map.onLoaded({ data: range(count).map(() => FactoryBot.create('Course', attrs)) });
+  return map;
+};
+
 
 Factories.ecosystemsMap = ({ count = 4 } = {}) => {
   const map = new EcosystemsMap();

--- a/tutor/src/models/course/enroll.js
+++ b/tutor/src/models/course/enroll.js
@@ -30,11 +30,11 @@ export default class CourseEnrollment extends BaseModel {
   @observable isComplete = false;
   @observable courseToJoin;
   @observable isLoadingCourses;
-  @session({ type: 'object' }) courses;
+  @observable courses = Courses;
 
-  constructor(...args) {
-    super(...args);
-    if (!this.courses) { this.courses = Courses; }
+  constructor(attrs = {}) {
+    super(attrs);
+    if (attrs.courses) { this.courses = attrs.courses; }
     this.originalEnrollmentCode = this.enrollment_code;
     when(
       () => this.isRegistered,
@@ -167,7 +167,10 @@ export default class CourseEnrollment extends BaseModel {
 
   fetchCourses() {
     this.isLoadingCourses = true;
-    User.refreshCourses().then(() => {
+    this.courses.fetch().then(() => {
+      if (this.course) { // should always be set but maybe the BE messes up and doesn't return the new course yet?
+        this.course.studentTasks.expecting_assignments_count = get(this, 'to.period.assignments_count', 0);
+      }
       this.isLoadingCourses = false;
       this.isComplete = true;
     });

--- a/tutor/src/models/course/enroll.js
+++ b/tutor/src/models/course/enroll.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  BaseModel, identifiedBy, field, identifier, computed, session,
+  BaseModel, identifiedBy, field, identifier, computed, session, belongsTo,
 } from 'shared/model';
 import { action, when, observable } from 'mobx';
 import { get, pick, isEmpty } from 'lodash';
@@ -9,7 +9,7 @@ import S from '../../helpers/string';
 import Router from '../../../src/helpers/router';
 import User from '../user';
 import StudentTasks from '../student-tasks';
-import Courses from '../courses-map';
+import Courses, { CoursesMap } from '../courses-map';
 import Activity from '../../../src/components/ox-fancy-loader';
 
 import Enroll from '../../../src/components/enroll';
@@ -30,9 +30,11 @@ export default class CourseEnrollment extends BaseModel {
   @observable isComplete = false;
   @observable courseToJoin;
   @observable isLoadingCourses;
+  @session({ type: 'object' }) courses;
 
   constructor(...args) {
     super(...args);
+    if (!this.courses) { this.courses = Courses; }
     this.originalEnrollmentCode = this.enrollment_code;
     when(
       () => this.isRegistered,
@@ -124,7 +126,7 @@ export default class CourseEnrollment extends BaseModel {
   }
 
   @computed get course() {
-    return Courses.array.find(c =>
+    return this.courses.array.find(c =>
       c.periods.find(p =>
         p.enrollment_code == this.enrollment_code
       )

--- a/tutor/src/models/course/onboarding/student-course.js
+++ b/tutor/src/models/course/onboarding/student-course.js
@@ -87,7 +87,9 @@ export default class StudentCourseOnboarding extends BaseOnboarding {
 
   @computed get isEmptyNewStudent() {
     return Boolean(
-      this.course.studentTasks.isEmpty && this.course.primaryRole.joinedAgo('minutes') < 30
+      this.course.studentTasks.expecting_assignments_count &&
+        this.course.studentTasks.isEmpty &&
+        this.course.primaryRole.joinedAgo('minutes') < 30
     );
   }
 

--- a/tutor/src/models/courses-map.js
+++ b/tutor/src/models/courses-map.js
@@ -3,7 +3,7 @@ import { computed, action } from 'mobx';
 import Course from './course';
 import { isEmpty } from 'lodash';
 
-class CoursesMap extends Map {
+export class CoursesMap extends Map {
 
   // override array in Map to return a sorted list with latest join date first
   @computed get array() {

--- a/tutor/src/models/student-tasks.js
+++ b/tutor/src/models/student-tasks.js
@@ -14,6 +14,7 @@ export class CourseStudentTasks extends Map {
   @readonly static Model = Task;
 
   @observable researchSurveys;
+  @observable expecting_assignments_count = 0;
 
   constructor(courseId) {
     super();

--- a/tutor/src/models/user.js
+++ b/tutor/src/models/user.js
@@ -78,10 +78,6 @@ export class User extends BaseModel {
     return Courses.delete(course.id);
   }
 
-  @action refreshCourses() {
-    return Courses.fetch();
-  }
-
   @computed get isConfirmedFaculty() {
     return this.faculty_status === 'confirmed_faculty';
   }


### PR DESCRIPTION
This fixes bug where it would fast poll for 30 minutes when a course was new and didn't have any tasks