### PR TITLE
Fix the continue button on reading steps

### DIFF
--- a/tutor/specs/screens/teacher-dashboard/month.spec.js
+++ b/tutor/specs/screens/teacher-dashboard/month.spec.js
@@ -11,9 +11,8 @@ describe('CourseCalendar Month display', () => {
   beforeEach(() => {
     course = Factory.course({ is_teacher: true });
     Factory.taskPlans({ course });
-
     props = {
-      date: moment(),
+      date: course.taskPlans.array[0].duration.end(),
       course: course,
       termEnd: moment().add(2, 'month'),
       termStart: moment().subtract(3, 'month'),

--- a/tutor/src/components/paging-navigation.jsx
+++ b/tutor/src/components/paging-navigation.jsx
@@ -8,7 +8,7 @@ import { observer } from 'mobx-react';
 import ScrollTo from '../helpers/scroll-to';
 
 @observer
-export default class PagingNavigation extends React.PureComponent {
+export default class PagingNavigation extends React.Component {
 
   static propTypes = {
     children:             React.PropTypes.node.isRequired,

--- a/tutor/src/components/task-step/all-steps.cjsx
+++ b/tutor/src/components/task-step/all-steps.cjsx
@@ -19,9 +19,9 @@ Reading = React.createClass
   displayName: 'Reading'
   mixins: [StepMixin]
   isContinueEnabled: -> true
-  onContinue: ->
-    @props.onStepCompleted()
-    @props.onNextStep()
+  onContinue: (cb) ->
+    @props.onStepCompleted().then(@props.onNextStep)
+
   renderBody: ->
     {id, taskId} = @props
     {courseId} = Router.currentParams()
@@ -37,8 +37,7 @@ Interactive = React.createClass
   mixins: [StepMixin]
   isContinueEnabled: -> true
   onContinue: ->
-    @props.onStepCompleted()
-    @props.onNextStep()
+    @props.onStepCompleted().then(@props.onNextStep)
   renderBody: ->
     {id} = @props
     {courseId} = Router.currentParams()
@@ -50,8 +49,7 @@ Video = React.createClass
   mixins: [StepMixin]
   isContinueEnabled: -> true
   onContinue: ->
-    @props.onStepCompleted()
-    @props.onNextStep()
+    @props.onStepCompleted().then(@props.onNextStep)
   renderBody: ->
     {id} = @props
     {courseId} = Router.currentParams()

--- a/tutor/src/components/task-step/index.cjsx
+++ b/tutor/src/components/task-step/index.cjsx
@@ -39,9 +39,11 @@ TaskStep = React.createClass
 
   onStepCompleted: (id) ->
     {id} = @props unless id? # need to allow `id` from arguments pass through, especially for multi-part
-
     if StepPanel.canWrite(id)
       TaskActions.completeStep(id, @props.taskId)
+      return new Promise((resolve) -> TaskStore.once('step.completed', resolve))
+    else
+      return Promise.resolve()
 
   render: ->
     {id, taskId} = @props

--- a/tutor/src/components/task-step/step-with-reading-content.cjsx
+++ b/tutor/src/components/task-step/step-with-reading-content.cjsx
@@ -31,9 +31,14 @@ ReadingStepContent = React.createClass
   getInitialState: ->
     { isContinuing: false }
 
+  componentDidMount: -> @isMounted = true
+  componentWillUnmount: -> @isMounted = false
+
   onContinue: ->
     @setState(isContinuing: true)
-    @props.onContinue()
+    @props.onContinue().then(=>
+      @setState(isContinuing: false) if @isMounted
+    )
 
   renderNextStepLink: ->
     return null unless @props.onContinue

--- a/tutor/src/components/task-step/step-with-reading-content.cjsx
+++ b/tutor/src/components/task-step/step-with-reading-content.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 {Button} = require 'react-bootstrap'
 {TaskStepStore} = require '../../flux/task-step'
 {TaskPanelStore} = require '../../flux/task-panel'
-{ArbitraryHtmlAndMath, ChapterSectionMixin} = require 'shared'
+{AsyncButton, ArbitraryHtmlAndMath, ChapterSectionMixin} = require 'shared'
 CourseData = require '../../helpers/course-data'
 {BookContentMixin, LinkContentMixin} = require '../book-content-mixin'
 RelatedContent = require '../related-content'
@@ -28,12 +28,24 @@ ReadingStepContent = React.createClass
 
   shouldExcludeFrame: ->
     @props.stepType is 'interactive'
+  getInitialState: ->
+    { isContinuing: false }
+
+  onContinue: ->
+    @setState(isContinuing: true)
+    @props.onContinue()
 
   renderNextStepLink: ->
     return null unless @props.onContinue
-    <Button bsStyle="primary" onClick={@props.onContinue}>
+
+    <AsyncButton
+      bsStyle="primary"
+      isWaiting={@state.isContinuing}
+      waitingText="Loading…"
+      onClick={this.onContinue}
+    >
       Continue
-    </Button>
+    </AsyncButton>
 
   shouldOpenNewTab: -> true
 


### PR DESCRIPTION
The continue button for reading content didn't work.  It would scroll to the top of the page but wouldn't display new content.

