### PR TITLE
Display ready tasks as the dashboard loads

### DIFF
--- a/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
+++ b/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
@@ -1,9 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Student Dashboard displays as loading 1`] = `
-.c0 {
+.c2 {
   margin-right: 0.5rem;
   margin-left: 0.5rem;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1 {
+  font-size: 1.2rem;
+  margin-top: 5px;
+  color: #6f6f6f;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 1rem 0;
+}
+
+.c3 span + span {
+  margin-left: 2rem;
 }
 
 <div
@@ -87,50 +120,336 @@ exports[`Student Dashboard displays as loading 1`] = `
           role="tabpanel"
         >
           <div
-            className="empty pending card"
+            className="-this-week card"
           >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-spinner fa-w-16 fa-spin ox-icon ox-icon-spinner c0"
-              data-icon="spinner"
-              data-prefix="fas"
-              data-variant="activity"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="row labels"
             >
-              <path
-                d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
-                fill="currentColor"
+              <div
+                className="col-sm-6 col-12"
+              >
+                <span
+                  className="date-range"
+                >
+                  <time>
+                    Oct 12, 2015
+                  </time>
+                  <span>
+                    –
+                  </span>
+                  <time>
+                    Oct 18, 2015
+                  </time>
+                </span>
+              </div>
+              <div
+                className="due-at-label col-sm-3 col-5 offset-sm-0 offset-2"
+              >
+                Due
+              </div>
+              <div
+                className="progress-label col-sm-3 col-5"
+              >
+                Progress
+              </div>
+            </div>
+            <a
+              aria-label="Work on reading: value-added strategize initiatives"
+              className="task row reading"
+              data-event-id={5}
+              href="/course/1/task/5"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                className="column-icon col-sm-1 col-2"
+              >
+                <i
+                  aria-label="reading icon"
+                  className="icon icon-lg icon-reading"
+                />
+              </div>
+              <div
+                className="title col-sm-5 col-10"
+              >
+                value-added strategize initiatives
+              </div>
+              <div
+                className="due-at col-sm-3 col-5"
+              >
+                <time>
+                  Su Oct 18, 7:00am
+                </time>
+              </div>
+              <div
+                className="feedback col-sm-3 col-5"
+              >
+                <div
+                  className="c0"
+                >
+                  <span
+                    className="tour-anchor"
+                    data-tour-anchor-id="assignment-progress-status"
+                  >
+                    Not started
+                  </span>
+                </div>
+              </div>
+            </a>
+            <a
+              aria-label="Work on external: granular e-enable technologies"
+              className="task row external"
+              data-event-id={6}
+              href="/course/1/task/6"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                className="column-icon col-sm-1 col-2"
+              >
+                <i
+                  aria-label="external icon"
+                  className="icon icon-lg icon-external"
+                />
+              </div>
+              <div
+                className="title col-sm-5 col-10"
+              >
+                granular e-enable technologies
+              </div>
+              <div
+                className="due-at col-sm-3 col-5"
+              >
+                <time>
+                  Su Oct 18, 7:00am
+                </time>
+              </div>
+              <div
+                className="feedback col-sm-3 col-5"
+              >
+                <div
+                  className="c0"
+                >
+                  <span
+                    className="tour-anchor"
+                    data-tour-anchor-id="assignment-progress-status"
+                  >
+                    Not started
+                  </span>
+                </div>
+              </div>
+            </a>
+            <a
+              aria-label="Work on event: sexy syndicate vortals"
+              className="task row event"
+              data-event-id={7}
+              href="/course/1/task/7"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                className="column-icon col-sm-1 col-2"
+              >
+                <i
+                  aria-label="event icon"
+                  className="icon icon-lg icon-event"
+                />
+              </div>
+              <div
+                className="title col-sm-5 col-10"
+              >
+                sexy syndicate vortals
+              </div>
+              <div
+                className="due-at col-sm-3 col-5"
+              >
+                <time>
+                  Su Oct 18, 7:00am
+                </time>
+              </div>
+              <div
+                className="feedback col-sm-3 col-5"
+              >
+                <div
+                  className="c0"
+                >
+                  
+                </div>
+              </div>
+            </a>
+            <a
+              aria-label="Work on homework: granular target technologies"
+              className="task row homework"
+              data-event-id={8}
+              href="/course/1/task/8"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                className="column-icon col-sm-1 col-2"
+              >
+                <i
+                  aria-label="homework icon"
+                  className="icon icon-lg icon-homework"
+                />
+              </div>
+              <div
+                className="title col-sm-5 col-10"
+              >
+                granular target technologies
+              </div>
+              <div
+                className="due-at col-sm-3 col-5"
+              >
+                <time>
+                  Su Oct 18, 7:00am
+                </time>
+              </div>
+              <div
+                className="feedback col-sm-3 col-5"
+              >
+                <div
+                  className="c0"
+                >
+                  <span
+                    className="tour-anchor"
+                    data-tour-anchor-id="assignment-progress-status"
+                  >
+                    Not started
+                  </span>
+                </div>
+                <div
+                  className="c1"
+                >
+                  0
+                  /
+                  11
+                   answered on due date
+                </div>
+              </div>
+            </a>
+            <div
+              className="empty pending card"
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-spinner fa-w-16 fa-spin ox-icon ox-icon-spinner c2"
+                data-icon="spinner"
+                data-prefix="fas"
+                data-variant="activity"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
-             Preparing assignments for your course.  This can take up to 10 minutes.
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+               Preparing assignments for your course.  This can take up to 10 minutes.
+            </div>
           </div>
           <div
-            className="empty pending upcoming card"
+            className="c3"
           >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-spinner fa-w-16 fa-spin ox-icon ox-icon-spinner c0"
-              data-icon="spinner"
-              data-prefix="fas"
-              data-variant="activity"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
-                fill="currentColor"
+            <span>
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-exclamation-circle fa-w-16 ox-icon ox-icon-exclamation-circle c2"
+                color="#f4d019"
+                data-icon="exclamation-circle"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
-             Preparing assignments for your course.  This can take up to 10 minutes.
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+               Due soon
+            </span>
+            <span>
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-clock fa-w-16 ox-icon ox-icon-clock c2"
+                color="#c2002f"
+                data-icon="clock"
+                data-prefix="far"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm0 448c-110.5 0-200-89.5-200-200S145.5 56 256 56s200 89.5 200 200-89.5 200-200 200zm61.8-104.4l-84.9-61.7c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v141.7l66.8 48.6c5.4 3.9 6.5 11.4 2.6 16.8L334.6 349c-3.9 5.3-11.4 6.5-16.8 2.6z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+               Late
+            </span>
+            <span>
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-clock fa-w-16 ox-icon ox-icon-clock c2"
+                color="#6f6f6f"
+                data-icon="clock"
+                data-prefix="far"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm0 448c-110.5 0-200-89.5-200-200S145.5 56 256 56s200 89.5 200 200-89.5 200-200 200zm61.8-104.4l-84.9-61.7c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v141.7l66.8 48.6c5.4 3.9 6.5 11.4 2.6 16.8L334.6 349c-3.9 5.3-11.4 6.5-16.8 2.6z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+               Late but accepted
+            </span>
+          </div>
+          <div
+            className="upcoming card"
+          >
+            <div
+              className="row labels"
+            >
+              <div
+                className="col-sm-6 col-12"
+              >
+                <span
+                  className="title"
+                >
+                  Coming Up
+                </span>
+              </div>
+              <div
+                className="due-at-label col-sm-3 col-5 offset-sm-0 offset-2"
+              >
+                Due
+              </div>
+              <div
+                className="progress-label col-sm-3 col-5"
+              >
+                Progress
+              </div>
+            </div>
+            <div
+              className="empty upcoming card"
+            >
+              No upcoming assignments
+            </div>
           </div>
         </div>
       </div>
@@ -165,7 +484,7 @@ exports[`Student Dashboard displays as loading 1`] = `
 `;
 
 exports[`Student Dashboard matches snapshot 1`] = `
-.c3 {
+.c2 {
   margin-right: 0.5rem;
   margin-left: 0.5rem;
 }
@@ -191,7 +510,7 @@ exports[`Student Dashboard matches snapshot 1`] = `
   color: #6f6f6f;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -199,7 +518,7 @@ exports[`Student Dashboard matches snapshot 1`] = `
   margin: 1rem 0;
 }
 
-.c2 span + span {
+.c3 span + span {
   margin-left: 2rem;
 }
 
@@ -492,14 +811,37 @@ exports[`Student Dashboard matches snapshot 1`] = `
                 </div>
               </div>
             </a>
+            <div
+              className="empty pending card"
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-spinner fa-w-16 fa-spin ox-icon ox-icon-spinner c2"
+                data-icon="spinner"
+                data-prefix="fas"
+                data-variant="activity"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+               Preparing assignments for your course.  This can take up to 10 minutes.
+            </div>
           </div>
           <div
-            className="c2"
+            className="c3"
           >
             <span>
               <svg
                 aria-hidden="true"
-                className="svg-inline--fa fa-exclamation-circle fa-w-16 ox-icon ox-icon-exclamation-circle c3"
+                className="svg-inline--fa fa-exclamation-circle fa-w-16 ox-icon ox-icon-exclamation-circle c2"
                 color="#f4d019"
                 data-icon="exclamation-circle"
                 data-prefix="fas"
@@ -520,7 +862,7 @@ exports[`Student Dashboard matches snapshot 1`] = `
             <span>
               <svg
                 aria-hidden="true"
-                className="svg-inline--fa fa-clock fa-w-16 ox-icon ox-icon-clock c3"
+                className="svg-inline--fa fa-clock fa-w-16 ox-icon ox-icon-clock c2"
                 color="#c2002f"
                 data-icon="clock"
                 data-prefix="far"
@@ -541,7 +883,7 @@ exports[`Student Dashboard matches snapshot 1`] = `
             <span>
               <svg
                 aria-hidden="true"
-                className="svg-inline--fa fa-clock fa-w-16 ox-icon ox-icon-clock c3"
+                className="svg-inline--fa fa-clock fa-w-16 ox-icon ox-icon-clock c2"
                 color="#6f6f6f"
                 data-icon="clock"
                 data-prefix="far"
@@ -561,9 +903,36 @@ exports[`Student Dashboard matches snapshot 1`] = `
             </span>
           </div>
           <div
-            className="empty upcoming card"
+            className="upcoming card"
           >
-            No upcoming assignments
+            <div
+              className="row labels"
+            >
+              <div
+                className="col-sm-6 col-12"
+              >
+                <span
+                  className="title"
+                >
+                  Coming Up
+                </span>
+              </div>
+              <div
+                className="due-at-label col-sm-3 col-5 offset-sm-0 offset-2"
+              >
+                Due
+              </div>
+              <div
+                className="progress-label col-sm-3 col-5"
+              >
+                Progress
+              </div>
+            </div>
+            <div
+              className="empty upcoming card"
+            >
+              No upcoming assignments
+            </div>
           </div>
         </div>
       </div>

--- a/tutor/specs/screens/student-dashboard/dashboard.spec.jsx
+++ b/tutor/specs/screens/student-dashboard/dashboard.spec.jsx
@@ -44,9 +44,8 @@ describe('Student Dashboard', () => {
     dash.unmount();
   });
 
-  it('logs when BL times out', () => {
+  it('logs when Biglearn times out', () => {
     props.course.studentTaskPlans.all_tasks_are_ready = false;
-    props.course.primaryRole.joined_at = new Date('2015-10-11T12:00:00.000Z');
     const tp = props.course.studentTaskPlans;
     tp.api.requestCounts.read = 10;
     expect(tp.taskReadinessTimedOut).toBe(true);

--- a/tutor/specs/screens/student-dashboard/dashboard.spec.jsx
+++ b/tutor/specs/screens/student-dashboard/dashboard.spec.jsx
@@ -15,6 +15,9 @@ describe('Student Dashboard', () => {
     const course = bootstrapCoursesList().get(1);
     Factory.studentTaskPlans({ course, attributes: { now: new Date('2015-10-21T12:00:00.000Z') } });
     course.studentTaskPlans.fetch = jest.fn();
+    course.studentTaskPlans.fetch.mockReturnValue(new Promise(done => {
+      done();
+    }));
     props = {
       course,
       params: {},
@@ -45,11 +48,11 @@ describe('Student Dashboard', () => {
     props.course.studentTaskPlans.all_tasks_are_ready = false;
     props.course.primaryRole.joined_at = new Date('2015-10-11T12:00:00.000Z');
     const tp = props.course.studentTaskPlans;
-    tp.api.requestCounts.read = 2;
+    tp.api.requestCounts.read = 10;
     expect(tp.taskReadinessTimedOut).toBe(true);
-    const dash = mount(<Router><Dashboard {...props} /></Router>);
+    tp.startFetching();
+    tp.stopFetching();
     expect(Raven.log).toHaveBeenCalled();
-    dash.unmount();
   });
 
 });

--- a/tutor/specs/screens/student-dashboard/empty-panel.spec.js
+++ b/tutor/specs/screens/student-dashboard/empty-panel.spec.js
@@ -28,6 +28,7 @@ describe('Empty Panel', () => {
       title: 'upcoming',
       className: 'updog',
       course: Factory.course(),
+      spinner: true,
     };
   });
 

--- a/tutor/specs/screens/student-dashboard/this-week-panel.spec.js
+++ b/tutor/specs/screens/student-dashboard/this-week-panel.spec.js
@@ -16,8 +16,10 @@ describe('This Week Events', () => {
 
   it('shows anything due this week', () => {
     const panel = mount(<ThisWeek {...props} />);
+    expect(panel.text()).toContain('Preparing assignments for your course.');
 
     // no tasks
+    props.course.studentTaskPlans.all_tasks_are_ready = true;
     expect(panel.text()).toContain('No assignments this week');
 
     const event = Factory.studentDashboardTask();

--- a/tutor/src/models/task-plans/student.js
+++ b/tutor/src/models/task-plans/student.js
@@ -91,7 +91,8 @@ class StudentTaskPlans extends Map {
       this.taskReadinessTimedOut &&
       this.api.requestCounts.read % 10 == 0
     ) {
-      Raven.log('dashboard task timed out waiting on BL');
+      Raven.log(`Dashboard loading timed out waiting on Biglearn after ${
+        this.api.requestCounts.read} attempts.`);
     }
     else if (!this.isPendingTaskLoading) {
       this.api.reset();

--- a/tutor/src/models/task-plans/student.js
+++ b/tutor/src/models/task-plans/student.js
@@ -6,6 +6,7 @@ import { filter, groupBy, sortBy, pickBy, find } from 'lodash';
 import StudentTask from './student/task';
 import ResearchSurveys from '../research-surveys';
 import Time from '../time';
+import Raven from '../app/raven';
 
 const MAX_POLLING_ATTEMPTS = 10;
 const POLL_SECONDS = 30;
@@ -77,20 +78,25 @@ class StudentTaskPlans extends Map {
   }
 
   @computed get isPendingTaskLoading() {
-    return Boolean(
-      (false === this.all_tasks_are_ready) &&
-        this.course.primaryRole.joinedAgo('minutes') < 30
-    );
+    return Boolean(false === this.all_tasks_are_ready);
   }
 
   @computed get taskReadinessTimedOut() {
-    return Boolean(
-      (false === this.all_tasks_are_ready) &&
-        this.course.primaryRole.joinedAgo('minutes') > 30
-    );
+    return Boolean(this.api.requestCounts.read >= 10); // 10 minutes
   }
 
   @action.bound fetchTaskPeriodically() {
+    if (
+      this.isPendingTaskLoading &&
+      this.taskReadinessTimedOut &&
+      this.api.requestCounts.read % 10 == 0
+    ) {
+      Raven.log('dashboard task timed out waiting on BL');
+    }
+    else if (!this.isPendingTaskLoading) {
+      this.api.reset();
+    }
+
     return this.fetch().then(() => {
       const interval = (this.isPendingTaskLoading || this.isTeacherWaitingForLatest) ?
         FETCH_INITIAL_TASKS_INTERVAL : REFRESH_TASKS_INTERVAL;

--- a/tutor/src/screens/student-dashboard/all-events-by-week.jsx
+++ b/tutor/src/screens/student-dashboard/all-events-by-week.jsx
@@ -6,7 +6,7 @@ import { autobind } from 'core-decorators';
 import Course from '../../models/course';
 import EmptyCard from './empty-panel';
 import EventsCard from './events-panel';
-import { map, isEmpty } from 'lodash';
+import { map } from 'lodash';
 import LateIconLedgend from './late-icon-ledgend';
 
 export default
@@ -35,15 +35,12 @@ class AllEventsByWeek extends React.Component {
     const { course, course: { studentTaskPlans } } = this.props;
     const weeks = studentTaskPlans.pastTasksByWeek;
 
-    if (studentTaskPlans.isPendingTaskLoading || isEmpty(weeks)) {
-      return <EmptyCard course={course} message="No past assignments" />;
-    }
-
     return (
       <div>
+        <EmptyCard course={course} message="No past assignments" tasks={weeks} />
         {map(weeks, this.renderWeek)}
-        <LateIconLedgend />
+        <LateIconLedgend tasks={weeks} />
       </div>
     );
   }
-};
+}

--- a/tutor/src/screens/student-dashboard/dashboard.jsx
+++ b/tutor/src/screens/student-dashboard/dashboard.jsx
@@ -4,7 +4,6 @@ import { get } from 'lodash';
 import { Row, Col, Card } from 'react-bootstrap';
 import { action, observable } from 'mobx';
 import { includes } from 'lodash';
-import Raven from '../../models/app/raven';
 import UpcomingCard from './upcoming-panel';
 import AllEventsByWeek from './all-events-by-week';
 import ThisWeekCard from './this-week-panel';
@@ -47,11 +46,6 @@ export default class StudentDashboard extends React.Component {
     const role = course.currentRole;
     if (role.isStudentLike && !get(course.userStudentRecord, 'mustPayImmediately')) {
       this.props.course.studentTaskPlans.fetch();
-    }
-
-    const plans = course.studentTaskPlans;
-    if (plans.taskReadinessTimedOut && plans.api.requestCounts.read > 1) {
-      Raven.log('dashboard task timed out waiting on BL');
     }
   }
 

--- a/tutor/src/screens/student-dashboard/empty-panel.jsx
+++ b/tutor/src/screens/student-dashboard/empty-panel.jsx
@@ -1,5 +1,6 @@
 import { React, cn, observer } from '../../helpers/react';
 import Course from '../../models/course';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Card } from 'react-bootstrap';
 import { Icon } from 'shared';
@@ -7,37 +8,46 @@ import { Icon } from 'shared';
 const EmptyCard = observer(({
   course,
   message,
+  spinner,
+  tasks,
   title,
   className,
 }) => {
   const { studentTaskPlans } = course;
 
-  if (studentTaskPlans.isPendingTaskLoading) {
-    return (
-      <Card className={cn('empty', 'pending', className)} header={title}>
-        <Icon variant="activity" /> Preparing assignments for your course.  This
-        can take up to 10 minutes.
-      </Card>
-    );
+  if (spinner) {
+    if (studentTaskPlans.isPendingTaskLoading) {
+      return (
+        <Card className={cn('empty', 'pending', className)} header={title}>
+          <Icon variant="activity" /> Preparing assignments for your course.  This
+          can take up to 10 minutes.
+        </Card>
+      );
+    }
+
+    if (studentTaskPlans.api.isPendingInitialFetch) {
+      return (
+        <Card className={cn('empty', 'pending', className)} header={title}>
+          <Icon variant="activity" /> Fetching assignments for your course.
+        </Card>
+      );
+    }
   }
-  if (studentTaskPlans.api.isPendingInitialFetch) {
+
+  if (isEmpty(tasks) && message) {
     return (
-      <Card className={cn('empty', 'pending', className)} header={title}>
-        <Icon variant="activity" /> Fetching assignments for your course.
+      <Card className={cn('empty', className)} header={title}>
+        {message}
       </Card>
     );
   }
 
-  return (
-    <Card className={cn('empty', className)} header={title}>
-      {message}
-    </Card>
-  );
+  return null;
 });
 
 EmptyCard.propTypes = {
   course: PropTypes.instanceOf(Course).isRequired,
-  message: PropTypes.string.isRequired,
+  message: PropTypes.string,
   title: PropTypes.string,
 };
 

--- a/tutor/src/screens/student-dashboard/events-panel.jsx
+++ b/tutor/src/screens/student-dashboard/events-panel.jsx
@@ -7,19 +7,24 @@ import { autobind } from 'core-decorators';
 import Time from '../../components/time';
 import moment from 'moment';
 import Course from '../../models/course';
+import EmptyCard from './empty-panel';
 import EventRow from './event-row';
+import TeacherPendingLoad from './teacher-pending-load';
 
 export default
 @observer
 class EventsCard extends React.Component {
   static propTypes = {
-    events:     PropTypes.array.isRequired,
-    course:     PropTypes.instanceOf(Course).isRequired,
-    startAt:    PropTypes.object,
-    endAt:      PropTypes.object,
-    limit:      PropTypes.number,
-    title:      PropTypes.string,
-    className:  PropTypes.string,
+    events:         PropTypes.array.isRequired,
+    course:         PropTypes.instanceOf(Course).isRequired,
+    emptyClassName: PropTypes.string,
+    emptyMessage:   PropTypes.string,
+    spinner:        PropTypes.bool,
+    startAt:        PropTypes.object,
+    endAt:          PropTypes.object,
+    limit:          PropTypes.number,
+    title:          PropTypes.string,
+    className:      PropTypes.string,
   }
 
   renderTitle() {
@@ -65,7 +70,14 @@ class EventsCard extends React.Component {
           </Col>
         </div>
         {map(this.props.events, this.renderEvent)}
+        <EmptyCard
+          className={this.props.emptyClassName}
+          course={this.props.course}
+          message={this.props.emptyMessage}
+          spinner={this.props.spinner}
+          tasks={this.props.events} />
+        <TeacherPendingLoad course={this.props.course} />
       </Card>
     );
   }
-};
+}

--- a/tutor/src/screens/student-dashboard/late-icon-ledgend.js
+++ b/tutor/src/screens/student-dashboard/late-icon-ledgend.js
@@ -1,4 +1,6 @@
 import { React, styled } from '../../helpers/react';
+import { isEmpty } from 'lodash';
+import PropTypes from 'prop-types';
 import { Icon } from 'shared';
 import Theme from '../../theme';
 
@@ -10,7 +12,11 @@ const Wrapper = styled.div`
   }
 `;
 
-const LateIconLedgend = () => {
+const LateIconLedgend = props => {
+  if (isEmpty(props.tasks)) {
+    return null;
+  }
+
   return (
     <Wrapper>
       <span>
@@ -24,6 +30,10 @@ const LateIconLedgend = () => {
       </span>
     </Wrapper>
   );
+};
+
+LateIconLedgend.propTypes = {
+  tasks: PropTypes.array.isRequired,
 };
 
 export default LateIconLedgend;

--- a/tutor/src/screens/student-dashboard/styles/empty-card.scss
+++ b/tutor/src/screens/student-dashboard/styles/empty-card.scss
@@ -1,18 +1,17 @@
 .student-dashboard {
   .card.empty {
+    margin-top: 0;
+    border-right: none;
+    border-bottom: none;
+    border-left: none;
+    border-radius: 0;
     padding: 20px;
     text-align: center;
     flex-direction: row;
     justify-content: center;
+
     .spinner {
       margin-right: 1rem;
-    }
-
-    &.pending {
-      margin-top: 5rem;
-      &.upcoming {
-        display: none;
-      }
     }
   }
 }

--- a/tutor/src/screens/student-dashboard/this-week-panel.jsx
+++ b/tutor/src/screens/student-dashboard/this-week-panel.jsx
@@ -26,7 +26,7 @@ class ThisWeekCard extends React.Component {
           startAt={studentTaskPlans.startOfThisWeek}
           endAt={studentTaskPlans.endOfThisWeek}
           emptyMessage='No assignments this week'
-          spinner={true}
+          spinner
         />
         <LateIconLedgend tasks={tasks}/>
       </React.Fragment>

--- a/tutor/src/screens/student-dashboard/this-week-panel.jsx
+++ b/tutor/src/screens/student-dashboard/this-week-panel.jsx
@@ -1,11 +1,8 @@
 import PropTypes from 'prop-types';
-import { isEmpty } from 'lodash';
 import React from 'react';
 import Course from '../../models/course';
 import { observer } from 'mobx-react';
-import Events from './events-panel';
-import EmptyCard from './empty-panel';
-import TeacherPendingLoad from './teacher-pending-load';
+import EventsCard from './events-panel';
 import LateIconLedgend from './late-icon-ledgend';
 
 export default
@@ -20,27 +17,18 @@ class ThisWeekCard extends React.Component {
     const { course, course: { studentTaskPlans } } = this.props;
     const tasks = studentTaskPlans.thisWeeksTasks;
 
-    if (studentTaskPlans.isPendingTaskLoading || isEmpty(tasks)) {
-      return (
-        <React.Fragment>
-          <EmptyCard course={course} message='No assignments this week' />
-          <TeacherPendingLoad course={course} />
-        </React.Fragment>
-      );
-
-    }
-
     return (
       <React.Fragment>
-        <Events
+        <EventsCard
           className="-this-week"
           course={course}
           events={tasks}
           startAt={studentTaskPlans.startOfThisWeek}
           endAt={studentTaskPlans.endOfThisWeek}
+          emptyMessage='No assignments this week'
+          spinner={true}
         />
-        <LateIconLedgend />
-        <TeacherPendingLoad course={course} />
+        <LateIconLedgend tasks={tasks}/>
       </React.Fragment>
     );
   }

--- a/tutor/src/screens/student-dashboard/upcoming-panel.jsx
+++ b/tutor/src/screens/student-dashboard/upcoming-panel.jsx
@@ -1,9 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { isEmpty } from 'lodash';
 import { observer } from 'mobx-react';
 import EventsCard from './events-panel';
-import EmptyCard from './empty-panel';
 import Course from '../../models/course';
 
 export default
@@ -19,18 +17,18 @@ class UpcomingCard extends React.Component {
 
     const tasks = studentTaskPlans.upcomingTasks;
 
-    if (studentTaskPlans.isPendingTaskLoading || isEmpty(tasks)) {
-      return <EmptyCard className="upcoming" course={course} message='No upcoming assignments' />;
-    }
-
     return (
-      <EventsCard
-        className="upcoming"
-        onTaskClick={this.onTaskClick}
-        course={course}
-        events={tasks}
-        title="Coming Up" />
+      <React.Fragment>
+        <EventsCard
+          className="upcoming"
+          onTaskClick={this.onTaskClick}
+          course={course}
+          events={tasks}
+          title="Coming Up"
+          emptyClassName="upcoming"
+          emptyMessage='No upcoming assignments' />
+      </React.Fragment>
     );
   }
 
-};
+}


### PR DESCRIPTION
Instead of waiting for all tasks to be ready.
The following screenshots were taken by artificially manipulating the APIs to get the correct flags:

Preparing (10 min):
<img width="1447" alt="Screen Shot 2019-08-27 at 4 21 01 PM" src="https://user-images.githubusercontent.com/1017808/63813630-c210cd80-c8f3-11e9-82a9-da524ee31eee.png">

Fetching:
<img width="1447" alt="Screen Shot 2019-08-27 at 4 21 40 PM" src="https://user-images.githubusercontent.com/1017808/63813638-c6d58180-c8f3-11e9-8c0b-650a677ceb2e.png">

Loading some more:
<img width="1447" alt="Screen Shot 2019-08-27 at 4 23 33 PM" src="https://user-images.githubusercontent.com/1017808/63813654-d48b0700-c8f3-11e9-8f65-72aba1c11798.png">

No past work:
<img width="1447" alt="Screen Shot 2019-08-27 at 4 21 04 PM" src="https://user-images.githubusercontent.com/1017808/63813672-de146f00-c8f3-11e9-9df4-c9121f4c866b.png">