### PR TITLE
Recent topics fixes

### DIFF
--- a/tutor/api/courses/1/guide.json
+++ b/tutor/api/courses/1/guide.json
@@ -25,6 +25,8 @@
         "2",
         "3"
       ],
+      "first_worked_at": "2016-05-29T16:41:24.750Z",
+      "last_worked_at": "2016-05-29T16:41:24.750Z",
       "children": [
         {
           "title": "Acceleration",
@@ -39,7 +41,9 @@
           "practice_count": 0,
           "page_ids": [
             "2"
-          ]
+          ],
+          "first_worked_at": "2016-05-29T16:41:46.457Z",
+          "last_worked_at": "2016-05-29T16:41:46.457Z"
         },
         {
           "title": "Representing Acceleration with Equations and Graphs",
@@ -54,7 +58,9 @@
           "practice_count": 0,
           "page_ids": [
             "3"
-          ]
+          ],
+          "first_worked_at": "2016-05-29T16:41:32.750Z",
+          "last_worked_at": "2016-05-29T16:41:46.457Z"
         }
       ]
     },
@@ -62,7 +68,7 @@
       "title": "Force and Newton's Laws of Motion",
       "chapter_section": [ 4 ],
       "questions_answered_count": 3,
-      "clue":{
+      "clue": {
         "minimum": 0.13278347571119187,
         "most_likely": 0.5331585527121938,
         "maximum": 0.7331585527121938,
@@ -70,6 +76,8 @@
       },
       "practice_count": 0,
       "page_ids": [ "5", "6" ],
+      "first_worked_at": "2016-06-01T16:21:52.101Z",
+      "last_worked_at": "2016-06-01T16:52:16.508Z",
       "children": [
         {
           "title": "Force",
@@ -85,7 +93,9 @@
             "is_real": true
           },
           "practice_count": 0,
-          "page_ids": [ "5" ]
+          "page_ids": [ "5" ],
+          "first_worked_at": "2016-06-01T16:21:52.101Z",
+          "last_worked_at": "2016-06-01T16:21:52.101Z"
         },
         {
           "title": "Newton's First Law of Motion: Inertia",
@@ -98,7 +108,9 @@
             "is_real": true
           },
           "practice_count": 0,
-          "page_ids": [ "6" ]
+          "page_ids": [ "6" ],
+          "first_worked_at": "2016-06-01T16:51:52.101Z",
+          "last_worked_at": "2016-06-01T16:52:16.508Z"
         }
       ]
     }

