### PR TITLE
clear student data anytime role is changed

### DIFF
--- a/tutor/src/helpers/conditional-handlers.jsx
+++ b/tutor/src/helpers/conditional-handlers.jsx
@@ -43,17 +43,14 @@ const getConditionalHandlers = (Router) => {
   // eslint-disable-next-line react/prop-types
   const renderBecomeRole = ({ params: { courseId, roleId } }) => {
     const course = Courses.get(courseId);
-    const role = course.roles.find(r => r.id == roleId);
+    if (!course) { return <CourseNotFoundWarning />; }
 
-    if (!course || !course.roles.teacher || !role) {
+    const role = course.roles.find(r => r.id == roleId);
+    // only teachers can switch their role
+    if (!role || !course.roles.teacher) {
       return <CourseNotFoundWarning />;
     }
-
-    if (course.currentRole.isTeacherStudent) {
-      course.current_role_id = null;
-    } else {
-      role.become();
-    }
+    role.become();
 
     return <Redirect push to={`/course/${courseId}`} />;
   };

--- a/tutor/src/models/course/role.js
+++ b/tutor/src/models/course/role.js
@@ -37,7 +37,7 @@ class CourseRole extends BaseModel {
   }
 
   @action async become({ reset = true } = {}) {
-    if (this.isStudentLike && reset) {
+    if (reset) {
       this.course.clearCachedStudentData();
     }
     this.course.current_role_id = this.id;

--- a/tutor/src/screens/task/ux.js
+++ b/tutor/src/screens/task/ux.js
@@ -42,6 +42,9 @@ export default class TaskUX {
       return this._task.students.find(s => s.role_id == r.id);
     });
     if (teacherAsStudentRole) {
+      // become the role, but do not reset the data so we
+      // can re-use whatever is present.  Task is per-user,
+      // so the data will be for this user
       teacherAsStudentRole.become({ reset: false });
     }
   }


### PR DESCRIPTION
Previously a student's data was not cleared when going back to teacher role, causing the teacher to briefly see student score data