### PR TITLE
handle long content in error modal

### DIFF
--- a/tutor/resources/styles/components/tutor-dialog.scss
+++ b/tutor/resources/styles/components/tutor-dialog.scss
@@ -1,9 +1,11 @@
 .tutor-dialog {
 
   .server-error {
+    word-break: break-all;
+
     .response {
       max-height: 200px;
-      overflow: scroll;
+      overflow: auto;
     }
   }
   .modal-footer {


### PR DESCRIPTION
also changed overflow from `scroll` to `auto` so it doesn't show unnecessary scroll bars

![image](https://user-images.githubusercontent.com/636227/42522854-2d0a1f60-843a-11e8-9b30-2c936ecb11a8.png)
