### PR TITLE
Fix "Waiting for page to load.." message for pages with no images

### DIFF
--- a/tutor/specs/helpers/images-complete.spec.js
+++ b/tutor/specs/helpers/images-complete.spec.js
@@ -1,0 +1,46 @@
+import imagesComplete from '../../src/helpers/images-complete';
+import { JSDOM } from 'jsdom';
+
+jest.useFakeTimers();
+
+describe('Images Complete Helper', () => {
+
+  let body;
+
+  beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>' );
+    body = dom.window.document.body;
+  });
+
+  it('resolves immediatly when no images are present', () => {
+    return imagesComplete({ body }).then((images) => {
+      expect(images).toHaveLength(0);
+    });
+  });
+
+  it('times out when images never resolve', () => {
+    body.innerHTML = '<img id="one" /><img id="two" />';
+    const complete = imagesComplete({ body });
+    jest.runAllTimers();
+    return complete.catch((images) => {
+      expect(images).toHaveLength(2);
+    });
+  });
+
+  it('resolves after images are loaded', () => {
+    body.innerHTML = '<img id="one" /><img id="two" />';
+    const imgs = Array.from(body.querySelectorAll('img'));
+    imgs.forEach(img => img.addEventListener = jest.fn());
+    const complete = jest.fn();
+    const reject = jest.fn();
+    imagesComplete({ body }).then(complete).catch(reject);
+    imgs.forEach(img => {
+      expect(img.addEventListener).toHaveBeenCalledWith('load', expect.any(Function), false);
+      img.addEventListener.mock.calls[0][1]();
+    });
+    jest.runAllTimers();
+    expect(complete).toHaveBeenCalledWith(expect.arrayContaining(imgs));
+    expect(reject).not.toHaveBeenCalled();
+  });
+
+});

--- a/tutor/src/components/annotations/annotation.jsx
+++ b/tutor/src/components/annotations/annotation.jsx
@@ -144,15 +144,17 @@ export default class AnnotationWidget extends React.Component {
 
     this.getReferenceElements();
     invokeMap(this.annotationsForThisPage, 'selection.restore', highlighter);
-    return imagesComplete({
-      body: this.props.windowImpl.document.querySelector('.book-content'),
-    }).then(() => {
+    const initialize = () => {
       invokeMap(this.annotationsForThisPage, 'selection.restore', highlighter);
       if (this.scrollToPendingAnnotation) {
         this.scrollToPendingAnnotation();
       }
       this.ux.statusMessage.hide();
-    });
+    };
+    return imagesComplete({
+      body: this.props.windowImpl.document.querySelector('.book-content'),
+    }).then(initialize).catch(initialize);
+
   }
 
   getCurrentSelectionInfo() {

--- a/tutor/src/helpers/images-complete.js
+++ b/tutor/src/helpers/images-complete.js
@@ -2,15 +2,17 @@ export default function imagesComplete({
   body = document.body,
   timeoutAfter = 10000, // in ms, 10 seconds
 } = {}) {
-  return new Promise((resolve) => {
-    const images = body.querySelectorAll('img');
+  return new Promise((resolve, reject) => {
+    const images = Array.from(body.querySelectorAll('img'));
+
+    if (0 === images.length) {
+      resolve(images);
+      return;
+    }
     let complete = 0;
     let pendingTimeout = setTimeout(() => {
-      if (complete < images.length) {
-        complete = images.length;
-        pendingTimeout = null;
-        resolve(images);
-      }
+      pendingTimeout = null;
+      reject(images);
     }, timeoutAfter);
     const markComplete = () => {
       complete += 1;
@@ -22,7 +24,7 @@ export default function imagesComplete({
         resolve(images);
       }
     };
-    Array.from(images).forEach((img) => {
+    images.forEach((img) => {
       if (img.naturalWidth) {
         markComplete();
       } else {


### PR DESCRIPTION
We wait until all the images are loaded before displaying annotations and hiding the message, but it would never resolve if the page had no images