### PR TITLE
Display errors when hypothesis server malfunctions

### DIFF
--- a/tutor/resources/styles/components/tutor-dialog.scss
+++ b/tutor/resources/styles/components/tutor-dialog.scss
@@ -2,7 +2,6 @@
 
   .server-error {
     word-break: break-all;
-
     .response {
       max-height: 200px;
       overflow: auto;

--- a/tutor/specs/components/error-monitoring/server-error-message.spec.jsx
+++ b/tutor/specs/components/error-monitoring/server-error-message.spec.jsx
@@ -1,5 +1,4 @@
 import { React } from '../helpers/component-testing';
-
 import ErrorMessage from '../../../src/components/error-monitoring/server-error-message';
 
 
@@ -17,10 +16,16 @@ describe('Error monitoring: server-error message', function() {
     }
   );
 
-  return it('renders for errors with status 500', function() {
+  it('renders for errors with status 500', function() {
     props.status = 500;
     const wrapper = shallow(<ErrorMessage {...props} />);
     expect(wrapper.text()).to.include('500');
-    return undefined;
   });
+
+  it('shows interrupted message', function() {
+    props.status = undefined;
+    const wrapper = shallow(<ErrorMessage {...props} />);
+    expect(wrapper.text()).to.include('It looks like your internet connection was interrupted');
+  });
+
 });

--- a/tutor/src/components/error-monitoring/server-error-message.jsx
+++ b/tutor/src/components/error-monitoring/server-error-message.jsx
@@ -22,7 +22,6 @@ ${reqDetails}.`;
 };
 
 const makeContactURL = function({ status, statusMessage, config }) {
-  if (!status) { status = 0; }
   const location = window.location.href;
   const body = encodeURIComponent(makeContactMessage({ status, statusMessage, config, location }));
   const subject = encodeURIComponent(`OpenStax Tutor Error ${status} at ${location}`);
@@ -33,6 +32,9 @@ const ServerErrorMessage = observer((props) => {
   let dataMessage, debugInfo;
   let { status, statusMessage, config, debug, data } = props;
   if (statusMessage == null) { statusMessage = 'No response was received'; }
+  if (status == null) { status = 0; }
+
+  const noStatusMessage = status ? '' : <h4>It looks like your internet connection was interrupted,<br />please check your connection and retry</h4>;
 
   const errorsMessage = (
     <span>
@@ -65,6 +67,7 @@ const ServerErrorMessage = observer((props) => {
       <h3>
         An error with code {status} has occured
       </h3>
+      {noStatusMessage}
       <p>
         Please <a href={mailTo}>contact us</a> to file a bug report.
       </p>

--- a/tutor/src/components/error-monitoring/server-error-message.jsx
+++ b/tutor/src/components/error-monitoring/server-error-message.jsx
@@ -4,29 +4,27 @@ import UserMenu from '../../models/user/menu';
 
 const SUPPORT_LINK_PARAMS = '&cu=1&fs=ContactUs&q=';
 
-const makeContactMessage = function(status, message, data, request) {
-  if (request == null) { request = { method: 'unknown', url: '' }; }
+const makeContactMessage = function({ status, statusMessage, config, location }) {
   const { userAgent } = window.navigator;
-  const location = window.location.href;
-
-  let errorInfo = `${status} with ${message} for ${request.method} on ${request.url}`;
-
-  if (request.data) {
-    const data = isObject(request.data) ? JSON.stringify(request.data, null, 2) : request.data;
-    errorInfo += ` with\n${data}`;
+  const { data } = config;
+  let reqDetails = `${config.method} on ${config.url} returned status "${status}" with message "${statusMessage}"`;
+  if (data) {
+    reqDetails += `\n\nThe request body was:\n${isObject(data) ? JSON.stringify(data, null, 2) : data}`;
   }
 
   return `Hello!
-I ran into a problem on
-${userAgent} at ${location}.
 
-Here is some additional info:
-${errorInfo}.`;
+I ran into a problem at ${location} while using browser
+${userAgent}.
+
+The request details are:
+${reqDetails}.`;
 };
 
-const makeContactURL = function(supportLinkBase, status, message, data, request) {
+const makeContactURL = function({ status, statusMessage, config }) {
+  if (!status) { status = 0; }
   const location = window.location.href;
-  const body = encodeURIComponent(makeContactMessage(status, message, data, request));
+  const body = encodeURIComponent(makeContactMessage({ status, statusMessage, config, location }));
   const subject = encodeURIComponent(`OpenStax Tutor Error ${status} at ${location}`);
   return `mailto:${UserMenu.supportEmail}?subject=${subject}&body=${body}`;
 };
@@ -60,7 +58,7 @@ const ServerErrorMessage = observer((props) => {
     ];
   }
 
-  const mailTo = makeContactURL(status, statusMessage, data, config);
+  const mailTo = makeContactURL({ status, statusMessage, config });
 
   return (
     <div className="server-error">

--- a/tutor/src/models/annotations/hypothesis.js
+++ b/tutor/src/models/annotations/hypothesis.js
@@ -65,6 +65,8 @@ class Hypothesis extends BaseModel {
           return this.fetchAllAnnotations();
         });
       } else { return this; }
+    }).catch(err => {
+      AppActions.setServerError(err);
     });
   }
 


### PR DESCRIPTION
I'd removed the call to `AppActions.setServerError(err)` in https://github.com/openstax/tutor-js/pull/2224 

Then when I was looking at the error message it had a bunch of `undefined` in it because the vars weren't being passed around correctly.

![screen shot 2018-08-31 at 12 33 05 pm](https://user-images.githubusercontent.com/79566/44927414-12257600-ad1a-11e8-86cf-c20e10e188db.png)


<img width="792" alt="screen shot 2018-08-31 at 11 34 07 am" src="https://user-images.githubusercontent.com/79566/44926533-60854580-ad17-11e8-8194-23471c9d6953.png">

