### PR TITLE
Consider author and vocabulary when calulating readOnly status

### DIFF
--- a/exercises/specs/components/__snapshots__/exercise.spec.js.snap
+++ b/exercises/specs/components/__snapshots__/exercise.spec.js.snap
@@ -1620,13 +1620,13 @@ exports[`Exercises component renders and matches snapshot 1`] = `
       <div
         className="c3"
         color="navy"
+        hidden={false}
       >
         <div>
           READ ONLY
         </div>
         <div>
-          Author: 
-          
+          Author: Alene
         </div>
       </div>
       <div
@@ -2100,7 +2100,7 @@ exports[`Exercises component resets fields when model is new 1`] = `
                                     <div className=\\"nickname\\">
                                       <label>
                                         Exercise Nickname:
-                                        <input onChange={[Function: res]} value=\\"nia\\" />
+                                        <input onChange={[Function: res]} value=\\"burley\\" />
                                       </label>
                                     </div>
                                     <Question onRemove={[Function: onRemove]} onMove={[Function: onMove]} question={{...}}>
@@ -3110,18 +3110,18 @@ exports[`Exercises component resets fields when model is new 1`] = `
           <preview__Preview>
             <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
               <div className=\\"preview__Preview-sc-1vfgcxn-0 kDJIdF\\">
-                <CornerRibbon shadow={true} color=\\"navy\\" position=\\"topRight\\" label={{...}}>
+                <CornerRibbon shadow={true} color=\\"navy\\" position=\\"topRight\\" hidden={false} label={{...}}>
                   <corner-ribbon__Ribbon>
                     <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                       <div className=\\"corner-ribbon__Ribbon-ky3mx8-0 dTqhIT\\">
-                        <corner-ribbon__Content shadow={true} color=\\"navy\\" position=\\"topRight\\">
-                          <StyledComponent shadow={true} color=\\"navy\\" position=\\"topRight\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div color=\\"navy\\" className=\\"corner-ribbon__Content-ky3mx8-1 kwMsFn\\">
+                        <corner-ribbon__Content shadow={true} color=\\"navy\\" position=\\"topRight\\" hidden={false}>
+                          <StyledComponent shadow={true} color=\\"navy\\" position=\\"topRight\\" hidden={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                            <div color=\\"navy\\" hidden={false} className=\\"corner-ribbon__Content-ky3mx8-1 kwMsFn\\">
                               <div>
                                 READ ONLY
                               </div>
                               <div>
-                                Author: 
+                                Author: Tyler
                               </div>
                             </div>
                           </StyledComponent>
@@ -3326,7 +3326,7 @@ exports[`Exercises component resets fields when model is new 1`] = `
                                           lo:stax-phys:1-2-1
                                         </span>
                                         <span className=\\"exercise-tag\\">
-                                          Nickname:nia
+                                          Nickname:burley
                                         </span>
                                         <span className=\\"exercise-tag\\">
                                           ID:14@1

--- a/exercises/specs/components/__snapshots__/exercise.spec.js.snap
+++ b/exercises/specs/components/__snapshots__/exercise.spec.js.snap
@@ -53,6 +53,11 @@ exports[`Exercises component renders and matches snapshot 1`] = `
   background: #232e66;
 }
 
+.c3 > div {
+  font-size: 13px;
+  white-space: nowrap;
+}
+
 .c1 {
   margin-top: 1.5rem;
 }
@@ -3116,7 +3121,7 @@ exports[`Exercises component resets fields when model is new 1`] = `
                       <div className=\\"corner-ribbon__Ribbon-ky3mx8-0 dTqhIT\\">
                         <corner-ribbon__Content shadow={true} color=\\"navy\\" position=\\"topRight\\" hidden={false}>
                           <StyledComponent shadow={true} color=\\"navy\\" position=\\"topRight\\" hidden={false} forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div color=\\"navy\\" hidden={false} className=\\"corner-ribbon__Content-ky3mx8-1 kwMsFn\\">
