### PR TITLE
set highlighter to be inline-block so it wraps math elements

### DIFF
--- a/tutor/resources/styles/components/annotations/annotation.scss
+++ b/tutor/resources/styles/components/annotations/annotation.scss
@@ -2,6 +2,7 @@
   background-color: $tutor-highlight;
   cursor: pointer;
   transition: 0.3s background-color;
+  display: inline-block;
   &.focus {
     background-color: $tutor-neutral-light;
   }


### PR DESCRIPTION
otherwise the highlight looks like this:

![screen shot 2018-08-08 at 5 35 20 pm](https://user-images.githubusercontent.com/79566/43868068-7485ba30-9b31-11e8-9f8f-22c4f96771db.png)