### PR TITLE
use serif font for all exercise content

### DIFF
--- a/tutor/resources/styles/book-content/questions.scss
+++ b/tutor/resources/styles/book-content/questions.scss
@@ -14,6 +14,8 @@
 
   .exercise,
   [data-type=exercise] {
+    @include tutor-serif-font(1.75rem, 190%);
+
     &:not(.unnumbered) {
       > [data-type=problem] {
         > p {


### PR DESCRIPTION
Some exercise content wasn't inside a `p` tag, causing the font to be Helvetica instead of the desired Merriweather.


before:
<img width="839" alt="screen shot 2018-08-16 at 10 35 50 am" src="https://user-images.githubusercontent.com/79566/44219053-ae5b5480-a140-11e8-93a4-bea45066a8f7.png">


after: 
<img width="827" alt="screen shot 2018-08-16 at 10 40 00 am" src="https://user-images.githubusercontent.com/79566/44219074-be733400-a140-11e8-868a-68ff3595bf41.png">