+                            <div color=\\"navy\\" hidden={false} className=\\"corner-ribbon__Content-ky3mx8-1 bghwDv\\">
                               <div>
                                 READ ONLY
                               </div>

--- a/exercises/specs/models/exercises/exercise.spec.js
+++ b/exercises/specs/models/exercises/exercise.spec.js
@@ -10,6 +10,10 @@ describe('Exercises model', () => {
       user_id: 1,
       name: 'Bob',
     } ] });
+    expect(ex.isNew).toBe(true);
+    expect(ex.canEdit).toBe(true);
+    ex.uuid = '1234'; // no longer new
+    expect(ex.isNew).toBe(false);
     expect(ex.canEdit).toBe(false);
     expect(ex.readOnlyReason).toEqual('Author: Bob');
     User.id = 1;

--- a/exercises/specs/models/exercises/exercise.spec.js
+++ b/exercises/specs/models/exercises/exercise.spec.js
@@ -1,0 +1,21 @@
+import Exercise from '../../../src/models/exercises/exercise';
+import User from '../../../src/models/user';
+
+jest.mock('../../../src/models/user');
+
+describe('Exercises model', () => {
+
+  it('calculates read-only status', () => {
+    const ex = new Exercise({ authors: [ {
+      user_id: 1,
+      name: 'Bob',
+    } ] });
+    expect(ex.canEdit).toBe(false);
+    expect(ex.readOnlyReason).toEqual('Author: Bob');
+    User.id = 1;
+    expect(ex.canEdit).toBe(true);
+    ex.is_vocab = true;
+    expect(ex.canEdit).toBe(false);
+    expect(ex.readOnlyReason).toEqual('Vocabulary');
+  });
+});

--- a/exercises/src/components/exercise/preview.jsx
+++ b/exercises/src/components/exercise/preview.jsx
@@ -1,14 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { find } from 'lodash';
 import styled from 'styled-components';
 import { ExercisePreview } from 'shared';
 import { Link } from 'react-router-dom';
-import { computed } from 'mobx';
 import { observer } from 'mobx-react';
 import { CornerRibbon } from 'shared';
-import CurrentUser from '../../models/user';
-
 
 const Preview = styled.div`
   margin-top: 1.5rem;
@@ -24,13 +20,6 @@ class ExerciseEditingPreview extends React.Component {
     showEdit: PropTypes.bool,
   }
 
-  @computed get isAuthor() {
-    const { exercise } = this.props;
-    return Boolean(
-      exercise.isNew || find(exercise.authors, { user_id: CurrentUser.id })
-    );
-  }
-
   render() {
     const { showEdit, exercise, ...previewProps } = this.props;
 
@@ -40,9 +29,10 @@ class ExerciseEditingPreview extends React.Component {
           shadow
           color="navy"
           position="topRight"
+          hidden={exercise.canEdit}
           label={[
             <div key="ro">READ ONLY</div>,
-            <div key="n">Author: {exercise.authors.names().join(',')}</div>,
+            <div key="n">{exercise.readOnlyReason}</div>,
           ]}
         >
           <ExercisePreview
@@ -55,7 +45,7 @@ class ExerciseEditingPreview extends React.Component {
             exercise={exercise}
             {...previewProps}
           >
-            {showEdit && this.isAuthor && <Link className="btn" to={`/exercise/${exercise.uid}`}>EDIT</Link>}
+            {showEdit && exercise.canEdit && <Link className="btn" to={`/exercise/${exercise.uid}`}>EDIT</Link>}
           </ExercisePreview>
         </CornerRibbon>
       </Preview>

--- a/exercises/src/models/exercises/exercise.js
+++ b/exercises/src/models/exercises/exercise.js
@@ -1,6 +1,8 @@
-import { action } from 'mobx';
+import { action, computed } from 'mobx';
+import { find } from 'lodash';
 import { identifiedBy, session } from 'shared/model';
 import SharedExercise from 'shared/model/exercise';
+import CurrentUser from '../user';
 
 export default
 @identifiedBy('exercises/exercise')
@@ -10,5 +12,19 @@ class Exercise extends SharedExercise {
 
   @action onError({ message }) {
     this.error = message;
+  }
+
+  @computed get readOnlyReason() {
+    if (!find(this.authors, { user_id: CurrentUser.id })) {
+      return `Author: ${this.authors.names().join(',')}`;
+    }
+    if (this.is_vocab) {
+      return 'Vocabulary';
+    }
+    return null;
+  }
+
+  @computed get canEdit() {
+    return !this.readOnlyReason;
   }
 };

--- a/exercises/src/models/exercises/exercise.js
+++ b/exercises/src/models/exercises/exercise.js
@@ -15,6 +15,7 @@ class Exercise extends SharedExercise {
   }
 
   @computed get readOnlyReason() {
+    if (this.isNew) { return null; } // new records can always be edited
     if (!find(this.authors, { user_id: CurrentUser.id })) {
       return `Author: ${this.authors.names().join(',')}`;
     }

--- a/exercises/src/models/search.js
+++ b/exercises/src/models/search.js
@@ -4,7 +4,7 @@ import {
   BaseModel, identifiedBy, belongsTo, identifier, field, hasMany, observable, computed, action,
 } from 'shared/model';
 
-import Exercise from 'shared/model/exercise';
+import Exercise from './exercises/exercise';
 
 
 @identifiedBy('search/clause')

--- a/shared/specs/components/__snapshots__/corner-ribbon.spec.jsx.snap
+++ b/shared/specs/components/__snapshots__/corner-ribbon.spec.jsx.snap
@@ -46,6 +46,11 @@ exports[`CornerRibbon renders and matches snapshot for bottomLeft 1`] = `
   transform: rotate(45deg);
 }
 
