### PR TITLE
Don't load annotations when feature flag is off

### DIFF
--- a/tutor/specs/models/annotations.spec.js
+++ b/tutor/specs/models/annotations.spec.js
@@ -1,0 +1,28 @@
+import DATA from '../../api/annotations.json';
+import { keys } from 'lodash';
+import Annotations from '../../src/models/annotations';
+import FeatureFlags from '../../src/models/feature_flags';
+import Hypothesis from '../../src/models/annotations/hypothesis';
+jest.mock('../../src/models/feature_flags');
+jest.mock('../../src/models/annotations/hypothesis');
+
+describe('Annotations Model', () => {
+
+  beforeEach(() => {
+    FeatureFlags.is_highlighting_allowed = false;
+  });
+
+  it('does not request info when feature flag is off', () => {
+    const annotations = new Annotations();
+    expect(annotations.api.isPending).toBe(false);
+    expect(Hypothesis.fetchUserInfo).not.toHaveBeenCalled();
+  });
+
+  it('sets annotations', () => {
+    const annotations = new Annotations();
+    annotations.updateAnnotations(DATA.rows);
+    expect(annotations.byCourseAndPage).toHaveProperty('1');
+    expect(keys(annotations.byCourseAndPage['1'])).toEqual(['2.1']);
+  });
+
+});

--- a/tutor/src/models/annotations.js
+++ b/tutor/src/models/annotations.js
@@ -5,13 +5,16 @@ import lazyGetter from 'shared/helpers/lazy-getter';
 import { chapterSectionToNumber } from '../helpers/content';
 import Hypothesis from './annotations/hypothesis';
 import Annotation from './annotations/annotation';
+import FeatureFlags from './feature_flags';
 import AnnotationsUX from './annotations/ux';
 export default class Annotations extends Map {
 
   constructor() {
     super();
-    this.api.requestsInProgress.set('fetch', true);
-    Hypothesis.fetchUserInfo().then(this.updateAnnotations);
+    if (FeatureFlags.is_highlighting_allowed) {
+      this.api.requestsInProgress.set('fetch', true);
+      Hypothesis.fetchUserInfo().then(this.updateAnnotations);
+    }
   }
 
   @lazyGetter ux = new AnnotationsUX();


### PR DESCRIPTION
Fixes bug on tutor-content where it was attempting to load annotation data even though the feature flag was off.