### PR TITLE
Fix scores recalculation when accepting late work

### DIFF
--- a/configs/test/matchers.coffee
+++ b/configs/test/matchers.coffee
@@ -18,6 +18,7 @@ expect.extend({
     failures = []
     utils = @utils
     testValue = (i, type, expected, actual) ->
+      actual = parseFloat(actual) unless typeof actual is 'number'
       if test.precision
         utils.ensureNumbers(actual, expected, "test index #{i}")
         pass = Math.abs(expected - actual) < Math.pow(10, -test.precision) / 2

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "axios": "0.15.3",
     "babel-polyfill": "6.22.0",
+    "big.js": "^5.0.3",
     "bootstrap-sass": "3.3.7",
     "classnames": "2.2.5",
     "core-decorators": "0.19.0",
@@ -59,9 +60,9 @@
     "htmlparser2": "3.9.2",
     "interpolate": "0.1.0",
     "invariant": "2.2.2",
+    "jest-axe": "^2.1.4",
     "jest-changed-files": "^22.4.3",
     "jest-cli": "22.4.3",
-    "jest-axe": "^2.1.4",
     "keymaster": "1.6.2",
     "loadjs": "3.5.0",
     "lodash": "4.17.4",

--- a/shared/src/model.js
+++ b/shared/src/model.js
@@ -1,12 +1,12 @@
 // will eventually hook into data loading/saving using the
 // derived model's identifiedBy strings
-
 import { computed, action } from 'mobx';
 import { find, isNil, get } from 'lodash';
 
 const FLUX_NEW = /_CREATING_/;
 import lazyGetter from './helpers/lazy-getter.js';
 import ModelApi from './model/api';
+import './model/types';
 
 export class BaseModel {
 

--- a/shared/src/model/types.js
+++ b/shared/src/model/types.js
@@ -1,0 +1,7 @@
+import { registerCustomType } from 'mobx-decorated-models';
+import Big from 'big.js';
+
+registerCustomType('bignum', {
+  serialize(num) { num ? num.toJSON() : num; },
+  deserialize(num) { return new Big(num); },
+});

--- a/tutor/api/courses/1/performance.json
+++ b/tutor/api/courses/1/performance.json
@@ -262,6 +262,10 @@
         "course_average": 0.0,
         "student_identifier": "3UPNAI8JD2",
         "role": 4,
+        "reading_score": 0.0,
+        "homework_score": 0.0,
+        "homework_progress": 0.0,
+        "reading_progress": 0.0,
         "last_name": "Hackett",
         "first_name": "Bettie",
         "name": "Bettie Hackett"

--- a/tutor/specs/models/courses/scores.spec.js
+++ b/tutor/specs/models/courses/scores.spec.js
@@ -97,10 +97,10 @@ describe('scores store', function() {
 
   it('calculates scored counts', function() {
     expect(period.students[0].scoredStepCount).toMatchObject({
-      external: 1, homework: 4, reading: 29,
+      external: 1, homework: 4, reading: 0,
     });
     expect(period.scoredStepCount).toMatchObject({
-      external: 1, homework: 36, reading: 261,
+      external: 1, homework: 36, reading: 0,
     });
     expect(map(period.data_headings, 'scoredStepCount')).toEqual([
       36, 0, 1,

--- a/tutor/specs/models/courses/scores.spec.js
+++ b/tutor/specs/models/courses/scores.spec.js
@@ -22,13 +22,13 @@ const testChangedScoreBy = (taskId, scoreDiff) => {
   const task = gT(taskId);
   const updated = acceptTask(taskId);
   if (isObject(scoreDiff)) {
-    expect(task.score).toBeCloseTo(scoreDiff.from, 0.01,
-                                   `original score should have been ${scoreDiff.from} but was ${task.score}`);
-    expect(updated.score).toBeCloseTo(scoreDiff.to, 0.01,
-                                      `updated score should have been set to ${scoreDiff.to} but was ${updated.score}`);
+    expect(parseFloat(task.score)).toBeCloseTo(parseFloat(scoreDiff.from), 0.01,
+      `original score should have been ${scoreDiff.from} but was ${task.score}`);
+    expect(parseFloat(updated.score)).toBeCloseTo(parseFloat(scoreDiff.to), 0.01,
+      `updated score should have been set to ${scoreDiff.to} but was ${updated.score}`);
   } else {
-    expect(updated.score - task.score).toBeCloseTo(scoreDiff, 0.01,
-                                                   `expected updated score to change by ${scoreDiff}`
+    expect(parseFloat(updated.score) - parseFloat(task.score)).toBeCloseTo(parseFloat(scoreDiff), 0.01,
+      `expected updated score to change by ${scoreDiff}`
     );
   }
 };

--- a/tutor/specs/models/courses/scores/task-result.spec.js
+++ b/tutor/specs/models/courses/scores/task-result.spec.js
@@ -36,52 +36,51 @@ describe('scores store task results', () => {
           from: 0, to: 2,
         }, {
           value: () => task.score,
-          from: 0.25, to: 0.5,  // 1/4 correct on time, 1/4 correct but late
+          from: 0.25, to: 0.5, // 1/4 correct on time, 1/4 correct but late
         }, {
           value: () => task.student.homework_progress,
-          precision: 5, from: 0.125, to: 0.375 // 1/8 -> 3/8
+          precision: 5, from: 0.125, to: 0.375, // 1/8 -> 3/8
         }, {
           value: () => task.student.homework_score,
-          precision: 5, from: 0.375, to: 0.5  // 3/8 correct -> 4/8
+          precision: 5, from: 0.375, to: 0.5, // 3/8 correct -> 4/8
         }, {
           value: () => task.student.reading_progress,
-          precision: 5, from: 0.169491, to: 0.169491 // no change
+          precision: 5, from: 0.169491, to: 0.169491, // no change
         }, {
           value: () => task.student.reading_score,
-          precision: 5, from: 0.0, to: 0.0 // no change
+          precision: 5, from: 0.0, to: 0.0, // no change
         }, {
           value: () => task.reportHeading.average_score,
-          precision: 5, from: 0.375, to: 0.5 // 3/8 -> 4/8
+          precision: 5, from: 0.375, to: 0.5, // 3/8 -> 4/8
         }, {
           value: () => task.reportHeading.average_progress,
-          precision: 5, from: 0.375, to: 0.625  // 3/8 -> 5/8
+          precision: 5, from: 0.375, to: 0.625, // 3/8 -> 5/8
         }, {
           value: () => period.overall_homework_progress,
-          precision: 5, from: 0.4375, to: 0.46875, // 7/16 -> 9/16 * 0.25
+          precision: 5, from: 0.4375, to: 0.5625, // 7/16 -> 9/16 * 0.25
         }, {
           value: () => period.overall_homework_score,
-          precision: 5, from: 0.022556, to: 0.03818, // 3/16 -> 4/16 * 0.25
-        }
+          precision: 5, from: 0.022556, to: 0.0850563, // 3/16 -> 4/16 * 0.25
+        },
       ];
-
-    })
+    });
 
     it('matches expected values', () => {
       expect(
         () => task.onLateWorkAccepted()
-      ).toHaveChanged(tests)
-    })
+      ).toHaveChanged(tests);
+    });
 
     it('onLateWorkRejected matches expected values', () => {
-        task.onLateWorkAccepted();
-        tests.forEach((t) => {
-          const { from, to } = t;
-          t.from = to;
-          t.to = from;
-        });
-        expect(
-          () => task.onLateWorkRejected()
-        ).toHaveChanged(tests);
+      task.onLateWorkAccepted();
+      tests.forEach((t) => {
+        const { from, to } = t;
+        t.from = to;
+        t.to = from;
+      });
+      expect(
+        () => task.onLateWorkRejected()
+      ).toHaveChanged(tests);
     });
   });
 
