### PR TITLE
add left margin when image is last

### DIFF
--- a/tutor/resources/styles/mixins/figures.scss
+++ b/tutor/resources/styles/mixins/figures.scss
@@ -1,4 +1,5 @@
 @mixin tutor-figure() {
+  $vertical-image-margin: 1rem;
   figure {
     display: flex;
     flex-wrap: wrap;
@@ -9,10 +10,11 @@
     }
 
     &.tutor-ui-vertical-img {
-      margin-right: 30px;
-      width: calc(50% - 30px);
+      margin-right: $vertical-image-margin;
+      width: calc(50% - #{$vertical-image-margin});
       float: left;
       & + .tutor-ui-vertical-img {
+        margin-left: $vertical-image-margin;
         margin-right: 0;
       }
     }


### PR DESCRIPTION
This way they add up to 100% and will fill the content, preventing small words
from appearing on the side

Before:
![screen shot 2018-10-09 at 2 22 46 pm](https://user-images.githubusercontent.com/79566/46693219-ceeadc80-cbce-11e8-8e55-3d8daa3d9a10.png)


After:
![screen shot 2018-10-09 at 2 22 13 pm](https://user-images.githubusercontent.com/79566/46693226-d6aa8100-cbce-11e8-9ee4-ddaa77ec807c.png)

