### PR TITLE
adjust opens_at if needed when initializing with a due date

### DIFF
--- a/tutor/specs/models/task-plans/teacher/tasking.spec.js
+++ b/tutor/specs/models/task-plans/teacher/tasking.spec.js
@@ -70,4 +70,27 @@ describe('Teacher tasking plan tasking', () => {
     expect(tasking.defaultOpensAt()).toEqual(inCourseTime(plan.course.starts_at));
   });
 
+  it('#initializeWithDueAt', () => {
+    expect(course.time_zone).toEqual('Central Time (US & Canada)');
+
+    plan.course.default_open_time = '10:20';
+    plan.course.default_due_time = '15:40';
+    tasking.opens_at = '2015-10-21T12:00:00.000Z';
+
+    // simple case, no conflict with opens
+    tasking.initializeWithDueAt('2015-10-25T12:00:00.000Z');
+    expect(tasking.due_at).toEqual('2015-10-25T20:40:00.000Z'); // same date but -5hours tz
+    expect(tasking.opens_at).toEqual('2015-10-21T12:00:00.000Z'); // unchanged
+
+    // set to before the opens_at
+    tasking.initializeWithDueAt('2015-10-20T12:00:00.000Z');
+    expect(tasking.due_at).toEqual('2015-10-20T20:40:00.000Z'); // same date but -5hours tz
+    expect(tasking.opens_at).toEqual('2015-10-14T15:20:00.000Z'); // set to Time.now but with time -5hours tz
+
+    // set to before the now
+    tasking.initializeWithDueAt('2015-10-01T12:00:00.000Z');
+    expect(tasking.due_at).toEqual('2015-10-01T20:40:00.000Z'); // same date but -5hours tz
+    expect(tasking.opens_at).toEqual('2015-10-01T20:39:00.000Z'); // set to one minute before due_at
+
+  });
 });

--- a/tutor/src/screens/assignment-builder/ux.js
+++ b/tutor/src/screens/assignment-builder/ux.js
@@ -26,7 +26,6 @@ class AssignmentBuilderUX {
     exercises = Exercises,
     windowImpl = window,
   }) {
-
     if ('clone' === type) {
       if (!course.pastTaskPlans.api.hasBeenFetched) {
         await course.pastTaskPlans.fetch();
@@ -64,7 +63,7 @@ class AssignmentBuilderUX {
       this.plan.findOrCreateTaskingForPeriod(period),
     );
     if (due_at) {
-      this.plan.tasking_plans.forEach(tp => tp.due_at = moment(due_at).startOf('minute').toISOString());
+      this.plan.tasking_plans.forEach(tp => tp.initializeWithDueAt(due_at));
     }
     this.isShowingPeriodTaskings = !this.plan.areTaskingDatesSame;
     this.scroller = new ScrollTo({ windowImpl });
@@ -126,7 +125,6 @@ class AssignmentBuilderUX {
       book: this.referenceBook,
       exercise_ids: this.plan.settings.exercise_ids,
     });
-
   }
 
   @computed get selectedExercises() {


### PR DESCRIPTION
fixes bug when the teacher clicks a date on the calendar to start editing with that as the due date