### PR TITLE
generate audit html files

### DIFF
--- a/jenkins/continuous-delivery.jenkins
+++ b/jenkins/continuous-delivery.jenkins
@@ -12,8 +12,12 @@ pipeline {
             }
             stage('Run Audit') {
               steps {
-                sh 'docker run -v $(pwd):/code -v /code/node_modules openstax/tutor-js:ui-testing node tutor/scripts/accessibility-audit --json=accessibility-report.json'
+                sh '''
+                  docker run -v $(pwd):/code -v /code/node_modules openstax/tutor-js:ui-testing \
+                    node tutor/scripts/accessibility-audit --json=accessibility-report.json --html=audits
+                '''
                 archiveArtifacts artifacts: 'accessibility-report.json', fingerprint: true
+                archiveArtifacts artifacts: 'audits/*.html', fingerprint: true
               }
             }
           }

--- a/tutor/scripts/accessibility-audit/index.js
+++ b/tutor/scripts/accessibility-audit/index.js
@@ -145,7 +145,7 @@ ${tips.map(printAudit).join('\n')}
   if (argv.html) {
     await Promise.all(results.map(({lhr}) => {
       const fileName = path.join(htmlOutDir, new URL(lhr.requestedUrl).pathname.replace(/\//g, '_').replace(/^_/, ''));
-      return write(reportGenerator.generateReportHtml(lhr), 'html', fileName)
+      return write(reportGenerator.generateReportHtml(lhr), 'html', fileName + '.html')
     }));
   }
 }


### PR DESCRIPTION
artifacts like this will be generated on master

https://jenkins-dev.cnx.org:8080/blue/organizations/jenkins/OpenStax%20-%20Continuous%20Integration%2Ftutor-js/detail/PR-2359/2/artifacts/


had to run 
```groovy
System.setProperty("hudson.model.DirectoryBrowserSupport.CSP", "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src *");
```

on jenkins to get it to allow the html content