### PR TITLE
Fix splash image and figures size on narrow screens

### DIFF
--- a/tutor/resources/styles/book-content/mixins.scss
+++ b/tutor/resources/styles/book-content/mixins.scss
@@ -57,7 +57,7 @@
   min-width: calc(100% + #{$tutor-card-body-padding-horizontal * 2} );
   @media screen and ( max-width: $book-content-collapse-breakpoint ){
     margin-left: -$book-content-narrow-horizontal-padding;
-    width: calc(100% + #{$book-content-narrow-horizontal-padding * 2});
+    min-width: calc(100% + #{$book-content-narrow-horizontal-padding * 2});
   }
 }
 

--- a/tutor/resources/styles/book-content/splash-image.scss
+++ b/tutor/resources/styles/book-content/splash-image.scss
@@ -10,10 +10,7 @@
   .splash {
     @include book-content-full-width();
     margin-bottom: 2rem;
-
-//    &:last-of-type {
-      padding-bottom: 2rem;
-//    }
+    padding-bottom: 2rem;
 
     img {
       border: 0;


### PR DESCRIPTION
Prevents expanding past the page margin
![image](https://user-images.githubusercontent.com/79566/57896354-ed285300-7815-11e9-8cb9-a1c602e3da7a.png)
