### PR TITLE
Update URL to remove "2018" date on teacher guide

### DIFF
--- a/tutor/src/models/course/information.js
+++ b/tutor/src/models/course/information.js
@@ -79,7 +79,7 @@ export default {
   },
 
   gettingStartedGuide: {
-    teacher: 'https://d3bxy9euw4e147.cloudfront.net/oscms-prodcms/media/documents/openstax_tutor_instructor_getting_started_guide_2018.pdf',
+    teacher: 'https://d3bxy9euw4e147.cloudfront.net/oscms-prodcms/media/documents/openstax_tutor_instructor_getting_started_guide.pdf',
     student: 'https://d3bxy9euw4e147.cloudfront.net/oscms-prodcms/media/documents/openstax_tutor_student_getting_started_guide.pdf',
   },
 


### PR DESCRIPTION
devops will upload matching file sometime in the next few days