### PR TITLE
Tweak task builder ui

### DIFF
--- a/tutor/resources/styles/components/top-nav-bar.scss
+++ b/tutor/resources/styles/components/top-nav-bar.scss
@@ -90,6 +90,8 @@
     align-items: center;
     justify-content: center;
     flex-wrap: wrap-reverse;
+    min-width: 250px;
+    white-space: nowrap;
     .btn { margin-left: 10px; }
   }
 

--- a/tutor/specs/models/task-plans/teacher/plan.spec.js
+++ b/tutor/specs/models/task-plans/teacher/plan.spec.js
@@ -1,6 +1,7 @@
-import { Factory, ld } from '../../../helpers';
+import { Factory, ld, TimeMock } from '../../../helpers';
 
 describe('CourseCalendar Header', function() {
+  TimeMock.setTo('2015-01-12T10:00:00.000Z');
   let plan;
 
   beforeEach(() => {
@@ -58,5 +59,30 @@ describe('CourseCalendar Header', function() {
     expect(plan.clonedAttributes).toMatchObject({
       ...ld.pick(plan, 'title', 'description', 'settings', 'type', 'ecosystem_id'),
     });
+  });
+
+  it('copies tasking times', () => {
+    plan.tasking_plans[0].opens_at = '2015-01-12T03:30:00.000Z';
+    expect(plan.clonedAttributes.tasking_plans[0].opens_at).toEqual(
+      plan.tasking_plans[0].opens_at
+    );
+    const newPlan = new plan.constructor({});
+    newPlan.update(plan.serialize());
+    expect(newPlan.tasking_plans[0].opens_at).toEqual(
+      plan.tasking_plans[0].opens_at
+    );
+  });
+
+  it('calculates duration', () => {
+    plan.tasking_plans[0].opens_at = '2015-01-01T03:30:00.000Z';
+    plan.tasking_plans[0].due_at = '2015-01-30T03:30:00.000Z';
+    plan.tasking_plans.push({
+      opens_at: '2015-01-01T03:30:00.000Z',
+      due_at: '2015-02-10T03:30:00.000Z',
+    });
+    expect(plan.duration.start.toISOString())
+      .toEqual('2015-01-01T03:30:00.000Z');
+    expect(plan.dateRanges.due.end.toISOString())
+      .toEqual('2015-02-10T03:30:00.000Z');
   });
 });

--- a/tutor/specs/models/task-plans/teacher/tasking.spec.js
+++ b/tutor/specs/models/task-plans/teacher/tasking.spec.js
@@ -70,7 +70,7 @@ describe('Teacher tasking plan tasking', () => {
     expect(tasking.defaultOpensAt()).toEqual(inCourseTime(plan.course.starts_at));
   });
 
-  it('#initializeWithDueAt', () => {
+  fit('#initializeWithDueAt', () => {
     expect(course.time_zone).toEqual('Central Time (US & Canada)');
 
     plan.course.default_open_time = '10:20';

--- a/tutor/specs/models/task-plans/teacher/teacher.spec.js
+++ b/tutor/specs/models/task-plans/teacher/teacher.spec.js
@@ -18,11 +18,11 @@ describe('Task Plan for Teachers', () => {
       tp.due_at = moment(now).add(i, 'day').toDate();
     });
     expect(
-      moment(now).isSame(plan.dueRange.start),
+      moment(now).isSame(plan.duration.start),
     ).toBe(true);
     expect(
       moment(now).add(plan.tasking_plans.length-1, 'day').isSame(
-        plan.dueRange.end
+        plan.duration.end
       ),
     ).toBe(true);
   });

--- a/tutor/specs/screens/teacher-dashboard/dashboard.spec.js
+++ b/tutor/specs/screens/teacher-dashboard/dashboard.spec.js
@@ -11,7 +11,7 @@ describe('CourseCalendar Month display', () => {
     course = Factory.course({ is_teacher: true });
     Factory.teacherTaskPlans({ course });
     props = {
-      date: course.teacherTaskPlans.array[0].duration.end(),
+      date: course.teacherTaskPlans.array[0].duration.end,
       course: course,
       termEnd: moment().add(2, 'month'),
       termStart: moment().subtract(3, 'month'),

--- a/tutor/specs/screens/teacher-dashboard/month.spec.js
+++ b/tutor/specs/screens/teacher-dashboard/month.spec.js
@@ -12,7 +12,7 @@ describe('CourseCalendar Month display', () => {
     course = Factory.course({ is_teacher: true });
     Factory.teacherTaskPlans({ course });
     props = {
-      date: course.teacherTaskPlans.array[0].duration.end(),
+      date: course.teacherTaskPlans.array[0].duration.end,
       course: course,
       onDrop: jest.fn(),
       onDrag: jest.fn(),

--- a/tutor/src/components/book-page.js
+++ b/tutor/src/components/book-page.js
@@ -41,12 +41,13 @@ function processImage() {
     figure.classList.add('full-width');
   }
   let isScaled = false;
-  IMAGE_SIZE_CLASSES.forEach(cls => {
+  for (let i = 0; i < IMAGE_SIZE_CLASSES.length; i++) {
+    const cls = IMAGE_SIZE_CLASSES[i];
     if (figure.querySelector(`.${cls}`)) {
       figure.classList.add(cls);
       isScaled = true;
     }
-  });
+  }
 
   // don't autosize splash or manually scaled images
   if (isScaled || figure.classList.contains('splash')) {
@@ -264,7 +265,7 @@ class BookPage extends React.Component {
   }
 
   detectImgAspectRatio(root) {
-    root.querySelectorAll('figure img').forEach((img) =>
+    forEach(root.querySelectorAll('figure img'), (img) =>
       img.complete ? processImage.call(img) : (img.onload = processImage));
   }
 
@@ -332,7 +333,7 @@ class BookPage extends React.Component {
         }
       }
 
-      root.querySelectorAll(INTER_BOOK_LINKS).forEach(link => {
+      forEach(root.querySelectorAll(INTER_BOOK_LINKS), link => {
         this.props.ux.rewriteBookLink(link);
         link.target = '_self';
       });

--- a/tutor/src/components/tutor-input.js
+++ b/tutor/src/components/tutor-input.js
@@ -34,6 +34,8 @@ class TutorInput extends React.Component {
     onUpdated: PropTypes.func,
     autoFocus: PropTypes.bool,
     hasValue: PropTypes.bool,
+    defaultValue: PropTypes.string,
+    default: PropTypes.string,
   };
 
   state = { errors: [] };

--- a/tutor/src/components/tutor-input.js
+++ b/tutor/src/components/tutor-input.js
@@ -39,7 +39,7 @@ class TutorInput extends React.Component {
   state = { errors: [] };
 
   componentDidMount() {
-    const errors = this.props.validate(this.props.default);
+    const errors = this.props.validate(this.props.value || this.props.default);
     if (!isEmpty(errors)) { this.setState({ errors }); }
     if (this.props.autoFocus) { return defer(() => this.focus().cursorToEnd()); }
   }
@@ -227,6 +227,7 @@ class TutorDateInput extends React.Component {
     if (!this.props.disabled) {
       dateElem = (
         <DatePicker
+          autoComplete="off"
           id={this.props.id}
           utcOffset={this.tzOffset}
           minDate={min.toDate()}
@@ -323,7 +324,7 @@ class TutorTimeInput extends React.Component {
   };
 
   render() {
-    const inputProps = omit(this.props, 'defaultValue', 'onChange', 'formatCharacters', 'value');
+    const inputProps = omit(this.props, 'default', 'onChange', 'formatCharacters', 'value');
 
     let { value } = this.props;
     if (!supportsTime) {
@@ -332,6 +333,7 @@ class TutorTimeInput extends React.Component {
 
     return (
       <TutorInput
+        autoComplete="off"
         {...inputProps}
         value={value}
         ref={this.input}

--- a/tutor/src/models/task-plans/teacher/plan.js
+++ b/tutor/src/models/task-plans/teacher/plan.js
@@ -35,7 +35,7 @@ const calculateDefaultOpensAt = ({ course }) => {
         course.bounds.end,
         defaultOpensAt,
       ),
-      course.bounds.start.add(1, 'minute'),
+      moment(course.bounds.start).add(1, 'day'),
     ),
   ).hour(hour).minute(minute).startOf('minute').toISOString();
 };

--- a/tutor/src/models/task-plans/teacher/plan.js
+++ b/tutor/src/models/task-plans/teacher/plan.js
@@ -32,7 +32,7 @@ const calculateDefaultOpensAt = ({ course }) => {
   return moment(
     findLatest(
       findEarliest(
-        course.bounds.end,
+        moment(course.bounds.end).subtract(1, 'day'),
         defaultOpensAt,
       ),
       moment(course.bounds.start).add(1, 'day'),

--- a/tutor/src/models/task-plans/teacher/tasking.js
+++ b/tutor/src/models/task-plans/teacher/tasking.js
@@ -24,13 +24,6 @@ class TaskingPlan extends BaseModel {
   @field opens_at;
   @field due_at;
 
-  constructor(attrs) {
-    super(attrs);
-    if (!this.opens_at) {
-      this.opens_at = this.defaultOpensAt();
-    }
-  }
-
   get course() {
     return get(this.plan, 'course');
   }

--- a/tutor/src/screens/student-dashboard/event-row.jsx
+++ b/tutor/src/screens/student-dashboard/event-row.jsx
@@ -11,6 +11,8 @@ import Course from '../../models/course';
 import Theme from '../../theme';
 
 const NotOpenNoticeWrapper=styled.div`
+  margin: 1rem 1rem 0 1rem;
+  font-size: 12px;
   display: flex;
   min-height: 3rem;
   align-items: center;

--- a/tutor/src/screens/teacher-dashboard/month.js
+++ b/tutor/src/screens/teacher-dashboard/month.js
@@ -1,7 +1,6 @@
 import {
   React, cn, observable, computed, observer, action,
 } from '../../helpers/react';
-import moment from '../../helpers/moment-range';
 import TimeHelper from '../../helpers/time';
 import { partial } from 'lodash';
 import 'moment-timezone';
@@ -42,7 +41,7 @@ class Month extends React.Component {
 
     const plans = teacherTaskPlans.active.array.map(plan => ({
       plan,
-      range: plan.dueRange,
+      range: plan.dateRanges.due,
       className: `type-${plan.type}`,
       render: ({ event }) => (
         <Plan

--- a/tutor/src/screens/teacher-dashboard/plan-label.jsx
+++ b/tutor/src/screens/teacher-dashboard/plan-label.jsx
@@ -1,4 +1,4 @@
-import { React, observable, observer, styled } from '../../helpers/react';
+import { React, observer, styled } from '../../helpers/react';
 import PropTypes from 'prop-types';
 import TourAnchor from '../../components/tours/anchor';
 import TroubleIcon from '../../components/icons/trouble';
@@ -24,7 +24,7 @@ class CoursePlanLabel extends React.Component {
     return (
       <TourAnchor id="calendar-task-plan">
         <Label
-          data-opens-at={plan.opensAt}
+          data-opens-at={plan.opensAtString}
           data-title={plan.title}
         >
           <TroubleIcon plan={plan} />


### PR DESCRIPTION
Fixes a few small irritants:

* Sometimes the individual taskings for a new assignment would be shown one-per-period
* Sometimes the time would be shown as invalid even though it wasn't
* hides the browser auto-complete on the date inputs
* Shows opens at time if it's the same day as today
<img width="171" alt="image" src="https://user-images.githubusercontent.com/79566/63733504-43a62400-c83e-11e9-80bc-bce7da4f2ad8.png">

