### PR TITLE
remove notice about roster split

### DIFF
--- a/tutor/specs/models/course.spec.js
+++ b/tutor/specs/models/course.spec.js
@@ -56,8 +56,6 @@ describe('Course Model', () => {
     UiSettings.get = jest.fn(() => 2);
     teacher.just_created = false;
     expect(teacher.tourAudienceTags).toEqual(['teacher']);
-    teacher.primaryRole.joined_at = new Date();
-    expect(teacher.tourAudienceTags).toEqual(['teacher', 'teacher-settings-roster-split']);
     teacher.is_preview = true;
     expect(teacher.tourAudienceTags).toEqual(['teacher-preview']);
     const course = Courses.get(3);

--- a/tutor/src/models/course.js
+++ b/tutor/src/models/course.js
@@ -219,9 +219,6 @@ export default class Course extends BaseModel {
     if (this.isTeacher) {
       tags.push(this.is_preview ? 'teacher-preview' : 'teacher');
       if (!this.is_preview) {
-        if (this.notifyAboutRosterSplit) {
-          tags.push('teacher-settings-roster-split');
-        }
         if (this.taskPlans.reading.hasPublishing) {
           tags.push('teacher-reading-published');
         }
@@ -236,16 +233,6 @@ export default class Course extends BaseModel {
 
     if (this.isStudent) { tags.push('student'); }
     return tags;
-  }
-
-  // remove after 2018 spring semester
-  @computed get notifyAboutRosterSplit() {
-    return Boolean(
-      !this.is_preview &&
-      this.primaryRole.joinedAgo('days') <= 7 &&
-      find(this.map.nonPreview.teaching.array,
-           c => c != this && c.isBeforeTerm('winter', 2017))
-    );
   }
 
   isBeforeTerm(term, year) {

--- a/tutor/src/screens/teacher-dashboard/month.jsx
+++ b/tutor/src/screens/teacher-dashboard/month.jsx
@@ -302,8 +302,7 @@ class CourseMonth extends React.Component {
         className={calendarClassName}
         id="teacher-calendar"
         otherTours={[
-          'teacher-calendar-super', 'reading-published', 'homework-published',
-          'teacher-settings-roster-split', 'new-enrollment-link',
+          'teacher-calendar-super', 'reading-published', 'homework-published', 'new-enrollment-link',
         ]}
         courseId={course.id}>
         <AddAssignment

--- a/tutor/src/tours/teacher-calendar.json
+++ b/tutor/src/tours/teacher-calendar.json
@@ -109,21 +109,4 @@
       }
     }
   ]
-}, {
-  "id": "teacher-settings-roster-split",
-  "autoplay": true,
-  "standalone": true,
-  "audience_tags": [
-    "teacher-settings-roster-split"
-  ],
-  "steps": [{
-    "title": "Student enrollment links have moved",
-    "body": "You can now find student enrollment links and other course info in Course Settings.",
-    "anchor_id": "menu-option-courseSettings",
-    "position": "left",
-    "is_fixed": true,
-    "action": {
-      "id": "open-actions-menu"
-    }
-  }]
 }]


### PR DESCRIPTION
It's well past sprint 2018, shoulda removed it awhile ago

