### PR TITLE
display a loading spinner while student dashboard fetches tasks

### DIFF
--- a/tutor/specs/screens/student-dashboard/empty-panel.spec.js
+++ b/tutor/specs/screens/student-dashboard/empty-panel.spec.js
@@ -1,0 +1,43 @@
+import EmptyPanel from '../../../src/screens/student-dashboard/empty-panel';
+import { observable as mockObservable } from 'mobx';
+import { Testing, _, React } from '../../components/helpers/component-testing';
+import Factory from '../../factories';
+
+jest.mock('../../../src/models/student-tasks', () => ({
+  forCourse() {
+    return mockObservable({
+      isPendingTaskLoading: false,
+      api: {
+        isPending: false,
+      },
+    });
+  },
+}));
+
+
+describe('Empty Panel', () => {
+
+  let props;
+
+  beforeEach(() => {
+
+    props = {
+      message: 'Yes, I be empty',
+      title: 'upcoming',
+      className: 'updog',
+      course: Factory.course(),
+    };
+  });
+
+
+  it('shows the various states', () => {
+    const panel = mount(<EmptyPanel {...props} />);
+    expect(panel.text()).toContain('I be empty');
+    props.course.studentTasks.api.isPending = true;
+    expect(panel.text()).toContain('Fetching assignments for your course');
+    expect(panel.text()).not.toContain('This can take up to 10 minutes');
+    props.course.studentTasks.isPendingTaskLoading = true;
+    expect(panel.text()).toContain('This can take up to 10 minutes');
+  });
+
+});

--- a/tutor/src/screens/student-dashboard/empty-panel.jsx
+++ b/tutor/src/screens/student-dashboard/empty-panel.jsx
@@ -19,6 +19,13 @@ const EmptyPanel = observer(({
       </Panel>
     );
   }
+  if (studentTasks.api.isPending) {
+    return (
+      <Panel className={cn('empty', 'pending', className)} header={title}>
+        <Icon type="spinner" spin /> Fetching assignments for your course.
+      </Panel>
+    );
+  }
 
   return (
     <Panel className={cn('empty', className)} header={title}>

--- a/tutor/src/screens/student-dashboard/this-week-panel.jsx
+++ b/tutor/src/screens/student-dashboard/this-week-panel.jsx
@@ -18,6 +18,7 @@ export default class ThisWeekPanel extends React.PureComponent {
 
     const startAt = moment(TimeStore.getNow()).startOf('isoweek');
     const events = studentTasks.weeklyEventsForDay(startAt);
+
     if (studentTasks.isPendingTaskLoading || !events.length) {
       return <EmptyPanel course={course} message='No assignments this week' />;
     }


### PR DESCRIPTION
Otherwise it says "empty" and then shows

![screen shot 2018-10-08 at 4 31 14 pm](https://user-images.githubusercontent.com/79566/46634800-b79ce800-cb17-11e8-9efd-6c544aff6ec6.png)
