### PR TITLE
Update book urls to have "section" in between id and chapter/section

### DIFF
--- a/tutor/specs/components/__snapshots__/sections-chooser.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/sections-chooser.spec.jsx.snap
@@ -70,7 +70,6 @@ exports[`Sections Chooser renders and matches snapshot 1`] = `
             </span>
             <div
               aria-role="link"
-              chapterSection="1"
               className="browse-the-book"
               onClick={[Function]}
             >
@@ -240,7 +239,6 @@ exports[`Sections Chooser renders and matches snapshot 1`] = `
             </span>
             <div
               aria-role="link"
-              chapterSection="2"
               className="browse-the-book"
               onClick={[Function]}
             >
@@ -410,7 +408,6 @@ exports[`Sections Chooser renders and matches snapshot 1`] = `
             </span>
             <div
               aria-role="link"
-              chapterSection="3"
               className="browse-the-book"
               onClick={[Function]}
             >

--- a/tutor/specs/components/buttons/__snapshots__/browse-the-book.spec.jsx.snap
+++ b/tutor/specs/components/buttons/__snapshots__/browse-the-book.spec.jsx.snap
@@ -2,9 +2,8 @@
 
 exports[`_class2 renders and matches snapshot 1`] = `
 <a
-  chapterSection="1.2"
   className="browse-the-book btn btn-default"
-  href="/book/1/1.2"
+  href="/book/1/section/1.2"
   onClick={[Function]}
   target="_blank"
 >

--- a/tutor/specs/components/buttons/browse-the-book.spec.jsx
+++ b/tutor/specs/components/buttons/browse-the-book.spec.jsx
@@ -28,7 +28,7 @@ describe(BTB, () => {
     const btb = mount(<BTB {...props} />, context);
     btb.find('div.browse-the-book').simulate('click');
     expect(props.windowImpl.open).toHaveBeenCalledWith(
-      `/book/${course.ecosystem_id}/${props.chapterSection}`
+      `/book/${course.ecosystem_id}/section/${props.chapterSection}`
     );
   });
 });

--- a/tutor/specs/components/task-plan/__snapshots__/select-topics.spec.jsx.snap
+++ b/tutor/specs/components/task-plan/__snapshots__/select-topics.spec.jsx.snap
@@ -93,7 +93,6 @@ exports[`Select Topics matches snapshot 1`] = `
                     </span>
                     <div
                       aria-role="link"
-                      chapterSection="1"
                       className="browse-the-book"
                       onClick={[Function]}
                     >
@@ -263,7 +262,6 @@ exports[`Select Topics matches snapshot 1`] = `
                     </span>
                     <div
                       aria-role="link"
-                      chapterSection="2"
                       className="browse-the-book"
                       onClick={[Function]}
                     >
@@ -433,7 +431,6 @@ exports[`Select Topics matches snapshot 1`] = `
                     </span>
                     <div
                       aria-role="link"
-                      chapterSection="3"
                       className="browse-the-book"
                       onClick={[Function]}
                     >

--- a/tutor/specs/components/task-plan/homework/__snapshots__/choose-exercises.spec.js.snap
+++ b/tutor/specs/components/task-plan/homework/__snapshots__/choose-exercises.spec.js.snap
@@ -96,7 +96,6 @@ exports[`choose exercises component can select exercises 1`] = `
                       </span>
                       <div
                         aria-role="link"
-                        chapterSection="1"
                         className="browse-the-book"
                         onClick={[Function]}
                       >
@@ -266,7 +265,6 @@ exports[`choose exercises component can select exercises 1`] = `
                       </span>
                       <div
                         aria-role="link"
-                        chapterSection="2"
                         className="browse-the-book"
                         onClick={[Function]}
                       >
@@ -436,7 +434,6 @@ exports[`choose exercises component can select exercises 1`] = `
                       </span>
                       <div
                         aria-role="link"
-                        chapterSection="3"
                         className="browse-the-book"
                         onClick={[Function]}
                       >
