### PR TITLE
Adjust styles for enrollment spinners

### DIFF
--- a/tutor/resources/styles/components/ox-fancy-loader.scss
+++ b/tutor/resources/styles/components/ox-fancy-loader.scss
@@ -10,26 +10,24 @@
     display: flex;
     align-items: center;
     height: 100%;
-
-    .ox-loader--inner {
-      padding-bottom: 7rem;
-    }
   }
 }
 
 .ox-loader {
   .message {
     text-align: center;
+    font-weight: bold;
+    font-size: 2rem;
   }
   .ox-loader--inner {
     margin: auto;
-
+    padding: 5rem;
     svg {
       display: block;
       height: 100%;
       margin: 0 auto;
       position: relative;
-      padding: 3rem;
+      padding-top: 2rem;
       max-width: 200px;
       .ox-green,
       .ox-orange,

--- a/tutor/resources/styles/components/ox-fancy-loader.scss
+++ b/tutor/resources/styles/components/ox-fancy-loader.scss
@@ -23,14 +23,14 @@
   }
   .ox-loader--inner {
     margin: auto;
-    width: 25%;
 
     svg {
       display: block;
       height: 100%;
       margin: 0 auto;
       position: relative;
-      padding-top: 5px;
+      padding: 3rem;
+      max-width: 200px;
       .ox-green,
       .ox-orange,
       .ox-gray,

--- a/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
+++ b/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
@@ -82,7 +82,7 @@ exports[`Student Dashboard displays as loading 1`] = `
           role="tabpanel"
         >
           <div
-            className="empty panel panel-default"
+            className="empty pending panel panel-default"
             id={undefined}
           >
             <div
@@ -97,7 +97,7 @@ exports[`Student Dashboard displays as loading 1`] = `
             </div>
           </div>
           <div
-            className="empty panel panel-default"
+            className="empty pending upcoming panel panel-default"
             id={undefined}
           >
             <div
@@ -234,7 +234,7 @@ exports[`Student Dashboard matches snapshot 1`] = `
             </div>
           </div>
           <div
-            className="-upcoming panel panel-default"
+            className="upcoming panel panel-default"
             id={undefined}
           >
             <div

--- a/tutor/src/screens/student-dashboard/empty-panel.jsx
+++ b/tutor/src/screens/student-dashboard/empty-panel.jsx
@@ -1,19 +1,17 @@
-import React from 'react';
-import { observer, inject } from 'mobx-react';
+import { React, cn, observer, inject } from '../../helpers/react';
 import { Panel } from 'react-bootstrap';
-import moment from 'moment';
-import StudentTasks from '../../models/student-tasks';
 import Icon from '../../components/icon';
 
 const EmptyPanel = inject('studentDashboardUX')(observer(({
   studentDashboardUX,
   message,
   title,
+  className,
 }) => {
 
   if (studentDashboardUX && studentDashboardUX.isPendingTaskLoading) {
     return (
-      <Panel className="empty" header={title}>
+      <Panel className={cn('empty', 'pending', className)} header={title}>
         <Icon type="spinner" spin /> Preparing assignments for your course.  This
         can take up to 10 minutes.
       </Panel>
@@ -21,7 +19,7 @@ const EmptyPanel = inject('studentDashboardUX')(observer(({
   }
 
   return (
-    <Panel className="empty" header={title}>
+    <Panel className={cn('empty', className)} header={title}>
       {message}
     </Panel>
   );

--- a/tutor/src/screens/student-dashboard/styles/empty-panel.scss
+++ b/tutor/src/screens/student-dashboard/styles/empty-panel.scss
@@ -1,7 +1,14 @@
 .student-dashboard {
-  .panel.empty .panel-body {
-    padding: 20px;
-    text-align: center;
+  .panel.empty {
+    .panel-body {
+      padding: 20px;
+      text-align: center;
+    }
+    &.pending {
+      margin-top: 5rem;
+      &.upcoming {
+        display: none;
+      }
+    }
   }
 }
-

--- a/tutor/src/screens/student-dashboard/upcoming-panel.jsx
+++ b/tutor/src/screens/student-dashboard/upcoming-panel.jsx
@@ -26,12 +26,12 @@ export default class UpcomingPanel extends React.PureComponent {
     const events  = tasks ? tasks.upcomingEvents(startAt.toDate()) : [];
 
     if (studentDashboardUX.isPendingTaskLoading || isEmpty(events)) {
-      return <EmptyPanel courseId={courseId} message='No upcoming assignments' />;
+      return <EmptyPanel className="upcoming" courseId={courseId} message='No upcoming assignments' />;
     }
 
     return (
       <EventsPanel
-        className="-upcoming"
+        className="upcoming"
         onTaskClick={this.onTaskClick}
         courseId={courseId}
         isCollege={this.props.isCollege}


### PR DESCRIPTION
* add top margin to the main staxly spinner
* hide "upcoming" panel when waiting for assignments
* add some additional margin to the top of the first panel

![screen shot 2018-09-27 at 12 13 21 pm](https://user-images.githubusercontent.com/79566/46163229-33617f80-c250-11e8-9e55-b63a9c69f8a4.png)
![screen shot 2018-09-27 at 11 59 02 am](https://user-images.githubusercontent.com/79566/46163230-33617f80-c250-11e8-90bc-1c3648448463.png)
