### PR TITLE
display figures inline and adjust preview modal styles

### DIFF
--- a/tutor/resources/styles/components/media-preview.scss
+++ b/tutor/resources/styles/components/media-preview.scss
@@ -1,6 +1,9 @@
 .media-preview {
-  max-width: 300px;
-
+  max-width: 400px;
+  width: 400px;
+  .popover-body {
+    width: 100%;
+  }
   &.popover {
     z-index: 3;
   }
@@ -15,7 +18,20 @@
 
   @include tutor-figure();
   @include tutor-tables($tutor-neutral-light, $tutor-neutral-light);
-
+  .os-figure:not(.splash):not(.full-width) {
+    width: 100%;
+  }
+  .os-figure {
+    figure {
+      align-items: center;
+      margin: 2rem;
+      img {
+        max-height: 300px;
+        max-width: 100%;
+        width: auto;
+      }
+    }
+  }
   table {
     text-align: left;
 
@@ -44,8 +60,4 @@
       }
     }
   }
-}
-
-.media-preview-link {
-  display: inline-block;
 }


### PR DESCRIPTION
fixes wrapping like:
![image](https://user-images.githubusercontent.com/79566/63039636-59543a80-be89-11e9-9ce3-a20bccd1c597.png)

the paren should stay with the figure when it's not set to `inline-block`
![image](https://user-images.githubusercontent.com/79566/63039664-66712980-be89-11e9-9534-893bda96423e.png)