### PR TITLE
don't use scopes for keybinding, and fix paging loop

### DIFF
--- a/tutor/specs/components/__snapshots__/paging-navigation.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/paging-navigation.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Student Enrollment renders and matches snapshot 1`] = `
+exports[`Paging Navigation renders and matches snapshot 1`] = `
 <div
   className="tutor-paging-navigation my-nav-test"
 >

--- a/tutor/specs/components/annotations.spec.jsx
+++ b/tutor/specs/components/annotations.spec.jsx
@@ -67,14 +67,13 @@ describe('Annotations', () => {
     expect(widget).toHaveRendered('.highlights-windowshade.up');
     annotations.ux.isSummaryVisible = true;
     expect(widget).toHaveRendered('.highlights-windowshade.down');
-    expect(keymaster.setScope).toHaveBeenCalled();
-    expect(keymaster).toHaveBeenCalledWith('esc', expect.any(String), expect.any(Function));
+    expect(keymaster).toHaveBeenCalledWith('esc', expect.any(Function));
     expect(annotations.ux.isSummaryVisible).toBe(true);
-    keymaster.mock.calls[0][2]();
+    keymaster.mock.calls[0][1]();
     expect(widget).toHaveRendered('.highlights-windowshade.up');
     expect(annotations.ux.isSummaryVisible).toBe(false);
     widget.unmount();
-    expect(keymaster.deleteScope).toHaveBeenCalled();
+    expect(keymaster.unbind).toHaveBeenCalledWith('esc', expect.any(Function));
   });
 
   it('sorts in model', () => {

--- a/tutor/specs/components/paging-navigation.spec.jsx
+++ b/tutor/specs/components/paging-navigation.spec.jsx
@@ -1,13 +1,15 @@
 import { SnapShot } from './helpers/component-testing';
-
+import keymaster from 'keymaster';
 import Nav from '../../src/components/paging-navigation';
 
+jest.mock('keymaster');
+jest.useFakeTimers();
 
 function TestComponent() {
   return <h1>Imma child</h1>;
 }
 
-describe('Student Enrollment', () => {
+describe('Paging Navigation', () => {
   let props;
 
   beforeEach(() => {
@@ -26,6 +28,23 @@ describe('Student Enrollment', () => {
         previous: 'The Page Before This One',
       },
     };
+  });
+
+  it('binds / unbinds on mount/unmount', () => {
+    const nav = shallow(<Nav {...props}><TestComponent /></Nav>);
+    jest.runAllTimers();
+    expect(keymaster).toHaveBeenCalledTimes(2);
+    expect(keymaster).toHaveBeenCalledWith('left', expect.any(Function));
+    expect(keymaster).toHaveBeenCalledWith('right', expect.any(Function));
+
+    nav.setProps({ enableKeys: false });
+    expect(keymaster.unbind).toHaveBeenCalledWith('left');
+    expect(keymaster.unbind).toHaveBeenCalledWith('right');
+    nav.setProps({ enableKeys: true });
+    jest.runAllTimers();
+    expect(keymaster).toHaveBeenCalledTimes(4);
+    nav.unmount();
+    expect(keymaster.unbind).toHaveBeenCalledTimes(4);
   });
 
   it('renders and matches snapshot', () => {
@@ -48,4 +67,5 @@ describe('Student Enrollment', () => {
     expect(props.onBackwardNavigation).toHaveBeenCalled();
     expect(preventDefault).toHaveBeenCalledTimes(2);
   });
+
 });

--- a/tutor/src/components/annotations/window-shade.jsx
+++ b/tutor/src/components/annotations/window-shade.jsx
@@ -3,8 +3,6 @@ import { observer } from 'mobx-react';
 import { action } from 'mobx';
 import keymaster from 'keymaster';
 
-const KEYBINDING_SCOPE  = 'annotation-window-shade';
-
 @observer
 export default class WindowShade extends React.Component {
 
@@ -14,12 +12,11 @@ export default class WindowShade extends React.Component {
   };
 
   componentDidMount() {
-    keymaster('esc' , KEYBINDING_SCOPE, this.onEscKey);
-    keymaster.setScope(KEYBINDING_SCOPE);
+    keymaster('esc', this.onEscKey);
   }
 
   componentWillUnmount() {
-    keymaster.deleteScope(KEYBINDING_SCOPE);
+    keymaster.unbind('esc', this.onEscKey);
   }
 
   @action.bound onEscKey() {

--- a/tutor/src/components/paging-navigation.jsx
+++ b/tutor/src/components/paging-navigation.jsx
@@ -53,11 +53,11 @@ export default class PagingNavigation extends React.PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    // if (nextProps.enableKeys && !this.props.enableKeys) {
-    //   this.enableKeys();
-    // } else if (!nextProps.enableKeys && this.props.enableKeys) {
-    //   this.disableKeys();
-    // }
+    if (nextProps.enableKeys && !this.props.enableKeys) {
+      this.enableKeys();
+    } else if (!nextProps.enableKeys && this.props.enableKeys) {
+      this.disableKeys();
+    }
     if (nextProps.titles.current) {
       this.props.documentImpl.title = nextProps.titles.current;
     } else {


### PR DESCRIPTION
Since only one scope can be active at once, the scopes would cancel each other out.

Also discovered a bug where the mount/unmount could occur in the same event loop causing the page to flip rapidly through several pages