### PR TITLE
Fix purchases refund button

### DIFF
--- a/tutor/specs/models/purchases.spec.js
+++ b/tutor/specs/models/purchases.spec.js
@@ -1,0 +1,23 @@
+import { Purchase, PurchasesMap } from '../../src/models/purchases';
+
+describe('Purchases', () => {
+  let purchases;
+
+  beforeEach(() => {
+    purchases = new PurchasesMap();
+    purchases.onLoaded({ data: { orders: [{
+      identifier: '1234abcd',
+      total: 12.82,
+      product: { name: 'Foo' },
+    }] } });
+  });
+
+  test('#get', () => {
+    expect(purchases.get('1234abcd')).toBeInstanceOf(Purchase);
+  });
+
+  test('#withRefunds', () => {
+    expect(purchases.withRefunds).toHaveLength(1);
+  });
+
+});

--- a/tutor/src/models/purchases.js
+++ b/tutor/src/models/purchases.js
@@ -6,6 +6,8 @@ import Purchase from './purchases/purchase';
 
 class PurchasesMap extends Map {
 
+  keyType = String
+
   @computed get isAnyRefundable() {
     return find(this.array, 'isRefundable');
   }
@@ -27,5 +29,5 @@ class PurchasesMap extends Map {
 }
 
 const purchasesMap = new PurchasesMap();
-
+export { PurchasesMap, Purchase };
 export default purchasesMap;


### PR DESCRIPTION
The map wasn't using strings for keys making it never find the order to refund since it's alphanumeric