### PR TITLE
Fix blank terms being displayed

### DIFF
--- a/tutor/specs/components/terms-modal.spec.jsx
+++ b/tutor/specs/components/terms-modal.spec.jsx
@@ -1,4 +1,3 @@
-import { Factory } from '../helpers';
 import TermsModal from '../../src/components/terms-modal';
 import User from '../../src/models/user';
 import { Term, UserTerms } from '../../src/models/user/terms';
@@ -31,14 +30,14 @@ describe('Terms agreement modal', () => {
         User.terms.terms = [
           {
             id: 42,
-            name: "general_terms_of_use",
-            title: "Terms of Use",
-            content: "bunch of HTML",
+            name: 'general_terms_of_use',
+            title: 'Terms of Use',
+            content: 'bunch of HTML',
             version: 2,
             is_signed: true,
             has_signed_before: true,
-            is_proxy_signed: true
-          }
+            is_proxy_signed: true,
+          },
         ];
         User.unsignedTerms = User.terms.unsigned;
       });
@@ -54,14 +53,14 @@ describe('Terms agreement modal', () => {
         User.terms.terms = [
           {
             id: 42,
-            name: "general_terms_of_use",
-            title: "Terms of Use",
-            content: "bunch of HTML",
+            name: 'general_terms_of_use',
+            title: 'Terms of Use',
+            content: 'bunch of HTML',
             version: 2,
             is_signed: false,
             has_signed_before: true,
-            is_proxy_signed: false
-          }
+            is_proxy_signed: false,
+          },
         ];
         User.unsignedTerms = User.terms.unsigned;
       });

--- a/tutor/specs/components/terms-modal.spec.jsx
+++ b/tutor/specs/components/terms-modal.spec.jsx
@@ -1,7 +1,7 @@
 import { Factory } from '../helpers';
 import TermsModal from '../../src/components/terms-modal';
 import User from '../../src/models/user';
-import { Term } from '../../src/models/user/terms';
+import { Term, UserTerms } from '../../src/models/user/terms';
 
 jest.mock('../../src/models/user', () => ({
   terms_signatures_needed: false,
@@ -12,14 +12,65 @@ jest.mock('../../src/models/user', () => ({
 }));
 
 describe('Terms agreement modal', () => {
+  describe('when there are no courses and no terms', () => {
+    it('does not render', () => {
+      const modal = shallow(<TermsModal />);
+      expect(modal.is('Modal')).toBe(false);
+      expect(modal.text()).toBe('');
+    });
+  });
 
-  it('only renders when there are terms and course', () => {
-    const modal = shallow(<TermsModal />);
-    expect(modal.is('Modal')).toBe(false);
-    expect(modal.text()).toBe('');
-    User.terms_signatures_needed = true;
-    modal.setProps({ canBeDisplayed: true });
-    expect(modal.text()).toContain('I agree');
+  describe('when there are courses and', () => {
+    beforeEach(() => {
+      User.terms_signatures_needed = true;
+      User.terms = new UserTerms({ user: User });
+    });
+
+    describe('only signed terms', () => {
+      beforeEach(() => {
+        User.terms.terms = [
+          {
+            id: 42,
+            name: "general_terms_of_use",
+            title: "Terms of Use",
+            content: "bunch of HTML",
+            version: 2,
+            is_signed: true,
+            has_signed_before: true,
+            is_proxy_signed: true
+          }
+        ];
+        User.unsignedTerms = User.terms.unsigned;
+      });
+
+      it('does not render', () => {
+        const modal = shallow(<TermsModal canBeDisplayed />);
+        expect(modal.text()).toBe('');
+      });
+    });
+
+    describe('some unsigned terms', () => {
+      beforeEach(() => {
+        User.terms.terms = [
+          {
+            id: 42,
+            name: "general_terms_of_use",
+            title: "Terms of Use",
+            content: "bunch of HTML",
+            version: 2,
+            is_signed: false,
+            has_signed_before: true,
+            is_proxy_signed: false
+          }
+        ];
+        User.unsignedTerms = User.terms.unsigned;
+      });
+
+      it('renders', () => {
+        const modal = shallow(<TermsModal canBeDisplayed />);
+        expect(modal.text()).toContain('I agree');
+      });
+    });
   });
 
   it('signs term when agreed', () => {
@@ -34,6 +85,4 @@ describe('Terms agreement modal', () => {
     modal.find('Button').simulate('click');
     expect(User.terms.sign).toHaveBeenCalled();
   });
-
-
 });

--- a/tutor/src/components/terms-modal.jsx
+++ b/tutor/src/components/terms-modal.jsx
@@ -6,7 +6,6 @@ import { Modal, Button } from 'react-bootstrap';
 import classnames from 'classnames';
 import Branding from './branding/course';
 import User from '../models/user';
-import Course from '../models/course';
 import { isEmpty, map } from 'lodash';
 import String from '../helpers/string';
 
@@ -57,4 +56,4 @@ class TermsModal extends React.Component {
       </Modal>
     );
   }
-};
+}

--- a/tutor/src/components/terms-modal.jsx
+++ b/tutor/src/components/terms-modal.jsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import Branding from './branding/course';
 import User from '../models/user';
 import Course from '../models/course';
-import { map } from 'lodash';
+import { isEmpty, map } from 'lodash';
 import String from '../helpers/string';
 
 export default
@@ -28,7 +28,9 @@ class TermsModal extends React.Component {
 
   render() {
     // for terms to be displayed the user must need them signed and be in a course
-    if (!User.terms_signatures_needed || !this.props.canBeDisplayed) { return null; }
+    if (
+      !User.terms_signatures_needed || !this.props.canBeDisplayed || isEmpty(User.unsignedTerms)
+    ) { return null; }
 
     const className = classnames('user-terms', { 'is-loading': User.terms.api.isPending });
 


### PR DESCRIPTION
 When the user has a targeted contract that signs all existing terms