### PR TITLE
set exercise choice button to white in safari

### DIFF
--- a/shared/resources/styles/mixins/questions.scss
+++ b/shared/resources/styles/mixins/questions.scss
@@ -68,6 +68,7 @@
   color: $openstax-answer-label-color;
   .answer-letter {
     @include answer-bubble();
+    background-color: $openstax-white;
   }
 }
 


### PR DESCRIPTION
Continuation of https://github.com/openstax/tutor-js/pull/2329

before:
![screen shot 2018-09-12 at 4 29 52 pm](https://user-images.githubusercontent.com/79566/45454332-1900a100-b6a9-11e8-8ea0-7753ccb0b3a1.png)



after:
![screen shot 2018-09-12 at 4 28 56 pm](https://user-images.githubusercontent.com/79566/45454306-071efe00-b6a9-11e8-99f5-52a32bb9d9e6.png)
