### PR TITLE
fix question answer alignment when text is long

### DIFF
--- a/shared/resources/styles/components/question.scss
+++ b/shared/resources/styles/components/question.scss
@@ -75,6 +75,7 @@
     }
 
     .answer-answer {
+      flex: 1;
       margin-left: $openstax-answer-horizontal-spacing;
     }
 


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/636227/42832858-914db686-89c0-11e8-988b-5d7471021599.png)

after:
![image](https://user-images.githubusercontent.com/636227/42832844-8545bf78-89c0-11e8-9dd7-af53b352f09e.png)
