### PR TITLE
copy ecosystem_id when cloning a task plan

### DIFF
--- a/tutor/specs/components/exercises/details.spec.jsx
+++ b/tutor/specs/components/exercises/details.spec.jsx
@@ -17,6 +17,7 @@ describe('Exercise Details Component', function() {
       book,
       exercises,
       pageIds,
+      selectedSection:        book.chapter_section,
       windowImpl:             new FakeWindow,
       selectedExercise:       exercises.array[1],
       onExerciseToggle:       jest.fn(),

--- a/tutor/specs/models/task-plans/teacher/plan.spec.js
+++ b/tutor/specs/models/task-plans/teacher/plan.spec.js
@@ -1,10 +1,11 @@
-import { Factory } from '../../../helpers';
+import { Factory, ld } from '../../../helpers';
 
 describe('CourseCalendar Header', function() {
   let plan;
 
   beforeEach(() => {
     plan = Factory.teacherTaskPlan();
+    plan.course = Factory.course();
   });
 
   it('tasking plan changed', () => {
@@ -53,4 +54,9 @@ describe('CourseCalendar Header', function() {
     expect(onDelete).toHaveBeenCalledWith(plan.id);
   });
 
+  it('clones with attributes', () => {
+    expect(plan.clonedAttributes).toMatchObject({
+      ...ld.pick(plan, 'title', 'description', 'settings', 'type', 'ecosystem_id'),
+    });
+  });
 });

--- a/tutor/specs/screens/assignment-builder/homework.spec.js
+++ b/tutor/specs/screens/assignment-builder/homework.spec.js
@@ -46,6 +46,7 @@ describe('Homework Builder', function() {
     expect(props.ux.plan.dataForSave).toEqual({
       type: 'homework',
       title: 'a homework',
+      ecosystem_id: 1,
       is_publish_requested: !ux.plan.is_published,
       description: 'a homework description',
       tasking_plans: props.ux.course.periods.map(p => ({

--- a/tutor/specs/screens/assignment-builder/mini-editor/editor.spec.js
+++ b/tutor/specs/screens/assignment-builder/mini-editor/editor.spec.js
@@ -37,6 +37,7 @@ describe('TaskPlan MiniEditor wrapper', function() {
     expect(props.ux.plan.dataForSave).toEqual({
       type: 'homework',
       title: 'a homework',
+      ecosystem_id: 1,
       description: props.ux.plan.description,
       is_publish_requested: !props.ux.plan.is_published,
       tasking_plans: props.ux.course.periods.map(p => ({

--- a/tutor/specs/screens/assignment-builder/reading.spec.js
+++ b/tutor/specs/screens/assignment-builder/reading.spec.js
@@ -40,6 +40,7 @@ describe('Reading Builder', function() {
     expect(props.ux.plan.dataForSave).toEqual({
       type: 'reading',
       title: 'a reading',
+      ecosystem_id: 1,
       description: 'a reading description',
       is_publish_requested: !ux.plan.is_published,
       tasking_plans: props.ux.course.periods.map(p => ({

--- a/tutor/specs/screens/assignment-builder/ux.spec.js
+++ b/tutor/specs/screens/assignment-builder/ux.spec.js
@@ -37,6 +37,7 @@ describe('Assignment Builder UX', function() {
     expect(ux.sourcePlanId).toEqual(plan.id);
     expect(ux.plan.isNew).toBe(true);
     expect(ux.plan.title).toEqual(plan.title);
+    expect(ux.referenceBook.id).toEqual(plan.ecosystem_id);
   });
 
 });

--- a/tutor/src/models/task-plans/teacher/plan.js
+++ b/tutor/src/models/task-plans/teacher/plan.js
@@ -296,7 +296,7 @@ class TeacherTaskPlan extends BaseModel {
   @computed get clonedAttributes() {
     return extend(pick(
       this,
-      'title', 'description', 'settings', 'type',
+      'title', 'description', 'settings', 'type', 'ecosystem_id',
     ), {
       tasking_plans: map(this.tasking_plans, 'dataForSave'),
     });
@@ -314,7 +314,7 @@ class TeacherTaskPlan extends BaseModel {
   }
 
   @computed get dataForSave() {
-    return extend(this.clonedAttributes, pick(this, 'is_publish_requested' ));
+    return extend(this.clonedAttributes, pick(this, 'is_publish_requested'));
   }
 
   @computed get isExternalUrlValid() {
@@ -348,9 +348,6 @@ class TeacherTaskPlan extends BaseModel {
     } : {
       url: `plans/${this.id}`,
     };
-    if (this.ecosystem_id) {
-      options.params = { ecosystem_id: this.ecosystem_id };
-    }
     options.data = this.dataForSave;
     return options;
   }


### PR DESCRIPTION
Previously the ecosystem id wouldn't transfer, causing the plan to load the wrong book