### PR TITLE
remove ability to delete attachments from exercise

### DIFF
--- a/exercises/specs/components/__snapshots__/exercise.spec.js.snap
+++ b/exercises/specs/components/__snapshots__/exercise.spec.js.snap
@@ -1067,18 +1067,6 @@ exports[`Exercises component renders and matches snapshot 1`] = `
                 className="preview"
                 src="/attachments/1.png"
               />
-              <div
-                className="controls"
-              >
-                <button
-                  className="btn btn-default"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  Delete
-                </button>
-              </div>
               <textarea
                 className="copypaste"
                 readOnly={true}
@@ -1092,18 +1080,6 @@ exports[`Exercises component renders and matches snapshot 1`] = `
                 className="preview"
                 src="/attachments/2.png"
               />
-              <div
-                className="controls"
-              >
-                <button
-                  className="btn btn-default"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  Delete
-                </button>
-              </div>
               <textarea
                 className="copypaste"
                 readOnly={true}
@@ -2525,18 +2501,6 @@ exports[`Exercises component renders with intro and a multiple questions when ex
                 className="preview"
                 src="/attachments/9.png"
               />
-              <div
-                className="controls"
-              >
-                <button
-                  className="btn btn-default"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  Delete
-                </button>
-              </div>
               <textarea
                 className="copypaste"
                 readOnly={true}
@@ -2550,18 +2514,6 @@ exports[`Exercises component renders with intro and a multiple questions when ex
                 className="preview"
                 src="/attachments/10.png"
               />
-              <div
-                className="controls"
-              >
-                <button
-                  className="btn btn-default"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  Delete
-                </button>
-              </div>
               <textarea
                 className="copypaste"
                 readOnly={true}

--- a/exercises/specs/models/exercises.spec.js
+++ b/exercises/specs/models/exercises.spec.js
@@ -17,12 +17,4 @@ describe('Exercises map', () => {
     });
   });
 
-  it('deletes attachments', () => {
-    const exercise = new Exercise(FactoryBot.create('Exercise'));
-    const [ attachment ] = exercise.attachments;
-    expect(exercise.attachments).toContain(attachment);
-    exercise.deleteAttachment(attachment);
-    expect(exercise.attachments).not.toContain(attachment);
-  });
-
 });

--- a/exercises/src/api/index.js
+++ b/exercises/src/api/index.js
@@ -33,13 +33,6 @@ const start = function() {
     onFail: 'onError',
   });
 
-  connectModelUpdate(Exercise, 'deleteAttachment', {
-    method: 'DELETE',
-    pattern: 'exercises/{exerciseId}/attachments',
-    onSuccess: 'onAttachmentDelete',
-    onFail: 'onError',
-  });
-
 };
 
 const CSRF_TOKEN = get(document.head.querySelector('meta[name=csrf-token]'), 'content');

--- a/exercises/src/components/exercise/attachments.jsx
+++ b/exercises/src/components/exercise/attachments.jsx
@@ -10,7 +10,6 @@ function Attachments({ exercise }) {
       {exercise.attachments.map((attachment) =>
         <Attachment
           key={attachment.asset.url}
-          exercise={exercise}
           attachment={attachment}
         />
       )}

--- a/exercises/src/components/exercise/attachments/attachment.jsx
+++ b/exercises/src/components/exercise/attachments/attachment.jsx
@@ -8,40 +8,29 @@ import Exercise from '../../../models/exercises/exercise';
 @observer
 class Attachment extends React.Component {
   static propTypes = {
-    exercise: React.PropTypes.instanceOf(Exercise).isRequired,
     attachment: React.PropTypes.shape({
       asset: React.PropTypes.shape({
         filename: React.PropTypes.string.isRequired,
         url: React.PropTypes.string.isRequired,
         large: React.PropTypes.shape({ url: React.PropTypes.string.isRequired }).isRequired,
         medium: React.PropTypes.shape({ url: React.PropTypes.string.isRequired }).isRequired,
-        small: React.PropTypes.shape({ url: React.PropTypes.string.isRequired }).isRequired
-      }).isRequired
-    }).isRequired
+        small: React.PropTypes.shape({ url: React.PropTypes.string.isRequired }).isRequired,
+      }).isRequired,
+    }).isRequired,
   };
 
-  @action.bound deleteImage() {
-    this.props.exercise.deleteAttachment(this.props.attachment);
-  }
-
   render() {
+    const { attachment } = this.props;
     // large.url will be null on non-image assets (like PDF)
     const url = (
-      this.props.attachment.asset.large != null ?
-        this.props.attachment.asset.large.url : undefined
-    ) || this.props.attachment.asset.url;
+      attachment.asset.large != null ?
+        attachment.asset.large.url : undefined
+    ) || attachment.asset.url;
 
     const copypaste = `<img src="${url}" alt="">`;
     return (
       <div className="attachment with-image">
-        <img className="preview" src={this.props.attachment.asset.url} />
-        <div className="controls">
-          <Button
-            onClick={this.deleteImage}
-          >
-            Delete
-          </Button>
-        </div>
+        <img className="preview" src={attachment.asset.url} />
         <textarea value={copypaste} readOnly={true} className="copypaste" />
       </div>
     );

--- a/exercises/src/models/exercises/exercise.js
+++ b/exercises/src/models/exercises/exercise.js
@@ -11,17 +11,6 @@ export default class Exercise extends SharedExercise {
 
   @session error;
 
-  @action deleteAttachment(attachment) {
-    this.attachments.remove(attachment);
-    return {
-      exerciseId: this.uid,
-      attachmentId: attachment.id,
-      query: { filename: attachment.asset.filename },
-    };
-  }
-
-  @action onAttachmentDelete() {}
-
   @action onError({ message }) {
     this.error = message;
   }


### PR DESCRIPTION
Since attachments are shared between versions, removing an attachment might break links on published versions