### PR TITLE
replace loadable-component with built-in React.Lazy

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "react-dnd-test-utils": "^9.3.4",
     "react-dom": "^16.9.0",
     "react-floater": "^0.6.5",
-    "react-loadable": "^5.5.0",
     "react-maskedinput": "4.0.1",
     "react-overlays": "^1.2.0",
     "react-router-dom": "5.0.1",

--- a/tutor/specs/components/error-monitoring/__snapshots__/async-load-error.spec.jsx.snap
+++ b/tutor/specs/components/error-monitoring/__snapshots__/async-load-error.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AsyncLoadErrors Component renders and matches snapshot if page is reloaded 1`] = `
+exports[`AsyncLoadErrors Component renders and matches snapshot when there is an error 1`] = `
 <div
   className="invalid-page"
 >
@@ -27,7 +27,7 @@ exports[`AsyncLoadErrors Component renders and matches snapshot if page is reloa
     Uh-oh, the page failed to load
   </h1>
   <p>
-    Error: SOMETHING FAILED!
+    Error: hi, im an error
   </p>
   <button
     className="btn btn-primary"
@@ -38,4 +38,10 @@ exports[`AsyncLoadErrors Component renders and matches snapshot if page is reloa
     Retry
   </button>
 </div>
+`;
+
+exports[`AsyncLoadErrors Component renders and matches snapshot when there is no error 1`] = `
+<p>
+  I should be shown
+</p>
 `;

--- a/tutor/specs/components/error-monitoring/async-load-error.spec.jsx
+++ b/tutor/specs/components/error-monitoring/async-load-error.spec.jsx
@@ -1,39 +1,70 @@
 import AsyncLoadErrors from '../../../src/components/error-monitoring/async-load-error';
-import { isReloaded, reloadOnce, forceReload } from '../../../src/helpers/reload';
+import { isReloaded, forceReload } from '../../../src/helpers/reload';
 jest.mock('../../../src/helpers/reload');
 
+const ErrorProne = ({ error, children }) => {
+  if (error) { throw error; }
+  return children;
+};
+
 describe('AsyncLoadErrors Component', function() {
-  let props;
-  let consoleMock;
+  let consoleMocks;
 
   beforeEach(() => {
-    consoleMock = jest.spyOn(console, 'warn');
-    consoleMock.mockImplementation(() => {})
-    props = { error: new Error('SOMETHING FAILED!') };
+    consoleMocks = [
+      jest.spyOn(console, 'error'),
+      jest.spyOn(console, 'warn'),
+    ];
+    consoleMocks.forEach(m => m.mockImplementation(() => {}));
   });
 
   afterEach(() => {
-    consoleMock.mockRestore();
+    consoleMocks.forEach(m => m.mockRestore());
   });
 
-  it('does not render if page isnt reloaded', () => {
-    const err = mount(<AsyncLoadErrors {...props} />);
-    expect(reloadOnce).toHaveBeenCalled();
-    expect(err.html()).toBeNull();
+  it('renders when error', () => {
+    const err = mount(
+      <AsyncLoadErrors>
+        <ErrorProne error={new Error('hi, im an error')}/>
+        <p>I should not be shown</p>
+      </AsyncLoadErrors>
+    );
+    expect(err.text()).toContain('hi, im an error');
   });
 
-  it('renders and matches snapshot if page is reloaded', () => {
+  it('renders and matches snapshot when there is no error', () => {
     isReloaded.mockImplementation(() => true);
-    const err = mount(<AsyncLoadErrors {...props} />);
-    expect(err.html()).not.toBeNull();
-    expect.snapshot(<AsyncLoadErrors {...props} />).toMatchSnapshot();
+    const err = (
+      <AsyncLoadErrors>
+        <ErrorProne>
+          <p>I should be shown</p>
+        </ErrorProne>
+      </AsyncLoadErrors>
+    );
+    expect.snapshot(err).toMatchSnapshot();
+  });
+
+  it('renders and matches snapshot when there is an error', () => {
+    isReloaded.mockImplementation(() => true);
+    const err = (
+      <AsyncLoadErrors>
+        <ErrorProne error={new Error('hi, im an error')}>
+          <p>I should not be shown</p>
+        </ErrorProne>
+      </AsyncLoadErrors>
+    );
+    expect.snapshot(err).toMatchSnapshot();
   });
 
   it('forces a reload when clicked', () => {
     isReloaded.mockImplementation(() => true);
-    const err = mount(<AsyncLoadErrors {...props} />);
+    const err = mount(
+      <AsyncLoadErrors>
+        <ErrorProne error={new Error('hi, im an error')} />
+        <p>I should not be shown</p>
+      </AsyncLoadErrors>
+    );
     err.find('Button').simulate('click');
     expect(forceReload).toHaveBeenCalled();
   });
-
 });

--- a/tutor/src/components/error-monitoring/async-load-error.jsx
+++ b/tutor/src/components/error-monitoring/async-load-error.jsx
@@ -2,22 +2,21 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Button } from 'react-bootstrap';
 import OXColoredStripe from 'shared/components/ox-colored-stripe';
-import { isReloaded, reloadOnce, forceReload } from '../../helpers/reload';
+import { reloadOnce, forceReload } from '../../helpers/reload';
 
-export default class AsyncLoadError extends React.Component {
+import Raven from '../../models/app/raven';
+
+class AsyncLoadError extends React.Component {
 
   static propTypes = {
     error: PropTypes.object.isRequired,
   }
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     reloadOnce();
   }
 
   render() {
-    if (!isReloaded()) { return null; }
-    // eslint-disable-next-line no-console
-    console.warn(this.props.error);
 
     return (
       <div className="invalid-page">
@@ -31,4 +30,33 @@ export default class AsyncLoadError extends React.Component {
     );
   }
 
+}
+
+
+export default
+class ErrorBoundary extends React.Component {
+
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+  }
+
+  state = { error: null };
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    return { error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    Raven.captureException(error, errorInfo);
+  }
+
+  render() {
+    const { error } = this.state;
+    if (error) {
+      return <AsyncLoadError error={error} />;
+    }
+
+    return this.props.children;
+  }
 }

--- a/tutor/src/helpers/async-component.js
+++ b/tutor/src/helpers/async-component.js
@@ -1,23 +1,26 @@
 import React from 'react';
-import Loadable from 'react-loadable';
-import ErrorComponent from '../components/error-monitoring/async-load-error';
+import AsyncErrorBoundary from '../components/error-monitoring/async-load-error';
 import Loading from 'shared/components/loading-animation';
 
-export function asyncComponent(loader, name = '') {
-  const loading = ({ error }) => {
-    return (
-      error ? <ErrorComponent error={error} />
-        : <Loading message={`Loading ${name}…`} />
-    );
-  };
-  return Loadable({
-    loader, loading,
-  });
 
+export function asyncComponent(loader, name = '') {
+  const Component = React.lazy(loader);
+  const loading = <Loading message={`Loading ${name}…`} />;
+
+  const Loader = (props) => (
+    <AsyncErrorBoundary>
+      <React.Suspense fallback={loading}>
+        <Component {...props} />
+      </React.Suspense>
+    </AsyncErrorBoundary>
+  );
+
+  return (props) => <Loader {...props} />;
 }
+
 
 export function loadAsync(resolve, name) {
   // return a function so the router will only evaluate it when it's needed
-  // in the future we can insert role dependant logic here
+  // in the future we may insert role dependant logic here
   return () => asyncComponent(resolve, name);
 }

--- a/tutor/src/helpers/conditional-handlers.jsx
+++ b/tutor/src/helpers/conditional-handlers.jsx
@@ -7,11 +7,13 @@ import Courses from '../models/courses-map';
 import { OXMatchByRouter } from 'shared';
 
 const StudentDashboard = asyncComponent(
-  () => import('../screens/student-dashboard')
+  () => import('../screens/student-dashboard'),
+  'Student Dashboard',
 );
 
 const TeacherDashboard = asyncComponent(
-  () => import('../screens/teacher-dashboard')
+  () => import('../screens/teacher-dashboard'),
+  'Teacher Dashboard',
 );
 
 const getConditionalHandlers = (Router) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9004,7 +9004,7 @@ prop-types-extra@^1.1.0:
     react-is "^16.3.2"
     warning "^3.0.0"
 
-prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9372,13 +9372,6 @@ react-live@^2.2.0:
     prop-types "^15.5.8"
     react-simple-code-editor "^0.9.0"
     unescape "^0.2.0"
-
-react-loadable@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/react-loadable/-/react-loadable-5.5.0.tgz#582251679d3da86c32aae2c8e689c59f1196d8c4"
-  integrity sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==
-  dependencies:
-    prop-types "^15.5.0"
 
 react-maskedinput@4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Fixes some of the console warnings about use of deprecated `componentWillMount` 