### PR TITLE
Misc upgrade style fixes

### DIFF
--- a/shared/resources/styles/components/exercise-preview/index.scss
+++ b/shared/resources/styles/components/exercise-preview/index.scss
@@ -183,7 +183,7 @@
         display: flex;
         align-items: center;
         .correct-incorrect {
-          min-width: 2rem;
+          min-width: 1em; // match font-awesome icon width
         }
         .ox-icon {
           margin: 0;

--- a/tutor/resources/styles/components/enrollment-student-id.scss
+++ b/tutor/resources/styles/components/enrollment-student-id.scss
@@ -4,7 +4,6 @@
 
   &.course-enroll,
   &.change-student-id {
-    overflow: scroll;
 
     @include tutor-shadow(pop);
     @include ost-hero-backdrop();
@@ -13,6 +12,9 @@
     .modal-body,
     .modal-footer {
       background-color: $tutor-neutral-bright;
+    }
+    .modal-body {
+      overflow: scroll;
     }
     .alert-danger {
       color: $tutor-danger;

--- a/tutor/resources/styles/components/modals.scss
+++ b/tutor/resources/styles/components/modals.scss
@@ -7,9 +7,8 @@
     background-color: $tutor-neutral-bright;
     border-bottom: 1px solid $tutor-neutral-light;
     align-items: center;
-    justify-content: flex-start;
+    justify-content: space-between;
   }
-
   .modal-content {
     border-radius: 0;
     border: 0;

--- a/tutor/resources/styles/components/modals/warning.scss
+++ b/tutor/resources/styles/components/modals/warning.scss
@@ -6,10 +6,8 @@
 .modal-header.warning {
   background-color: #f5e9ea;
   color: #b33238;
-  display: flex;
   align-items: center;
-  padding: 25px 50px;
-
+  justify-content: flex-start;
   .ox-icon {
     font-size: 24px;
     fill: $tutor-danger;

--- a/tutor/resources/styles/components/plan-stats.scss
+++ b/tutor/resources/styles/components/plan-stats.scss
@@ -1,9 +1,5 @@
 .plan-modal {
-  .modal-content {
-    .modal-header {
-      justify-content: space-between;
-    }
-  }
+
   .no-students {
     margin: 20px;
   }

--- a/tutor/resources/styles/components/plan-stats.scss
+++ b/tutor/resources/styles/components/plan-stats.scss
@@ -1,5 +1,9 @@
 .plan-modal {
-
+  .modal-content {
+    .modal-header {
+      justify-content: space-between;
+    }
+  }
   .no-students {
     margin: 20px;
   }

--- a/tutor/resources/styles/components/task-teacher-review/question.scss
+++ b/tutor/resources/styles/components/task-teacher-review/question.scss
@@ -47,7 +47,12 @@ $free-response-background:  $tutor-neutral-lighter;
   padding-right: 20px;
   @include tutor-sans-font(1.8rem, 2.4rem);
 
+  .question-stem {
+    display: flex;
+  }
+
   .answers-answer {
+    min-width: 2rem;
     &::before {
       @include answer-label();
       @include answer-icon-label();
@@ -62,11 +67,11 @@ $free-response-background:  $tutor-neutral-lighter;
       line-height: 2.4rem;
     }
     .correct-incorrect {
-      margin-right: 30px;
+      margin-right: 2rem;
     }
     .selected-count {
       display: inline-block;
-      width: 35px;
+      width: 2.4rem;
 
       @media (max-width: $tutor-card-padding-collapse-breakpoint) {
         width: 40px;

--- a/tutor/specs/components/__snapshots__/lms-info-card.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/lms-info-card.spec.jsx.snap
@@ -8,16 +8,18 @@ exports[`LmsInfo Component matches snapshot 1`] = `
 
 .c0 {
   margin: 10px 0 20px 0;
-  display: block;
+  padding-left: 0 !important;
   font-size: 16px;
 }
 
 <div
   className="lms-info"
 >
-  <a
-    className="c0"
+  <button
+    className="c0 btn btn-link"
+    disabled={false}
     onClick={[MockFunction]}
+    type="button"
   >
     <svg
       aria-hidden="true"
@@ -36,7 +38,7 @@ exports[`LmsInfo Component matches snapshot 1`] = `
       />
     </svg>
      Back
-  </a>
+  </button>
   <p>
     Copy and send to your students directly, or paste manually into your LMS.
   </p>

--- a/tutor/specs/screens/student-dashboard/reading-row.spec.jsx
+++ b/tutor/specs/screens/student-dashboard/reading-row.spec.jsx
@@ -36,7 +36,7 @@ describe('Reading Row', function() {
 
   it('renders close to being due', () => {
     props.event.complete_exercise_count = 1;
-    props.event.due_at = new Date(now.getTime() + ( 24*60*60*1000 ));
+    props.event.due_at = new Date(now.getTime() + ( 24*60*60*1000 ) - 1000);
     props.event.complete = false;
     const row = mount(<ReadingRow {...props} />);
     expect(row.find('Col[className="feedback"]').text()).toEqual('In progress');

--- a/tutor/src/components/lms-info-card.js
+++ b/tutor/src/components/lms-info-card.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { observer } from 'mobx-react';
 import { action, computed } from 'mobx';
+import { Button } from 'react-bootstrap';
 import moment from 'moment';
 import { autobind } from 'core-decorators';
 import TaskPlanHelper from '../helpers/task-plan';
@@ -13,11 +14,18 @@ import styled from 'styled-components';
 
 const DUE_FORMAT = 'M/D/YYYY [at] h:mma';
 
-const BackLink = styled.a`
+const BackLinkButton = styled(Button)`
   margin: 10px 0 20px 0;
-  display: block;
+  padding-left: 0 !important;
   font-size: 16px;
 `;
+
+const BackLink = (props) => (
+  <BackLinkButton variant="link" {...props}>
+    <Icon type="chevron-left" /> Back
+  </BackLinkButton>
+);
+
 
 export default
 @observer
@@ -103,9 +111,7 @@ class LmsInfoCard extends React.Component {
   renderPreview() {
     return (
       <div className="lms-info preview">
-        <BackLink onClick={this.props.onBack}>
-          <Icon type="chevron-left" /> Back
-        </BackLink>
+        <BackLink onClick={this.props.onBack} />
         <p>
           Assignment links are not available in preview courses. In
           a live course, you can send assignment links directly
@@ -122,9 +128,7 @@ class LmsInfoCard extends React.Component {
     }
     return (
       <div className="lms-info">
-        <BackLink onClick={this.props.onBack}>
-          <Icon type="chevron-left" /> Back
-        </BackLink>
+        <BackLink onClick={this.props.onBack} />
         <p>
           Copy and send to your students directly, or paste manually into your LMS.
         </p>

--- a/tutor/src/components/notes/note-card.js
+++ b/tutor/src/components/notes/note-card.js
@@ -46,7 +46,7 @@ class EditBox extends React.Component {
         {this.renderWarning()}
         <div className="button-group">
           <button title="Save" onClick={this.callUpdateText}><Icon type="check" /></button>
-          <button title="Cancel editing" onClick={dismiss}><Icon type="close" /></button>
+          <button title="Cancel editing" variant="default" onClick={dismiss}><Icon type="close" /></button>
         </div>
       </div>
     );

--- a/tutor/src/components/notes/summary-popup.jsx
+++ b/tutor/src/components/notes/summary-popup.jsx
@@ -57,6 +57,7 @@ class SummaryPopup extends React.Component {
       <div>
         <Button
           className="print-btn"
+          variant="default"
           onClick={this.openSummaryWindow}
         >
           <Icon type="print"/> Print this page

--- a/tutor/src/components/payments/refund-modal.jsx
+++ b/tutor/src/components/payments/refund-modal.jsx
@@ -46,7 +46,7 @@ class ProcessRefund extends React.Component {
           >
             Process refund
           </AsyncButton>
-          <Button onClick={onCancel}>Cancel</Button>
+          <Button onClick={onCancel} variant="default">Cancel</Button>
         </Modal.Footer>
       </Modal>
     );
@@ -137,7 +137,7 @@ function AreYouSure({ purchase, onCancel, onContinue }) {
       </Modal.Body>
       <Modal.Footer>
         <Button onClick={onContinue} variant="primary">Continue</Button>
-        <Button onClick={onCancel}>Cancel</Button>
+        <Button onClick={onCancel} variant="default">Cancel</Button>
       </Modal.Footer>
     </Modal>
   );

--- a/tutor/src/models/task-plan/teacher.js
+++ b/tutor/src/models/task-plan/teacher.js
@@ -25,7 +25,8 @@ class TeacherTaskPlan extends BaseModel {
   @field({ type: 'date' }) first_published_at
   @field({ type: 'date' }) last_published_at;
   @session({ type: 'date' }) publish_last_requested_at;
-
+  @field failed_at;
+  @field killed_at;
   @field is_draft;
   @field is_preview;
   @field is_published;

--- a/tutor/src/models/tour/ride.js
+++ b/tutor/src/models/tour/ride.js
@@ -1,5 +1,5 @@
 import {
-  BaseModel, identifiedBy, belongsTo, computed,
+  BaseModel, identifiedBy, computed, session,
 } from 'shared/model';
 import { defaults, compact } from 'lodash';
 import { action, observable } from 'mobx';
@@ -23,9 +23,9 @@ export default
 @identifiedBy('tour/ride')
 class TourRide extends BaseModel {
 
-  @belongsTo({ model: 'tour' }) tour;
-  @belongsTo({ model: 'tour/context' }) context;
-  @belongsTo({ model: 'tour/region' }) region;
+  @session({ type: 'object' }) tour;
+  @session({ type: 'object' }) context;
+  @session({ type: 'object' }) region;
 
   @observable currentStep = 0;
   @observable joyrideRef;

--- a/tutor/src/screens/course-roster/delete-period.jsx
+++ b/tutor/src/screens/course-roster/delete-period.jsx
@@ -40,7 +40,7 @@ const DeletePeriodModal = ({ section, show, onClose, period, isBusy, onDelete })
         isWaiting={isBusy}>
         Delete
       </AsyncButton>
-      <Button disabled={isBusy} onClick={onClose}>
+      <Button disabled={isBusy} onClick={onClose} variant="default">
         Cancel
       </Button>
     </Modal.Footer>

--- a/tutor/src/screens/lms-pair/create-course.jsx
+++ b/tutor/src/screens/lms-pair/create-course.jsx
@@ -4,7 +4,7 @@ import Wizard from '../new-course/wizard';
 
 export default
 @observer
-class NewOrExisting extends React.Component {
+class CreateNewCourse extends React.Component {
 
   static propTypes = {
     ux: PropTypes.object.isRequired,

--- a/tutor/src/screens/lms-pair/ux.js
+++ b/tutor/src/screens/lms-pair/ux.js
@@ -16,9 +16,9 @@ export default class LmsPairUX {
   @observable createCourseUX = new CreateCourseUX(this);
 
   constructor({
-    courses = Courses.nonPreview.teaching.currentAndFuture.withoutStudents,
+    courses = Courses.nonPreview.teaching.currentAndFuture,
   } = {}) {
-    this.courses = courses;
+    this.courses = courses.where(c => c.is_access_switchable);
   }
 
   @computed get panel() {

--- a/tutor/src/screens/student-dashboard/event-info-icon.jsx
+++ b/tutor/src/screens/student-dashboard/event-info-icon.jsx
@@ -2,11 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Tooltip, OverlayTrigger }  from 'react-bootstrap';
 import S from '../../helpers/string';
-import { TimeStore } from '../../flux/time';
+import Time from '../../models/time';
 import moment from 'moment';
 import { Icon } from 'shared';
 import { observer } from 'mobx-react';
-
+import Theme from '../../theme';
 import TourAnchor from '../../components/tours/anchor';
 
 export default
@@ -21,8 +21,7 @@ class EventInfoIcon extends React.Component {
     const { event, isCollege } = this.props;
 
     const shouldShowLate = isCollege || (event.type === 'homework');
-    // TODO this is naive and not timezone aware.  As a hotfix, this should suffice.
-    const now   = moment(TimeStore.getNow());
+    const now   = moment(Time.now);
     const dueAt = moment(event.due_at);
     const isIncomplete = !event.complete;
     const pastDue      = shouldShowLate && dueAt.isBefore(now);
@@ -35,31 +34,30 @@ class EventInfoIcon extends React.Component {
 
     const isLate = workedLate || pastDue;
 
-    const tooltip =
+    const tooltip = (
       <Tooltip id={`event-info-icon-${event.id}`}>
         <b>
           {S.capitalize(isLate ? 'late' : 'incomplete')}
         </b>
-      </Tooltip>;
+      </Tooltip>
+    );
 
 
     let icon = (
       <Icon
         tooltip={tooltip}
-        variant={isLate ? 'warning' : 'danger'}
+        color={Theme.colors[isLate ? 'danger' : 'warning']}
         type={isLate ? 'clock' : 'exclamation-circle'}
       />
     );
 
-    //  <OverlayTrigger placement="top" overlay={tooltip}>
-    //     <i className={`info ${status}`} />
-    //  </OverlayTrigger>;
-
     if (pastDue) {
-      icon = <TourAnchor
-        id="about-late-icon"
-        tag="span"
-      >{icon}</TourAnchor>;
+      icon = (
+        <TourAnchor
+          id="about-late-icon"
+          tag="span"
+        >{icon}</TourAnchor>
+      );
     }
 
     return icon;

--- a/tutor/src/screens/teacher-dashboard/styles/plan-details.scss
+++ b/tutor/src/screens/teacher-dashboard/styles/plan-details.scss
@@ -3,43 +3,36 @@ body.modal-open {
 }
 
 .plan-modal {
-
-
-// @include tutor-plan-modal($calendar-inactive-background);
-
-  &.is-published,
-  &.is-publishing {
+  .modal-dialog{
     &:not(.is-failed) {
       @include tutor-plan-set(modal);
     }
-  }
-
-  &.is-publishing {
-    .modal-title::before {
-      @include is-publishing();
-      margin-right: $modal-padding/2;
-      margin-left: -$modal-padding/2;
-    }
-  }
-
-  &.is-published{
-    &.is-open.is-trouble {
+    &.is-publishing {
       .modal-title::before {
+        @include is-publishing();
         margin-right: $modal-padding/2;
         margin-left: -$modal-padding/2;
       }
     }
-  }
 
-  &.is-failed {
-    .modal-header {
-      background-color: fade_out($tutor-danger, 0.2);
+    &.is-published{
+      &.is-open.is-trouble {
+        .modal-title::before {
+          margin-right: $modal-padding/2;
+          margin-left: -$modal-padding/2;
+        }
+      }
     }
-    .modal-title::before {
-      content: 'failed ';
+
+    &.is-failed {
+      .modal-header {
+        background-color: fade_out($tutor-danger, 0.2);
+      }
+      .modal-title::before {
+        content: 'failed ';
+      }
     }
   }
-
 
   @include tutor-modal();
 

--- a/tutor/src/screens/teacher-dashboard/styles/plan.scss
+++ b/tutor/src/screens/teacher-dashboard/styles/plan.scss
@@ -17,31 +17,15 @@ $calendar-inactive-background: $tutor-neutral;
 
 .list-task-plans {
   .plan {
-    // display: block;
-    // position: absolute;
-    // border: 1px solid $openstax-neutral-light;
     font-size: 1.25rem;
-    // max-height: $calendar-plan-height;
-    // height: auto;
-    // line-height: $calendar-plan-height;
-    // margin-top: $calendar-plan-top-margin;
-    // margin-left: $calendar-plan-left-offset;
     cursor: pointer;
-    // border: none;
     font-weight: bold;
-    // transition: max-height .1s ease-in, margin-top .1s ease-in;
-    // overflow: hidden;
     @include tutor-plan-display($calendar-inactive-background);
     transition: background-color 0.1s linear;
-
-    // takes on CALENDAR_EVENT_DYNAMIC_WIDTH and CALENDAR_EVENT_DYNAMIC_POSITION
-    // Based on event duration and event offset from start of week
-    // see CoursePlan component
 
     &.is-new {
       @include is-progressing-background();
       border-left: none;
-      //height: 20px;
       label {
         display: none,
       }
@@ -86,10 +70,6 @@ $calendar-inactive-background: $tutor-neutral;
       }
     }
 
-
-    // CALENDAR_EVENT_LABEL_DYNAMIC_WIDTH
-    // Takes width based on visible width of plan to center label.
-    // see CoursePlan component
     label {
       padding-left: $calendar-plan-left-label-offset;
       text-align: left;
@@ -97,21 +77,6 @@ $calendar-inactive-background: $tutor-neutral;
       margin-bottom: 0;
       cursor: pointer;
       transition: background .1s ease-in, margin-top .1s ease-in;
-
-      &.continued {
-        &::before {
-          content: '...';
-          margin-right: $calendar-plan-left-label-offset;
-          margin-left: $calendar-plan-left-label-offset / 2;
-          @include psuedo-text-label();
-        }
-
-        &::after {
-          content: 'continued';
-          margin-left: $calendar-plan-left-label-offset;
-          @include psuedo-text-label();
-        }
-      }
     }
 
     &.plan-label-long {

--- a/tutor/src/theme.js
+++ b/tutor/src/theme.js
@@ -25,6 +25,7 @@ const TutorTheme = {
     blue_control:  '#337eb5', // 337eb5
     black:         'black',
     white:         'white',
+    warning:       '#f4d019', // yellow
     danger:        '#c2002f', // dark red
     neutral,
 


### PR DESCRIPTION
* [x] tick mark in the question library is far from the options
* [x] Add student Id window during course signup is missing background
* [x] Cancel button in Delete modal - Highlights & notes page is orange by default vs. staging where Cancel button is grey
* [x] Delete section modal in course roster has pink and orange color. Cancel button is grey in staging but orange in QA
* [x] Window that opens on clicking an existing assignment in teacher view has yellow panel at the top in staging but after upgrade its grey
* [x] The "X" button in the Window that opens on clicking an existing assignment in teacher view is displayed close the the window title instead of right corner
* [x] The "X" button in most of the pop-up windows are close to the window title vs. the right corner
* [x] Highlight & Notes tool tip - too much white space and the line spacing appears to be less. This spacing issue applies to all tool tips
* [x] Refund request modal has both Continue & Cancel button in Orange. I think Cancel would be grey before upgrade. Same with the next window "Help us improve"