### PR TITLE
explicitly set answer choice background to white

### DIFF
--- a/tutor/resources/styles/book-content/questions.scss
+++ b/tutor/resources/styles/book-content/questions.scss
@@ -49,7 +49,9 @@
             }
           }
         }
-
+        .answer-letter {
+          background-color: $openstax-white;
+        }
       }
     }
 


### PR DESCRIPTION
Otherwise FF/Safari inherit the grey font color

before:
<img width="635" alt="screen shot 2018-08-22 at 11 39 20 am" src="https://user-images.githubusercontent.com/79566/44480426-c895a680-a608-11e8-877b-70d6b4c45fd2.png">


After:
<img width="605" alt="screen shot 2018-08-22 at 11 39 06 am" src="https://user-images.githubusercontent.com/79566/44480427-c895a680-a608-11e8-8dfc-4d412673aff6.png">