--- a/tutor/specs/flux/performance-forecast.spec.js
+++ b/tutor/specs/flux/performance-forecast.spec.js
@@ -53,9 +53,11 @@ describe('Learning Guide Store', function() {
 
   it('returns recent', function() {
     const sections = makeSections(10, 3);
-    expect( LGH.recentSections(sections) ).toEqual(ld.take(ld.orderBy(ld.filter(
-      sections, s => s.last_worked_at && s.clue.is_real
-    ), 'last_worked_at', 'desc'), 4));
+    expect( LGH.recentSections(sections) ).toEqual(
+      ld.take(ld.orderBy(
+        sections, s => [LGH.canDisplayForecast(s.clue), s.last_worked_at], ['desc', 'desc']
+      ), 4)
+    );
   });
 
   it('finds sections with a valid forecast', function() {

--- a/tutor/specs/flux/performance-forecast.spec.js
+++ b/tutor/specs/flux/performance-forecast.spec.js
@@ -54,9 +54,13 @@ describe('Learning Guide Store', function() {
   it('returns recent', function() {
     const sections = makeSections(10, 3);
     expect( LGH.recentSections(sections) ).toEqual(
-      ld.take(ld.orderBy(
-        sections, s => [LGH.canDisplayForecast(s.clue), s.last_worked_at], ['desc', 'desc']
-      ), 4)
+      ld.take(
+        ld.orderBy(
+          ld.filter(
+            sections, s => s.last_worked_at
+          ), s => [LGH.canDisplayForecast(s.clue), s.last_worked_at], ['desc', 'desc']
+        ), 4
+      )
     );
   });
 

--- a/tutor/specs/flux/performance-forecast.spec.js
+++ b/tutor/specs/flux/performance-forecast.spec.js
@@ -1,9 +1,10 @@
-import ld from 'underscore';
+import ld from 'lodash';
+import moment from 'moment';
 import * as PerformanceForecast from '../../src/flux/performance-forecast';
 const LGH = PerformanceForecast.Helpers;
 
 const makeSections = function(valid, invalid) {
-  const sections = ld.times(valid, function(i) {
+  const sections = ld.times(valid, function() {
     // Sort the values to guarantee that minimum <= most_likely <= maximum
     const values = ld.sortBy([Math.random(), Math.random(), Math.random()], n => n);
 
@@ -14,9 +15,11 @@ const makeSections = function(valid, invalid) {
         maximum: values[2],
         is_real: true,
       },
+      first_worked_at: moment().format(),
+      last_worked_at: moment().format(),
     };
   }).concat(
-    ld.times(invalid, function(i) {
+    ld.times(invalid, function() {
       const values = ld.sortBy([Math.random(), Math.random(), Math.random()], n => n);
 
       return {
@@ -26,6 +29,8 @@ const makeSections = function(valid, invalid) {
           maximum: values[2],
           is_real: false,
         },
+        first_worked_at: null,
+        last_worked_at: null,
       };
     })
   );
@@ -48,14 +53,16 @@ describe('Learning Guide Store', function() {
 
   it('returns recent', function() {
     const sections = makeSections(10, 3);
-    expect( LGH.recentSections(sections) ).toEqual( ld.last(sections, 4) );
+    expect( LGH.recentSections(sections) ).toEqual(
+      ld.take(ld.orderBy(ld.filter(sections, s => s.last_worked_at), 'last_worked_at', 'desc'), 4)
+    );
   });
 
   it('finds sections with a valid forecast', function() {
     const sections = makeSections(8, 33);
     const valid = LGH.filterForecastedSections(sections);
     expect( valid.length ).toEqual(8);
-    expect( ld.findWhere(valid, { is_real: false }) ).toBeUndefined();
+    expect( ld.find(valid, { is_real: false }) ).toBeUndefined();
   });
 
   it('finds the weakest sections', function() {

--- a/tutor/specs/flux/performance-forecast.spec.js
+++ b/tutor/specs/flux/performance-forecast.spec.js
@@ -53,9 +53,9 @@ describe('Learning Guide Store', function() {
 
   it('returns recent', function() {
     const sections = makeSections(10, 3);
-    expect( LGH.recentSections(sections) ).toEqual(
-      ld.take(ld.orderBy(ld.filter(sections, s => s.last_worked_at), 'last_worked_at', 'desc'), 4)
-    );
+    expect( LGH.recentSections(sections) ).toEqual(ld.take(ld.orderBy(ld.filter(
+      sections, s => s.last_worked_at && s.clue.is_real
+    ), 'last_worked_at', 'desc'), 4));
   });
 
   it('finds sections with a valid forecast', function() {

--- a/tutor/src/flux/performance-forecast.js
+++ b/tutor/src/flux/performance-forecast.js
@@ -117,7 +117,9 @@ const TeacherStudent = makeSimpleStore(extendConfig({
 
 const Helpers = {
   recentSections(sections, limit = 4) {
-    return take(orderBy(filter(sections, s => s.last_worked_at), 'last_worked_at', 'desc'), limit);
+    return take(orderBy(filter(
+      sections, s => s.last_worked_at && s.clue.is_real
+    ), 'last_worked_at', 'desc'), limit);
   },
 
   canDisplayForecast(clue) { return clue.is_real; },

--- a/tutor/src/flux/performance-forecast.js
+++ b/tutor/src/flux/performance-forecast.js
@@ -117,15 +117,15 @@ const TeacherStudent = makeSimpleStore(extendConfig({
 
 const Helpers = {
   recentSections(sections, limit = 4) {
-    return take(orderBy(filter(
-      sections, s => s.last_worked_at && s.clue.is_real
-    ), 'last_worked_at', 'desc'), limit);
+    return take(orderBy(
+      sections, s => [this.canDisplayForecast(s.clue), s.last_worked_at], ['desc', 'desc']
+    ), limit);
   },
 
   canDisplayForecast(clue) { return clue.is_real; },
 
   filterForecastedSections(sections) {
-    return filter(sections, s => Helpers.canDisplayForecast(s.clue));
+    return filter(sections, s => this.canDisplayForecast(s.clue));
   },
 
   weakestSections(sections, displayCount = 4) {

--- a/tutor/src/flux/performance-forecast.js
+++ b/tutor/src/flux/performance-forecast.js
@@ -1,5 +1,5 @@
 import { CrudConfig, makeSimpleStore, extendConfig } from './helpers';
-import { find, sortBy, take, takeRight, filter, map, flatten, uniq } from 'lodash';
+import { find, orderBy, sortBy, take, filter, map, flatten, uniq } from 'lodash';
 
 // Unlike other stores defined in TutorJS, this contains three separate stores that have very similar capabilities.
 // They're combined in one file because they're pretty lightweight and share helper methods.
@@ -9,7 +9,7 @@ import { find, sortBy, take, takeRight, filter, map, flatten, uniq } from 'lodas
 const findAllSections = function(section) {
   if (!section) { return []; }
   const sections = [];
-  if ((section.chapter_section != null ? section.chapter_section.length : undefined) > 1) {
+  if (section.chapter_section != null && section.chapter_section.length > 1) {
     sections.push(section);
   }
   if (section.children) {
@@ -116,10 +116,8 @@ const TeacherStudent = makeSimpleStore(extendConfig({
 );
 
 const Helpers = {
-  // Since the learning guide doesn't currently include worked dates
-  // the best we can do is return from the end of the list
   recentSections(sections, limit = 4) {
-    return takeRight(sections, limit);
+    return take(orderBy(filter(sections, s => s.last_worked_at), 'last_worked_at', 'desc'), limit);
   },
 
   canDisplayForecast(clue) { return clue.is_real; },

--- a/tutor/src/flux/performance-forecast.js
+++ b/tutor/src/flux/performance-forecast.js
@@ -117,9 +117,13 @@ const TeacherStudent = makeSimpleStore(extendConfig({
 
 const Helpers = {
   recentSections(sections, limit = 4) {
-    return take(orderBy(
-      sections, s => [this.canDisplayForecast(s.clue), s.last_worked_at], ['desc', 'desc']
-    ), limit);
+    return take(
+      orderBy(
+        filter(
+          sections, s => s.last_worked_at
+        ), s => [this.canDisplayForecast(s.clue), s.last_worked_at], ['desc', 'desc']
+      ), limit
+    );
   },
 
   canDisplayForecast(clue) { return clue.is_real; },


### PR DESCRIPTION
- Don't display performance forecast sections without any work done in recent topics.
- Prioritize sections with bars.
- Sort sections by last_worked_at date.

Needs: https://github.com/openstax/tutor-server/pull/1911