@@ -664,7 +661,6 @@ exports[`choose exercises component renders selections 1`] = `
                       </span>
                       <div
                         aria-role="link"
-                        chapterSection="1"
                         className="browse-the-book"
                         onClick={[Function]}
                       >
@@ -834,7 +830,6 @@ exports[`choose exercises component renders selections 1`] = `
                       </span>
                       <div
                         aria-role="link"
-                        chapterSection="2"
                         className="browse-the-book"
                         onClick={[Function]}
                       >
@@ -1004,7 +999,6 @@ exports[`choose exercises component renders selections 1`] = `
                       </span>
                       <div
                         aria-role="link"
-                        chapterSection="3"
                         className="browse-the-book"
                         onClick={[Function]}
                       >

--- a/tutor/specs/helpers/analytics.spec.js
+++ b/tutor/specs/helpers/analytics.spec.js
@@ -86,7 +86,7 @@ describe('Analytics', function() {
       [`${c}/external/new`]:                '/teacher/assignment/create/external/1',
       [`${c}/t/month/2011-11-11/plan/66`]:  '/teacher/metrics/quick/1',
       '/book/991':                           '/reference-view/1',
-      '/book/991/2.2':                       '/reference-view/1/section/2.2',
+      '/book/991/section/2.2':               '/reference-view/1/section/2.2',
     };
     for (let route in tests) {
       const translated = tests[route];

--- a/tutor/specs/screens/question-library/__snapshots__/dashboard.spec.jsx.snap
+++ b/tutor/specs/screens/question-library/__snapshots__/dashboard.spec.jsx.snap
@@ -98,7 +98,6 @@ exports[`Questions Dashboard Component matches snapshot 1`] = `
                   </span>
                   <div
                     aria-role="link"
-                    chapterSection="1"
                     className="browse-the-book"
                     onClick={[Function]}
                   >
@@ -268,7 +267,6 @@ exports[`Questions Dashboard Component matches snapshot 1`] = `
                   </span>
                   <div
                     aria-role="link"
-                    chapterSection="2"
                     className="browse-the-book"
                     onClick={[Function]}
                   >
@@ -438,7 +436,6 @@ exports[`Questions Dashboard Component matches snapshot 1`] = `
                   </span>
                   <div
                     aria-role="link"
-                    chapterSection="3"
                     className="browse-the-book"
                     onClick={[Function]}
                   >

--- a/tutor/specs/screens/reference-book.spec.js
+++ b/tutor/specs/screens/reference-book.spec.js
@@ -57,4 +57,12 @@ describe('Reference Book Component', function() {
     expect(book).toHaveRendered(`.book-menu [data-section='${ux.page.chapter_section.asString}'] .active`);
   });
 
+  it('displays a not found message when needed', () => {
+    ux.chapterSection = '99.99';
+    expect(ux.isFetching).toBe(false);
+    const book = mount(<ReferenceBook {...props} />, EnzymeContext.build());
+    expect(book).toHaveRendered('.not-found');
+    expect(book.text()).toContain('Section 99.99 was not found');
+  });
+
 });

--- a/tutor/src/components/book-content-mixin.cjsx
+++ b/tutor/src/components/book-content-mixin.cjsx
@@ -53,9 +53,12 @@ LinkContentMixin =
       related_content = TaskStepStore.get(id)?.related_content
 
       if related_content?
-        page = @sectionFormat?(related_content[0]?.chapter_section or related_content[0]?.book_location)
+        chapterSection = @sectionFormat?(related_content[0]?.chapter_section or related_content[0]?.book_location)
 
-    return Router.makePathname('viewReferenceBook', {ecosystemId, page}, query)
+    Router.makePathname(
+      if chapterSection then 'viewReferenceBookSection' else 'viewReferenceBook',
+      {ecosystemId, chapterSection}, query
+    )
 
 
   isMediaLink: (link) ->