+.c1 > div {
+  font-size: 13px;
+  white-space: nowrap;
+}
+
 <div
   className="c0"
 >
@@ -107,6 +112,11 @@ exports[`CornerRibbon renders and matches snapshot for bottomRight 1`] = `
   transform: rotate(-45deg);
 }
 
+.c1 > div {
+  font-size: 13px;
+  white-space: nowrap;
+}
+
 <div
   className="c0"
 >
@@ -164,6 +174,11 @@ exports[`CornerRibbon renders and matches snapshot for topLeft 1`] = `
   -webkit-transform: rotate(-45deg);
   -ms-transform: rotate(-45deg);
   transform: rotate(-45deg);
+}
+
+.c1 > div {
+  font-size: 13px;
+  white-space: nowrap;
 }
 
 <div
@@ -224,6 +239,11 @@ exports[`CornerRibbon renders and matches snapshot for topRight 1`] = `
   -webkit-transform: rotate(45deg);
   -ms-transform: rotate(45deg);
   transform: rotate(45deg);
+}
+
+.c1 > div {
+  font-size: 13px;
+  white-space: nowrap;
 }
 
 <div

--- a/shared/specs/factories/exercise.js
+++ b/shared/specs/factories/exercise.js
@@ -8,7 +8,8 @@ const {
 } = require('./helpers');
 
 Factory.define('ExerciseUser')
-  .user_id(sequence);
+  .user_id(sequence)
+  .name(fake.name.firstName);
 
 Factory.define('ExerciseAnswer')
   .id(sequence)

--- a/shared/src/components/corner-ribbon.jsx
+++ b/shared/src/components/corner-ribbon.jsx
@@ -73,6 +73,10 @@ const Content = styled.div`
 
   ${props => Positions[props.position]}
   ${props => Colors[props.color]}
