### PR TITLE
Fix scores report for teach-as-student 

### DIFF
--- a/tutor/specs/components/buttons/teacher-becomes-student.spec.js
+++ b/tutor/specs/components/buttons/teacher-becomes-student.spec.js
@@ -22,4 +22,15 @@ describe(TBS, () => {
     expect(tbs).not.toBeEmptyRender();
     tbs.unmount();
   });
+
+  it('renders as button when single ACTIVE period', () => {
+    props.course.roles[0].type = 'teacher';
+    const tbs = mount(<TBS {...props} />);
+    expect(tbs).toHaveRendered('Dropdown');
+    expect(tbs).not.toHaveRendered('BecomeButton');
+    props.course.periods.forEach((p, i) => p.is_archived = i !== 0);
+    expect(tbs).not.toHaveRendered('Dropdown');
+    expect(tbs).toHaveRendered('BecomeButton');
+    tbs.unmount();
+  });
 });

--- a/tutor/specs/screens/scores-report/table.spec.jsx
+++ b/tutor/specs/screens/scores-report/table.spec.jsx
@@ -1,0 +1,27 @@
+import { C, React } from '../../helpers';
+import ScoresUX from '../../../src/screens/scores-report/ux';
+import bootstrapScores from '../../helpers/scores-data.js';
+import Table from '../../../src/screens/scores-report/table';
+
+describe('Student Scores Report Table', () => {
+  let course;
+  let props;
+  let ux;
+
+  beforeEach(function() {
+    ({ course } = bootstrapScores());
+    ux = new ScoresUX(course);
+    props = {
+      ux,
+    };
+  });
+
+  it('renders no students only to teachers', function() {
+    course.periods[0].num_enrolled_students = 0;
+    const table = mount(<C><Table {...props} /></C>);
+    expect(table).toHaveRendered('.no-students');
+    course.currentRole.type = 'student';
+    expect(table).not.toHaveRendered('.no-students');
+    table.unmount();
+  });
+});

--- a/tutor/src/components/buttons/teacher-become-student.js
+++ b/tutor/src/components/buttons/teacher-become-student.js
@@ -114,7 +114,7 @@ class TeacherBecomesStudent extends React.Component {
       );
     }
 
-    if (1 === course.periods.length) {
+    if (1 === course.periods.active.length) {
       return (
         <BecomeButton onClick={this.onBecomeStudentClick}>
           <Icon size="2x" type="glasses" />
@@ -136,7 +136,7 @@ class TeacherBecomesStudent extends React.Component {
             type={this.periodMenuIsOpen ? 'close' : 'angle-down'}
           />
         </Dropdown.Toggle>
-        <Dropdown.Menu >
+        <Dropdown.Menu>
           {course.periods.active.map((period) => (
             <React.Fragment key={period.id}>
               <Dropdown.Item eventKey={period.id}>{period.name}</Dropdown.Item>

--- a/tutor/src/models/course.js
+++ b/tutor/src/models/course.js
@@ -115,6 +115,7 @@ class Course extends BaseModel {
 
   @action clearCachedStudentData() {
     this.studentTaskPlans.reset();
+    this.scores.api.reset();
     this.scores.periods.reset();
     this.studentTasks.reset();
   }

--- a/tutor/src/screens/scores-report/table.jsx
+++ b/tutor/src/screens/scores-report/table.jsx
@@ -138,10 +138,14 @@ class ScoresTable extends React.Component {
   }
 
   render() {
-    const { ux, ux: { students, COLUMN_WIDTH, ROW_HEIGHT, period } }  = this.props;
+    const { ux, ux: { course, students, COLUMN_WIDTH, ROW_HEIGHT, period } }  = this.props;
 
-    if (!period.coursePeriod.num_enrolled_students) { return this.renderNoStudents(); }
-    if (isEmpty(students)) { return this.renderNoAssignments(); }
+    if (course.currentRole.isTeacher && !period.coursePeriod.num_enrolled_students) {
+      return this.renderNoStudents();
+    }
+    if (isEmpty(students)) {
+      return this.renderNoAssignments();
+    }
 
     return (
       <Table

--- a/tutor/src/screens/scores-report/ux.js
+++ b/tutor/src/screens/scores-report/ux.js
@@ -76,9 +76,9 @@ export default class ScoresReportUX {
   }
 
   @computed get period() {
-    return this.course.scores.periods.get(
-      this.course.periods.active[this.periodIndex].id
-    );
+    const role = this.course.currentRole;
+    const periodId = role.period_id || this.course.periods.active[this.periodIndex].id;
+    return this.course.scores.periods.get(periodId);
   }
 
   @computed get periodTasksByType() {


### PR DESCRIPTION
When the scores report had no students enrolled and a teacher became a student it would show the "students need to enroll" message

It would also break if the teacher became a student in any period other than the 1st one.

Also the teacher-as-student button would show dropdown state if there were archived periods.