### PR TITLE
Fix bug where placeholder steps wouldn't re-load when visited

### DIFF
--- a/tutor/specs/models/student-tasks/step.spec.js
+++ b/tutor/specs/models/student-tasks/step.spec.js
@@ -9,8 +9,21 @@ describe('Student Task Step', () => {
     expect(step.isFetched).toBe(true);
   });
 
+  it('only fetches when needed', () => {
+    const step = Factory.studentTask({ type: 'homework', stepCount: 1 }).steps[0];
+    expect(step.needsFetched).toBe(true);
+    step.api.requestCounts.read = 1;
+    expect(step.needsFetched).toBe(false);
+    step.api.requestCounts.read = 0;
+    expect(step.needsFetched).toBe(true);
+    step.type = 'external_url'; // doesn't need fetched
+    expect(step.needsFetched).toBe(false);
+  });
+
   it('calculates if free response is needed', () => {
     const step = Factory.studentTask({ type: 'homework', stepCount: 1 }).steps[0];
+    step.formats = ['free-response'];
+    expect(step.isTwoStep).toBe(true);
     expect(step.needsFreeResponse).toBe(true);
     step.free_response = 'a question with answers';
     expect(step.needsFreeResponse).toBe(false);

--- a/tutor/specs/screens/task/homework.spec.js
+++ b/tutor/specs/screens/task/homework.spec.js
@@ -21,10 +21,9 @@ describe('Reading Tasks Screen', () => {
     expect(<C><Homework {...props} /></C>).toMatchSnapshot();
   });
 
-  it('renders value props', () => {
-    props.ux._task.steps.unshift({ type: 'two-step-intro' });
-    props.ux._stepIndex = 0;
+  fit('renders value props', () => {
     const h = mount(<C><Homework {...props} /></C>);
+    expect(props.ux.currentStep.type).toEqual('two-step-intro');
     expect(h).toHaveRendered('TwoStepValueProp');
     h.unmount();
   });
@@ -34,6 +33,8 @@ describe('Reading Tasks Screen', () => {
     const h = mount(<C><Homework {...props} /></C>);
     expect(h).toHaveRendered('IndividualReview');
     props.ux.goForward();
+    expect(h).toHaveRendered('LoadingCard');
+    props.ux.currentStep.api.requestCounts.read = 1;
     expect(h).toHaveRendered('PlaceHolderTaskStep');
     h.unmount();
   });

--- a/tutor/specs/screens/task/reading.spec.js
+++ b/tutor/specs/screens/task/reading.spec.js
@@ -34,10 +34,10 @@ describe('Reading Tasks Screen', () => {
   });
 
   it('renders value props', () => {
-    props.ux._task.steps.unshift({ type: 'personalized-intro' });
-    props.ux._stepIndex = 0;
+    props.ux._stepIndex = props.ux.steps.findIndex(s=>s.type === 'two-step-intro');
     const r = mount(<C><Reading {...props} /></C>);
-    expect(r).toHaveRendered('PersonalizedGroup');
+    expect(props.ux.currentStep.type).toEqual('two-step-intro');
+    expect(r).toHaveRendered('TwoStepValueProp');
     r.unmount();
   });
 

--- a/tutor/specs/screens/task/ux.spec.js
+++ b/tutor/specs/screens/task/ux.spec.js
@@ -27,11 +27,26 @@ describe('Task UX Model', () => {
     ).not.toBeUndefined();
   });
 
+  it('groups steps', () => {
+    const i = 1 + ux.steps.findIndex(s => s.type == 'two-step-intro');
+    // steps with null uid do not group
+    ux.steps[i+1].uid = ux.groupedSteps[i].uid = undefined;
+    expect(ux.groupedSteps[i].type).not.toBe('mpq');
+
+    ux.steps[i+1].uid = ux.groupedSteps[i].uid = '123@4';
+    const group = ux.groupedSteps[i];
+    expect(group.type).toBe('mpq');
+    expect(group.steps.map(s=>s.id)).toEqual([
+      ux.steps[i].id,
+      ux.steps[i+1].id,
+    ]);
+
+  });
+
   it('scrolls to next mpq', async () => {
     const i = 1 + ux.steps.findIndex(s => s.type == 'two-step-intro');
     ux.steps[i+1].uid = ux.groupedSteps[i].uid;
     const group = ux.groupedSteps[i];
-    expect(group.type).toBe('mpq');
     const s = group.steps[0];
     expect(s.multiPartGroup).toBe(group);
 

--- a/tutor/src/models/student-tasks/step.js
+++ b/tutor/src/models/student-tasks/step.js
@@ -59,8 +59,8 @@ const UNSAVEABLE_TYPES = [
   'placeholder',
 ];
 
-const HAS_ADDITIONAL_CONTENT = [
-  'reading', 'exercise', 'interactive', 'video',
+const NO_ADDITIONAL_CONTENT = [
+  'external_url',
 ];
 
 export default
@@ -141,7 +141,7 @@ class StudentTaskStep extends BaseModel {
 
   @computed get needsFetched() {
     return Boolean(
-      HAS_ADDITIONAL_CONTENT.includes(this.type) && !this.api.hasBeenFetched
+      !NO_ADDITIONAL_CONTENT.includes(this.type) && !this.api.hasBeenFetched
     );
   }
 

--- a/tutor/src/screens/task/ux.js
+++ b/tutor/src/screens/task/ux.js
@@ -54,7 +54,7 @@ export default class TaskUX {
     const { steps } = this.manipulated;
     if (this.task.isHomework) {
       return map(
-        groupBy(steps, s => `${s.type}.${s.uid}`),
+        groupBy(steps, s => `${s.type}.${s.uid || s.id}`),
         (steps, uid) => steps.length > 1 ?
           new StepGroup({ steps, uid }) : steps[0]
       );


### PR DESCRIPTION
Usually the steps would be ready when the entire task was fetched, but for new students they sometimes wouldn't be