### PR TITLE
Fix payment_overdue error

### DIFF
--- a/configs/test/jest.config.json
+++ b/configs/test/jest.config.json
@@ -1,6 +1,6 @@
 {
   "verbose": true,
-  "notify": true,
+  "notify": false,
   "collectCoverageFrom": ["**/*.{jsx,js,coffee,cjsx}", "!**/node_modules/**"],
   "coverageDirectory": "../coverage/",
   "coverageReporters": ["json", "lcov", "text-summary"],

--- a/tutor/specs/components/error-monitoring/handlers.spec.jsx
+++ b/tutor/specs/components/error-monitoring/handlers.spec.jsx
@@ -34,14 +34,14 @@ describe('Error monitoring: handlers', () => {
     args.error = {
       status: 500, statusMessage: '500 Error fool!', config: {},
     };
-    const attrs = Handlers.getAttributesForCode('blarg', args);
+    const attrs = Handlers.forError('blarg', args);
     expect(attrs.title).to.include('Server Error');
     const wrapper = shallow(<Wrapper body={attrs.body} />);
     expect(wrapper.find('ServerErrorMessage')).to.have.length(1);
   });
 
   it('renders not started message', function() {
-    const attrs = Handlers.getAttributesForCode('course_not_started', args);
+    const attrs = Handlers.forError('course_not_started', args);
     expect(attrs.title).to.include('Future');
     const wrapper = shallow(<Wrapper body={attrs.body} />);
     expect(wrapper.text()).to.include('not yet started');
@@ -51,7 +51,7 @@ describe('Error monitoring: handlers', () => {
   });
 
   it('renders course ended message', function() {
-    const attrs = Handlers.getAttributesForCode('course_ended', args);
+    const attrs = Handlers.forError('course_ended', args);
     expect(attrs.title).to.include('Past');
     const wrapper = shallow(<Wrapper body={attrs.body} />);
     expect(wrapper.text()).to.include('course ended');
@@ -61,12 +61,16 @@ describe('Error monitoring: handlers', () => {
   });
 
   it('renders exercises not found', function() {
-    const attrs = Handlers.getAttributesForCode('no_exercises', args);
+    const attrs = Handlers.forError('no_exercises', args);
     expect(attrs.title).to.include('No exercises are available');
     const wrapper = shallow(<Wrapper body={attrs.body} />);
     expect(wrapper.text()).to.include('no problems to show');
     attrs.onOk();
     expect(TutorRouter.makePathname).toHaveBeenCalledWith('dashboard', { courseId: COURSE_ID });
     expect(args.context.router.history.push).toHaveBeenCalledWith('/go/to/dash');
+  });
+
+  it('renders nothing for payment_overdue', function() {
+    expect(Handlers.forError('paymend_overdue', args)).to.be.null;
   });
 });

--- a/tutor/specs/components/navbar/index.spec.jsx
+++ b/tutor/specs/components/navbar/index.spec.jsx
@@ -1,12 +1,22 @@
 import Navbar from '../../../src/components/navbar';
+import { Provider } from 'mobx-react';
+import { MemoryRouter as R } from 'react-router-dom';
 import { Wrapper, SnapShot } from '../helpers/component-testing';
 import { bootstrapCoursesList } from '../../courses-test-data';
+import TourContext from '../../../src/models/tour/context';
 jest.mock('../../../src/models/chat');
 
 describe('Main navbar', () => {
   it('renders and matches snapshot', () => {
-    expect(SnapShot.create(
-      <Wrapper _wrapped_component={Navbar.bar} noReference />).toJSON()
+    const tourContext = new TourContext();
+    expect(
+      SnapShot.create(
+        <R>
+          <Provider tourContext={tourContext}>
+            <Navbar.bar />
+          </Provider>
+        </R>
+      ).toJSON()
     ).toMatchSnapshot();
   });
 });

--- a/tutor/specs/components/terms-modal.spec.jsx
+++ b/tutor/specs/components/terms-modal.spec.jsx
@@ -2,6 +2,7 @@ import { Wrapper, SnapShot } from './helpers/component-testing';
 
 import TermsModal from '../../src/components/terms-modal';
 import User from '../../src/models/user';
+import Factory from '../factories';
 import { Term } from '../../src/models/user/terms';
 
 jest.mock('../../src/models/user', () => ({
@@ -14,9 +15,13 @@ jest.mock('../../src/models/user', () => ({
 
 describe('Terms agreement modal', () => {
 
-  it('does not render when there are no terms', () => {
+  it('only renders when there are terms and course', () => {
     const modal = shallow(<TermsModal />);
-    expect(modal.children()).toHaveLength(0);
+    expect(modal.is('Modal')).toBe(false);
+    User.terms_signatures_needed = true;
+    expect(modal.is('Modal')).toBe(false);
+    modal.setProps({ course: Factory.course() });
+    expect(modal.is('Modal')).toBe(true);
   });
 
   it('signs term when agreed', () => {
@@ -27,7 +32,8 @@ describe('Terms agreement modal', () => {
     User.terms.sign = jest.fn();
     User.terms_signatures_needed = true;
     User.unsignedTerms = [ term ];
-    const modal = shallow(<TermsModal />);
+    const course = Factory.course();
+    const modal = shallow(<TermsModal course={course} />);
     modal.find('Button').simulate('click');
     expect(User.terms.sign).toHaveBeenCalled();
   });

--- a/tutor/src/components/enroll.jsx
+++ b/tutor/src/components/enroll.jsx
@@ -13,7 +13,6 @@ import selectPeriod from './enroll/select-periods';
 import droppedStudent from './enroll/dropped-student';
 import courseEnded from './enroll/course-ended';
 import unknownError from './enroll/unknown-error';
-import User from '../models/user';
 
 @observer
 export default class CourseEnroll extends React.PureComponent {

--- a/tutor/src/components/enroll.jsx
+++ b/tutor/src/components/enroll.jsx
@@ -13,6 +13,7 @@ import selectPeriod from './enroll/select-periods';
 import droppedStudent from './enroll/dropped-student';
 import courseEnded from './enroll/course-ended';
 import unknownError from './enroll/unknown-error';
+import User from '../models/user';
 
 @observer
 export default class CourseEnroll extends React.PureComponent {
@@ -47,6 +48,7 @@ export default class CourseEnroll extends React.PureComponent {
 
   render() {
     const { enrollment } = this;
+    if (User.terms_signatures_needed) { return null; }
 
     return (
       <Modal.Dialog

--- a/tutor/src/components/enroll.jsx
+++ b/tutor/src/components/enroll.jsx
@@ -48,7 +48,6 @@ export default class CourseEnroll extends React.PureComponent {
 
   render() {
     const { enrollment } = this;
-    if (User.terms_signatures_needed) { return null; }
 
     return (
       <Modal.Dialog

--- a/tutor/src/components/error-monitoring/handlers.jsx
+++ b/tutor/src/components/error-monitoring/handlers.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { Button } from 'react-bootstrap';
-
-import partial from 'lodash/partial';
-import isEmpty from 'lodash/isEmpty';
-import isObject from 'lodash/isObject';
+import { partial, isString, isObject } from 'lodash';
 
 import Dialog from '../tutor-dialog';
 import TutorRouter from '../../helpers/router';
@@ -152,7 +149,7 @@ const ERROR_HANDLERS = {
   // Payment overdue: don't render the error dialog because we want to display the modal instead
   payment_overdue(error, message, context) {
     return null;
-  }
+  },
 
   // The default error dialog that's displayed when we have no idea what's going on
   default(error, message, context) {

--- a/tutor/src/components/error-monitoring/index.jsx
+++ b/tutor/src/components/error-monitoring/index.jsx
@@ -24,7 +24,9 @@ export default class ServerErrorMonitoring extends React.Component {
     const error = AppStore.getError();
     if (error && !isReloaded()) {
       const dialogAttrs = ErrorHandlers.forError(error, this.context);
-      Dialog.show( dialogAttrs ).then(dialogAttrs.onOk, dialogAttrs.onCancel);
+      if (dialogAttrs) {
+        Dialog.show( dialogAttrs ).then(dialogAttrs.onOk, dialogAttrs.onCancel);
+      }
     }
   }
 

--- a/tutor/src/components/error-monitoring/index.jsx
+++ b/tutor/src/components/error-monitoring/index.jsx
@@ -1,7 +1,6 @@
 import { React, action, observer } from '../../helpers/react';
 import ErrorHandlers from './handlers';
 import { isReloaded } from '../../helpers/reload';
-import fluxToMobx from '../../helpers/flux-to-mobx';
 import { AppStore } from '../../flux/app';
 import Dialog from '../tutor-dialog';
 

--- a/tutor/src/components/navbar/index.jsx
+++ b/tutor/src/components/navbar/index.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { get } from 'lodash';
-import { Provider } from 'mobx-react';
+import { Provider, inject, observer, observable, computed } from '../../helpers/react';
+import CourseNagModal        from '../../components/onboarding/course-nag';
+import TermsModal            from '../../components/terms-modal';
+import Courses               from '../../models/courses-map';
 import Toasts                from 'shared/components/toasts';
 import Router                from '../../helpers/router';
 import TutorLink             from '../link';
@@ -14,31 +17,72 @@ import SupportMenu           from './support-menu';
 import StudentPayNowBtn      from './student-pay-now-btn';
 import PlugableNavBar        from './plugable';
 import NavbarContext         from './context';
+import onboardingForCourse   from '../../models/course/onboarding';
 
-function DefaultNavBar({ params }) {
-  const { courseId } = params;
-  return (
-    <nav className="tutor-top-navbar">
-      <div className="tutor-nav-controls">
-        <div className="left-side-controls">
-          <TutorLink to="myCourses" className="brand" aria-label="dashboard">
-            <i className="ui-brand-logo" />
-          </TutorLink>
-          <BookLinks courseId={courseId} />
+@inject((allStores, props) => ({ tourContext: ( props.tourContext || allStores.tourContext ) }))
+@observer
+class DefaultNavBar extends React.Component {
+
+
+  static propTypes = {
+    params: React.PropTypes.shape({
+      courseId: React.PropTypes.string,
+    }).isRequired,
+    tourContext: React.PropTypes.object,
+  }
+
+  @observable courseOnboarding;
+
+  componentWillMount() {
+    if (!this.course) { return; }
+    this.courseOnboarding = onboardingForCourse(this.course, this.props.tourContext);
+    this.courseOnboarding.mount();
+  }
+
+  @computed get course() {
+    const { params: { courseId } } = this.props;
+    return courseId ? Courses.get(courseId) : null;
+  }
+
+  componentDidUpdate() {
+    if (this.courseOnboarding) {
+      this.courseOnboarding.course = this.course;
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.courseOnboarding) { this.courseOnboarding.close(); } // courseOnboarding will tell context it's ok to display tours
+  }
+
+  render() {
+    const { params, params: { courseId } } = this.props;
+
+    return (
+      <nav className="tutor-top-navbar">
+        <div className="tutor-nav-controls">
+          <div className="left-side-controls">
+            <TutorLink to="myCourses" className="brand" aria-label="dashboard">
+              <i className="ui-brand-logo" />
+            </TutorLink>
+            <BookLinks courseId={courseId} />
+          </div>
+          <CenterControls params={params} />
+          <div className="right-side-controls">
+            <SupportMenu         courseId={courseId} />
+            <StudentPayNowBtn    courseId={courseId} />
+            <ActionsMenu         courseId={courseId} />
+            <PreviewAddCourseBtn courseId={courseId} />
+            <UserMenu />
+          </div>
         </div>
-        <CenterControls params={params} />
-        <div className="right-side-controls">
-          <SupportMenu         courseId={courseId} />
-          <StudentPayNowBtn    courseId={courseId} />
-          <ActionsMenu         courseId={courseId} />
-          <PreviewAddCourseBtn courseId={courseId} />
-          <UserMenu />
-        </div>
-      </div>
-      <ServerErrorMonitoring />
-      <Toasts />
-    </nav>
-  );
+        <ServerErrorMonitoring />
+        <TermsModal />
+        <Toasts />
+        <CourseNagModal ux={this.courseOnboarding} />
+      </nav>
+    );
+  }
+
 }
 
 const NavBarTypes = {

--- a/tutor/src/components/terms-modal.jsx
+++ b/tutor/src/components/terms-modal.jsx
@@ -5,11 +5,16 @@ import { Modal, Button } from 'react-bootstrap';
 import classnames from 'classnames';
 import Branding from './branding/course';
 import User from '../models/user';
+import Course from '../models/course';
 import { map } from 'lodash';
 import String from '../helpers/string';
 
 @observer
 export default class TermsModal extends React.PureComponent {
+
+  static propTypes = {
+    course: React.PropTypes.instanceOf(Course), // is NOT required
+  }
 
   @computed get title() {
     return String.toSentence(map(User.unsignedTerms, 'title'));
@@ -20,7 +25,8 @@ export default class TermsModal extends React.PureComponent {
   }
 
   render() {
-    if (!User.terms_signatures_needed) { return null; }
+    // for terms to be displayed the user must need them signed and be in a course
+    if (!User.terms_signatures_needed || !this.props.course) { return null; }
 
     const className = classnames('user-terms', { 'is-loading': User.terms.api.isPending });
 

--- a/tutor/src/components/terms-modal.jsx
+++ b/tutor/src/components/terms-modal.jsx
@@ -11,10 +11,6 @@ import String from '../helpers/string';
 @observer
 export default class TermsModal extends React.PureComponent {
 
-  static propTypes = {
-    ux: MobxPropTypes.observableObject,
-  }
-
   @computed get title() {
     return String.toSentence(map(User.unsignedTerms, 'title'));
   }

--- a/tutor/src/helpers/react.js
+++ b/tutor/src/helpers/react.js
@@ -5,4 +5,4 @@ import { propTypes as mobxPropTypes } from 'mobx-react';
 
 export { React, cn, ReactDOM, mobxPropTypes };
 export { observable, action, computed } from 'mobx';
-export { observer, inject } from 'mobx-react';
+export { observer, inject, Provider } from 'mobx-react';

--- a/tutor/src/models/course/enroll.js
+++ b/tutor/src/models/course/enroll.js
@@ -1,15 +1,13 @@
 import React from 'react';
 import {
-  BaseModel, identifiedBy, field, identifier, computed, session, belongsTo,
+  BaseModel, identifiedBy, field, identifier, computed, session,
 } from 'shared/model';
 import { action, when, observable } from 'mobx';
 import { get, pick, isEmpty } from 'lodash';
 import { Redirect } from 'react-router-dom';
 import S from '../../helpers/string';
 import Router from '../../../src/helpers/router';
-import User from '../user';
-import StudentTasks from '../student-tasks';
-import Courses, { CoursesMap } from '../courses-map';
+import Courses from '../courses-map';
 import Activity from '../../../src/components/ox-fancy-loader';
 
 import Enroll from '../../../src/components/enroll';

--- a/tutor/src/screens/student-dashboard/index.jsx
+++ b/tutor/src/screens/student-dashboard/index.jsx
@@ -3,8 +3,7 @@ import React from 'react';
 import { observable, computed, action, observe } from 'mobx';
 import { observer, inject, Provider } from 'mobx-react';
 import StudentDashboard from './dashboard';
-import CourseNagModal from '../../components/onboarding/course-nag';
-import TermsModal from '../../components/terms-modal';
+
 import onboardingForCourse from '../../models/course/onboarding';
 import Courses from '../../models/courses-map';
 import WarningModal from '../../components/warning-modal';
@@ -55,14 +54,9 @@ export default class StudentDashboardShell extends React.PureComponent {
 
     const { params, params: { courseId } } = this.props;
 
-    // if student is past due BE will raise "forbidden" if we load the dashboard data
-    if (this.ux.paymentIsPastDue) { return <CourseNagModal ux={this.ux} />; }
-
     return (
       <Provider studentDashboardUX={this.ux}>
         <div className="student-dashboard ">
-          <TermsModal />
-          <CourseNagModal ux={this.ux} />
           <StudentDashboard params={params} courseId={courseId} />
         </div>
       </Provider>


### PR DESCRIPTION
This change: 
 - Prevent error modal from showing for payment_overdue errors
 - Will force the "Terms and Conditions" and  "You Must Pay Now!" modals to show anywhere the user in in a course, even if they bypass the dashboard by using an assignment link
