### PR TITLE
only cache webpack when cache ENV is set

### DIFF
--- a/configs/webpack/base.coffee
+++ b/configs/webpack/base.coffee
@@ -168,7 +168,7 @@ makeDevelopmentBase = (projectConfig) ->
     new ProgressBarPlugin(),
   ]
 
-  plugins.push(new HardSourceWebpackPlugin()) unless process.env.SOFT
+  plugins.push(new HardSourceWebpackPlugin()) if process.env.CACHE
 
   developmentBase =
     context: path.resolve(__dirname, '../../', projectConfig.basePath)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "tdd": "./bin/tdd",
     "precoverage": "npm run validate",
     "serve": "./bin/serve",
-    "soft-serve": "SOFT=true npm run serve",
+    "cached-serve": "CACHE=true npm run serve",
     "debug": "./bin/debug",
     "build": "./bin/build",
     "release": "./bin/release",
@@ -26,7 +26,7 @@
     "validate": "./bin/validate-console-messages.sh",
     "prestart": "npm run validate",
     "start": "./bin/tdd",
-    "soft-start": "SOFT=true ./bin/tdd"
+    "cached-start": "CACHE=true ./bin/tdd"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
HardSource keeps causing errors for me, so this flips the logic so it's only used if the CACHE env is set