### PR TITLE
Attempt 2 at fixing notes inside notes styles

### DIFF
--- a/tutor/resources/styles/book-content/note.scss
+++ b/tutor/resources/styles/book-content/note.scss
@@ -121,11 +121,17 @@ $tutor-book-note-selector: '
 }
 
 @mixin tutor-book-theme-notes($background, $text-color) {
-  *:not(.os-note-body) > {
+  #{$tutor-book-note-selector} {
+    @include tutor-book-label-style() {
+      color: $text-color;
+      background-color: $background;
+    }
+  }
+  .os-note-body {
     #{$tutor-book-note-selector} {
       @include tutor-book-label-style() {
-        color: $text-color;
-        background-color: $background;
+        color: $caption-font-color;
+        background: $tutor-neutral-lightest;
       }
     }
   }


### PR DESCRIPTION
use cascade override to fix note in notes, when it's not a direct child the :not fails

![image](https://user-images.githubusercontent.com/79566/57732165-11433300-7662-11e9-821e-de1e7a3a787b.png)