@@ -100,37 +99,38 @@ describe('scores store task results', () => {
           from: 0, to: 0,
         }, {
           value: () => task.correct_accepted_late_exercise_count,
-          from: 0, to: 4
+          from: 0, to: 4,
         }, {
           value: () => task.score,
+          precision: 2,
           from: 0.0, to: 0.36, // 0/11 -> 4/11
         }, {
           value: () => task.student.homework_progress,
           precision: 5, from: 0.125, to: 0.125, //  no change
         }, {
           value: () => task.student.homework_score,
-          precision: 5, from: 0.375, to: 0.375 //  no change
+          precision: 5, from: 0.375, to: 0.375, //  no change
         }, {
           value: () => task.student.reading_progress,
-          precision: 5, from: 0.169491, to: 0.254237,  // 10/59 -> 15/59
+          precision: 5, from: 0.169491, to: 0.254237, // 10/59 -> 15/59
         }, {
           value: () => task.student.reading_score,
-          precision: 5, from: 0.0, to: 0.067796,  // 0/59 -> 4/59
+          precision: 2, from: 0.0, to: 0.18, // 0/59 -> 4/59
         }, {
           value: () => period.overall_reading_progress,
-          precision: 5, from: 0.094017, to: 0.104700,  // 11/117 -> 14/117 * 0.25
+          precision: 5, from: 0.094017, to: 0.13675, // 11/117 -> 14/117 * 0.25
         }, {
           value: () => period.overall_reading_score,
-          precision: 5, from: 0.042735, to: 0.05128 // 5/117 -> 8/117 * 0.25
-        }
+          precision: 5, from: 0.0427350, to: 0.13364, // 5/117 -> 8/117 * 0.25
+        },
       ];
     });
 
     it('matches expected values', () => {
       expect(
         () => task.onLateWorkAccepted()
-      ).toHaveChanged(tests)
-    })
+      ).toHaveChanged(tests);
+    });
 
     it('onLateWorkRejected matches expected values', () => {
       task.onLateWorkAccepted();
@@ -144,6 +144,6 @@ describe('scores store task results', () => {
       ).toHaveChanged(tests);
     });
 
-  })
+  });
 
