### PR TITLE
Display the terms of use faster

### DIFF
--- a/tutor/specs/models/user.spec.js
+++ b/tutor/specs/models/user.spec.js
@@ -13,19 +13,14 @@ describe('User Model', () => {
     User.viewed_tour_stats.clear();
   });
 
-  it('has terms', () => {
-    User.terms_signatures_needed = false;
-    expect(User.terms).toBeNull();
-    User.terms_signatures_needed = true;
-    expect(User.terms).toBeInstanceOf(UserTerms);
-  });
-
   it('can be bootstrapped', () => {
     const spy = jest.fn();
     autorun(() => spy(User.name));
     expect(spy).toHaveBeenCalledWith(undefined);
+    expect(User.terms).toBeUndefined();
     User.bootstrap(USER_DATA);
     expect(spy).toHaveBeenCalledWith(USER_DATA.name);
+    expect(User.terms).toBeInstanceOf(UserTerms);
   });
 
   it('calculates audience tags', () => {

--- a/tutor/src/models/user.js
+++ b/tutor/src/models/user.js
@@ -16,9 +16,11 @@ class User extends BaseModel {
   bootstrap(data) {
     this.update(data);
     this.csrf_token = read_csrf();
+    this.terms = new UserTerms({ user: this });
   }
 
   @observable csrf_token;
+  @observable terms;
 
   @field account_uuid;
 
@@ -90,12 +92,8 @@ class User extends BaseModel {
     return Boolean(this.isConfirmedFaculty || this.self_reported_role === 'instructor' || Courses.teaching.any);
   }
 
-  @computed get terms() {
-    return this.terms_signatures_needed ? new UserTerms({ user: this }) : null;
-  }
-
   @computed get unsignedTerms() {
-    return this.terms ? this.terms.unsigned : [];
+    return this.terms.unsigned;
   }
 
   @computed get tourAudienceTags() {

--- a/tutor/src/screens/student-dashboard/index.jsx
+++ b/tutor/src/screens/student-dashboard/index.jsx
@@ -4,6 +4,8 @@ import { computed } from 'mobx';
 import { observer, inject } from 'mobx-react';
 import StudentDashboard from './dashboard';
 import Courses from '../../models/courses-map';
+import User from '../../models/user';
+import LoadingScreen from 'shared/components/loading-animation';
 import { CourseNotFoundWarning } from '../../components/course-not-found-warning';
 import './styles.scss';
 
@@ -24,6 +26,12 @@ class StudentDashboardShell extends React.Component {
   }
 
   render() {
+    // keep rendering loading screen if the user needs to agree to terms
+    // this way the screen stays the same without a flash of other content
+    if (User.terms_signatures_needed) {
+      return <LoadingScreen />;
+    }
+
     if (!this.course) { return <CourseNotFoundWarning />; }
 
     return (

--- a/tutor/src/screens/teacher-dashboard/index.jsx
+++ b/tutor/src/screens/teacher-dashboard/index.jsx
@@ -12,7 +12,6 @@ import Time from '../../models/time';
 import TimeHelper from '../../helpers/time';
 import NotificationHelpers from '../../helpers/notifications';
 import TeacherBecomesStudent from '../../components/buttons/teacher-become-student';
-import TermsModal from '../../components/terms-modal';
 import Dashboard from './dashboard';
 import CourseCalendarHeader from './header';
 
@@ -148,7 +147,6 @@ class TeacherDashboardWrapper extends React.Component {
           />
         }
       >
-        <TermsModal />
         <Dashboard {...dashboardProps} />
       </CoursePage>
     );


### PR DESCRIPTION
Set User.terms during bootstrap instead of making it a computed value.
Previously something was causing it to re-initialize and delay the rendering of the terms modal.
Still flashes the content behind the modal briefly though (same as staging).