### PR TITLE
use flex as the default for cells

### DIFF
--- a/tutor/src/screens/scores-report/styles/table.scss
+++ b/tutor/src/screens/scores-report/styles/table.scss
@@ -38,6 +38,9 @@ $pie-color-due: #268FBE;
     }
   }
 
+  // override the display:table
+  // otherwise firefox will render with minimal height
+  .fixedDataTableCellLayout_wrap1,
   .fixedDataTableCellLayout_wrap2,
   .fixedDataTableCellLayout_wrap2 {
     display: flex;


### PR DESCRIPTION
this is needed for Firefox so that all the nested cells are using `flex` layout.