-})
+});

--- a/tutor/src/models/course/scores.js
+++ b/tutor/src/models/course/scores.js
@@ -5,6 +5,7 @@ import {
 } from 'shared/model';
 import { TimeStore } from '../../flux/time';
 import moment from 'moment';
+
 import TaskResult from './scores/task-result';
 
 @identifiedBy('course/scores/student')
@@ -17,16 +18,25 @@ class Student extends BaseModel {
   @field role;
   @field student_identifier;
 
-  @field course_average;
-  @field homework_score;
-  @field homework_progress;
-  @field reading_score;
-  @field reading_progress;
+  @field({ type: 'bignum' }) course_average;
+  @field({ type: 'bignum' }) homework_score;
+  @field({ type: 'bignum' }) homework_progress;
+  @field({ type: 'bignum' }) reading_score;
+  @field({ type: 'bignum' }) reading_progress;
+
 
   @computed get scoredStepCount() {
+    return this._countsFor('step_count');
+  }
+
+  @computed get scoredExerciseCount() {
+    return this._countsFor('exercise_count');
+  }
+
+  _countsFor(attr) {
     return mapValues(
       groupBy(this.data, 'type'),
-      tasks => sumBy(tasks, 'step_count') || 0
+      tasks => sumBy(tasks, attr) || 0
     );
   }
 
@@ -34,8 +44,8 @@ class Student extends BaseModel {
 
 @identifiedBy('course/scores/heading')
 class Heading extends BaseModel {
-  @field average_score;
-  @field average_progress;
+  @field({ type: 'bignum' }) average_score;
+  @field({ type: 'bignum' }) average_progress;
   @field({ type: 'date' }) due_at;
   @field plan_id;
   @field title;
@@ -55,8 +65,16 @@ class Heading extends BaseModel {
   }
 
   @computed get scoredStepCount() {
+    return this._countsFor('step_count');
+  }
+
+  @computed get scoredExerciseCount() {
+    return this._countsFor('exercise_count');
+  }
+
+  _countsFor(attr) {
     return reduce(this.tasks,
-      (count, task) => task.is_included_in_averages ? count + task.step_count : count,
+      (count, task) => task.is_included_in_averages ? count + task[attr] : count,
       0);
   }
 
@@ -65,11 +83,11 @@ class Heading extends BaseModel {
 @identifiedBy('course/scores/period')
 export class CourseScoresPeriod extends BaseModel {
 
-  @field overall_course_average;
-  @field overall_reading_score;
-  @field overall_reading_progress;
-  @field overall_homework_score;
-  @field overall_homework_progress;
+  @field({ type: 'bignum' }) overall_course_average;
+  @field({ type: 'bignum' }) overall_reading_score;
+  @field({ type: 'bignum' }) overall_reading_progress;
+  @field({ type: 'bignum' }) overall_homework_score;
+  @field({ type: 'bignum' }) overall_homework_progress;
   @field period_id;
   @hasMany({ model: Heading, inverseOf: 'period' }) data_headings;
   @hasMany({ model: Student, inverseOf: 'period' }) students;
@@ -92,14 +110,23 @@ export class CourseScoresPeriod extends BaseModel {
   }
 
   @computed get scoredStepCount() {
+    return this._countsFor('scoredStepCount');
+  }
+
+  @computed get scoredExerciseCount() {
+    return this._countsFor('scoredExerciseCount');
+  }
+
+  _countsFor(attr) {
     const counts = {};
     each(this.students, (student) => {
-      each(student.scoredStepCount, (count, key) => {
+      each(student[attr], (count, key) => {
         counts[key] = ((counts[key] || 0) + count);
       });
     });
     return counts;
   }
+
 }
 
 @identifiedBy('course/scores')

--- a/tutor/src/models/course/scores.js
+++ b/tutor/src/models/course/scores.js
@@ -36,7 +36,7 @@ class Student extends BaseModel {
   _countsFor(attr) {
     return mapValues(
       groupBy(this.data, 'type'),
-      tasks => sumBy(tasks, attr) || 0
+      tasks => sumBy(tasks, t => t.is_included_in_averages ? t[attr] : 0),
     );
   }
 

--- a/tutor/src/screens/scores-report/assignment-header.jsx
+++ b/tutor/src/screens/scores-report/assignment-header.jsx
@@ -3,14 +3,13 @@ import { isNil } from 'lodash';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { observer } from 'mobx-react';
 import classnames from 'classnames';
-import Icon from '../../components/icon';
 import TutorLink from '../../components/link';
 import SortingHeader from './sorting-header';
 import Time from '../../components/time';
 import TourAnchor from '../../components/tours/anchor';
 import UX from './ux';
 
-const ReviewLink = (props) => {
+const ReviewLink = observer((props) => {
   const { ux } = props;
   if (props.isConceptCoach || (props.heading.type === 'external') || (props.heading.plan_id == null)) {
     return null;
@@ -26,10 +25,10 @@ const ReviewLink = (props) => {
       </TutorLink>
     </span>
   );
-}
+});
 
 
-const AverageLabel = ({ heading }) => {
+const AverageLabel = observer(({ heading }) => {
   if (heading.type === 'external') {
     const p = heading.average_progress || 0;
     let percent;
@@ -62,9 +61,9 @@ const AverageLabel = ({ heading }) => {
       ---
     </span>
   );
-};
+});
 
-const AssignmentSortingHeader = (props) => {
+const AssignmentSortingHeader = observer((props) => {
   const { heading, dataType, columnIndex, sort, onSort } = props;
   if (heading.type === 'external') {
     return (
@@ -107,9 +106,9 @@ const AssignmentSortingHeader = (props) => {
       </SortingHeader>
     </div>
   );
-};
+});
 
-const TeacherAssignmentHeaderRow = function(props) {
+const TeacherAssignmentHeaderRow = observer((props) => {
   const { ux, heading } = props;
 
   if (!ux.course.isTeacher) {
@@ -121,10 +120,9 @@ const TeacherAssignmentHeaderRow = function(props) {
     <ReviewLink {...props} heading={heading} />
   </div>
   );
+});
 
-}
-
-const AssignmentHeader = function(props) {
+const AssignmentHeader = observer((props) => {
   const { ux, columnIndex, isConceptCoach } = props;
   const heading = ux.period.data_headings[columnIndex];
 
@@ -151,10 +149,10 @@ const AssignmentHeader = function(props) {
       <TeacherAssignmentHeaderRow {...props} heading={heading} />
     </div>
   );
-};
+});
 
 AssignmentHeader.propTypes = {
   ux: React.PropTypes.instanceOf(UX).isRequired,
+};
 
-}
 export default AssignmentHeader;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1196,6 +1196,10 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
+big.js@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.0.3.tgz#9679fb0a3599a7d3df397f855e89c4dba016960e"
+
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"


### PR DESCRIPTION
Bugs found/fixed:
 * Some of the components weren't observers so they didn't re-render after update
 * Reading assignments was reading all steps instead of only exercises
 * Lack of precision in calculations when togging from accepted/rejected 