### PR TITLE
don't mark external url steps as complete until link is clicked

### DIFF
--- a/tutor/specs/screens/task/__snapshots__/external.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/external.spec.js.snap
@@ -31,7 +31,7 @@ exports[`Tasks External URL Screen matches snapshot 1`] = `
               "group": undefined,
               "id": 1,
               "isFetched": true,
-              "is_completed": true,
+              "is_completed": false,
               "labels": Array [],
               "multiPartGroup": undefined,
               "preview": "Regulation of Hormone Production",

--- a/tutor/specs/screens/task/external.spec.js
+++ b/tutor/specs/screens/task/external.spec.js
@@ -24,4 +24,14 @@ describe('Tasks External URL Screen', () => {
     ex.unmount();
   });
 
+  it('marks step as complete when clicked', () => {
+    const ex = mount(<C><External {...props} /></C>);
+    expect(props.ux.currentStep.isExternalUrl).toBe(true);
+    expect(props.ux.currentStep.is_completed).toBe(false);
+    props.ux.currentStep.save = jest.fn();
+    ex.find(`a[href="${props.ux.steps[0].external_url}"]`).simulate('click');
+    expect(props.ux.currentStep.is_completed).toBe(true);
+    expect(props.ux.currentStep.save).toHaveBeenCalled();
+    ex.unmount();
+  });
 });

--- a/tutor/src/models/student-tasks/step.js
+++ b/tutor/src/models/student-tasks/step.js
@@ -104,6 +104,9 @@ class StudentTaskStep extends BaseModel {
   @computed get isReading() {
     return 'reading' === this.type;
   }
+  @computed get isExternalUrl() {
+    return 'external_url' === this.type;
+  }
   @computed get isInteractive() {
     return 'interactive' === this.type;
   }
@@ -165,7 +168,7 @@ class StudentTaskStep extends BaseModel {
   }
 
   @action markViewed() {
-    if (!this.isExercise && !this.is_completed) {
+    if (!this.isExercise && !this.isExternalUrl && !this.is_completed) {
       this.is_completed = true;
       this.save();
     }

--- a/tutor/src/screens/task/external.js
+++ b/tutor/src/screens/task/external.js
@@ -41,7 +41,8 @@ class ExternalTaskStep extends React.Component {
   }
 
   @action.bound onContinue() {
-    const [step] = this.props.ux.steps[0];
+    const step = this.props.ux.currentStep;
+    step.is_completed = true;
     step.save();
   }
 


### PR DESCRIPTION
the issue was that steps were marking themselves complete as soon as they were viewed, but "complete" in the context of a external url means it was clicked.