### PR TITLE
break links anwhere

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -75,7 +75,12 @@
 
   // prevent larger images from pushing out past their container.
   // Most images are inside a <figure> and will be handled by the rules below
-  img { max-width: 100%, }
+  img {
+    max-width: 100%;
+  }
+  a {
+    word-break: break-all;
+  }
 
   @include tutor-figure();
 


### PR DESCRIPTION
Most of the links are just urls which lack spaces.  that causes
them to overflow the page unless set to 'break-all'

![image](https://user-images.githubusercontent.com/79566/65707187-a19e7500-e051-11e9-96d6-157dfa5e6c5c.png)
