### PR TITLE
only display chapter section if it's present

### DIFF
--- a/tutor/src/models/reference-book/page.js
+++ b/tutor/src/models/reference-book/page.js
@@ -109,7 +109,12 @@ class ReferenceBookPage extends BaseModel {
   }
 
   @computed get isChapterSectionDisplayed() {
-    return Boolean(!this.isIntro && this.isAssignable);
+    return Boolean(
+      this.displayedChapterSection &&
+        this.displayedChapterSection.isPresent &&
+        !this.isIntro &&
+        this.isAssignable
+    );
   }
 
   @computed get isAssignable() {


### PR DESCRIPTION
fixes bug where "Connections for AP courses" would have "undefined" chapter section
before:
![image](https://user-images.githubusercontent.com/79566/63470057-40232f00-c431-11e9-98e6-52c7b45d4b55.png)



after:

![image](https://user-images.githubusercontent.com/79566/63469932-f89ca300-c430-11e9-93f5-817ef879478b.png)
