### PR TITLE
merge steps on load instead of re-creating them all

### DIFF
--- a/tutor/specs/models/student-tasks/task.spec.js
+++ b/tutor/specs/models/student-tasks/task.spec.js
@@ -1,0 +1,18 @@
+import { Factory, TimeMock } from '../../helpers';
+
+
+describe('Student Task', () => {
+  const now = new Date('2017-10-14T12:00:00.000Z');
+  let task;
+  beforeEach(() => {
+    task = Factory.studentTask({ type: 'reading', stepCount: 5 });
+  });
+
+  it('updates steps on load', () => {
+    const step = task.steps[3];
+    task.onFetchComplete({ data: Factory.bot.create('StudentTask', { stepCount: 10 }) });
+    expect(task.steps).toHaveLength(10);
+    expect(task.steps[3]).toBe(step); // toBe tests object equality
+  });
+
+});

--- a/tutor/specs/models/student-tasks/task.spec.js
+++ b/tutor/specs/models/student-tasks/task.spec.js
@@ -2,16 +2,20 @@ import { Factory, TimeMock } from '../../helpers';
 
 
 describe('Student Task', () => {
-  const now = new Date('2017-10-14T12:00:00.000Z');
+  const now = new TimeMock.setTo('2017-10-14T12:00:00.000Z');
   let task;
   beforeEach(() => {
-    task = Factory.studentTask({ type: 'reading', stepCount: 5 });
+    task = Factory.studentTask({ type: 'reading', now, stepCount: 5 });
   });
 
   it('updates steps on load', () => {
     const step = task.steps[3];
-    task.onFetchComplete({ data: Factory.bot.create('StudentTask', { stepCount: 10 }) });
+    task.onFetchComplete({ data: Factory.bot.create('StudentTask', { now, stepCount: 10 }) });
     expect(task.steps).toHaveLength(10);
+    expect(task.steps[3]).toBe(step); // toBe tests object equality
+    // test that steps are truncated
+    task.onFetchComplete({ data: Factory.bot.create('StudentTask', { now, stepCount: 4 }) });
+    expect(task.steps).toHaveLength(4);
     expect(task.steps[3]).toBe(step); // toBe tests object equality
   });
 

--- a/tutor/src/api/index.js
+++ b/tutor/src/api/index.js
@@ -209,7 +209,7 @@ const startAPI = function() {
   });
 
   connectModelRead(StudentTask, 'fetch', {
-    onSuccess: 'onApiRequestComplete', onFail: 'setApiErrors', pattern: '/tasks/{id}',
+    onSuccess: 'onFetchComplete', onFail: 'setApiErrors', pattern: '/tasks/{id}',
   });
 
   connectModelUpdate(StudentTaskStep, 'save', {

--- a/tutor/src/components/buttons/teacher-become-student.js
+++ b/tutor/src/components/buttons/teacher-become-student.js
@@ -109,7 +109,7 @@ class TeacherBecomesStudent extends React.Component {
       return (
         <Waiting className="control">
           <Icon type="spinner" spin size="2x" />
-          Creating student record…
+          Generating student view…
         </Waiting>
       );
     }

--- a/tutor/src/models/student-tasks/task.js
+++ b/tutor/src/models/student-tasks/task.js
@@ -58,5 +58,8 @@ class StudentTask extends BaseModel {
         this.steps.push(stepData);
       }
     });
+    if (steps.length < this.steps.length) {
+      this.steps.splice(steps.length, this.steps.length - steps.length);
+    }
   }
 }

--- a/tutor/src/models/student-tasks/task.js
+++ b/tutor/src/models/student-tasks/task.js
@@ -47,5 +47,16 @@ class StudentTask extends BaseModel {
 
   // called by API
   fetch() { }
-
+  onFetchComplete({ data }) {
+    const { steps, ...task } = data;
+    this.api.errors = {};
+    this.update(task);
+    steps.forEach((stepData, i) => {
+      if (this.steps.length > i) {
+        this.steps[i].update(stepData);
+      } else {
+        this.steps.push(stepData);
+      }
+    });
+  }
 }


### PR DESCRIPTION
Otherwise the task steps can get caught in an infinite loading when a placeholder is encountered because the UX class for the task steps attempts to reload when the step changes.  Since the step is a new object it technically has changed, so the onStepChange handler is called https://github.com/openstax/tutor-js/blob/master/tutor/src/screens/task/ux.js#L116