### PR TITLE
Fix tasks jumping to first step when they're completed

### DIFF
--- a/tutor/src/flux/task.coffee
+++ b/tutor/src/flux/task.coffee
@@ -109,7 +109,8 @@ TaskConfig =
 
   stepCompleted: (obj, taskStepId) ->
     TaskStepActions.completed(obj, taskStepId)
-    this.loaded(obj, obj.id)
+    this._loaded(obj, obj.id)
+    Object.assign(@_local[obj.id], obj)
     @emit('step.completed', taskStepId, obj.id)
 
   exports:


### PR DESCRIPTION
assign to _local directly instead of calling loaded

Reverts change in commit 8b151dadd1b28ea7c77c9af083da5bd65ef91182

For some unknown reason that causes the task steps to repeat the first step
when the task is completed