### PR TITLE
Fix student dashboard past events to list all events

### DIFF
--- a/tutor/specs/models/student-tasks.spec.jsx
+++ b/tutor/specs/models/student-tasks.spec.jsx
@@ -37,6 +37,12 @@ describe('Student Tasks Model', () => {
     expect(keys(StudentTasks.forCourseId(2).byWeek)).toEqual([
       '201515', '201516', '201517', '201519', '201521',
     ]);
+    const task = StudentTasks.forCourseId(1).array[0];
+    task.due_at = new Date('2014-12-30');
+    expect(keys(StudentTasks.forCourseId(1).byWeek)).toEqual([
+      '201501', '201515', '201516', '201517', '201519', '201521', '201616',
+    ]);
+
   });
 
   it('#upcomingEvents', () => {

--- a/tutor/src/models/student-tasks.js
+++ b/tutor/src/models/student-tasks.js
@@ -22,7 +22,7 @@ export class CourseStudentTasks extends Map {
   }
 
   @computed get byWeek() {
-    const weeks = groupBy(this.array, event => moment(event.due_at).startOf('isoweek').format('YYYYW'));
+    const weeks = groupBy(this.array, event => moment(event.due_at).startOf('isoweek').format('YYYYWW'));
     const sorted = {};
     for (let weekId in weeks) {
       const events = weeks[weekId];
@@ -32,12 +32,12 @@ export class CourseStudentTasks extends Map {
   }
 
   @computed get pastEventsByWeek() {
-    const thisWeek = moment(TimeStore.getNow()).startOf('isoweek').format('YYYYW');
+    const thisWeek = moment(TimeStore.getNow()).startOf('isoweek').format('YYYYWW');
     return pickBy(this.byWeek, (events, week) => week < thisWeek);
   }
 
   weeklyEventsForDay(day) {
-    return this.byWeek[moment(day).startOf('isoweek').format('YYYYW')] || [];
+    return this.byWeek[moment(day).startOf('isoweek').format('YYYYWW')] || [];
   }
 
   // Returns events who's due date has not passed

--- a/tutor/src/models/student-tasks.js
+++ b/tutor/src/models/student-tasks.js
@@ -9,6 +9,7 @@ import ResearchSurveys from './research-surveys';
 
 const MAX_POLLING_ATTEMPTS = 10;
 const POLL_SECONDS = 30;
+const ISOWEEK_FORMAT = 'GGGGWW';
 
 export class CourseStudentTasks extends Map {
   @readonly static Model = Task;
@@ -22,7 +23,7 @@ export class CourseStudentTasks extends Map {
   }
 
   @computed get byWeek() {
-    const weeks = groupBy(this.array, event => moment(event.due_at).startOf('isoweek').format('YYYYWW'));
+    const weeks = groupBy(this.array, event => moment(event.due_at).startOf('isoweek').format(ISOWEEK_FORMAT));
     const sorted = {};
     for (let weekId in weeks) {
       const events = weeks[weekId];
@@ -32,12 +33,12 @@ export class CourseStudentTasks extends Map {
   }
 
   @computed get pastEventsByWeek() {
-    const thisWeek = moment(TimeStore.getNow()).startOf('isoweek').format('YYYYWW');
+    const thisWeek = moment(TimeStore.getNow()).startOf('isoweek').format(ISOWEEK_FORMAT);
     return pickBy(this.byWeek, (events, week) => week < thisWeek);
   }
 
   weeklyEventsForDay(day) {
-    return this.byWeek[moment(day).startOf('isoweek').format('YYYYWW')] || [];
+    return this.byWeek[moment(day).startOf('isoweek').format(ISOWEEK_FORMAT)] || [];
   }
 
   // Returns events who's due date has not passed


### PR DESCRIPTION
We were using the `w` format which made didn't add a leading 0, so weeks less than 10 didn't sort properly.

Testing also revealed that we need to use the GGGG format otherwise dates that belong to a week that overlaps years such as `2017-01-03`, would become `201601` when formatted, rather than the proper `201701`