### PR TITLE
set "uid" to be the default search

### DIFF
--- a/exercises/src/models/search.js
+++ b/exercises/src/models/search.js
@@ -10,7 +10,7 @@ import Exercise from 'shared/model/exercise';
 @identifiedBy('search/clause')
 class Clause extends BaseModel {
 
-  @observable filter = 'id';
+  @observable filter = 'uid';
   @observable value = '';
   @belongsTo({ model: 'search' }) search;
 


### PR DESCRIPTION
The property is only updated when search options change,
meaning the default will be used for a query that's performed without
modifiying the options