### PR TITLE
remove annotation drawer from dom when closed, and allow tabbing to elements inside

### DIFF
--- a/tutor/resources/styles/components/annotations/summary-page.scss
+++ b/tutor/resources/styles/components/annotations/summary-page.scss
@@ -1,27 +1,39 @@
 .annotater {
   .highlights-windowshade {
     background-color: $tutor-neutral-light;
-    bottom: 100%;
     display: flex;
     justify-content: center;
     left: 0;
-    overflow: hidden;
     position: fixed;
     right: 0;
     top: 0;
-    transition: 0.3s;
     z-index: 20;
+    bottom: 0;
+    overflow: auto;
+    padding-top: 5rem;
+
+    @media print {
+      padding: 0;
+      position: static;
+    }
     @include no-select();
 
-    &.down {
+    &.animate-enter {
+      bottom: 100%;
+      overflow: hidden;
+    }
+    &.animate-enter-active {
+      transition: bottom 0.3s;
       bottom: 0;
-      overflow: auto;
-      padding-top: 5rem;
+    }
 
-      @media print {
-        padding: 0;
-        position: static;
-      }
+    &.animate-leave {
+      bottom: 0;
+      overflow: hidden;
+    }
+    &.animate-leave-active {
+      transition: bottom 0.3s;
+      bottom: 100%;
     }
 
     h1 {

--- a/tutor/resources/styles/components/top-nav-bar/center-controls.scss
+++ b/tutor/resources/styles/components/top-nav-bar/center-controls.scss
@@ -58,6 +58,7 @@
   .annotation-summary-toggle {
     background-color: transparent;
     border: none;
+    outline: none;
     .i {
       fill: $icon-color;
     }

--- a/tutor/src/components/annotations/annotation-card.jsx
+++ b/tutor/src/components/annotations/annotation-card.jsx
@@ -118,16 +118,16 @@ export default class AnnotationCard extends React.Component {
             )}
           </div>
           <div className="controls">
-            {!this.editing && <button title="Edit" onClick={this.startEditing} tabIndex={-1}><Icon type="edit" /></button>}
+            {!this.editing && <button title="Edit" onClick={this.startEditing}><Icon type="edit" /></button>}
 
-            <button title="View in book" onClick={this.openPage} tabIndex={-1}><Icon type="external-link" /></button>
+            <button title="View in book" onClick={this.openPage}><Icon type="external-link" /></button>
             <SuretyGuard
               title="Are you sure you want to delete this note?"
               message="If you delete this note, your work cannot be recovered."
               okButtonLabel="Delete"
               onConfirm={this.doDelete}
             >
-              <button title="Delete" tabIndex={-1}><Icon type="trash" /></button>
+              <button title="Delete"><Icon type="trash" /></button>
             </SuretyGuard>
           </div>
         </div>

--- a/tutor/src/components/annotations/sections-filter.jsx
+++ b/tutor/src/components/annotations/sections-filter.jsx
@@ -39,7 +39,6 @@ export default class SectionsFilter extends React.Component {
           title="Display sections"
           onSelect={this.onSelect}
           selections={this.choices}
-          tabIndex={-1}
         />
       </div>
     );

--- a/tutor/src/components/annotations/summary-page.jsx
+++ b/tutor/src/components/annotations/summary-page.jsx
@@ -30,6 +30,10 @@ export default class AnnotationSummaryPage extends React.Component {
     this.resetToSection(this.props.currentChapter, this.props.currentSection);
   }
 
+  componentDidMount() {
+    this.prepareFocus();
+  }
+
   componentWillReceiveProps(nextProps) {
     if (
       nextProps.currentSection !== this.props.currentSection ||
@@ -37,6 +41,15 @@ export default class AnnotationSummaryPage extends React.Component {
     ) {
       this.resetToSection(nextProps.currentChapter, nextProps.currentSection);
     }
+  }
+
+  prepareFocus() {
+    const {containerRef} = this;
+    const focusAnchor = document.createElement("a");
+    focusAnchor.setAttribute("href", "#");
+    containerRef.insertBefore(focusAnchor, containerRef.firstChild);
+    focusAnchor.focus();
+    focusAnchor.addEventListener("blur", () => containerRef.removeChild(focusAnchor), false);
   }
 
   @computed get annotationsBySection() {
@@ -49,7 +62,7 @@ export default class AnnotationSummaryPage extends React.Component {
 
   renderEmpty() {
     return (
-      <div className="summary-page">
+      <div className="summary-page" ref={ref => this.containerRef = ref}>
         <div className="annotations">
           <h1>
             Highlights and annotations
@@ -81,7 +94,7 @@ export default class AnnotationSummaryPage extends React.Component {
     }
 
     return (
-      <div className="summary-page">
+      <div className="summary-page" ref={ref => this.containerRef = ref}>
         <h1>
           Highlights and annotations
         </h1>

--- a/tutor/src/components/annotations/summary-popup.jsx
+++ b/tutor/src/components/annotations/summary-popup.jsx
@@ -48,7 +48,6 @@ export default class SummaryPopup extends React.Component {
         <Button
           className="print-btn"
           onClick={this.openSummaryWindow}
-          tabIndex={-1}
         >
           <Icon type="print"/> Print this page
         </Button>

--- a/tutor/src/components/annotations/window-shade.jsx
+++ b/tutor/src/components/annotations/window-shade.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { observer } from 'mobx-react';
 import { action } from 'mobx';
 import keymaster from 'keymaster';
@@ -29,11 +30,20 @@ export default class WindowShade extends React.Component {
     const { ux, children } = this.props;
 
     return (
-      <div className={`highlights-windowshade ${ux.isSummaryVisible ? 'down' : 'up'}`}>
-        <div className='centered-content'>
-          {children}
-        </div>
-      </div>
+      <ReactCSSTransitionGroup
+        component={(props) => React.Children.toArray(props.children)[0] || null}
+        transitionName="animate"
+        transitionEnterTimeout={300}
+        transitionLeaveTimeout={300}
+      >
+        {ux.isSummaryVisible &&
+          <div key="shade" className="highlights-windowshade">
+            <div className='centered-content'>
+              {children}
+            </div>
+          </div>
+        }
+      </ReactCSSTransitionGroup>
     );
 
   }


### PR DESCRIPTION
There is a little bit of a hack to ensure that when you tab after the drawer opens, it selects the drawer content first. otherwise you have to tab through all the content behind before getting to the stuff you can see. If anyone knows a cleaner way to accomplish that please let me know.