### PR TITLE
vertically center button icons in Firefox

### DIFF
--- a/tutor/resources/styles/components/notes/summary-page.scss
+++ b/tutor/resources/styles/components/notes/summary-page.scss
@@ -76,6 +76,7 @@
         width: 4.6rem;
         display: flex;
         justify-content: center;
+        align-items: center;
 
         &:last-child {
           margin: 0;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/79566/51199546-a30d8000-18bc-11e9-9392-748d18880d2c.png)
