### PR TITLE
Removed the annotations summary page from the tab order

### DIFF
--- a/tutor/specs/components/__snapshots__/annotations.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/annotations.spec.jsx.snap
@@ -67,6 +67,7 @@ exports[`Annotations renders and matches snapshot 1`] = `
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="button"
+                  tabIndex={-1}
                   type="button"
                 >
                   Display sections
@@ -122,6 +123,7 @@ exports[`Annotations renders and matches snapshot 1`] = `
               className="print-btn btn btn-default"
               disabled={false}
               onClick={[Function]}
+              tabIndex={-1}
               type="button"
             >
               <i
@@ -172,6 +174,7 @@ exports[`Annotations renders and matches snapshot 1`] = `
                   >
                     <button
                       onClick={[Function]}
+                      tabIndex={-1}
                       title="Edit"
                     >
                       <i
@@ -182,6 +185,7 @@ exports[`Annotations renders and matches snapshot 1`] = `
                     </button>
                     <button
                       onClick={[Function]}
+                      tabIndex={-1}
                       title="View in book"
                     >
                       <i
@@ -192,6 +196,7 @@ exports[`Annotations renders and matches snapshot 1`] = `
                     </button>
                     <button
                       onClick={[Function]}
+                      tabIndex={-1}
                       title="Delete"
                     >
                       <i
@@ -231,6 +236,7 @@ exports[`Annotations renders and matches snapshot 1`] = `
                   >
                     <button
                       onClick={[Function]}
+                      tabIndex={-1}
                       title="Edit"
                     >
                       <i
@@ -241,6 +247,7 @@ exports[`Annotations renders and matches snapshot 1`] = `
                     </button>
                     <button
                       onClick={[Function]}
+                      tabIndex={-1}
                       title="View in book"
                     >
                       <i
@@ -251,6 +258,7 @@ exports[`Annotations renders and matches snapshot 1`] = `
                     </button>
                     <button
                       onClick={[Function]}
+                      tabIndex={-1}
                       title="Delete"
                     >
                       <i

--- a/tutor/specs/components/__snapshots__/multi-select.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/multi-select.spec.jsx.snap
@@ -16,6 +16,7 @@ exports[`MultiSelect component renders selections 1`] = `
       onClick={[Function]}
       onKeyDown={[Function]}
       role="button"
+      tabIndex={0}
       type="button"
     >
       Food Selections

--- a/tutor/src/components/annotations/annotation-card.jsx
+++ b/tutor/src/components/annotations/annotation-card.jsx
@@ -116,16 +116,16 @@ export default class AnnotationCard extends React.Component {
             )}
           </div>
           <div className="controls">
-            {!this.editing && <button title="Edit" onClick={this.startEditing}><Icon type="edit" /></button>}
+            {!this.editing && <button title="Edit" onClick={this.startEditing} tabIndex={-1}><Icon type="edit" /></button>}
 
-            <button title="View in book" onClick={this.openPage}><Icon type="external-link" /></button>
+            <button title="View in book" onClick={this.openPage} tabIndex={-1}><Icon type="external-link" /></button>
             <SuretyGuard
               title="Are you sure you want to delete this note?"
               message="If you delete this note, your work cannot be recovered."
               okButtonLabel="Delete"
               onConfirm={this.doDelete}
             >
-              <button title="Delete"><Icon type="trash" /></button>
+              <button title="Delete" tabIndex={-1}><Icon type="trash" /></button>
             </SuretyGuard>
           </div>
         </div>

--- a/tutor/src/components/annotations/sections-filter.jsx
+++ b/tutor/src/components/annotations/sections-filter.jsx
@@ -39,6 +39,7 @@ export default class SectionsFilter extends React.Component {
           title="Display sections"
           onSelect={this.onSelect}
           selections={this.choices}
+          tabIndex={-1}
         />
       </div>
     );

--- a/tutor/src/components/annotations/summary-popup.jsx
+++ b/tutor/src/components/annotations/summary-popup.jsx
@@ -48,6 +48,7 @@ export default class SummaryPopup extends React.Component {
         <Button
           className="print-btn"
           onClick={this.openSummaryWindow}
+          tabIndex={-1}
         >
           <Icon type="print"/> Print this page
         </Button>

--- a/tutor/src/components/multi-select.jsx
+++ b/tutor/src/components/multi-select.jsx
@@ -24,10 +24,12 @@ class MultiSelect extends React.Component {
     ).isRequired,
     onOnlySelection: React.PropTypes.func,
     onSelect: React.PropTypes.func,
+    tabIndex: React.PropTypes.number
   };
 
   static defaultProps = {
     closeAfterSelect: true,
+    tabIndex: 0
   }
 
   @observable isOpen = false;
@@ -82,6 +84,7 @@ class MultiSelect extends React.Component {
           title={this.props.title}
           onToggle={this.onToggle}
           open={this.isOpen}
+          tabIndex={this.props.tabIndex}
         >
           {Array.from(this.props.selections).map((selection) => this.renderMenuSelection(selection))}
         </DropdownButton>


### PR DESCRIPTION
I have only tested this by manually adding the tabindex="-1" to those buttons on tutor-qa. I don't have hypothesis installed locally.