### PR TITLE
load exercises from course endpoint for QL

### DIFF
--- a/tutor/specs/models/exercises.spec.js
+++ b/tutor/specs/models/exercises.spec.js
@@ -45,4 +45,19 @@ describe('Exercises Map', () => {
 
   });
 
+  it('loads for course with optional limit', () => {
+    page_ids.forEach(page_id => { expect(exercises.isFetching({ book, page_id })).toBe(false); });
+    const course = Factory.course();
+    expect(
+      exercises.fetch({ course, page_ids })
+    ).toEqual({ url: `courses/${course.id}/exercises/homework_core`, query: { page_ids } });
+    expect(
+      exercises.fetch({ course, page_ids, limit: 'reading-things' })
+    ).toEqual({ url: `courses/${course.id}/exercises/reading-things`, query: { page_ids } });
+    expect(
+      exercises.fetch({ course, page_ids, limit: false })
+    ).toEqual({ url: `courses/${course.id}/exercises`, query: { page_ids } });
+
+  });
+
 });

--- a/tutor/specs/screens/question-library/dashboard.spec.jsx
+++ b/tutor/specs/screens/question-library/dashboard.spec.jsx
@@ -51,6 +51,9 @@ describe('Questions Dashboard Component', function() {
     expect(dash).not.toHaveRendered('.no-exercises');
     dash.find(`[data-page-id="${page_ids[0]}"]`).simulate('click');
     dash.find('.section-controls .btn-primary').simulate('click');
+    expect(exercises.fetch).toHaveBeenCalledWith({
+      course, limit: false, page_ids: [page_ids[0]],
+    });
     expect(dash).not.toHaveRendered('.no-exercises');
     dash.unmount();
   });

--- a/tutor/src/models/exercises.js
+++ b/tutor/src/models/exercises.js
@@ -45,11 +45,12 @@ export class ExercisesMap extends Map {
   }
 
   // called by API
-  fetch({ book, course, page_ids }) {
+  fetch({ book, course, page_ids, limit = 'homework_core' }) {
     let id, url;
     if (course) {
       id = course.id;
-      url = `courses/${id}/exercises/homework_core`;
+      url = `courses/${id}/exercises`;
+      if (limit) { url += `/${limit}`; }
     } else {
       id = book.id;
       url = `ecosystems/${id}/exercises`;

--- a/tutor/src/screens/question-library/sections-chooser.jsx
+++ b/tutor/src/screens/question-library/sections-chooser.jsx
@@ -26,7 +26,8 @@ export default class QLSectionsChooser extends React.Component {
   @action.bound showQuestions() {
 
     this.props.exercises.fetch({
-      book: this.props.course.referenceBook,
+      limit: false,
+      course: this.props.course,
       page_ids: this.pageIds.peek(),
     });
     this.props.onSelectionsChange(this.pageIds);


### PR DESCRIPTION
Otherwise the returned exercises lack the "is_excluded" flag 