+  > div {
+   font-size: 13px;
+   white-space: nowrap;
+  }
 `;
 
 

--- a/tutor/specs/components/exercises/__snapshots__/cards.spec.js.snap
+++ b/tutor/specs/components/exercises/__snapshots__/cards.spec.js.snap
@@ -28,7 +28,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
           data-exercise-id="1@1"
           tabIndex={-1}
         >
@@ -42,7 +42,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                 className="openstax-exercise-badges"
               >
                 <span
-                  className="interactive"
+                  className="video"
                 >
                   <svg
                     className="icon interactive"
@@ -94,7 +94,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     </g>
                   </svg>
                   <span>
-                    Interactive
+                    Video
                   </span>
                 </span>
               </div>
@@ -383,6 +383,66 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
               className="exercise-body"
             >
               <div
+                className="openstax-exercise-badges"
+              >
+                <span
+                  className="video"
+                >
+                  <svg
+                    className="icon interactive"
+                    version="1.1"
+                    viewBox="0 0 53.23 53.21"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      data-name="Layer 2"
+                      id="Layer_2"
+                    >
+                      <g
+                        data-name="Layer 1"
+                        id="Layer_1-2"
+                      >
+                        <path
+                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
+                          style={
+                            Object {
+                              "fill": "none",
+                            }
+                          }
+                        />
+                        <path
+                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
+                          style={
+                            Object {
+                              "fill": "#15c0dc",
+                            }
+                          }
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                  <span>
+                    Video
+                  </span>
+                </span>
+              </div>
+              <div
                 className="openstax-question openstax-question-preview"
               >
                 <div
@@ -631,7 +691,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
           data-exercise-id="3@1"
           tabIndex={-1}
         >
@@ -645,7 +705,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                 className="openstax-exercise-badges"
               >
                 <span
-                  className="video"
+                  className="interactive"
                 >
                   <svg
                     className="icon interactive"
@@ -697,7 +757,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     </g>
                   </svg>
                   <span>
-                    Video
+                    Interactive
                   </span>
                 </span>
               </div>
@@ -1308,66 +1368,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
               className="exercise-body"
             >
               <div
-                className="openstax-exercise-badges"
-              >
-                <span
-                  className="video"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Video
-                  </span>
-                </span>
-              </div>
-              <div
                 className="openstax-question openstax-question-preview"
               >
                 <div
@@ -1626,66 +1626,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
             <div
               className="exercise-body"
             >
-              <div
-                className="openstax-exercise-badges"
-              >
-                <span
-                  className="video"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Video
-                  </span>
-                </span>
-              </div>
               <div
                 className="openstax-question openstax-question-preview"
               >
@@ -2219,7 +2159,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
           data-exercise-id="8@1"
           tabIndex={-1}
         >
@@ -2229,66 +2169,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
             <div
               className="exercise-body"
             >
-              <div
-                className="openstax-exercise-badges"
-              >
-                <span
-                  className="interactive"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Interactive
-                  </span>
-                </span>
-              </div>
               <div
                 className="openstax-question openstax-question-preview"
               >
@@ -2576,66 +2456,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
             <div
               className="exercise-body"
             >
-              <div
-                className="openstax-exercise-badges"
-              >
-                <span
-                  className="video"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Video
-                  </span>
-                </span>
-              </div>
               <div
                 className="openstax-question openstax-question-preview"
               >
@@ -2954,62 +2774,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
                     Interactive
                   </span>
                 </span>
-                <span
-                  className="video"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Video
-                  </span>
-                </span>
               </div>
               <div
                 className="openstax-question openstax-question-preview"
@@ -3270,6 +3034,66 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
             <div
               className="exercise-body"
             >
+              <div
+                className="openstax-exercise-badges"
+              >
+                <span
+                  className="video"
+                >
+                  <svg
+                    className="icon interactive"
+                    version="1.1"
+                    viewBox="0 0 53.23 53.21"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      data-name="Layer 2"
+                      id="Layer_2"
+                    >
+                      <g
+                        data-name="Layer 1"
+                        id="Layer_1-2"
+                      >
+                        <path
+                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
+                          style={
+                            Object {
+                              "fill": "none",
+                            }
+                          }
+                        />
+                        <path
+                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
+                          style={
+                            Object {
+                              "fill": "#15c0dc",
+                            }
+                          }
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                  <span>
+                    Video
+                  </span>
+                </span>
+              </div>
               <div
                 className="openstax-question openstax-question-preview"
               >
@@ -3835,6 +3659,66 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
               className="exercise-body"
             >
               <div
+                className="openstax-exercise-badges"
+              >
+                <span
+                  className="video"
+                >
+                  <svg
+                    className="icon interactive"
+                    version="1.1"
+                    viewBox="0 0 53.23 53.21"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      data-name="Layer 2"
+                      id="Layer_2"
+                    >
+                      <g
+                        data-name="Layer 1"
+                        id="Layer_1-2"
+                      >
+                        <path
+                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
+                          style={
+                            Object {
+                              "fill": "none",
+                            }
+                          }
+                        />
+                        <path
+                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
+                          style={
+                            Object {
+                              "fill": "#15c0dc",
+                            }
+                          }
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                  <span>
+                    Video
+                  </span>
+                </span>
+              </div>
+              <div
                 className="openstax-question openstax-question-preview"
               >
                 <div
@@ -4101,6 +3985,66 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
               className="exercise-body"
             >
               <div
+                className="openstax-exercise-badges"
+              >
+                <span
+                  className="video"
+                >
+                  <svg
+                    className="icon interactive"
+                    version="1.1"
+                    viewBox="0 0 53.23 53.21"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      data-name="Layer 2"
+                      id="Layer_2"
+                    >
+                      <g
+                        data-name="Layer 1"
+                        id="Layer_1-2"
+                      >
+                        <path
+                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
+                          style={
+                            Object {
+                              "fill": "none",
+                            }
+                          }
+                        />
+                        <path
+                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
+                          style={
+                            Object {
+                              "fill": "#15c0dc",
+                            }
+                          }
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                  <span>
+                    Video
+                  </span>
+                </span>
+              </div>
+              <div
                 className="openstax-question openstax-question-preview"
               >
                 <div
@@ -4349,7 +4293,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
           data-exercise-id="15@1"
           tabIndex={-1}
         >
@@ -4359,122 +4303,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
             <div
               className="exercise-body"
             >
-              <div
-                className="openstax-exercise-badges"
-              >
-                <span
-                  className="interactive"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Interactive
-                  </span>
-                </span>
-                <span
-                  className="video"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Video
-                  </span>
-                </span>
-              </div>
               <div
                 className="openstax-question openstax-question-preview"
               >
@@ -4724,7 +4552,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
           data-exercise-id="16@1"
           tabIndex={-1}
         >
@@ -4734,6 +4562,66 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
             <div
               className="exercise-body"
             >
+              <div
+                className="openstax-exercise-badges"
+              >
+                <span
+                  className="interactive"
+                >
+                  <svg
+                    className="icon interactive"
+                    version="1.1"
+                    viewBox="0 0 53.23 53.21"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      data-name="Layer 2"
+                      id="Layer_2"
+                    >
+                      <g
+                        data-name="Layer 1"
+                        id="Layer_1-2"
+                      >
+                        <path
+                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
+                          style={
+                            Object {
+                              "fill": "none",
+                            }
+                          }
+                        />
+                        <path
+                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
+                          style={
+                            Object {
+                              "fill": "#15c0dc",
+                            }
+                          }
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                  <span>
+                    Interactive
+                  </span>
+                </span>
+              </div>
               <div
                 className="openstax-question openstax-question-preview"
               >
@@ -5040,6 +4928,66 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
               className="exercise-body"
             >
               <div
+                className="openstax-exercise-badges"
+              >
+                <span
+                  className="video"
+                >
+                  <svg
+                    className="icon interactive"
+                    version="1.1"
+                    viewBox="0 0 53.23 53.21"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      data-name="Layer 2"
+                      id="Layer_2"
+                    >
+                      <g
+                        data-name="Layer 1"
+                        id="Layer_1-2"
+                      >
+                        <path
+                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
+                          style={
+                            Object {
+                              "fill": "none",
+                            }
+                          }
+                        />
+                        <path
+                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
+                          style={
+                            Object {
+                              "fill": "#15c0dc",
+                            }
+                          }
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                  <span>
+                    Video
+                  </span>
+                </span>
+              </div>
+              <div
                 className="openstax-question openstax-question-preview"
               >
                 <div
@@ -5288,7 +5236,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
           data-exercise-id="18@1"
           tabIndex={-1}
         >
@@ -5298,122 +5246,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
             <div
               className="exercise-body"
             >
-              <div
-                className="openstax-exercise-badges"
-              >
-                <span
-                  className="interactive"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Interactive
-                  </span>
-                </span>
-                <span
-                  className="video"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Video
-                  </span>
-                </span>
-              </div>
               <div
                 className="openstax-question openstax-question-preview"
               >
@@ -5929,7 +5761,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
           data-exercise-id="20@1"
           tabIndex={-1}
         >
@@ -5939,66 +5771,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
             <div
               className="exercise-body"
             >
-              <div
-                className="openstax-exercise-badges"
-              >
-                <span
-                  className="interactive"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Interactive
-                  </span>
-                </span>
-              </div>
               <div
                 className="openstax-question openstax-question-preview"
               >
@@ -6553,7 +6325,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
           data-exercise-id="22@1"
           tabIndex={-1}
         >
@@ -6563,66 +6335,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
             <div
               className="exercise-body"
             >
-              <div
-                className="openstax-exercise-badges"
-              >
-                <span
-                  className="interactive"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Interactive
-                  </span>
-                </span>
-              </div>
               <div
                 className="openstax-question openstax-question-preview"
               >
@@ -7198,7 +6910,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
           data-exercise-id="24@1"
           tabIndex={-1}
         >
@@ -7208,66 +6920,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
             <div
               className="exercise-body"
             >
-              <div
-                className="openstax-exercise-badges"
-              >
-                <span
-                  className="interactive"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Interactive
-                  </span>
-                </span>
-              </div>
               <div
                 className="openstax-question openstax-question-preview"
               >
@@ -7857,7 +7509,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
           data-exercise-id="26@1"
           tabIndex={-1}
         >
@@ -7870,62 +7522,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
               <div
                 className="openstax-exercise-badges"
               >
-                <span
-                  className="interactive"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Interactive
-                  </span>
-                </span>
                 <span
                   className="video"
                 >
@@ -8803,7 +8399,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
           data-exercise-id="29@1"
           tabIndex={-1}
         >
@@ -8813,6 +8409,66 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
             <div
               className="exercise-body"
             >
+              <div
+                className="openstax-exercise-badges"
+              >
+                <span
+                  className="interactive"
+                >
+                  <svg
+                    className="icon interactive"
+                    version="1.1"
+                    viewBox="0 0 53.23 53.21"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      data-name="Layer 2"
+                      id="Layer_2"
+                    >
+                      <g
+                        data-name="Layer 1"
+                        id="Layer_1-2"
+                      >
+                        <path
+                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
+                          style={
+                            Object {
+                              "fill": "none",
+                            }
+                          }
+                        />
+                        <path
+                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
+                          style={
+                            Object {
+                              "fill": "#15c0dc",
+                            }
+                          }
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                  <span>
+                    Interactive
+                  </span>
+                </span>
+              </div>
               <div
                 className="openstax-question openstax-question-preview"
               >
@@ -9616,6 +9272,66 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
               className="exercise-body"
             >
               <div
+                className="openstax-exercise-badges"
+              >
+                <span
+                  className="video"
+                >
+                  <svg
+                    className="icon interactive"
+                    version="1.1"
+                    viewBox="0 0 53.23 53.21"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      data-name="Layer 2"
+                      id="Layer_2"
+                    >
+                      <g
+                        data-name="Layer 1"
+                        id="Layer_1-2"
+                      >
+                        <path
+                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
+                          style={
+                            Object {
+                              "fill": "none",
+                            }
+                          }
+                        />
+                        <path
+                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
+                          style={
+                            Object {
+                              "fill": "#15c0dc",
+                            }
+                          }
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                  <span>
+                    Video
+                  </span>
+                </span>
+              </div>
+              <div
                 className="openstax-question openstax-question-preview"
               >
                 <div
@@ -9885,7 +9601,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
           data-exercise-id="33@1"
           tabIndex={-1}
         >
@@ -9898,6 +9614,62 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
               <div
                 className="openstax-exercise-badges"
               >
+                <span
+                  className="interactive"
+                >
+                  <svg
+                    className="icon interactive"
+                    version="1.1"
+                    viewBox="0 0 53.23 53.21"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      data-name="Layer 2"
+                      id="Layer_2"
+                    >
+                      <g
+                        data-name="Layer 1"
+                        id="Layer_1-2"
+                      >
+                        <path
+                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
+                          style={
+                            Object {
+                              "fill": "none",
+                            }
+                          }
+                        />
+                        <path
+                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
+                          style={
+                            Object {
+                              "fill": "#15c0dc",
+                            }
+                          }
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                  <span>
+                    Interactive
+                  </span>
+                </span>
                 <span
                   className="video"
                 >
@@ -10211,7 +9983,7 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
         data-tour-anchor-id="exercise-preview"
       >
         <div
-          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated has-interactive card"
+          className="openstax-exercise-preview exercise-card non-interactive is-vertically-truncated card"
           data-exercise-id="34@1"
           tabIndex={-1}
         >
@@ -10224,62 +9996,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
               <div
                 className="openstax-exercise-badges"
               >
-                <span
-                  className="interactive"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Interactive
-                  </span>
-                </span>
                 <span
                   className="video"
                 >
@@ -10597,66 +10313,6 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
               className="exercise-body"
             >
               <div
-                className="openstax-exercise-badges"
-              >
-                <span
-                  className="video"
-                >
-                  <svg
-                    className="icon interactive"
-                    version="1.1"
-                    viewBox="0 0 53.23 53.21"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      data-name="Layer 2"
-                      id="Layer_2"
-                    >
-                      <g
-                        data-name="Layer 1"
-                        id="Layer_1-2"
-                      >
-                        <path
-                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                          style={
-                            Object {
-                              "fill": "none",
-                            }
-                          }
-                        />
-                        <path
-                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                          style={
-                            Object {
-                              "fill": "#222e65",
-                            }
-                          }
-                        />
-                        <path
-                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                          style={
-                            Object {
-                              "fill": "#15c0dc",
-                            }
-                          }
-                        />
-                      </g>
-                    </g>
-                  </svg>
-                  <span>
-                    Video
-                  </span>
-                </span>
-              </div>
-              <div
                 className="openstax-question openstax-question-preview"
               >
                 <div
@@ -10915,6 +10571,66 @@ exports[`Exercise Cards Component renders and matches snapshot 1`] = `
             <div
               className="exercise-body"
             >
