### PR TITLE
debounce call to typesetMath and run it for entire document

### DIFF
--- a/shared/specs/helpers/mathjax.spec.js
+++ b/shared/specs/helpers/mathjax.spec.js
@@ -4,7 +4,7 @@ import { delay } from 'lodash';
 
 const callTypeset = (dom, window) =>
   new Promise( function( res ) {
-    typesetMath(dom, window);
+    typesetMath(window);
     return delay(() => res(dom)
       , 190);
   })

--- a/shared/src/components/html.js
+++ b/shared/src/components/html.js
@@ -21,6 +21,7 @@ class ArbitraryHtmlAndMath extends React.Component {
     block: PropTypes.bool.isRequired,
     processHtmlAndMath: PropTypes.func,
     shouldExcludeFrame: PropTypes.func,
+    windowImpl: PropTypes.object,
   };
 
   componentDidMount() { return this.updateDOMNode(); }
@@ -54,7 +55,7 @@ class ArbitraryHtmlAndMath extends React.Component {
     for (let link of links) {
       if (__guard__(link.getAttribute('href'), x => x[0]) !== '#') { link.setAttribute('target', '_blank'); }
     }
-    (typeof this.props.processHtmlAndMath === 'function' ? this.props.processHtmlAndMath(root) : undefined) || typesetMath(root);
+    (typeof this.props.processHtmlAndMath === 'function' ? this.props.processHtmlAndMath(root) : undefined) || typesetMath(this.props.windowImpl);
     return wrapFrames(root, this.props.shouldExcludeFrame);
   };
 


### PR DESCRIPTION
Bencharking suggest this is a 10x speed improvement for areas with
lots of small math components like the card view in HW builder.

In that case it cut rendering time from 4secs to 400ms