### PR TITLE
convert data to JSON then test if empty

### DIFF
--- a/shared/src/api/collections.coffee
+++ b/shared/src/api/collections.coffee
@@ -134,15 +134,16 @@ simplifyRequestConfig = (requestConfig) ->
   simpleRequest.url = simpleRequest.url.replace(requestConfig.baseURL, '') if requestConfig.baseURL
   simpleRequest.url = trim(simpleRequest.url, '/')
 
-  if isEmpty(simpleRequest.data)
-    simpleRequest = omit(simpleRequest, 'data')
-  else if isString(simpleRequest.data)
+  if isString(simpleRequest.data)
     try
       simpleRequest.data = JSON.parse(simpleRequest.data)
     catch e
 
-  simpleRequest.data = omitBy(simpleRequest.data, isUndefined) if simpleRequest.data
+  if isEmpty(simpleRequest.data)
+    delete simpleRequest.data
 
+  if simpleRequest.data
+    simpleRequest.data = omitBy(simpleRequest.data, isUndefined)
   simpleRequest
 
 class XHRRecords


### PR DESCRIPTION
Fixes bug where data was a string encoded empty object i.e. "{}"

It failed the isEmpty test since it was tested before converting to an object

That in turn threw of the isPending check here since the fingerprint was different 