### PR TITLE
supply bookUUID to identifier-link; make it required

### DIFF
--- a/shared/src/components/exercise-identifier-link.js
+++ b/shared/src/components/exercise-identifier-link.js
@@ -8,7 +8,7 @@ export default
 class ExerciseIdentifierLink extends React.Component {
 
   static propTypes = {
-    bookUUID: PropTypes.string,
+    bookUUID: PropTypes.string.isRequired,
     exerciseId: PropTypes.string.isRequired,
     project: PropTypes.oneOf(['concept-coach', 'tutor']),
     related_content: PropTypes.arrayOf(PropTypes.shape({

--- a/tutor/specs/screens/teacher-review-metrics/exercise.spec.jsx
+++ b/tutor/specs/screens/teacher-review-metrics/exercise.spec.jsx
@@ -10,7 +10,7 @@ describe('Task Teacher Review', () => {
     course = Factory.course();
     stat = Factory.taskPlanStat({ course });
     const exercise = stat.stats[0].current_pages[0].exercises[0];
-    props = { exercise };
+    props = { exercise, course };
   });
 
   it('renders exercise', async () => {

--- a/tutor/src/screens/teacher-review-metrics/exercise.jsx
+++ b/tutor/src/screens/teacher-review-metrics/exercise.jsx
@@ -5,8 +5,8 @@ import { isEmpty, map, pick, find } from 'lodash';
 import { Card } from 'react-bootstrap';
 import classnames from 'classnames';
 import Exercise from '../../models/exercises/exercise';
+import Course from '../../models/course';
 import { QuestionStats } from '../../models/task-plans/teacher/stats';
-
 import { Icon } from 'shared';
 import {
   ArbitraryHtmlAndMath, Question, ExerciseIdentifierLink,
@@ -154,10 +154,12 @@ TaskTeacherReviewQuestionTracker.propTypes = {
 
 TaskTeacherReviewQuestionTracker.displayName = 'TaskTeacherReviewQuestionTracker';
 
-export default class TaskTeacherReviewExercise extends React.Component {
+export default
+class TaskTeacherReviewExercise extends React.Component {
   static displayName = 'TaskTeacherReviewExercise';
 
   static propTypes = {
+    course: PropTypes.instanceOf(Course).isRequired,
     exercise: PropTypes.instanceOf(Exercise).isRequired,
     question_stats: PropTypes.object,
     sectionKey: PropTypes.string,
@@ -193,14 +195,18 @@ export default class TaskTeacherReviewExercise extends React.Component {
   }
 
   render() {
-    const { exercise } = this.props;
+    const { course, exercise } = this.props;
 
     return (
       <div className="task-step openstax-exercise openstax-exercise-card">
         {this.stimulusHTML}
         {map(exercise.question_stats, this.renderQuestion)}
         <TourAnchor id="errata-link">
-          <ExerciseIdentifierLink exerciseId={exercise.content.uid} project="tutor" />
+          <ExerciseIdentifierLink
+            bookUUID={course.ecosystem_book_uuid}
+            exerciseId={exercise.content.uid}
+            project="tutor"
+          />
         </TourAnchor>
       </div>
     );

--- a/tutor/src/screens/teacher-review-metrics/review.jsx
+++ b/tutor/src/screens/teacher-review-metrics/review.jsx
@@ -21,7 +21,11 @@ function ReviewHeading(props) {
 
 }
 
-const NotFound = () => <Alert variant="info">This assignment does‘t have any activity to display</Alert>
+const NotFound = () => (
+  <Alert variant="info">
+    This assignment does‘t have any activity to display
+  </Alert>
+);
 
 ReviewHeading.displayName = 'ReviewHeadingTracker';
 
@@ -44,7 +48,11 @@ export default function Review({ stats, course, period }) {
     return steps.concat(compact(map(exercises, (exercise, i) => {
       if (!exercise.content) { return null; }
       return (
-        <ReviewExercise key={`${section}-${i}`} exercise={exercise} />
+        <ReviewExercise
+          course={course}
+          key={`${section}-${i}`}
+          exercise={exercise}
+        />
       );
     })));
   });


### PR DESCRIPTION
Fixes bug where the trouble link didn't include the book name, causing the errata form would spin forever