### PR TITLE
only name and other info from source course if it's clonable

### DIFF
--- a/tutor/specs/models/courses/create.spec.js
+++ b/tutor/specs/models/courses/create.spec.js
@@ -59,24 +59,25 @@ describe('Course Builder UX Model', () => {
       creator.cloned_from = course;
       expect(creator.cloned_from_id).toBe(course.id);
       expect(creator.cloned_from).toBe(course);
-      return creator.save();
+      return { saved: creator.save(), course };
     };
 
     it('clones a course', () => {
       const mockOffering = { is_available: true };
       Offerings.get.mockImplementation(() => mockOffering);
-      const saved = prepCourseClone();
+      const { saved, course } = prepCourseClone();
       expect(creator.cloned_from_offering).toBe(mockOffering);
+      expect(creator.name).toEqual(course.name);
       expect(saved.url).toEqual('/courses/2/clone');
       expect(saved.data).toMatchSnapshot();
     });
 
     it('does not clone if the course offering is no longer available', () => {
-      const mockOffering = { is_available: false };
+      const mockOffering = { name: 'My Test Course', is_available: false };
       Offerings.get.mockImplementation(() => mockOffering);
-      const saved = prepCourseClone();
-      const course = bootstrapCoursesList().get('2');
+      const { course, saved } = prepCourseClone();
       expect(creator.cloned_from_offering).toBe(mockOffering);
+      expect(creator.name).not.toEqual(course.name);
       expect(Offerings.get).toHaveBeenCalledWith(course.offering_id);
       expect(saved.url).toEqual('/courses');
       expect(saved.data.cloned_from_id).toBeUndefined();

--- a/tutor/specs/screens/new-course/course-numbers.spec.jsx
+++ b/tutor/specs/screens/new-course/course-numbers.spec.jsx
@@ -3,6 +3,11 @@ import CourseNumbers from '../../../src/screens/new-course/course-numbers';
 import BuilderUX from '../../../src/screens/new-course/ux';
 import { bootstrapCoursesList } from '../../courses-test-data';
 
+jest.mock('../../../src/models/course/offerings', () => ({
+  fetch: jest.fn(),
+  get: jest.fn(() => ({ is_available: true })),
+}));
+
 const COURSE_ID = '1';
 
 jest.mock('../../../src/models/user', () => ({
@@ -27,7 +32,7 @@ describe('CreateCourse: entering details', function() {
     wrapper.unmount();
   });
 
-  it('sets field values', function() {
+  fit('sets field values', function() {
     ux.newCourse.cloned_from = courses.get(COURSE_ID);
     const wrapper = shallow(<CourseNumbers ux={ux} />);
     expect(wrapper).toHaveRendered('.course-details-sections FormControl[type="number"][defaultValue=0]');

--- a/tutor/specs/screens/new-course/ux.spec.js
+++ b/tutor/specs/screens/new-course/ux.spec.js
@@ -21,7 +21,7 @@ describe('Course Builder UX Model', () => {
     Router.currentParams.mockReturnValue({});
     User.isCollegeTeacher = true;
     courses = bootstrapCoursesList();
-    mockOffering = { id: 1, title: 'A Test Course' };
+    mockOffering = { id: 1, title: 'A Test Course', is_available: true };
     ux = new BuilderUX();
   });
 
@@ -46,6 +46,7 @@ describe('Course Builder UX Model', () => {
   it('sets cloned course when sourceId is present', () => {
     Router.currentParams.mockReturnValue({ sourceId: '2' });
     courses.get('2').name = 'CLONE ME';
+    Offerings.get.mockReturnValue(mockOffering);
     ux = new BuilderUX();
     expect(ux.newCourse.cloned_from_id).toEqual('2');
     expect(ux.newCourse.name).toEqual('CLONE ME');

--- a/tutor/src/models/course/create.js
+++ b/tutor/src/models/course/create.js
@@ -71,8 +71,10 @@ export default class CourseCreate extends BaseModel {
 
   set cloned_from(course) {
     this.cloned_from_id = course.id;
-    this.name = course.name;
-    this.num_sections = course.periods.length;
+    if (this.canCloneCourse) {
+      this.name = course.name;
+      this.num_sections = course.periods.length;
+    }
   }
 
   get cloned_from_offering() {


### PR DESCRIPTION
If we're able to clone the course, we shouldn't set the name from it