### PR TITLE
Disallow changing answers after assignment becomes due

### DIFF
--- a/tutor/specs/models/student-tasks/step.spec.js
+++ b/tutor/specs/models/student-tasks/step.spec.js
@@ -1,7 +1,9 @@
-import { Factory } from '../../helpers';
+import { Factory, TimeMock } from '../../helpers';
 
 
 describe('Student Task Step', () => {
+  const now = new Date('2017-10-14T12:00:00.000Z');
+  TimeMock.setTo(now);
 
   it('sets content', () => {
     const step = Factory.studentTask({ type: 'reading', stepCount: 1 }).steps[0];
@@ -27,6 +29,17 @@ describe('Student Task Step', () => {
     expect(step.needsFreeResponse).toBe(true);
     step.free_response = 'a question with answers';
     expect(step.needsFreeResponse).toBe(false);
+  });
+
+  it('calculates if it can be answered', () => {
+    const step = Factory.studentTask({ type: 'homework', stepCount: 1 }).steps[0];
+    expect(step.canAnswer).toBe(true);
+    step.task.feedback_at = now - 1;
+    expect(step.task.isFeedbackAvailable).toBe(true);
+    expect(step.canAnswer).toBe(true);
+    step.answer_id = 1234;
+    expect(step.hasBeenAnswered).toBe(true);
+    expect(step.canAnswer).toBe(false);
   });
 
 });

--- a/tutor/src/models/student-tasks/step.js
+++ b/tutor/src/models/student-tasks/step.js
@@ -144,6 +144,16 @@ class StudentTaskStep extends BaseModel {
     );
   }
 
+  @computed get hasBeenAnswered() {
+    return Boolean(this.answer_id);
+  }
+
+  @computed get canAnswer() {
+    return Boolean(
+      this.isExercise && (!this.hasBeenAnswered || !this.task.isFeedbackAvailable)
+    );
+  }
+
   @computed get needsFetched() {
     return Boolean(
       !NO_ADDITIONAL_CONTENT.includes(this.type) && !this.api.hasBeenFetched
@@ -151,7 +161,6 @@ class StudentTaskStep extends BaseModel {
   }
 
   @action fetchIfNeeded() {
-
     if (this.needsFetched) { this.fetch(); }
   }
 

--- a/tutor/src/screens/task/step/exercise-question.js
+++ b/tutor/src/screens/task/step/exercise-question.js
@@ -125,7 +125,7 @@ class ExerciseQuestion extends React.Component {
         <Question
           task={ux.task}
           question={question}
-          choicesEnabled={true}
+          choicesEnabled={step.canAnswer}
           answer_id={this.answerId}
           focus={!step.multiPartGroup}
           questionNumber={questionNumber}
@@ -137,7 +137,7 @@ class ExerciseQuestion extends React.Component {
           <FreeResponseReview course={course} step={step} />
         </Question>
         <Controls>
-          {this.needsSaved ?
+          {step.canAnswer && this.needsSaved ?
             this.renderSaveButton() : this.renderNextButton()}
         </Controls>
         <StepFooter course={course} step={step} />


### PR DESCRIPTION
Fixes tricky bug where updates would be allowed if a student started working an assignment before it was due, and did not reload after it was due.

The BE would still error and refuse the update but this will disable the controls once the due date passes