### PR TITLE
RC fixes

### DIFF
--- a/exercises/specs/components/__snapshots__/exercise.spec.js.snap
+++ b/exercises/specs/components/__snapshots__/exercise.spec.js.snap
@@ -1163,6 +1163,7 @@ exports[`Exercises component renders and matches snapshot 1`] = `
                 className="openstax-answer"
               >
                 <section
+                  aria-label="Choice a:"
                   className="answers-answer disabled"
                   role="region"
                 >
@@ -1172,7 +1173,6 @@ exports[`Exercises component renders and matches snapshot 1`] = `
                     onKeyPress={[Function]}
                   >
                     <button
-                      aria-label="Choice a:"
                       className="answer-letter"
                       disabled={true}
                       onClick={undefined}
@@ -1211,6 +1211,7 @@ exports[`Exercises component renders and matches snapshot 1`] = `
                 className="openstax-answer"
               >
                 <section
+                  aria-label="Choice b:"
                   className="answers-answer disabled"
                   role="region"
                 >
@@ -1220,7 +1221,6 @@ exports[`Exercises component renders and matches snapshot 1`] = `
                     onKeyPress={[Function]}
                   >
                     <button
-                      aria-label="Choice b:"
                       className="answer-letter"
                       disabled={true}
                       onClick={undefined}
@@ -1259,6 +1259,7 @@ exports[`Exercises component renders and matches snapshot 1`] = `
                 className="openstax-answer"
               >
                 <section
+                  aria-label="Choice c:"
                   className="answers-answer disabled"
                   role="region"
                 >
@@ -1268,7 +1269,6 @@ exports[`Exercises component renders and matches snapshot 1`] = `
                     onKeyPress={[Function]}
                   >
                     <button
-                      aria-label="Choice c:"
                       className="answer-letter"
                       disabled={true}
                       onClick={undefined}
@@ -1307,6 +1307,7 @@ exports[`Exercises component renders and matches snapshot 1`] = `
                 className="openstax-answer"
               >
                 <section
+                  aria-label="Choice d:"
                   className="answers-answer disabled"
                   role="region"
                 >
@@ -1316,7 +1317,6 @@ exports[`Exercises component renders and matches snapshot 1`] = `
                     onKeyPress={[Function]}
                   >
                     <button
-                      aria-label="Choice d:"
                       className="answer-letter"
                       disabled={true}
                       onClick={undefined}
@@ -1355,6 +1355,7 @@ exports[`Exercises component renders and matches snapshot 1`] = `
                 className="openstax-answer"
               >
                 <section
+                  aria-label="Choice e:"
                   className="answers-answer disabled"
                   role="region"
                 >
@@ -1364,7 +1365,6 @@ exports[`Exercises component renders and matches snapshot 1`] = `
                     onKeyPress={[Function]}
                   >
                     <button
-                      aria-label="Choice e:"
                       className="answer-letter"
                       disabled={true}
                       onClick={undefined}
