### PR TITLE
format math in highlight annotations

### DIFF
--- a/tutor/specs/components/__snapshots__/annotations.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/annotations.spec.jsx.snap
@@ -17,7 +17,7 @@ exports[`Annotations renders and matches snapshot 1`] = `
       role="button"
       style={
         Object {
-          "top": 100,
+          "top": 0,
         }
       }
       type="comment-o"

--- a/tutor/specs/models/course.spec.js
+++ b/tutor/specs/models/course.spec.js
@@ -148,8 +148,6 @@ describe('Course Model', () => {
     expect(course.canAnnotate).toBe(false);
     FeatureFlags.is_highlighting_allowed = true;
     expect(course.canAnnotate).toBe(true);
-    course.appearance_code = 'my_physics_test';
-    expect(course.canAnnotate).toBe(false);
   });
 
   it('calculates payments needed', () => {

--- a/tutor/src/helpers/dom.js
+++ b/tutor/src/helpers/dom.js
@@ -256,6 +256,18 @@ export default function dom(el) {
       }
     },
 
+    farthest(selector) {
+      const thisMatches = this.matches(selector);
+
+      if (el.parentNode && thisMatches) {
+        return dom(el.parentNode).farthest(selector) || el;
+      } else if (el.parentNode) {
+        return dom(el.parentNode).farthest(selector);
+      } else {
+        return thisMatches ? el : null;
+      }
+    },
+
   };
 
 }

--- a/tutor/src/models/course.js
+++ b/tutor/src/models/course.js
@@ -199,12 +199,7 @@ export default class Course extends BaseModel {
   }
 
   @computed get canAnnotate() {
-    return Boolean(
-      FeatureFlags.is_highlighting_allowed &&
-        this.isStudent &&
-        this.isActive &&
-        !/physics/.test(this.appearance_code)
-    );
+    return Boolean(FeatureFlags.is_highlighting_allowed && this.isStudent && this.isActive);
   }
 
   @computed get needsPayment() {


### PR DESCRIPTION
the annotation logic is just ripping out all the mathjax stuff so that it is just the `<math>` element that the document starts with, if there is a mathjaxy way to revert the content on the cloned dom and no affect the actual page that would be ideal, but i couldn't find anything like that.