### PR TITLE
hide create/clone course menu option from non-college teachers

### DIFF
--- a/tutor/specs/models/user/__snapshots__/menu.spec.js.snap
+++ b/tutor/specs/models/user/__snapshots__/menu.spec.js.snap
@@ -44,6 +44,16 @@ Array [
       "courseId": "1",
     },
   },
+  Object {
+    "label": "Create a Course",
+    "name": "createNewCourse",
+    "options": Object {
+      "separator": "before",
+    },
+    "params": Object {
+      "courseId": "1",
+    },
+  },
 ]
 `;
 
@@ -105,7 +115,38 @@ Array [
       "courseId": "2",
     },
   },
+  Object {
+    "label": "Create a Course",
+    "name": "createNewCourse",
+    "options": Object {
+      "separator": "before",
+    },
+    "params": Object {
+      "courseId": "2",
+    },
+  },
+  Object {
+    "label": "Copy this Course",
+    "name": "createNewCourse",
+    "options": Object {
+      "key": "clone-course",
+      "separator": "after",
+    },
+    "params": Object {
+      "sourceId": "2",
+    },
+  },
 ]
 `;
 
-exports[`Current User Store should return expected menu routes for courses 3`] = `Array []`;
+exports[`Current User Store should return expected menu routes for courses 3`] = `
+Array [
+  Object {
+    "label": "Create a Course",
+    "name": "createNewCourse",
+    "options": Object {
+      "separator": "both",
+    },
+  },
+]
+`;

--- a/tutor/specs/models/user/menu.spec.js
+++ b/tutor/specs/models/user/menu.spec.js
@@ -5,6 +5,7 @@ import User from '../../../src/models/user';
 import { bootstrapCoursesList } from '../../courses-test-data';
 
 jest.mock('../../../src/models/user', () => ({
+  isCollegeTeacher: true,
   isConfirmedFaculty: true,
 }));
 
@@ -28,5 +29,11 @@ describe('Current User Store', function() {
     expect(UserMenu.getRoutes('2')).toMatchSnapshot();
     Courses.clear();
     expect(UserMenu.getRoutes()).toMatchSnapshot();
+  });
+
+  it('hides course creation from non-college faculty', () => {
+    Courses.clear();
+    User.isCollegeTeacher = false;
+    expect(UserMenu.getRoutes()).toHaveLength(0);
   });
 });

--- a/tutor/src/models/user/menu.js
+++ b/tutor/src/models/user/menu.js
@@ -76,7 +76,7 @@ const ROUTES = {
   },
   createNewCourse: {
     label: 'Create a Course',
-    isAllowed() { return User.isConfirmedFaculty; },
+    isAllowed() { return User.isCollegeTeacher; },
     options({ courseId }) {
       return courseId ? { separator: 'before' } : { separator: 'both' };
     },
@@ -93,7 +93,7 @@ const ROUTES = {
       key: 'clone-course', separator: 'after',
     },
     isAllowed(course) {
-      return !!(course && !course.is_preview && !course.is_concept_coach && User.isConfirmedFaculty); },
+      return !!(course && !course.is_preview && !course.is_concept_coach && User.isCollegeTeacher); },
   },
   customer_service: {
     label: 'Customer Service',


### PR DESCRIPTION
prevents:
<img width="1311" alt="screen shot 2018-04-30 at 1 45 58 pm" src="https://user-images.githubusercontent.com/79566/39444298-d7c23f6e-4c7c-11e8-9f29-0d9a66ee4d43.png">


now:
<img width="1304" alt="screen shot 2018-04-30 at 1 46 23 pm" src="https://user-images.githubusercontent.com/79566/39444316-e3fa8fac-4c7c-11e8-973d-50536f31ff8e.png">
