### PR TITLE
Fix reference book teacher content indicator

### DIFF
--- a/tutor/src/components/book-page.cjsx
+++ b/tutor/src/components/book-page.cjsx
@@ -37,6 +37,9 @@ BookPage = React.createClass
   getSplashTitle: ->
     this.props.ux.page.title
 
+  componentDidMount: ->
+    this.props.ux.checkForTeacherContent()
+
   componentDidUpdate: ->
     this.props.ux.checkForTeacherContent()
 


### PR DESCRIPTION
Previously it wouldn't check for content when it was loaded