### PR TITLE
Fix QA view exercise loading

### DIFF
--- a/tutor/specs/screens/qa-view.spec.jsx
+++ b/tutor/specs/screens/qa-view.spec.jsx
@@ -18,7 +18,7 @@ describe('QA Screen', function() {
   beforeEach(function() {
     const exercises = Factory.exercisesMap();
     const ecosystems = Factory.ecosystemsMap();
-
+    exercises.fetch = jest.fn()
     jest.spyOn(Book.prototype, 'fetch').mockImplementation(function() {
       this.onApiRequestComplete({
         data: [FactoryBot.create('Book', { id: this.id, type: 'biology' })],
@@ -55,4 +55,14 @@ describe('QA Screen', function() {
     qa.unmount();
   });
 
+  it('loads exercises', () => {
+    const qa = mount(<MemoryRouter><QA {...props} /></MemoryRouter>);
+    expect(ux.exercisesMap.fetch).toHaveBeenCalledWith({
+      book: ux.book,
+      course: undefined,
+      limit: false,
+      page_ids: [ux.page.id],
+    });
+    qa.unmount();
+  });
 });

--- a/tutor/src/models/exercises.js
+++ b/tutor/src/models/exercises.js
@@ -80,19 +80,19 @@ export class ExercisesMap extends Map {
     return false;
   }
 
-  ensureExercisesLoaded({ book, exercise_ids }) {
+  ensureExercisesLoaded({ book, course, exercise_ids, limit }) {
     const unFetchedExerciseIds = filter(exercise_ids, exId => !this.get(exId));
     if (!isEmpty(unFetchedExerciseIds)) {
-      this.fetch({ book, exercise_ids: unFetchedExerciseIds });
+      this.fetch({ book, course, exercise_ids: unFetchedExerciseIds, limit });
     }
   }
 
-  ensurePagesLoaded({ book, page_ids }) {
+  ensurePagesLoaded({ book, course, page_ids, limit }) {
     const unFetchedPageIds = filter(page_ids, page_id =>
       !this.isFetching({ page_id }) && !this.hasFetched({ page_id })
     );
     if (!isEmpty(unFetchedPageIds)) {
-      this.fetch({ book, page_ids: unFetchedPageIds });
+      this.fetch({ book, course, page_ids: unFetchedPageIds, limit });
     }
   }
 

--- a/tutor/src/screens/qa-view/ux.js
+++ b/tutor/src/screens/qa-view/ux.js
@@ -40,7 +40,9 @@ export default class QaScreenUX extends BookUX {
         this.ecosystemId = this.ecosystem.id;
       }
       if (this.book && this.page) {
-        this.exercisesMap.ensureLoaded({ book: this.book, page_ids: [this.page.id] });
+        this.exercisesMap.ensurePagesLoaded({
+          book: this.book, page_ids: [this.page.id], limit: false,
+        });
       }
     });
   }


### PR DESCRIPTION
I think this was caused by a rebase that erased the change to rename the method to `ensurePagesLoaded` when we added the by exercise id methods