### PR TITLE
Move TeacherPendingLoad to this week panel

### DIFF
--- a/tutor/src/screens/student-dashboard/events-panel.jsx
+++ b/tutor/src/screens/student-dashboard/events-panel.jsx
@@ -9,7 +9,6 @@ import moment from 'moment';
 import Course from '../../models/course';
 import EmptyCard from './empty-panel';
 import EventRow from './event-row';
-import TeacherPendingLoad from './teacher-pending-load';
 
 export default
 @observer
@@ -76,7 +75,6 @@ class EventsCard extends React.Component {
           message={this.props.emptyMessage}
           spinner={this.props.spinner}
           tasks={this.props.events} />
-        <TeacherPendingLoad course={this.props.course} />
       </Card>
     );
   }

--- a/tutor/src/screens/student-dashboard/this-week-panel.jsx
+++ b/tutor/src/screens/student-dashboard/this-week-panel.jsx
@@ -4,6 +4,7 @@ import Course from '../../models/course';
 import { observer } from 'mobx-react';
 import EventsCard from './events-panel';
 import LateIconLedgend from './late-icon-ledgend';
+import TeacherPendingLoad from './teacher-pending-load';
 
 export default
 @observer
@@ -28,7 +29,8 @@ class ThisWeekCard extends React.Component {
           emptyMessage='No assignments this week'
           spinner
         />
-        <LateIconLedgend tasks={tasks}/>
+        <TeacherPendingLoad course={this.props.course} />
+        <LateIconLedgend tasks={tasks} />
       </React.Fragment>
     );
   }


### PR DESCRIPTION
The EventsPanel is rendered for both this week, upcoming and past
from:
![image](https://user-images.githubusercontent.com/79566/64387772-8916de00-d002-11e9-88b7-36f62663fad7.png)


to:
![image](https://user-images.githubusercontent.com/79566/64387740-6be20f80-d002-11e9-8b81-3f5a440bcce5.png)
