### PR TITLE
Removed the `archive` arg requirement for generating rev-manifest.json

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -28,25 +28,23 @@ node --max_old_space_size=4096 $(npm bin)/webpack --progress --config webpack.co
 
 SHA=`git rev-parse HEAD`
 
-if [ "$2" = "archive" ]; then
-  cd $OX_PROJECT/dist
-  echo '// unused' > tutor.min.css
-  echo "{" > ./rev-manifest.json
-  LAST_FILE=""
-  for minified in *.min.*; do
-    filename="${minified##*/}"  # discard directory
-    base="${filename%%.[^.]*}"  # Strip longest match of . plus at least one non-dot char from end
-    ext="${filename:${#base} + 1}"  # Substring from len of base thru end
-    hashed=$base-$SHA.$ext
-    if [ "$LAST_FILE" ]; then
-        echo "," >> ./rev-manifest.json
-    fi
-    echo -n '  "'$minified'": "'$hashed'"' >> ./rev-manifest.json
-    LAST_FILE=$hashed
-    cp $minified $hashed
-  done
-  echo -e "\n}" >> ./rev-manifest.json
-  cd ..
-  tar -czf ../archive.tar.gz -C ./dist .
-  mv ../archive.tar.gz ./dist/
-fi
+cd $OX_PROJECT/dist
+echo '// unused' > tutor.min.css
+echo "{" > ./rev-manifest.json
+LAST_FILE=""
+for minified in *.min.*; do
+  filename="${minified##*/}"  # discard directory
+  base="${filename%%.[^.]*}"  # Strip longest match of . plus at least one non-dot char from end
+  ext="${filename:${#base} + 1}"  # Substring from len of base thru end
+  hashed=$base-$SHA.$ext
+  if [ "$LAST_FILE" ]; then
+      echo "," >> ./rev-manifest.json
+  fi
+  echo -n '  "'$minified'": "'$hashed'"' >> ./rev-manifest.json
+  LAST_FILE=$hashed
+  cp $minified $hashed
+done
+echo -e "\n}" >> ./rev-manifest.json
+cd ..
+tar -czf ../archive.tar.gz -C ./dist .
+mv ../archive.tar.gz ./dist/


### PR DESCRIPTION
Needed so Jenkins builds the archive properly.