### PR TITLE
Fix annotation sorting and overlay page scroll position

### DIFF
--- a/tutor/src/components/annotations/annotation.jsx
+++ b/tutor/src/components/annotations/annotation.jsx
@@ -250,7 +250,8 @@ export default class AnnotationWidget extends React.Component {
       chapter: this.props.chapter,
       section: this.props.section,
       title: this.props.title,
-      ...serializedHighlight.data
+      rect: dom(highlight.range).boundingClientRect,
+      ...serializedHighlight.data,
     });
   }
 

--- a/tutor/src/components/obscured-page/overlay-registry.js
+++ b/tutor/src/components/obscured-page/overlay-registry.js
@@ -11,6 +11,7 @@ export class OverlayRegistry {
   @observable isOverlayExpanded = false;
   @observable isOverlayHidden = true;
   @observable isPageHidden = false;
+  @observable pageScrollPosition;
 
   @computed get pageClassName() {
     return cn('page', {
@@ -23,6 +24,9 @@ export class OverlayRegistry {
   }
 
   @action.bound onOverlayAnimated() {
+    if (this.isOverlayExpanded) {
+      this.pageScrollPosition = { x: window.pageXOffset, y: window.pageYOffset };
+    }
     this.isPageHidden = this.isOverlayExpanded;
     if (!this.isOverlayExpanded) {
       this.isOverlayHidden = true;
@@ -34,6 +38,12 @@ export class OverlayRegistry {
       this.onHide();
     }
     this.isPageHidden = false;
+    if (this.pageScrollPosition) {
+      defer(() => { // schedule a scroll to take place after the page is re-displayed
+        window.scroll(this.pageScrollPosition.x, this.pageScrollPosition.y);
+        this.pageScrollPosition = null;
+      });
+    }
     this.isOverlayExpanded = false;
   }
 

--- a/tutor/src/helpers/dom.js
+++ b/tutor/src/helpers/dom.js
@@ -271,6 +271,20 @@ export default function dom(el) {
       }
     },
 
+
+    get boundingClientRect() {
+      const rect = el.getBoundingClientRect();
+      const wLeft = window.pageXOffset;
+      const wTop = window.pageYOffset;
+      return {
+        bottom: rect.bottom + wTop,
+        top: rect.top + wTop,
+        left: rect.left + wLeft,
+        right: rect.right + wLeft,
+      };
+    },
+
+
   };
 
 }

--- a/tutor/src/models/annotations.js
+++ b/tutor/src/models/annotations.js
@@ -1,5 +1,5 @@
 import { action, computed } from 'mobx';
-import { get, pick, sortBy, map, groupBy, mapValues, extend, isArray } from 'lodash';
+import { get, sortBy, groupBy, mapValues, isArray } from 'lodash';
 import Map from 'shared/model/map';
 import lazyGetter from 'shared/helpers/lazy-getter';
 import { chapterSectionToNumber } from '../helpers/content';
@@ -28,7 +28,7 @@ export default class Annotations extends Map {
           sortBy(cpgs, c=>chapterSectionToNumber(c.chapter_section)),
           a => a.chapter_section.join('.')
         ),
-        (annotations) => sortBy(annotations, ['selection.rect.top', 'selection.start'])
+        (annotations) => sortBy(annotations, ['rect.top', 'selection.rect.top', 'selection.start'])
       )
     );
   }

--- a/tutor/src/models/annotations/annotation.js
+++ b/tutor/src/models/annotations/annotation.js
@@ -1,9 +1,8 @@
 import { get, pick, omit, extend, isString, isEmpty, toArray } from 'lodash';
-import { computed, action, observable, intercept } from 'mobx';
-import serializeSelection from 'serialize-selection';
-import {Highlight, SerializedHighlight} from '@openstax/highlighter';
+import { computed, action, intercept } from 'mobx';
+import { SerializedHighlight } from '@openstax/highlighter';
 import {
-  BaseModel, identifiedBy, field, identifier
+  BaseModel, identifiedBy, field, identifier,
 } from 'shared/model';
 
 
@@ -19,6 +18,7 @@ export default class Annotation extends BaseModel {
   @field title;
   @field text;
   @field type;
+  @field({ type: 'object' }) rect;
   highlight;
   listing;
 


### PR DESCRIPTION
stores the selection's bounding rect and the sorts by it when annotations load

Also fixes the window scroll position. bug discovered by @TomWoodward 