### PR TITLE
include counter-resets in book content instead of book-page

### DIFF
--- a/tutor/resources/styles/book-content/index.scss
+++ b/tutor/resources/styles/book-content/index.scss
@@ -21,6 +21,7 @@
   @media screen and ( max-width: $book-content-collapse-breakpoint ){
     padding: 0 $book-content-narrow-horizontal-padding;
   }
+  counter-reset: question figure;
 }
 
 @mixin tutor-book-content() {

--- a/tutor/resources/styles/book-content/page.scss
+++ b/tutor/resources/styles/book-content/page.scss
@@ -35,8 +35,7 @@
 
     .page {
       @include tutor-book-content-body();
-      counter-reset: question;
-      counter-reset: figure;
+
       border: 1px solid $tutor-neutral-bright;
       background-color: $tutor-white;
       // shown if parent is-teacher present below.


### PR DESCRIPTION
This way they're available everywhere such as readings

Broken images are because I have very old content, but the figures are working now 😁 
![screen shot 2018-06-14 at 1 04 17 pm](https://user-images.githubusercontent.com/79566/41429717-8385f290-6fd3-11e8-8456-a5c592fb7947.png)