--- a/tutor/src/components/buttons/browse-the-book.jsx
+++ b/tutor/src/components/buttons/browse-the-book.jsx
@@ -34,10 +34,13 @@ export default class extends React.Component {
 
   @computed get href() {
     const { course, book, chapterSection } = this.props;
-    return Router.makePathname('viewReferenceBook', {
-      chapterSection,
-      ecosystemId: book ? book.id : course.ecosystem_id,
-    });
+    return Router.makePathname(
+      chapterSection ? 'viewReferenceBookSection' : 'viewReferenceBook',
+      {
+        chapterSection,
+        ecosystemId: book ? book.id : course.ecosystem_id,
+      }
+    );
   }
 
   @action.bound onClick(ev) {
@@ -49,7 +52,7 @@ export default class extends React.Component {
 
   render() {
     const { tag: Tag, children, className, unstyled,
-      windowImpl, course, book, page, onClick, // eslint-disable-line no-unused-vars
+      windowImpl, course, book, chapterSection, onClick, // eslint-disable-line no-unused-vars
       ...tagProps
     } = this.props;
     invariant(book || course, 'browse the book requires either a course or book');

--- a/tutor/src/helpers/analytics.js
+++ b/tutor/src/helpers/analytics.js
@@ -27,6 +27,13 @@ const assignmentTypeTranslator = function(assignmentType, { courseId, id }) {
   return `/teacher/assignment/${type}/${assignmentType}/${courseId}`;
 };
 
+function viewReferenceBook({ ecosystemId, chapterSection }) {
+  const course = Courses.forEcosystemId(ecosystemId);
+  if (!course) { return `/reference-view/ecosystem/${ecosystemId}`; }
+  const url = `/reference-view/${course.id}`;
+  return chapterSection ? `${url}/section/${chapterSection}` : url;
+}
+
 // Translators convert a url like '/foo/bar/123/baz/1' into a simplified one like just '/foo/bar'
 const Translators = {
   dashboard({ courseId }) {
@@ -49,12 +56,8 @@ const Translators = {
   createEvent:    partial(assignmentTypeTranslator, 'event'),
   calendarViewPlanStats({ courseId }) { return `/teacher/metrics/quick/${courseId}`; },
   reviewTask({ courseId }) { return `/teacher/metrics/review/${courseId}`; },
-  viewReferenceBook({ ecosystemId, chapterSection }) {
-    const course = Courses.forEcosystemId(ecosystemId);
-    if (!course) { return `/reference-view/ecosystem/${ecosystemId}`; }
-    const url = `/reference-view/${course.id}`;
-    return chapterSection ? `${url}/section/${chapterSection}` : url;
-  },
+  viewReferenceBookSection: viewReferenceBook,
+  viewReferenceBook,
 
   // Task steps are viewed by both teacher and student with no difference in params
   viewTaskStep({ courseId }) {

--- a/tutor/src/helpers/conditional-handlers.jsx
+++ b/tutor/src/helpers/conditional-handlers.jsx
@@ -63,13 +63,16 @@ const getConditionalHandlers = (Router) => {
     const parts = params.parts.split('/');
     const course = Courses.get(first(parts));
     invariant(course, `Did not find course for params '${params}'`);
+    const chapterSection = parts.length > 1 ? last(parts) : 0;
     return (
       <Redirect
         to={{
-          pathname: Router.makePathname('viewReferenceBook', {
-            ecosystemId: course.ecosystem_id,
-            page: last(parts),
-          }),
+          pathname: Router.makePathname(
+            chapterSection ? 'viewReferenceBookSection' : 'viewReferenceBook',
+            {
+              ecosystemId: course.ecosystem_id,
+              chapterSection,
+            }),
           query: Router.currentQuery(),
         }}
       />

--- a/tutor/src/models/reference-book/ux.js
+++ b/tutor/src/models/reference-book/ux.js
@@ -31,7 +31,6 @@ export default class BookUX {
   }
 
   @action.bound onEcosystemChange({ newValue: ecosystemId }) {
-
     if (this.book && this.book.id == ecosystemId){ return; }
     this.book = new Book({ id: ecosystemId });
     this.book.fetch().then(() => {
@@ -39,6 +38,12 @@ export default class BookUX {
         this.setChapterSection();  // will default to first section
       }
     });
+  }
+
+  @computed get isFetching() {
+    return Boolean(
+      (this.book && this.book.api.isPending) || (this.page && this.page.api.isPending)
+    );
   }
 
   @action.bound onMenuSelection(section) {

--- a/tutor/src/routes.js
+++ b/tutor/src/routes.js
@@ -168,8 +168,14 @@ const getRoutes = (router) => {
     },
     { path: '/payments', name: 'managePayments', renderer: getPaymentsShell },
     {
-      path: '/book/:ecosystemId/:chapterSection?',
+      path: '/book/:ecosystemId',
       name: 'viewReferenceBook',
+      renderer: getReferenceBook,
+      settings: { navBar: 'Plugable' },
+    },
+    {
+      path: '/book/:ecosystemId/section/:chapterSection',
+      name: 'viewReferenceBookSection',
       renderer: getReferenceBook,
       settings: { navBar: 'Plugable' },
     },

--- a/tutor/src/screens/reference-book/index.jsx
+++ b/tutor/src/screens/reference-book/index.jsx
@@ -39,7 +39,7 @@ export default class ReferenceBookShell extends React.Component {
   render() {
     const { ux } = this;
 
-    if (!ux.page) {
+    if (ux.isFetching) {
       return <LoadingScreen />;
     }
 

--- a/tutor/src/screens/reference-book/reference-book.jsx
+++ b/tutor/src/screens/reference-book/reference-book.jsx
@@ -3,8 +3,25 @@ import { SpyMode } from 'shared';
 
 import Menu from '../../components/book-menu/menu';
 import Page from '../../components/book-page';
+
 import ReferenceViewPageNavigation from './page-navigation';
 import UX from './ux';
+
+const WrappedPage = observer(({ ux }) => {
+  if (ux.page) {
+    return (
+      <ReferenceViewPageNavigation ux={ux}>
+        <Page {...ux.pageProps} />
+      </ReferenceViewPageNavigation>
+    );
+  } else {
+    return (
+      <div className="book-page-wrapper not-found">
+        <h1>Section {ux.chapterSection} was not found</h1>
+      </div>
+    );
+  }
+});
 
 @observer
 export default class ReferenceBook extends React.Component {
@@ -27,9 +44,7 @@ export default class ReferenceBook extends React.Component {
         <SpyMode.Wrapper>
           <div className="content">
             <Menu ux={ux} />
-            <ReferenceViewPageNavigation ux={ux}>
-              <Page {...ux.pageProps} />
-            </ReferenceViewPageNavigation>
+            <WrappedPage ux={ux} />
           </div>
         </SpyMode.Wrapper>
       </div>

--- a/tutor/src/screens/reference-book/styles.scss
+++ b/tutor/src/screens/reference-book/styles.scss
@@ -10,4 +10,8 @@
     color: $tutor-secondary;
     margin-right: 0.4rem;
   }
+  .book-page-wrapper.not-found {
+    text-align: center;
+    height: 100vh;
+  }
 }

--- a/tutor/src/screens/reference-book/ux.js
+++ b/tutor/src/screens/reference-book/ux.js
@@ -59,7 +59,7 @@ export default class ReferenceBookUX extends BookUX {
 
   sectionHref(section) {
     if (!section) { return null; }
-    return Router.makePathname('viewReferenceBook', {
+    return Router.makePathname('viewReferenceBookSection', {
       ecosystemId: this.book.id,
       chapterSection: section.chapter_section.asString,
     }, { query: Router.currentQuery() });
@@ -67,7 +67,7 @@ export default class ReferenceBookUX extends BookUX {
 
   sectionLinkProps(section) {
     return {
-      to: 'viewReferenceBook',
+      to: 'viewReferenceBookSection',
       params: extend(Router.currentParams(), { chapterSection: section.chapter_section.asString }),
       query: Router.currentQuery(),
     };


### PR DESCRIPTION
before they were `/book/<ecosystemId>/<chapterSection>` but that didn't match what the BE used.

And also display a simple "not found" message instead of displaying spinner forever
![screen shot 2018-05-11 at 1 33 10 pm](https://user-images.githubusercontent.com/79566/39940760-eea48222-551f-11e8-869b-98a224f8cd95.png)

