### PR TITLE
remove LO column layout, only use theme color when it's splashy

### DIFF
--- a/tutor/resources/styles/book-content/learning-objectives.scss
+++ b/tutor/resources/styles/book-content/learning-objectives.scss
@@ -13,19 +13,15 @@
     width: 100%;
     min-height: 100px;
     @include book-content-full-width();
-    display: inline-flex;
-    margin-top: -$tutor-card-body-padding-vertical;
+
     padding: $tutor-book-padding-vertical;
-    border: none;
+    border-bottom: 1px solid $border-color;
 
     &::before {
       @include tutor-sans-font(1.4rem, 1.8em);
+      display: block;
       text-transform: uppercase;
-      text-align: right;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      margin: 0 20px 0 0;
+      margin: 0 0 1rem 1rem;
     }
 
     &[data-is-intro=true]::before {
@@ -33,8 +29,6 @@
     }
 
     &[data-is-intro=false]::before {
-      width: 220px; // keep line length consistent
-      margin-top: -1rem;
       content: 'By the end of this section, you will be able to:';
     }
 
@@ -56,11 +50,9 @@
       flex-direction: column;
       justify-content: center;
       flex: 1;
-      border-left-width: 1px;
-      border-left-style: solid;
 
       li {
-        @include tutor-sans-font(1.5rem, 1.4em);
+        @include tutor-sans-font(1.4rem, 1.3em);
         justify-content: center;
         margin-left: 20px;
         padding-bottom: 5px;
@@ -75,6 +67,5 @@
         }
       }
     }
-    @include printer-safe(inline-flex, inherit, inherit, 10px);
   }
 }

--- a/tutor/resources/styles/book-content/splash-image.scss
+++ b/tutor/resources/styles/book-content/splash-image.scss
@@ -1,8 +1,9 @@
 @mixin tutor-book-content-splash-image() {
 
-  // splash images are always full width without margin or surrounding padding
+  // splash elements are full width without margin or surrounding padding
   .splash {
     @include book-content-full-width();
+    margin-bottom: 2rem;
 
     img {
       border: 0;

--- a/tutor/resources/styles/book-content/theming-mixins.scss
+++ b/tutor/resources/styles/book-content/theming-mixins.scss
@@ -1,20 +1,18 @@
 @mixin tutor-book-theme-learning-objectives($background, $theme-accent, $text-color) {
-  .learning-objectives,
-  [data-type=abstract] {
+
+  .learning-objectives.splash {
     background: $background;
     color: $text-color;
-    ul {
-      border-left-color: fade_out($text-color, 0.6);
+    padding-top: 0;
+    border-bottom: 0;
+    margin-bottom: 0;
+
+    // add top margin to anything that's not itself a splash element
+    & + *:not(.splash) {
+      margin-top: 2rem;
     }
   }
 
-  .related-content[data-has-learning-objectives] + .book-content {
-    .learning-objectives,
-    [data-type=abstract] {
-      background: $theme-accent;
-      color: $text-color;
-    }
-  }
 }
 
 @mixin tutor-book-theme-related-content($background, $text-color) {

--- a/tutor/resources/styles/mixins/figures.scss
+++ b/tutor/resources/styles/mixins/figures.scss
@@ -45,9 +45,17 @@
       padding-bottom: 0.5rem;
       margin-bottom: 0.5rem;
       color: $caption-font-color;
-      .os-title-label,
-      .os-number {
-        font-style: italic;
+
+      padding: 10px 0;
+      font-weight: 300;
+      font-style: italic;
+      line-height: 150%;
+
+      border-bottom: 1px solid $border-color;
+
+      &::before {
+        counter-increment: figure;
+        content: "Figure " counter(figure);
         font-weight: 800;
       }
       .os-title-label + .os-number {

--- a/tutor/src/components/book-page.js
+++ b/tutor/src/components/book-page.js
@@ -109,20 +109,20 @@ class BookPage extends React.Component {
 
     const root = ReactDOM.findDOMNode(this);
 
-    this.insertSplash(root);
     this.insertCanonicalLink(root);
     this.detectImgAspectRatio(root);
     this.cleanUpAbstracts(root);
+    this.insertSplash(root);
     this.processLinks(root);
   }
 
   componentDidUpdate() {
     const root = ReactDOM.findDOMNode(this);
     this.props.ux.checkForTeacherContent();
-    this.insertSplash(root);
     this.updateCanonicalLink(root);
     this.detectImgAspectRatio(root);
     this.cleanUpAbstracts(root);
+    this.insertSplash(root);
     this.processLinks();
   }
 
@@ -223,7 +223,7 @@ class BookPage extends React.Component {
     const abstract = root.querySelector(LEARNING_OBJECTIVE_SELECTORS);
     // dont clean up if abstract does not exist or if it has already been cleaned up
     if ((abstract == null) || !abstract.dataset || (abstract.dataset.isIntro != null)) { return; }
-
+    abstract.classList.add('learning-objectives');
     for (let abstractChild of abstract.childNodes) {
       // leave the list alone -- this is the main content
       if ((abstractChild == null) || (abstractChild.tagName === 'UL')) { continue; }

--- a/tutor/src/components/book-page.js
+++ b/tutor/src/components/book-page.js
@@ -183,6 +183,10 @@ class BookPage extends React.Component {
     // abort if it already has a splash element
     if (splashFigure && !splashFigure.querySelector('.splash')) {
       splashFigure.classList.add('splash');
+      const nextEl = splashFigure.nextElementSibling;
+      if (nextEl && dom(nextEl).matches('.os-figure, figure') ){
+        nextEl.classList.add('splash');
+      }
     }
   }
 


### PR DESCRIPTION
The newer books have A LOT of learning objectives, which made the column layout very lengthy.  Plus the learning objectives often appeared after the splash image, which made the theme color styles
look strange

![image](https://user-images.githubusercontent.com/79566/57388906-cc5d5f00-717e-11e9-8fb8-1cf8ac063619.png)

![image](https://user-images.githubusercontent.com/79566/57388923-d3846d00-717e-11e9-92aa-faedec213edf.png)


![image](https://user-images.githubusercontent.com/79566/57388930-d8e1b780-717e-11e9-91d1-28362fda0613.png)
