### PR TITLE
Fix time controls to use native `time` input

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "styled-components": "^4.2.0",
     "survey-react": "^1.0.72",
     "svg-url-loader": "2.3.2",
+    "time-input-polyfill": "^1.0.6",
     "twix": "1.2.1",
     "ultimate-pagination": "1.0.0",
     "underscore": "1.9.1",

--- a/tutor/resources/styles/components/tutor-input.scss
+++ b/tutor/resources/styles/components/tutor-input.scss
@@ -1,7 +1,7 @@
 .tutor-input {
   &.form-control-wrapper {
 
-    // override line-height styles for paper form controls
+    display: block;
     line-height: 1em;
     margin: 0 0 28px 0;
     position: relative;
@@ -14,7 +14,6 @@
 
     textarea {
       overflow: hidden;
-      font-size: 2rem;
       color: $tutor-neutral-darker;
       min-height: 35px;
       margin: 0;
@@ -67,7 +66,7 @@
       width: 100%;
       height: 28px;
       display: flex;
-	    align-items: center;
+      align-items: center;
       .datepicker__input-container {
         z-index: 2;
       }

--- a/tutor/specs/screens/assignment-builder/builder/tasking.spec.js
+++ b/tutor/specs/screens/assignment-builder/builder/tasking.spec.js
@@ -24,18 +24,18 @@ describe('Tasking Builder', () => {
     tasking.find('.opens-at TutorDateInput input[onChange]')
       .simulate('change', { target: { value: opens_at.format('MM/DD/YYYY') } });
     tasking.find('.opens-at TutorTimeInput input').simulate('change', {
-      target: { value: '8:22 pm' },
+      target: { value: '8:22' },
     });
 
     expect(
       tasking.find('.due-at TutorDateInput').props().min.toISOString()
-    ).toEqual('2015-10-16T01:22:00.000Z');
+    ).toEqual(moment(opens_at).hour(8).minute(22).toISOString());
 
     tasking.find('.due-at TutorDateInput input[onChange]')
       .simulate('change', { target: { value: due_at.format('MM/DD/YYYY') } });
 
     tasking.find('.due-at TutorTimeInput input').simulate('change', {
-      target: { value: '945am' },
+      target: { value: '9:45' },
     });
 
     expect(

--- a/tutor/src/components/tutor-input.js
+++ b/tutor/src/components/tutor-input.js
@@ -106,7 +106,17 @@ class TutorInput extends React.Component {
       onChange: this.onChange,
     };
 
-    if (this.props.default != null) { if (inputProps.defaultValue == null) { inputProps.defaultValue = this.props.default; } }
+    // Please do not set value={@props.value} on input.
+    //
+    // Because we are updating the store in some cases on change, and
+    // the store is providing the @props.value being passed in here,
+    // the cursor for typing in this input could be forced to move to the
+    // right when the input re-renders since the props have changed.
+    //
+    // Instead, use @props.default to set an initial default value.
+    if (this.props.default != null) {
+      inputProps.defaultValue = this.props.default;
+    }
 
     if (children != null) {
       inputBox = React.cloneElement(children, inputProps);
@@ -117,15 +127,6 @@ class TutorInput extends React.Component {
       inputBox = <input {...inputProps} />;
     }
 
-
-    // Please do not set value={@props.value} on input.
-    //
-    // Because we are updating the store in some cases on change, and
-    // the store is providing the @props.value being passed in here,
-    // the cursor for typing in this input could be forced to move to the
-    // right when the input re-renders since the props have changed.
-    //
-    // Instead, use @props.default to set an intial defaul value.
     return (
       <div className={wrapperClasses}>
         {inputBox}
@@ -412,22 +413,22 @@ class TutorTimeInput extends React.Component {
   };
 
   render() {
-    const maskedProps = omit(this.props, 'defaultValue', 'onChange', 'formatCharacters');
-    const inputProps = pick(this.props, 'disabled', 'id');
+    const inputProps = omit(this.props, 'defaultValue', 'onChange', 'value', 'formatCharacters');
+    const maskedProps = pick(this.props, 'disabled', 'id');
     const { formatCharacters } = this.props;
     const { value } = this.props;
     const timePattern = this.getPatternFromValue(value);
     // console.log({ value, timePattern })
     return (
       <TutorInput
-        {...maskedProps}
+        {...inputProps}
         onChange={this.onChange}
         validate={this.validate}
         hasValue={!!value}
         ref="timeInput"
       >
         <MaskedInput
-          {...inputProps}
+          {...maskedProps}
           value={value}
           name="time"
           size="8"

--- a/tutor/src/components/tutor-input.js
+++ b/tutor/src/components/tutor-input.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import moment from 'moment-timezone';
-import { isEmpty, isEqual, map, omit, extend, defer, clone, pick, keys, isUndefined } from 'lodash';
+import { isEmpty, isEqual, map, omit, extend, defer, clone, pick, keys } from 'lodash';
 import classnames from 'classnames';
 import MaskedInput from 'react-maskedinput';
 import DatePicker from 'react-datepicker';
@@ -271,171 +271,24 @@ class TutorDateInput extends React.Component {
 }
 
 class TutorTimeInput extends React.Component {
-  static defaultProps = {
-    fromMomentFormat: TimeHelper.ISO_TIME_FORMAT,
-    toMomentFormat: TimeHelper.HUMAN_TIME_FORMAT,
-
-    formatCharacters: {
-      i: {
-        validate(char) { return /([0-2]|:)/.test(char); },
-      },
-
-      h: {
-        validate(char) { return /[0-9]/.test(char); },
-      },
-
-      H: {
-        validate(char) { return /[0-1]/.test(char); },
-      },
-
-      M: {
-        validate(char) { return /[0-5]/.test(char); },
-      },
-
-      m: {
-        validate(char) { return /[0-9]/.test(char); },
-      },
-
-      a: {
-        validate(char) { return /(A|P|a|p)/.test(char); },
-        transform(char) { return `${char}m`.toLowerCase(); },
-      },
-    },
-  };
-
-
   onChange = (value, input, changeEvent) => {
-    value = value.replace('_', '');
-    const timePattern = this.getPatternFromValue(value, changeEvent);
-
-    const time = moment(value, timePattern);
-
-//    console.log({ value, timePattern, valid: time.isValid() })
+    const time = moment(value, 'HH:mm');
 
     if (time.isValid()) {
       this.props.onChange(time.format('HH:mm'));
     }
   };
 
-  getInput = () => {
-    return (this.refs.timeInput != null ? this.refs.timeInput.refs.input : undefined);
-  };
-
-  getMask = () => {
-    return __guard__(this.getInput(), x => x.mask);
-  };
-
-  getPatternFromValue = (value, changeEvent) => {
-    let pattern;
-    if (/^([2-9])/.test(value) || /^(_+[1-9])/.test(value)) {
-      pattern = 'h:mm a';
-    } else if (/^1:/.test(value)) {
-      if ((changeEvent != null) && !this.shouldShrinkMask(changeEvent)) {
-        pattern = 'hh:mm a';
-      } else {
-        pattern = 'h:mm a';
-      }
-    } else {
-      pattern = 'hi:mm a';
-    }
-    // console.log({ value, pattern });
-    return pattern;
-  };
-
-  getRawValue = () => {
-    return __guard__(this.getMask(), x => x.getRawValue());
-  };
-
-  getUpdates = (timePattern, timeValue) => {
-    const cursorChange =  timePattern.length - this.state.timePattern.length;
-    let { selection } = this.getMask();
-    selection = clone(selection);
-
-    if (/^(_+[1-9])/.test(timeValue)) {
-      timeValue = S.removeAt(timeValue, 0);
-      selection.start = 2;
-      selection.end = 2;
-
-    } else if (cursorChange > 0) {
-      timeValue = S.insertAt(timeValue, 1, __guard__(this.getMask(), x => x.placeholderChar));
-      selection.start = 1;
-      selection.end = 1;
-
-    } else if (cursorChange < 0) {
-      timeValue = S.removeAt(timeValue, 1);
-      selection.start = 2;
-      selection.end = 2;
-    }
-
-    return { timeValue, selection };
-  };
-
-  getValue = () => {
-    return __guard__(this.getMask(), x => x.getValue());
-  };
-
-  isColon = (changeEvent) => {
-    const KEY_CODE = {
-      shiftKey: true,
-      charCode: 58,
-    };
-
-    return isEqual(pick(changeEvent, keys(KEY_CODE)), KEY_CODE);
-  };
-
-  isCursor = () => {
-    const { selection } = this.getMask();
-    return (selection.end - selection.start) === 0;
-  };
-
-  isValidTime = (value) => {
-    return !/_/.test(value);
-  };
-
-  shouldShrinkMask = (changeEvent) => {
-    return this.isColon(changeEvent);
-  };
-
-  timeIn = (value) => {
-    const { fromMomentFormat, toMomentFormat } = this.props;
-    return moment(value, fromMomentFormat).format(toMomentFormat);
-  };
-
-  timeOut = (value) => {
-    const { fromMomentFormat, toMomentFormat } = this.props;
-    return moment(value, toMomentFormat).format(fromMomentFormat);
-  };
-
-  validate = (inputValue) => {
-    if (!isUndefined(inputValue)) {
-      if (inputValue.indexOf(__guard__(this.getMask(), x => x.placeholderChar)) > -1) { return ['incorrectTime']; }
-    }
-  };
-
   render() {
-    const inputProps = omit(this.props, 'defaultValue', 'onChange', 'value', 'formatCharacters');
-    const maskedProps = pick(this.props, 'disabled', 'id');
-    const { formatCharacters } = this.props;
-    const { value } = this.props;
-    const timePattern = this.getPatternFromValue(value);
-    // console.log({ value, timePattern })
+    const inputProps = omit(this.props, 'defaultValue', 'onChange', 'formatCharacters');
+
     return (
       <TutorInput
         {...inputProps}
         onChange={this.onChange}
-        validate={this.validate}
-        hasValue={!!value}
         ref="timeInput"
-      >
-        <MaskedInput
-          {...maskedProps}
-          value={value}
-          name="time"
-          size="8"
-          mask={timePattern}
-          formatCharacters={formatCharacters}
-        />
-      </TutorInput>
+        type="time"
+      />
     );
   }
 }

--- a/tutor/src/models/task-plans/teacher/tasking.js
+++ b/tutor/src/models/task-plans/teacher/tasking.js
@@ -166,7 +166,7 @@ class TaskingPlan extends BaseModel {
   @computed get opensAtTime() {
     const { course } = this;
     const m = this.opens_at ? course.momentInZone(this.opens_at) : moment(course.default_open_time, 'HH:mm');
-    return m.format('h:mm a');
+    return m.format('HH:mm');
   }
 
   @computed get defaultDueTime() {
@@ -175,7 +175,7 @@ class TaskingPlan extends BaseModel {
 
   @computed get dueAtTime() {
     const m = this.due_at ? this.course.momentInZone(this.due_at) : this.defaultDueTime;
-    return m.format('h:mm a');
+    return m.format('HH:mm');
   }
 
 }

--- a/tutor/src/screens/assignment-builder/builder/tasking.js
+++ b/tutor/src/screens/assignment-builder/builder/tasking.js
@@ -167,11 +167,10 @@ class Tasking extends React.Component {
             </Col>
             <Col md={5} xs={4}>
               <TutorTimeInput
-                key={tasking.opensAtTime || 'opens_at_time'}
+                key={'opens-at-time'}
                 required={true}
                 label="Open Time"
                 id={`${type}-open-time`}
-                value={tasking.opens_at}
                 onChange={this.onOpensTimeChange}
                 value={tasking.opensAtTime}
               />
@@ -194,7 +193,7 @@ class Tasking extends React.Component {
             </Col>
             <Col md={5} xs={4}>
               <TutorTimeInput
-                key={tasking.dueAtTime || 'due_at_time'}
+                key={'due-at-time'}
                 required={true}
                 label="Due Time"
                 id={`${type}-due-time`}

--- a/tutor/src/screens/assignment-builder/builder/tasking.js
+++ b/tutor/src/screens/assignment-builder/builder/tasking.js
@@ -167,7 +167,6 @@ class Tasking extends React.Component {
             </Col>
             <Col md={5} xs={4}>
               <TutorTimeInput
-                key={'opens-at-time'}
                 required={true}
                 label="Open Time"
                 id={`${type}-open-time`}
@@ -193,7 +192,6 @@ class Tasking extends React.Component {
             </Col>
             <Col md={5} xs={4}>
               <TutorTimeInput
-                key={'due-at-time'}
                 required={true}
                 label="Due Time"
                 id={`${type}-due-time`}

--- a/tutor/src/screens/assignment-builder/footer/save-button.jsx
+++ b/tutor/src/screens/assignment-builder/footer/save-button.jsx
@@ -23,7 +23,7 @@ const SaveButton = observer(({ ux, ux: { plan } }) => {
         className="publish"
         disabled={ux.isSaving}
         onClick={ux.onPublish}
-        isWaiting={ux.isSaving}
+        isWaiting={ux.isPublishing}
         waitingText={text.waiting}
       >
         {text.action}

--- a/tutor/src/screens/assignment-builder/ux.js
+++ b/tutor/src/screens/assignment-builder/ux.js
@@ -260,6 +260,10 @@ class AssignmentBuilderUX {
     this.saveAndCopyPlan();
   }
 
+  @computed get isPublishing() {
+    return this.plan.api.isPending && this.plan.is_publish_requested;
+  }
+
   @computed get isSaving() {
     return this.plan.api.isPending;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9954,6 +9954,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.3.tgz#f5df732453407b09191dae73e2a8cc73f381a826"
   integrity sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==
 
+time-input-polyfill@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/time-input-polyfill/-/time-input-polyfill-1.0.6.tgz#6427a7eb59f59c64ca5ae8d47715d1bd50e4571e"
+  integrity sha512-RsaB3eXCSITFuEUiXdkGYYYbfQ4N6OcXrXd9LT0Oh1QLcPNBSeQD5+2iJGIPo/9empjqbi1uJhPgTWkDxTVDoQ==
+
 timed-out@4.0.1, timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"


### PR DESCRIPTION
First commit fixes inputs losing focus
Second commit replaces masked inputs with input[type=time]
Polyfill (maybe https://www.npmjs.com/package/time-input-polyfill) will be needed for Safari