### PR TITLE
fix scores report padding

### DIFF
--- a/tutor/src/screens/scores-report/styles/table.scss
+++ b/tutor/src/screens/scores-report/styles/table.scss
@@ -38,6 +38,11 @@ $pie-color-due: #268FBE;
     }
   }
 
+  .fixedDataTableCellLayout_wrap2,
+  .fixedDataTableCellLayout_wrap2 {
+    display: flex;
+  }
+
   .course-scores-table {
     &:focus {
       outline: 0
@@ -62,7 +67,6 @@ $pie-color-due: #268FBE;
   }
 
   i.late {
-//    @include tutor-late-icon();
     padding-left:8px;
   }
 
@@ -91,8 +95,8 @@ $pie-color-due: #268FBE;
     border-bottom: $scores-table-outer-border-width solid $scores-table-outer-border-color;
   }
 
-  .external-cell,   .overall-cell {
-    display: flex;
+  .external-cell,
+  .overall-cell {
     align-items: center;
     justify-content: center;
   }


### PR DESCRIPTION
style bug was triggered if loading the scores report, navigating to teacher dash, then back to scores.



![image](https://user-images.githubusercontent.com/79566/50995941-3b36ee00-14e6-11e9-946c-c8d4fa3c683e.png)
