### PR TITLE
Disable highlighting in physics

### DIFF
--- a/tutor/specs/models/course.spec.js
+++ b/tutor/specs/models/course.spec.js
@@ -148,7 +148,10 @@ describe('Course Model', () => {
     expect(course.canAnnotate).toBe(false);
     FeatureFlags.is_highlighting_allowed = true;
     expect(course.canAnnotate).toBe(true);
+    course.appearance_code = 'my_physics_test';
+    expect(course.canAnnotate).toBe(false);
   });
+
   it('calculates payments needed', () => {
     const course = Courses.get(1);
     expect(course.needsPayment).toBe(false);

--- a/tutor/src/models/course.js
+++ b/tutor/src/models/course.js
@@ -200,7 +200,10 @@ export default class Course extends BaseModel {
 
   @computed get canAnnotate() {
     return Boolean(
-      FeatureFlags.is_highlighting_allowed && this.isStudent && this.isActive
+      FeatureFlags.is_highlighting_allowed &&
+        this.isStudent &&
+        this.isActive &&
+        !/physics/.test(this.appearance_code)
     );
   }
 


### PR DESCRIPTION
We've gotten physics to the point where it can be annotated, but the
highlighted formulas are pretty ugly so we're temporarily disabling it