+              <div
+                className="openstax-exercise-badges"
+              >
+                <span
+                  className="video"
+                >
+                  <svg
+                    className="icon interactive"
+                    version="1.1"
+                    viewBox="0 0 53.23 53.21"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      data-name="Layer 2"
+                      id="Layer_2"
+                    >
+                      <g
+                        data-name="Layer 1"
+                        id="Layer_1-2"
+                      >
+                        <path
+                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
+                          style={
+                            Object {
+                              "fill": "none",
+                            }
+                          }
+                        />
+                        <path
+                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
+                          style={
+                            Object {
+                              "fill": "#15c0dc",
+                            }
+                          }
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                  <span>
+                    Video
+                  </span>
+                </span>
+              </div>
               <div
                 className="openstax-question openstax-question-preview"
               >

--- a/tutor/specs/components/exercises/__snapshots__/details.spec.jsx.snap
+++ b/tutor/specs/components/exercises/__snapshots__/details.spec.jsx.snap
@@ -87,6 +87,66 @@ exports[`Exercise Details Component renders and matches snapshot 1`] = `
               className="exercise-body"
             >
               <div
+                className="openstax-exercise-badges"
+              >
+                <span
+                  className="video"
+                >
+                  <svg
+                    className="icon interactive"
+                    version="1.1"
+                    viewBox="0 0 53.23 53.21"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      data-name="Layer 2"
+                      id="Layer_2"
+                    >
+                      <g
+                        data-name="Layer 1"
+                        id="Layer_1-2"
+                      >
+                        <path
+                          d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
+                          style={
+                            Object {
+                              "fill": "none",
+                            }
+                          }
+                        />
+                        <path
+                          d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
+                          style={
+                            Object {
+                              "fill": "#222e65",
+                            }
+                          }
+                        />
+                        <path
+                          d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
+                          style={
+                            Object {
+                              "fill": "#15c0dc",
+                            }
+                          }
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                  <span>
+                    Video
+                  </span>
+                </span>
+              </div>
+              <div
                 className="openstax-question openstax-question-preview"
               >
                 <div

--- a/tutor/specs/components/exercises/__snapshots__/preview.spec.js.snap
+++ b/tutor/specs/components/exercises/__snapshots__/preview.spec.js.snap
@@ -17,66 +17,6 @@ exports[`Exercise Preview Wrapper Component renders and matches snapshot 1`] = `
         className="exercise-body"
       >
         <div