@@ -2641,6 +2641,7 @@ exports[`Exercises component renders with intro and a multiple questions when ex
                 className="openstax-answer"
               >
                 <section
+                  aria-label="Choice a:"
                   className="answers-answer disabled"
                   role="region"
                 >
@@ -2650,7 +2651,6 @@ exports[`Exercises component renders with intro and a multiple questions when ex
                     onKeyPress={[Function]}
                   >
                     <button
-                      aria-label="Choice a:"
                       className="answer-letter"
                       disabled={true}
                       onClick={undefined}
@@ -2684,6 +2684,7 @@ exports[`Exercises component renders with intro and a multiple questions when ex
                 className="openstax-answer"
               >
                 <section
+                  aria-label="Choice b:"
                   className="answers-answer disabled"
                   role="region"
                 >
@@ -2693,7 +2694,6 @@ exports[`Exercises component renders with intro and a multiple questions when ex
                     onKeyPress={[Function]}
                   >
                     <button
-                      aria-label="Choice b:"
                       className="answer-letter"
                       disabled={true}
                       onClick={undefined}
@@ -2727,6 +2727,7 @@ exports[`Exercises component renders with intro and a multiple questions when ex
                 className="openstax-answer"
               >
                 <section
+                  aria-label="Choice c:"
                   className="answers-answer disabled"
                   role="region"
                 >
@@ -2736,7 +2737,6 @@ exports[`Exercises component renders with intro and a multiple questions when ex
                     onKeyPress={[Function]}
                   >
                     <button
-                      aria-label="Choice c:"
                       className="answer-letter"
                       disabled={true}
                       onClick={undefined}
@@ -2770,6 +2770,7 @@ exports[`Exercises component renders with intro and a multiple questions when ex
                 className="openstax-answer"
               >
                 <section
+                  aria-label="Choice d:"
                   className="answers-answer disabled"
                   role="region"
                 >
@@ -2779,7 +2780,6 @@ exports[`Exercises component renders with intro and a multiple questions when ex
                     onKeyPress={[Function]}
                   >
                     <button
-                      aria-label="Choice d:"
                       className="answer-letter"
                       disabled={true}
                       onClick={undefined}
@@ -2813,6 +2813,7 @@ exports[`Exercises component renders with intro and a multiple questions when ex
                 className="openstax-answer"
               >
                 <section
+                  aria-label="Choice e:"
                   className="answers-answer disabled"
                   role="region"
                 >
@@ -2822,7 +2823,6 @@ exports[`Exercises component renders with intro and a multiple questions when ex
                     onKeyPress={[Function]}
                   >
                     <button
-                      aria-label="Choice e:"
                       className="answer-letter"
                       disabled={true}
                       onClick={undefined}

--- a/shared/specs/components/exercise-preview/__snapshots__/index.spec.js.snap
+++ b/shared/specs/components/exercise-preview/__snapshots__/index.spec.js.snap
@@ -48,6 +48,7 @@ exports[`Exercise Preview Component callbacks are called when overlay and action
             className="openstax-answer"
           >
             <section
+              aria-label="Choice a:"
               className="answers-answer disabled"
               role="region"
             >
@@ -57,7 +58,6 @@ exports[`Exercise Preview Component callbacks are called when overlay and action
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice a:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -82,6 +82,7 @@ exports[`Exercise Preview Component callbacks are called when overlay and action
             className="openstax-answer"
           >
             <section
+              aria-label="Choice b:"
               className="answers-answer disabled"
               role="region"
             >
@@ -91,7 +92,6 @@ exports[`Exercise Preview Component callbacks are called when overlay and action
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice b:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -116,6 +116,7 @@ exports[`Exercise Preview Component callbacks are called when overlay and action
             className="openstax-answer"
           >
             <section
+              aria-label="Choice c:"
               className="answers-answer disabled"
               role="region"
             >
@@ -125,7 +126,6 @@ exports[`Exercise Preview Component callbacks are called when overlay and action
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice c:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -150,6 +150,7 @@ exports[`Exercise Preview Component callbacks are called when overlay and action
             className="openstax-answer"
           >
             <section
+              aria-label="Choice d:"
               className="answers-answer disabled"
               role="region"
             >
@@ -159,7 +160,6 @@ exports[`Exercise Preview Component callbacks are called when overlay and action
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice d:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -184,6 +184,7 @@ exports[`Exercise Preview Component callbacks are called when overlay and action
             className="openstax-answer"
           >
             <section
+              aria-label="Choice e:"
               className="answers-answer disabled"
               role="region"
             >
@@ -193,7 +194,6 @@ exports[`Exercise Preview Component callbacks are called when overlay and action
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice e:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -363,6 +363,7 @@ exports[`Exercise Preview Component can render question formats 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice a:"
               className="answers-answer disabled"
               role="region"
             >
@@ -372,7 +373,6 @@ exports[`Exercise Preview Component can render question formats 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice a:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -397,6 +397,7 @@ exports[`Exercise Preview Component can render question formats 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice b:"
               className="answers-answer disabled"
               role="region"
             >
@@ -406,7 +407,6 @@ exports[`Exercise Preview Component can render question formats 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice b:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -431,6 +431,7 @@ exports[`Exercise Preview Component can render question formats 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice c:"
               className="answers-answer disabled"
               role="region"
             >
@@ -440,7 +441,6 @@ exports[`Exercise Preview Component can render question formats 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice c:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -465,6 +465,7 @@ exports[`Exercise Preview Component can render question formats 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice d:"
               className="answers-answer disabled"
               role="region"
             >
@@ -474,7 +475,6 @@ exports[`Exercise Preview Component can render question formats 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice d:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -499,6 +499,7 @@ exports[`Exercise Preview Component can render question formats 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice e:"
               className="answers-answer disabled"
               role="region"
             >
@@ -508,7 +509,6 @@ exports[`Exercise Preview Component can render question formats 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice e:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -634,6 +634,7 @@ exports[`Exercise Preview Component hides context if missing 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice a:"
               className="answers-answer disabled"
               role="region"
             >
@@ -643,7 +644,6 @@ exports[`Exercise Preview Component hides context if missing 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice a:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -668,6 +668,7 @@ exports[`Exercise Preview Component hides context if missing 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice b:"
               className="answers-answer disabled"
               role="region"
             >
@@ -677,7 +678,6 @@ exports[`Exercise Preview Component hides context if missing 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice b:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -702,6 +702,7 @@ exports[`Exercise Preview Component hides context if missing 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice c:"
               className="answers-answer disabled"
               role="region"
             >
@@ -711,7 +712,6 @@ exports[`Exercise Preview Component hides context if missing 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice c:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -736,6 +736,7 @@ exports[`Exercise Preview Component hides context if missing 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice d:"
               className="answers-answer disabled"
               role="region"
             >
@@ -745,7 +746,6 @@ exports[`Exercise Preview Component hides context if missing 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice d:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -770,6 +770,7 @@ exports[`Exercise Preview Component hides context if missing 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice e:"
               className="answers-answer disabled"
               role="region"
             >
@@ -779,7 +780,6 @@ exports[`Exercise Preview Component hides context if missing 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice e:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -883,6 +883,7 @@ exports[`Exercise Preview Component limits tags 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice a:"
               className="answers-answer disabled"
               role="region"
             >
@@ -892,7 +893,6 @@ exports[`Exercise Preview Component limits tags 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice a:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -917,6 +917,7 @@ exports[`Exercise Preview Component limits tags 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice b:"
               className="answers-answer disabled"
               role="region"
             >
@@ -926,7 +927,6 @@ exports[`Exercise Preview Component limits tags 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice b:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -951,6 +951,7 @@ exports[`Exercise Preview Component limits tags 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice c:"
               className="answers-answer disabled"
               role="region"
             >
@@ -960,7 +961,6 @@ exports[`Exercise Preview Component limits tags 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice c:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -985,6 +985,7 @@ exports[`Exercise Preview Component limits tags 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice d:"
               className="answers-answer disabled"
               role="region"
             >
@@ -994,7 +995,6 @@ exports[`Exercise Preview Component limits tags 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice d:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -1019,6 +1019,7 @@ exports[`Exercise Preview Component limits tags 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice e:"
               className="answers-answer disabled"
               role="region"
             >
@@ -1028,7 +1029,6 @@ exports[`Exercise Preview Component limits tags 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice e:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -1162,6 +1162,7 @@ exports[`Exercise Preview Component renders and matches snapshot 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice a:"
               className="answers-answer disabled"
               role="region"
             >
@@ -1171,7 +1172,6 @@ exports[`Exercise Preview Component renders and matches snapshot 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice a:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -1201,6 +1201,7 @@ exports[`Exercise Preview Component renders and matches snapshot 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice b:"
               className="answers-answer disabled"
               role="region"
             >
@@ -1210,7 +1211,6 @@ exports[`Exercise Preview Component renders and matches snapshot 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice b:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -1240,6 +1240,7 @@ exports[`Exercise Preview Component renders and matches snapshot 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice c:"
               className="answers-answer disabled"
               role="region"
             >
@@ -1249,7 +1250,6 @@ exports[`Exercise Preview Component renders and matches snapshot 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice c:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -1279,6 +1279,7 @@ exports[`Exercise Preview Component renders and matches snapshot 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice d:"
               className="answers-answer disabled"
               role="region"
             >
@@ -1288,7 +1289,6 @@ exports[`Exercise Preview Component renders and matches snapshot 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice d:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -1318,6 +1318,7 @@ exports[`Exercise Preview Component renders and matches snapshot 1`] = `
             className="openstax-answer"
           >
             <section
+              aria-label="Choice e:"
               className="answers-answer disabled"
               role="region"
             >
@@ -1327,7 +1328,6 @@ exports[`Exercise Preview Component renders and matches snapshot 1`] = `
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice e:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -1436,6 +1436,7 @@ exports[`Exercise Preview Component sets the className when displaying feedback 
             className="openstax-answer"
           >
             <section
+              aria-label="Choice a:"
               className="answers-answer disabled"
               role="region"
             >
@@ -1445,7 +1446,6 @@ exports[`Exercise Preview Component sets the className when displaying feedback 
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice a:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -1479,6 +1479,7 @@ exports[`Exercise Preview Component sets the className when displaying feedback 
             className="openstax-answer"
           >
             <section
+              aria-label="Choice b:"
               className="answers-answer disabled"
               role="region"
             >
@@ -1488,7 +1489,6 @@ exports[`Exercise Preview Component sets the className when displaying feedback 
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice b:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -1522,6 +1522,7 @@ exports[`Exercise Preview Component sets the className when displaying feedback 
             className="openstax-answer"
           >
             <section
+              aria-label="Choice c:"
               className="answers-answer disabled"
               role="region"
             >
@@ -1531,7 +1532,6 @@ exports[`Exercise Preview Component sets the className when displaying feedback 
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice c:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -1565,6 +1565,7 @@ exports[`Exercise Preview Component sets the className when displaying feedback 
             className="openstax-answer"
           >
             <section
+              aria-label="Choice d:"
               className="answers-answer disabled"
               role="region"
             >
@@ -1574,7 +1575,6 @@ exports[`Exercise Preview Component sets the className when displaying feedback 
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice d:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}
@@ -1608,6 +1608,7 @@ exports[`Exercise Preview Component sets the className when displaying feedback 
             className="openstax-answer"
           >
             <section
+              aria-label="Choice e:"
               className="answers-answer disabled"
               role="region"
             >
@@ -1617,7 +1618,6 @@ exports[`Exercise Preview Component sets the className when displaying feedback 
                 onKeyPress={[Function]}
               >
                 <button
-                  aria-label="Choice e:"
                   className="answer-letter"
                   disabled={true}
                   onClick={undefined}

--- a/shared/specs/components/question/__snapshots__/answer.spec.js.snap
+++ b/shared/specs/components/question/__snapshots__/answer.spec.js.snap
@@ -5,6 +5,7 @@ exports[`Answer Component renders answer 1`] = `
   className="openstax-answer"
 >
   <section
+    aria-label="Choice b:"
     className="answers-answer"
     role="region"
   >
@@ -23,7 +24,6 @@ exports[`Answer Component renders answer 1`] = `
       onKeyPress={[Function]}
     >
       <button
-        aria-label="Choice b:"
         className="answer-letter"
         disabled={false}
         onClick={[Function]}
@@ -57,6 +57,7 @@ exports[`Answer Component renders answer feedback based on props 1`] = `
   className="openstax-answer"
 >
   <section
+    aria-label="Choice b:"
     className="answers-answer"
     role="region"
   >
@@ -75,7 +76,6 @@ exports[`Answer Component renders answer feedback based on props 1`] = `
       onKeyPress={[Function]}
     >
       <button
-        aria-label="Choice b:"
         className="answer-letter"
         disabled={false}
         onClick={[Function]}

--- a/shared/specs/components/question/__snapshots__/index.spec.js.snap
+++ b/shared/specs/components/question/__snapshots__/index.spec.js.snap
@@ -20,6 +20,7 @@ exports[`Question Component renders and matches snapshot 1`] = `
       className="openstax-answer"
     >
       <section
+        aria-label="Choice a:"
         className="answers-answer disabled"
         role="region"
       >
@@ -38,7 +39,6 @@ exports[`Question Component renders and matches snapshot 1`] = `
           onKeyPress={[Function]}
         >
           <button
-            aria-label="Choice a:"
             className="answer-letter"
             disabled={true}
             onClick={[Function]}
@@ -69,6 +69,7 @@ exports[`Question Component renders and matches snapshot 1`] = `
       className="openstax-answer"
     >
       <section
+        aria-label="Choice b:"
         className="answers-answer disabled"
         role="region"
       >
@@ -87,7 +88,6 @@ exports[`Question Component renders and matches snapshot 1`] = `
           onKeyPress={[Function]}
         >
           <button
-            aria-label="Choice b:"
             className="answer-letter"
             disabled={true}
             onClick={[Function]}
@@ -118,6 +118,7 @@ exports[`Question Component renders and matches snapshot 1`] = `
       className="openstax-answer"
     >
       <section
+        aria-label="Choice c:"
         className="answers-answer disabled"
         role="region"
       >
@@ -136,7 +137,6 @@ exports[`Question Component renders and matches snapshot 1`] = `
           onKeyPress={[Function]}
         >
           <button
-            aria-label="Choice c:"
             className="answer-letter"
             disabled={true}
             onClick={[Function]}
@@ -167,6 +167,7 @@ exports[`Question Component renders and matches snapshot 1`] = `
       className="openstax-answer"
     >
       <section
+        aria-label="Choice d:"
         className="answers-answer disabled"
         role="region"
       >
@@ -185,7 +186,6 @@ exports[`Question Component renders and matches snapshot 1`] = `
           onKeyPress={[Function]}
         >
           <button
-            aria-label="Choice d:"
             className="answer-letter"
             disabled={true}
             onClick={[Function]}
@@ -216,6 +216,7 @@ exports[`Question Component renders and matches snapshot 1`] = `
       className="openstax-answer"
     >
       <section
+        aria-label="Choice e:"
         className="answers-answer disabled"
         role="region"
       >
@@ -234,7 +235,6 @@ exports[`Question Component renders and matches snapshot 1`] = `
           onKeyPress={[Function]}
         >
           <button
-            aria-label="Choice e:"
             className="answer-letter"
             disabled={true}
             onClick={[Function]}

--- a/shared/src/components/question/answer.jsx
+++ b/shared/src/components/question/answer.jsx
@@ -179,7 +179,7 @@ export default class Answer extends React.Component {
 
     return (
       <div className="openstax-answer">
-        <section role="region" className={classes}>
+        <section aria-label={ariaLabel} role="region" className={classes}>
           {selectedCount}
           {radioBox}
           <label
@@ -189,7 +189,6 @@ export default class Answer extends React.Component {
             <button
               onClick={onChange}
               className="answer-letter"
-              aria-label={ariaLabel}
               disabled={disabled}>
               {ALPHABET[iter]}
             </button>

--- a/shared/src/model/exercise.js
+++ b/shared/src/model/exercise.js
@@ -66,6 +66,7 @@ export default class Exercise extends BaseModel {
   @action toggleMultiPart() {
     if (this.isMultiPart) {
       this.questions.replace([this.questions[0]]);
+      this.stimulus_html = '';
     } else {
       this.questions.push({});
     }

--- a/tutor/specs/components/exercises/__snapshots__/cards.spec.js.snap
+++ b/tutor/specs/components/exercises/__snapshots__/cards.spec.js.snap
@@ -57,6 +57,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -66,7 +67,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -96,6 +96,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -105,7 +106,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -135,6 +135,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -144,7 +145,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -174,6 +174,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -183,7 +184,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -213,6 +213,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -222,7 +223,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -333,6 +333,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -342,7 +343,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -367,6 +367,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -376,7 +377,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -401,6 +401,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -410,7 +411,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -435,6 +435,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -444,7 +445,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -469,6 +469,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -478,7 +479,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -591,6 +591,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -600,7 +601,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -625,6 +625,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -634,7 +635,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -659,6 +659,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -668,7 +669,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -693,6 +693,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -702,7 +703,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -727,6 +727,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -736,7 +737,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -842,6 +842,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -851,7 +852,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -876,6 +876,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -885,7 +886,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -910,6 +910,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -919,7 +920,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -944,6 +944,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -953,7 +954,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -978,6 +978,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -987,7 +988,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1114,6 +1114,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1123,7 +1124,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1148,6 +1148,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1157,7 +1158,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1182,6 +1182,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1191,7 +1192,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1216,6 +1216,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1225,7 +1226,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1250,6 +1250,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1259,7 +1260,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1365,6 +1365,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1374,7 +1375,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1404,6 +1404,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1413,7 +1414,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1443,6 +1443,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1452,7 +1453,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1482,6 +1482,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1491,7 +1492,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1521,6 +1521,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1530,7 +1531,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1641,6 +1641,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1650,7 +1651,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1675,6 +1675,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1684,7 +1685,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1709,6 +1709,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1718,7 +1719,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1743,6 +1743,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1752,7 +1753,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1777,6 +1777,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1786,7 +1787,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1899,6 +1899,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1908,7 +1909,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1933,6 +1933,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1942,7 +1943,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -1967,6 +1967,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -1976,7 +1977,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2001,6 +2001,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2010,7 +2011,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2035,6 +2035,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2044,7 +2045,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2171,6 +2171,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2180,7 +2181,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2205,6 +2205,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2214,7 +2215,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2239,6 +2239,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2248,7 +2249,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2273,6 +2273,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2282,7 +2283,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2307,6 +2307,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2316,7 +2317,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2422,6 +2422,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2431,7 +2432,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2456,6 +2456,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2465,7 +2466,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2490,6 +2490,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2499,7 +2500,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2524,6 +2524,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2533,7 +2534,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2558,6 +2558,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2567,7 +2568,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2673,6 +2673,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2682,7 +2683,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2712,6 +2712,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2721,7 +2722,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2751,6 +2751,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2760,7 +2761,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2790,6 +2790,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2799,7 +2800,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2829,6 +2829,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2838,7 +2839,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2949,6 +2949,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2958,7 +2959,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -2983,6 +2983,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -2992,7 +2993,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3017,6 +3017,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3026,7 +3027,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3051,6 +3051,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3060,7 +3061,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3085,6 +3085,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3094,7 +3095,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3228,6 +3228,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3237,7 +3238,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3262,6 +3262,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3271,7 +3272,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3296,6 +3296,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3305,7 +3306,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3330,6 +3330,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3339,7 +3340,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3364,6 +3364,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3373,7 +3374,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3479,6 +3479,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3488,7 +3489,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3513,6 +3513,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3522,7 +3523,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3547,6 +3547,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3556,7 +3557,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3581,6 +3581,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3590,7 +3591,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3615,6 +3615,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3624,7 +3625,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3730,6 +3730,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3739,7 +3740,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3764,6 +3764,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3773,7 +3774,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3798,6 +3798,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3807,7 +3808,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3832,6 +3832,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3841,7 +3842,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3866,6 +3866,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3875,7 +3876,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -3981,6 +3981,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -3990,7 +3991,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4020,6 +4020,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4029,7 +4030,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4059,6 +4059,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4068,7 +4069,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4098,6 +4098,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4107,7 +4108,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4137,6 +4137,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4146,7 +4147,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4278,6 +4278,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4287,7 +4288,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4312,6 +4312,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4321,7 +4322,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4346,6 +4346,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4355,7 +4356,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4380,6 +4380,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4389,7 +4390,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4414,6 +4414,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4423,7 +4424,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4536,6 +4536,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4545,7 +4546,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4570,6 +4570,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4579,7 +4580,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4604,6 +4604,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4613,7 +4614,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4638,6 +4638,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4647,7 +4648,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4672,6 +4672,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4681,7 +4682,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4787,6 +4787,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4796,7 +4797,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4821,6 +4821,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4830,7 +4831,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4855,6 +4855,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4864,7 +4865,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4889,6 +4889,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4898,7 +4899,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -4923,6 +4923,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -4932,7 +4933,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5038,6 +5038,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5047,7 +5048,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5072,6 +5072,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5081,7 +5082,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5106,6 +5106,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5115,7 +5116,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5140,6 +5140,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5149,7 +5150,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5174,6 +5174,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5183,7 +5184,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5310,6 +5310,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5319,7 +5320,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5349,6 +5349,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5358,7 +5359,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5388,6 +5388,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5397,7 +5398,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5427,6 +5427,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5436,7 +5437,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5466,6 +5466,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5475,7 +5476,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5586,6 +5586,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5595,7 +5596,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5620,6 +5620,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5629,7 +5630,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5654,6 +5654,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5663,7 +5664,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5688,6 +5688,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5697,7 +5698,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5722,6 +5722,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5731,7 +5732,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5844,6 +5844,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5853,7 +5854,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5878,6 +5878,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5887,7 +5888,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5912,6 +5912,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5921,7 +5922,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5946,6 +5946,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5955,7 +5956,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -5980,6 +5980,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -5989,7 +5990,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6095,6 +6095,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6104,7 +6105,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6129,6 +6129,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6138,7 +6139,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6163,6 +6163,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6172,7 +6173,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6197,6 +6197,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6206,7 +6207,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6231,6 +6231,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6240,7 +6241,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6367,6 +6367,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6376,7 +6377,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6401,6 +6401,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6410,7 +6411,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6435,6 +6435,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6444,7 +6445,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6469,6 +6469,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6478,7 +6479,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6503,6 +6503,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6512,7 +6513,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6618,6 +6618,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6627,7 +6628,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6657,6 +6657,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6666,7 +6667,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6696,6 +6696,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6705,7 +6706,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6735,6 +6735,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6744,7 +6745,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6774,6 +6774,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6783,7 +6784,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6894,6 +6894,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6903,7 +6904,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6928,6 +6928,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6937,7 +6938,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6962,6 +6962,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -6971,7 +6972,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -6996,6 +6996,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7005,7 +7006,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7030,6 +7030,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7039,7 +7040,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7152,6 +7152,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7161,7 +7162,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7186,6 +7186,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7195,7 +7196,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7220,6 +7220,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7229,7 +7230,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7254,6 +7254,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7263,7 +7264,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7288,6 +7288,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7297,7 +7298,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7424,6 +7424,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7433,7 +7434,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7458,6 +7458,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7467,7 +7468,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7492,6 +7492,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7501,7 +7502,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7526,6 +7526,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7535,7 +7536,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7560,6 +7560,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7569,7 +7570,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7675,6 +7675,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7684,7 +7685,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7709,6 +7709,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7718,7 +7719,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7743,6 +7743,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7752,7 +7753,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7777,6 +7777,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7786,7 +7787,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7811,6 +7811,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7820,7 +7821,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7926,6 +7926,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7935,7 +7936,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -7965,6 +7965,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -7974,7 +7975,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8004,6 +8004,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8013,7 +8014,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8043,6 +8043,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8052,7 +8053,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8082,6 +8082,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8091,7 +8092,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8202,6 +8202,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8211,7 +8212,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8236,6 +8236,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8245,7 +8246,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8270,6 +8270,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8279,7 +8280,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8304,6 +8304,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8313,7 +8314,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8338,6 +8338,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8347,7 +8348,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8481,6 +8481,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8490,7 +8491,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8515,6 +8515,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8524,7 +8525,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8549,6 +8549,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8558,7 +8559,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8583,6 +8583,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8592,7 +8593,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8617,6 +8617,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8626,7 +8627,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8732,6 +8732,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8741,7 +8742,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8766,6 +8766,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8775,7 +8776,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8800,6 +8800,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8809,7 +8810,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8834,6 +8834,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8843,7 +8844,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8868,6 +8868,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8877,7 +8878,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -8983,6 +8983,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -8992,7 +8993,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -9017,6 +9017,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -9026,7 +9027,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -9051,6 +9051,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -9060,7 +9061,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -9085,6 +9085,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -9094,7 +9095,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -9119,6 +9119,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -9128,7 +9129,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -9234,6 +9234,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -9243,7 +9244,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -9273,6 +9273,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -9282,7 +9283,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -9312,6 +9312,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -9321,7 +9322,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -9351,6 +9351,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -9360,7 +9361,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -9390,6 +9390,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -9399,7 +9400,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}

--- a/tutor/specs/components/exercises/__snapshots__/details.spec.jsx.snap
+++ b/tutor/specs/components/exercises/__snapshots__/details.spec.jsx.snap
@@ -89,6 +89,7 @@ exports[`Exercise Details Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice a:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -98,7 +99,6 @@ exports[`Exercise Details Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice a:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -123,6 +123,7 @@ exports[`Exercise Details Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice b:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -132,7 +133,6 @@ exports[`Exercise Details Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice b:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -157,6 +157,7 @@ exports[`Exercise Details Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice c:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -166,7 +167,6 @@ exports[`Exercise Details Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice c:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -191,6 +191,7 @@ exports[`Exercise Details Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice d:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -200,7 +201,6 @@ exports[`Exercise Details Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice d:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}
@@ -225,6 +225,7 @@ exports[`Exercise Details Component renders and matches snapshot 1`] = `
                     className="openstax-answer"
                   >
                     <section
+                      aria-label="Choice e:"
                       className="answers-answer disabled"
                       role="region"
                     >
@@ -234,7 +235,6 @@ exports[`Exercise Details Component renders and matches snapshot 1`] = `
                         onKeyPress={[Function]}
                       >
                         <button
-                          aria-label="Choice e:"
                           className="answer-letter"
                           disabled={true}
                           onClick={undefined}

--- a/tutor/specs/components/exercises/__snapshots__/preview.spec.js.snap
+++ b/tutor/specs/components/exercises/__snapshots__/preview.spec.js.snap
@@ -36,6 +36,7 @@ exports[`Exercise Preview Wrapper Component renders and matches snapshot 1`] = `
               className="openstax-answer"
             >
               <section
+                aria-label="Choice a:"
                 className="answers-answer disabled"
                 role="region"
               >
@@ -45,7 +46,6 @@ exports[`Exercise Preview Wrapper Component renders and matches snapshot 1`] = `
                   onKeyPress={[Function]}
                 >
                   <button
-                    aria-label="Choice a:"
                     className="answer-letter"
                     disabled={true}
                     onClick={undefined}
@@ -76,6 +76,7 @@ exports[`Exercise Preview Wrapper Component renders and matches snapshot 1`] = `
               className="openstax-answer"
             >
               <section
+                aria-label="Choice b:"
                 className="answers-answer disabled"
                 role="region"
               >
@@ -85,7 +86,6 @@ exports[`Exercise Preview Wrapper Component renders and matches snapshot 1`] = `
                   onKeyPress={[Function]}
                 >
                   <button
-                    aria-label="Choice b:"
                     className="answer-letter"
                     disabled={true}
                     onClick={undefined}
@@ -116,6 +116,7 @@ exports[`Exercise Preview Wrapper Component renders and matches snapshot 1`] = `
               className="openstax-answer"
             >
               <section
+                aria-label="Choice c:"
                 className="answers-answer disabled"
                 role="region"
               >
@@ -125,7 +126,6 @@ exports[`Exercise Preview Wrapper Component renders and matches snapshot 1`] = `
                   onKeyPress={[Function]}
                 >
                   <button
-                    aria-label="Choice c:"
                     className="answer-letter"
                     disabled={true}
                     onClick={undefined}
@@ -156,6 +156,7 @@ exports[`Exercise Preview Wrapper Component renders and matches snapshot 1`] = `
               className="openstax-answer"
             >
               <section
+                aria-label="Choice d:"
                 className="answers-answer disabled"
                 role="region"
               >
@@ -165,7 +166,6 @@ exports[`Exercise Preview Wrapper Component renders and matches snapshot 1`] = `
                   onKeyPress={[Function]}
                 >
                   <button
-                    aria-label="Choice d:"
                     className="answer-letter"
                     disabled={true}
                     onClick={undefined}
@@ -196,6 +196,7 @@ exports[`Exercise Preview Wrapper Component renders and matches snapshot 1`] = `
               className="openstax-answer"
             >
               <section
+                aria-label="Choice e:"
                 className="answers-answer disabled"
                 role="region"
               >
@@ -205,7 +206,6 @@ exports[`Exercise Preview Wrapper Component renders and matches snapshot 1`] = `
                   onKeyPress={[Function]}
                 >
                   <button
-                    aria-label="Choice e:"
                     className="answer-letter"
                     disabled={true}
                     onClick={undefined}

--- a/tutor/specs/components/task-plan/homework/__snapshots__/review-exercises.spec.js.snap
+++ b/tutor/specs/components/task-plan/homework/__snapshots__/review-exercises.spec.js.snap
@@ -255,6 +255,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice a:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -264,7 +265,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice a:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -294,6 +294,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice b:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -303,7 +304,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice b:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -333,6 +333,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice c:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -342,7 +343,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice c:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -372,6 +372,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice d:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -381,7 +382,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice d:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -411,6 +411,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice e:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -420,7 +421,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice e:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -543,6 +543,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice a:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -552,7 +553,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice a:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -577,6 +577,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice b:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -586,7 +587,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice b:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -611,6 +611,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice c:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -620,7 +621,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice c:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -645,6 +645,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice d:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -654,7 +655,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice d:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -679,6 +679,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice e:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -688,7 +689,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice e:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -813,6 +813,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice a:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -822,7 +823,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice a:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -847,6 +847,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice b:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -856,7 +857,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice b:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -881,6 +881,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice c:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -890,7 +891,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice c:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -915,6 +915,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice d:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -924,7 +925,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice d:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}
@@ -949,6 +949,7 @@ exports[`choose exercises component matches snapshot 1`] = `
                   className="openstax-answer"
                 >
                   <section
+                    aria-label="Choice e:"
                     className="answers-answer disabled"
                     role="region"
                   >
@@ -958,7 +959,6 @@ exports[`choose exercises component matches snapshot 1`] = `
                       onKeyPress={[Function]}
                     >
                       <button
-                        aria-label="Choice e:"
                         className="answer-letter"
                         disabled={true}
                         onClick={undefined}

--- a/tutor/src/components/task-step/all-steps.cjsx
+++ b/tutor/src/components/task-step/all-steps.cjsx
@@ -42,7 +42,7 @@ Interactive = React.createClass
     {id} = @props
     {courseId} = Router.currentParams()
 
-    <ReadingStepContent id={id} stepType='interactive' courseId={courseId} />
+    <ReadingStepContent id={id} onContinue={@onContinue} stepType='interactive' courseId={courseId} />
 
 Video = React.createClass
   displayName: 'Video'
@@ -54,7 +54,7 @@ Video = React.createClass
     {id} = @props
     {courseId} = Router.currentParams()
 
-    <ReadingStepContent id={id} stepType='video' courseId={courseId} />
+    <ReadingStepContent id={id} onContinue={@onContinue} stepType='video' courseId={courseId} />
 
 ExternalUrl = React.createClass
   displayName: 'ExternalUrl'


### PR DESCRIPTION
* Add continue button to video and sim steps; if the video or sim was the only thing on the step it lacked a continue button
* arial-label to question choices section so JAWS can treat it as a landmark
* clear the "stimulus" when converting a MPQ to a single part