### PR TITLE
Do not allow editing opens_at for published and open plans

### DIFF
--- a/tutor/resources/styles/components/tutor-input.scss
+++ b/tutor/resources/styles/components/tutor-input.scss
@@ -92,6 +92,11 @@
     cursor: not-allowed;
     font-size: 1.3rem;
   }
+  &.is-disabled {
+    input {
+      cursor: not-allowed;
+    }
+  }
 }
 
 .is-invalid-form {

--- a/tutor/specs/models/task-plans/teacher/tasking.spec.js
+++ b/tutor/specs/models/task-plans/teacher/tasking.spec.js
@@ -24,6 +24,21 @@ describe('Teacher tasking plan tasking', () => {
     });
   });
 
+  it('finds unmodified version', () => {
+    const attrs = { target_id: '123', target_type: 'test' };
+    plan.unmodified_plans.push(attrs);
+    tasking.update(attrs);
+    expect(tasking.unmodified).toEqual(attrs);
+  });
+
+  it('calculates if the opens_at can be edited', () => {
+    plan.is_published = false;
+    expect(tasking.canEditOpensAt).toBe(true);
+    plan.is_published = true;
+    tasking.unmodified.opens_at = '2015-10-10T12:00:00.000Z';
+    expect(tasking.canEditOpensAt).toBe(false);
+  });
+
   it('sets open/due but not past the opposing open/due', () => {
     tasking.setOpensDate(moment(now).year(2016));
 
@@ -70,7 +85,7 @@ describe('Teacher tasking plan tasking', () => {
     expect(tasking.defaultOpensAt()).toEqual(inCourseTime(plan.course.starts_at));
   });
 
-  fit('#initializeWithDueAt', () => {
+  it('#initializeWithDueAt', () => {
     expect(course.time_zone).toEqual('Central Time (US & Canada)');
 
     plan.course.default_open_time = '10:20';

--- a/tutor/specs/screens/assignment-builder/builder/tasking.spec.js
+++ b/tutor/specs/screens/assignment-builder/builder/tasking.spec.js
@@ -10,7 +10,7 @@ describe('Tasking Builder', () => {
 
   beforeEach(() => {
     course = Factory.course();
-    plan = Factory.teacherTaskPlan({ course });
+    plan = Factory.teacherTaskPlan({ course, is_published: false });
     const ux = new UX({ course, plan });
     props = { ux };
   });

--- a/tutor/src/components/tutor-input.js
+++ b/tutor/src/components/tutor-input.js
@@ -93,6 +93,7 @@ class TutorInput extends React.Component {
       this.props.className,
       {
         'is-required': this.props.required,
+        'is-disabled': this.props.disabled,
         'has-error': (this.state.errors != null ? this.state.errors.length : undefined),
       },
     );
@@ -213,6 +214,7 @@ class TutorDateInput extends React.Component {
         'is-required': this.props.required,
         'has-error': (this.state.errors != null ? this.state.errors.length : undefined),
         'disabled-datepicker':  isDatePickerDisabled,
+        'is-disabled': this.props.disabled,
       },
     );
 
@@ -267,7 +269,7 @@ class TutorDateInput extends React.Component {
         </div>
         <div className="date-wrapper">
           {dateElem}
-          <Icon type="calendar" />
+          {!this.props.disabled && <Icon type="calendar" />}
         </div>
       </div>
     );

--- a/tutor/src/models/task-plans/teacher/plan.js
+++ b/tutor/src/models/task-plans/teacher/plan.js
@@ -152,11 +152,8 @@ class TeacherTaskPlan extends BaseModel {
 
   @computed get areTaskingDatesSame() {
     return Boolean(
-      this.dateRanges.opens.start.isSame(
-        this.dateRanges.opens.end
-      ) && this.dateRanges.due.start.isSame(
-        this.dateRanges.due.end
-      )
+      0 === this.dateRanges.opens.start.diff(this.dateRanges.opens.end, 'minute') &&
+        0 === this.dateRanges.due.start.diff(this.dateRanges.due.end, 'minute')
     );
   }
 

--- a/tutor/src/models/task-plans/teacher/tasking.js
+++ b/tutor/src/models/task-plans/teacher/tasking.js
@@ -1,7 +1,7 @@
 import {
   BaseModel, identifiedBy, field, action, session, computed,
 } from 'shared/model';
-import { pick, get, extend } from 'lodash';
+import { pick, get, extend, find } from 'lodash';
 import moment from 'moment';
 import Time from '../../time';
 import {
@@ -94,6 +94,20 @@ class TaskingPlan extends BaseModel {
       opens_at: this.opensAtMoment.format('YYYY-MM-DD HH:mm'),
       due_at: this.dueAtMoment.format('YYYY-MM-DD HH:mm'),
     });
+  }
+
+  @computed get unmodified() {
+    return find(this.plan.unmodified_plans, {
+      target_type: this.target_type, target_id: this.target_id,
+    });
+  }
+
+  @computed get canEditOpensAt() {
+    return Boolean(
+      !this.plan.isPublished ||
+        !this.unmodified ||
+        moment(this.unmodified.opens_at).isAfter(Time.now),
+    );
   }
 
   // resets the due at time to course default

--- a/tutor/src/screens/assignment-builder/builder/index.js
+++ b/tutor/src/screens/assignment-builder/builder/index.js
@@ -68,10 +68,6 @@ class TaskPlanBuilder extends React.Component {
                 Set date and time to now to open
                 immediately. Course time zone: <TimeZoneSettings course={course} />
               </p>
-              {plan.isVisibleToStudents && (
-                <p>
-                  Open times cannot be edited after assignment is visible to students.
-                </p>)}
             </div>
           </Col>
         </Row>

--- a/tutor/src/screens/assignment-builder/builder/tasking.js
+++ b/tutor/src/screens/assignment-builder/builder/tasking.js
@@ -12,13 +12,22 @@ import SetTimeAsDefault from './set-time-as-default';
 
 const StyledTasking = styled(Row)`
 min-height: 7rem;
-.tutor-input.form-control-wrapper.tutor-input input[disabled] {
-  border-bottom: 0;
-}
 .react-datepicker-wrapper {
   height: 100%;
 }
 `;
+
+const StyledCantEditExplanation = styled(Col)`
+  margin-top: -25px;
+  font-size: 1.2rem;
+`;
+const CantEditExplanation = () => (
+  <Row>
+    <StyledCantEditExplanation xs={12}>
+       Cannot be edited after assignment is visible
+    </StyledCantEditExplanation>
+  </Row>
+);
 
 @observer
 class Tasking extends React.Component {
@@ -162,6 +171,7 @@ class Tasking extends React.Component {
                 value={tasking.opens_at}
                 min={this.minOpensAt}
                 max={this.maxOpensAt}
+                disabled={!tasking.canEditOpensAt}
                 onChange={this.onOpensDateChange}
               />
             </Col>
@@ -170,12 +180,14 @@ class Tasking extends React.Component {
                 required={true}
                 label="Open Time"
                 id={`${type}-open-time`}
+                disabled={!tasking.canEditOpensAt}
                 onChange={this.onOpensTimeChange}
                 value={tasking.opensAtTime}
               />
               <SetTimeAsDefault type="opens" tasking={tasking} />
             </Col>
           </Row>
+          {!tasking.canEditOpensAt && <CantEditExplanation />}
         </Col>
         <Col xs={12} md={6} className="due-at">
           <Row>

--- a/tutor/src/screens/assignment-builder/styles/builder.scss
+++ b/tutor/src/screens/assignment-builder/styles/builder.scss
@@ -54,7 +54,7 @@
     color: $tutor-info;
     text-transform: none;
     padding: 0;
-    margin-top: -20px;
+    margin-top: -25px;
     border-radius: 0;
 
     &.is-waiting {
@@ -78,12 +78,12 @@
   }
   .required-hint.hint.valid-external-url-required {
     display: block;
-    margin-top: -20px;
+    margin-top: -25px;
   }
 }
 .due-before-open {
   line-height: 1.2rem;
-  margin: -20px 0 20px;
+  margin: -25px -15px;
 }
 
 .due-before-open,

--- a/tutor/src/screens/assignment-builder/ux.js
+++ b/tutor/src/screens/assignment-builder/ux.js
@@ -285,8 +285,13 @@ class AssignmentBuilderUX {
 
   @action.bound togglePeriodTaskingsEnabled(ev) {
     this.isShowingPeriodTaskings = ev.target.value == 'periods';
+    if (this.isShowingPeriodTaskings) {
+      return;
+    }
+    const firstTasking = first(this.plan.tasking_plans);
     this.plan.tasking_plans = [];
-    const opens_at = calculateDefaultOpensAt({ course: this.course });
+    const opens_at = (firstTasking && firstTasking.opens_at) ||
+          calculateDefaultOpensAt({ course: this.course });
     this.periods.map((period) =>
       this.plan.findOrCreateTaskingForPeriod(period, { opens_at }),
     );


### PR DESCRIPTION
the tricky bit is that the check needs to be a per-tasking basis and only look at what's saved, not what is currently set