### PR TITLE
remove exercise style overrides when header changes

### DIFF
--- a/tutor/resources/styles/components/exercises.scss
+++ b/tutor/resources/styles/components/exercises.scss
@@ -21,12 +21,6 @@ $exercise-details-body-height: calc(100vh - 150px);
     margin-left: 450px;
     z-index: 1; // above details forward/back nav when scrolling up
 
-    .pinned-on & {
-      position: fixed;
-      top: 190px;
-      z-index: 10;
-    }
-
     .pinned-shy & {
       top: 130px;
       @include transition('top 0.2s ease-out');
@@ -61,30 +55,6 @@ $exercise-details-body-height: calc(100vh - 150px);
 
   .paging-control {
     .icon.arrow { position: absolute; }
-  }
-
-}
-
-// switch controls to fixed when not scrolling up
-.pinned-view.pinned-on {
-  .paging-control {
-    .icon.arrow { position: fixed; }
-  }
-
-  .exercise-details {
-    .exercise-card {
-      .controls-overlay {
-        height: 100vh;
-        position: fixed;
-        top: 0px;
-        left: calc(50% - 400px);
-      }
-      &.has-interactive {
-        .controls-overlay {
-          left: calc(50% - #{$tutor-interactive-iframe-width/2} );
-        }
-      }
-    }
   }
 
 }

--- a/tutor/resources/styles/mixins/exercise-cards-column-layout.scss
+++ b/tutor/resources/styles/mixins/exercise-cards-column-layout.scss
@@ -1,8 +1,6 @@
 @mixin exercise-cards-column-layout($column-width: 450px) {
-  margin-top: $tutor-panel-padding-vertical * 2;
-
   .exercise-sections {
-    margin-top: $tutor-panel-padding-vertical * 2;
+    padding-top: $tutor-panel-padding-vertical * 2;
   }
 
   .exercises {


### PR DESCRIPTION
@nathanstitt these styles were changing the document height when the navbar pinned, making it possible to be in just the right spot where the nav flashes in and out of it's pinned state.

it didn't seem like these styles were super necessary but if you let me know what they were trying to do i can try to update them to not alter the document height