### PR TITLE
log validation failures to console but don't notify

### DIFF
--- a/tutor/src/api/index.js
+++ b/tutor/src/api/index.js
@@ -250,7 +250,10 @@ const startAPI = function() {
     },
   );
 
-  connectModelRead(ResponseValidation, 'validate', { pattern: 'validate', onSuccess: 'onValidationComplete' });
+  connectModelRead(ResponseValidation, 'validate',
+    { pattern: 'validate', onSuccess: 'onValidationComplete',
+      onFail: 'onFailure',
+    });
 
   connectModelUpdate(Student, 'saveOwnStudentId', { pattern: 'user/courses/{course.id}/student', onSuccess: 'onApiRequestComplete' });
   connectModelUpdate(Student, 'saveStudentId', { pattern: 'students/{id}', onSuccess: 'onApiRequestComplete' });

--- a/tutor/src/flux/task-step.js
+++ b/tutor/src/flux/task-step.js
@@ -104,12 +104,16 @@ const TaskStepConfig = {
     this._change(id, { free_response });
     const { spy, content: { uid } } = this._local[id];
     const validation = new ResponseValidation();
-    await validation.validate({ uid, response: free_response });
-    const garbage_estimate = validation.serialize();
-    if (spy) {
-      spy.garbage_estimate = garbage_estimate;
+    try {
+      await validation.validate({ uid, response: free_response });
+      const garbage_estimate = validation.serialize();
+      if (spy) {
+        spy.garbage_estimate = garbage_estimate;
+      }
+      this._change(id, { spy, garbage_estimate });
+    } catch(e) {
+      console.warn(e); // eslint-disable-line no-console
     }
-    this._change(id, { spy, garbage_estimate });
     return actions.saveFreeResponseAnswer(id);
   },
   // called once setFreeResponseAnswer completes above.  will trigger saving the flux store

--- a/tutor/src/models/response_validation.js
+++ b/tutor/src/models/response_validation.js
@@ -1,9 +1,9 @@
 import {
-  BaseModel, identifiedBy, action, computed, field, identifier, hasMany,
+  BaseModel, identifiedBy, action, field,
 } from 'shared/model';
 
 const ResponseValidationConfig = {
-  url: null,
+  url: '',
 };
 
 @identifiedBy('response_validation')
@@ -40,6 +40,12 @@ class ResponseValidation extends BaseModel {
         remove_nonwords: 'True',
       },
     };
+  }
+
+  onFailure(error) {
+    console.warn(error); // eslint-disable-line no-console
+    // signal not to display error modal
+    error.isRecorded = true;
   }
 
   @action onValidationComplete({ data }) {


### PR DESCRIPTION
No longer display the modal, instead just log it to the console.  We'll probably change this behavior once the full UI for this is specced