### PR TITLE
update store data by calling loaded on flux base methods

### DIFF
--- a/tutor/src/flux/task.coffee
+++ b/tutor/src/flux/task.coffee
@@ -109,7 +109,7 @@ TaskConfig =
 
   stepCompleted: (obj, taskStepId) ->
     TaskStepActions.completed(obj, taskStepId)
-    this._loaded(obj, obj.id)
+    this.loaded(obj, obj.id)
     @emit('step.completed', taskStepId, obj.id)
 
   exports:


### PR DESCRIPTION
Otherwise it just updated the steps and didn't update the "feedback_available" property