### PR TITLE
add nickname to exercises

### DIFF
--- a/exercises/resources/styles/exercises.scss
+++ b/exercises/resources/styles/exercises.scss
@@ -58,6 +58,13 @@
     }
   }
 
+  .nickname {
+    margin-bottom: 1rem;
+    input {
+      margin-left: 1rem;
+    }
+  }
+
   @import './attachments';
   @import './question';
 

--- a/exercises/src/components/exercise.jsx
+++ b/exercises/src/components/exercise.jsx
@@ -52,6 +52,7 @@ export default class Exercise extends React.Component {
   renderIntroTab = () => {
     return (
       <Tab eventKey="intro" title="Intro">
+        {this.renderNickname()}
         <div className="exercise-stimulus">
           <label>
             Exercise Stimulus
@@ -76,6 +77,7 @@ export default class Exercise extends React.Component {
     const { exercise } = this;
     return (
       <Tab key={0} eventKey="question-0" title="Question">
+        {this.renderNickname()}
         <Question {...this.questionProps} question={exercise.questions[0]} />
       </Tab>
     );
@@ -104,6 +106,21 @@ export default class Exercise extends React.Component {
     };
   }
 
+  @action.bound updateNickname(ev) {
+    this.exercise.nickname = ev.target.value;
+  }
+
+  renderNickname() {
+    return (
+      <div className="nickname">
+        <label>
+          Exercise Nickname:
+          <input onChange={this.updateNickname} value={this.exercise.nickname || ''} />
+        </label>
+      </div>
+    );
+  }
+
   renderMPQ() {
     return (
       <Button onClick={this.addQuestion} className="add-mpq" bsStyle="primary">
@@ -123,6 +140,7 @@ export default class Exercise extends React.Component {
         <div className="editing-controls">
           {exercise.error && <Alert bsStyle="danger">{String(exercise.error)}</Alert>}
           {isMultiPart && this.renderMPQ()}
+
           <Tabs
             id="exercise-parts"
             activeKey={this.activeTabKey}

--- a/shared/src/model/exercise.js
+++ b/shared/src/model/exercise.js
@@ -21,6 +21,7 @@ export default class Exercise extends BaseModel {
   @field id;
   @field uid;
   @field version;
+  @field nickname;
   @field({ type: 'array' }) versions;
   @field({ type: 'array' }) formats;
   @field is_vocab;


### PR DESCRIPTION
Appears at the top above the radio/checkboxes:
![screen shot 2018-05-07 at 11 32 40 am](https://user-images.githubusercontent.com/79566/39712954-8150ac2e-51ea-11e8-93e2-b0fae81675de.png)


For MPQ the nickname field appears on the "Intro" tab since that's the only one that's not question related
![screen shot 2018-05-07 at 11 32 17 am](https://user-images.githubusercontent.com/79566/39712929-6f3375a8-51ea-11e8-8969-bd2ea0365998.png)
