### PR TITLE
include annotation content on summary popup

### DIFF
--- a/tutor/specs/components/notes/__snapshots__/summary-popup.spec.js.snap
+++ b/tutor/specs/components/notes/__snapshots__/summary-popup.spec.js.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Notes Summary Popup matches snapshot 1`] = `
+.c0 {
+  margin-right: 0.5rem;
+  margin-left: 0.5rem;
+}
+
+<div>
+  <button
+    className="print-btn btn btn-default"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-print fa-w-16 ox-icon print c0"
+      data-icon="print"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M448 192V77.25c0-8.49-3.37-16.62-9.37-22.63L393.37 9.37c-6-6-14.14-9.37-22.63-9.37H96C78.33 0 64 14.33 64 32v160c-35.35 0-64 28.65-64 64v112c0 8.84 7.16 16 16 16h48v96c0 17.67 14.33 32 32 32h320c17.67 0 32-14.33 32-32v-96h48c8.84 0 16-7.16 16-16V256c0-35.35-28.65-64-64-64zm-64 256H128v-96h256v96zm0-224H128V64h192v48c0 8.84 7.16 16 16 16h48v96zm48 72c-13.25 0-24-10.75-24-24 0-13.26 10.75-24 24-24s24 10.74 24 24c0 13.25-10.75 24-24 24z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+     Print this page
+  </button>
+  <div
+    data-mocked-popout={true}
+  >
+    <div
+      className="summary-preview summary-popup"
+    >
+      <div
+        className="notes"
+      >
+        <div
+          className="section"
+        >
+          <h2>
+            5.4
+            directional
+          </h2>
+          <div
+            style={
+              Object {
+                "marginBottom": "2rem",
+              }
+            }
+          >
+            <blockquote
+              style={
+                Object {
+                  "borderLeft": "2px solid lightgrey",
+                  "fontStyle": "italic",
+                  "margin": "0 0 1rem 0.5rem",
+                  "paddingLeft": "0.5rem",
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "“physics”? Did you imagine ",
+                  }
+                }
+              />
+            </blockquote>
+            <p
+              style={
+                Object {
+                  "marginLeft": "0.5rem",
+                }
+              }
+            >
+              This is a comment added by user
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/tutor/specs/components/notes/summary-popup.spec.js
+++ b/tutor/specs/components/notes/summary-popup.spec.js
@@ -1,6 +1,22 @@
 import SummaryPopup from '../../../src/components/notes/summary-popup';
 import { Factory } from '../../helpers';
 
+jest.mock('../../../../shared/src/components/html', () => ({ html }) =>
+  html ? <div dangerouslySetInnerHTML={{ __html: html }} /> : null
+);
+
+jest.mock('shared/components/popout-window', () => {
+  const React = require('react');
+  class MockPopout extends React.Component {
+    print() {}
+    open() {}
+    render () {
+      return <div data-mocked-popout>{this.props.children}</div>;
+    }
+  }
+  return MockPopout;
+});
+
 describe('Notes Summary Popup', () => {
   let pages;
   let props;
@@ -8,9 +24,10 @@ describe('Notes Summary Popup', () => {
   beforeEach(() => {
     const course = Factory.course();
     const note = Factory.note();
-    course.notes.forChapterSection(note.chapter_section)
-      .onLoaded({ data: [note] });
-    pages = [Factory.page()];
+    note.annotation = 'This is a comment added by user';
+    const pageNotes = course.notes.forChapterSection(note.chapter_section);
+    pageNotes.onLoaded({ data: [note] });
+    pages = [Factory.page({ chapter_section: note.chapter_section.asString } )];
     course.notes.onHighlightedSectionsLoaded({
       data: {
         pages,
@@ -19,14 +36,17 @@ describe('Notes Summary Popup', () => {
     props = {
       page: pages[0],
       notes: course.notes,
-      selected: [note.chapter_section],
+      selected: [note.chapter_section.key],
     };
   });
 
-  it('renders summary', () => {
-    const sp = mount(
-      <SummaryPopup {...props} />
-    );
-    expect(sp).toHaveRendered('PopoutWindow');
+  it('matches snapshot', () => {
+    expect.snapshot(<SummaryPopup {...props} />).toMatchSnapshot();
+  });
+
+  it('renders summary and annotations', () => {
+    const sp = mount(<SummaryPopup {...props} />);
+    expect(sp).toHaveRendered('MockPopout NotesForSection');
+    expect(sp.find('MockPopout NotesForSection').text()).toContain('added by user');
   });
 });

--- a/tutor/src/components/notes/summary-popup.jsx
+++ b/tutor/src/components/notes/summary-popup.jsx
@@ -11,12 +11,10 @@ import Analytics from '../../helpers/analytics';
 const NotesForSection = observer(({
   notes, section, selectedSections,
 }) => {
-
   if (!selectedSections.includes(section.chapter_section.key)) {
     return null;
   }
   const page = notes.forChapterSection(section.chapter_section);
-
   return (
     <div className="section">
       <h2>
@@ -45,14 +43,14 @@ const NotesForSection = observer(({
               marginLeft: '0.5rem',
             }}
           >
-            {note.text}
+            {note.annotation}
           </p>
         </div>
       ))}
     </div>
   );
 });
-
+NotesForSection.displayName = 'NotesForSection';
 
 export default
 @observer
@@ -133,4 +131,4 @@ class SummaryPopup extends React.Component {
       </div>
     );
   }
-};
+}


### PR DESCRIPTION
Fixes bug where the user generated note property was renamed to be
"annoation" but the print screen failed to be updated