-          className="openstax-exercise-badges"
-        >
-          <span
-            className="video"
-          >
-            <svg
-              className="icon interactive"
-              version="1.1"
-              viewBox="0 0 53.23 53.21"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                data-name="Layer 2"
-                id="Layer_2"
-              >
-                <g
-                  data-name="Layer 1"
-                  id="Layer_1-2"
-                >
-                  <path
-                    d="M48.86,0H11.37A4.34,4.34,0,0,0,7,4.35V41.6A4.34,4.34,0,0,0,11.37,46H48.86a4.34,4.34,0,0,0,4.35-4.35V4.35A4.19,4.19,0,0,0,48.86,0Zm1,40.88a1.65,1.65,0,0,1-1.69,1.69H11.85a1.65,1.65,0,0,1-1.69-1.69V5.32a1.65,1.65,0,0,1,1.69-1.69H48.14a1.65,1.65,0,0,1,1.69,1.69Z"
-                    style={
-                      Object {
-                        "fill": "#222e65",
-                      }
-                    }
-                  />
-                  <path
-                    d="M48.14,3.63H11.85a1.65,1.65,0,0,0-1.69,1.69V40.88a1.65,1.65,0,0,0,1.69,1.69H48.14a1.65,1.65,0,0,0,1.69-1.69V5.32A1.65,1.65,0,0,0,48.14,3.63ZM23.46,35.32V10.88L41.12,23.22Z"
-                    style={
-                      Object {
-                        "fill": "none",
-                      }
-                    }
-                  />
-                  <path
-                    d="M3.39,47.65V18.78a1.61,1.61,0,0,0-1.61-1.61H1.61A1.61,1.61,0,0,0,0,18.78V48.86a4.35,4.35,0,0,0,4.35,4.35H33.47a1.61,1.61,0,0,0,1.61-1.61v-.41a1.61,1.61,0,0,0-1.61-1.61H5.32A1.94,1.94,0,0,1,3.39,47.65Z"
-                    style={
-                      Object {
-                        "fill": "#222e65",
-                      }
-                    }
-                  />
-                  <path
-                    d="M26,33.59,39.2,24.53a1.61,1.61,0,0,0,0-2.64L26,12.65A1.61,1.61,0,0,0,23.46,14v18.3A1.61,1.61,0,0,0,26,33.59Z"
-                    style={
-                      Object {
-                        "fill": "#15c0dc",
-                      }
-                    }
-                  />
-                </g>
-              </g>
-            </svg>
-            <span>
-              Video
-            </span>
-          </span>
-        </div>
-        <div
           className="openstax-question openstax-question-preview"
         >
           <div


### PR DESCRIPTION
Previously there was 2 bugs:
 * The ribbon was always visible even when the user could edit
 * The logic behind the ribbon was intended to only check if the current user was the author
    * This failed for vocabulary terms, which aren't editable regardless of who authored them

![image](https://user-images.githubusercontent.com/79566/53668551-c193c480-3c39-11e9-9ed1-3e003123b123.png)

