### PR TITLE
only display the note summary toggle widget for reading steps

### DIFF
--- a/tutor/specs/components/navbar/center-controls.spec.jsx
+++ b/tutor/specs/components/navbar/center-controls.spec.jsx
@@ -29,4 +29,16 @@ describe('Center Controls', function() {
     cntrl.unmount();
   });
 
+  it('hides notes when not annotatable', () => {
+    const step = Factory.studentTask({ type: 'reading', stepCount: 1 }).steps[0];
+    step.type = 'reading';
+    expect(step.canAnnotate).toBe(true);
+    CenterControls.currentTaskStep = step;
+    const cntrl = mount(<CenterControls {...props} />, EnzymeContext.build());
+    expect(cntrl.find('NoteSummaryToggle').html()).not.toBeNull();
+    step.type = 'exercise';
+    expect(cntrl.find('NoteSummaryToggle').html()).toBeNull();
+    cntrl.unmount();
+  });
+
 });

--- a/tutor/src/components/navbar/center-controls.jsx
+++ b/tutor/src/components/navbar/center-controls.jsx
@@ -49,7 +49,7 @@ class CenterControls extends React.Component {
           <NotesSummaryToggle
             course={this.course}
             type="reading"
-            taskStep={taskStep}
+            model={taskStep}
           />
         </div>
       </div>


### PR DESCRIPTION
The correct prop name was renamed to "model" and this was missed

Before the note summary widget would appear on all reading steps, even exercises