### PR TITLE
Remove popover tooltip from past assignments

### DIFF
--- a/tutor/src/screens/assignment-builder/mini-editor/index.js
+++ b/tutor/src/screens/assignment-builder/mini-editor/index.js
@@ -15,6 +15,9 @@ const StyledPopover = styled(Popover)`
   min-width: 450px;
   max-width: 450px;
   max-height: 320px;
+  .loading-animation svg {
+    max-height: 200px;
+  }
   height: 320px;
   .popover-body {
     padding: 0;

--- a/tutor/src/screens/teacher-dashboard/past-assignments.jsx
+++ b/tutor/src/screens/teacher-dashboard/past-assignments.jsx
@@ -2,10 +2,8 @@ import { React, observer, action, observable, styled, cn  } from '../../helpers/
 import { partial } from 'lodash';
 import { Icon } from 'shared';
 import PropTypes from 'prop-types';
-import { Overlay, Popover } from 'react-bootstrap';
 import Course from '../../models/course';
 import { CloneAssignmentLink } from './task-dnd';
-import TaskPlanHelper from '../../helpers/task-plan';
 import TimeHelper from '../../helpers/time';
 
 const Loading = styled.div`
@@ -36,15 +34,13 @@ class PastAssignments extends React.Component {
     cloningPlanId: PropTypes.string,
   }
 
-  @observable tooltipTarget;
   @observable hoveredPlan;
 
   @action.bound offTaskHover() {
-    this.hoveredPlan = this.tooltipTarget = null;
+    this.hoveredPlan = null;
   }
 
-  @action.bound onTaskHover(plan, ev) {
-    this.tooltipTarget = ev.currentTarget;
+  @action.bound onTaskHover(plan) {
     this.hoveredPlan = plan;
   }
 
@@ -69,23 +65,16 @@ class PastAssignments extends React.Component {
         <div className="plans">
           {plans.array.map((plan) =>
             <CloneAssignmentLink
-              onHover={partial(this.onTaskHover, plan)}
-              offHover={this.offTaskHover}
-              key={plan.id}
               plan={plan}
-              isEditing={plan.id === this.props.cloningPlanId} />)}
+              toolTip={
+                `Orig. due date ${TimeHelper.toHumanDate(plan.dateRanges.due.start)}`
+              }
+              key={plan.id}
+              offHover={this.offTaskHover}
+              onHover={partial(this.onTaskHover, plan)}
+              isEditing={plan.id === this.props.cloningPlanId}
+            />)}
         </div>
-        <Overlay
-          show={!!this.tooltipTarget}
-          target={this.tooltipTarget}
-          placement="right"
-        >
-          <Popover id="task-original-due-date">
-            <Popover.Content>
-              Orig. due date {TimeHelper.toHumanDate(TaskPlanHelper.earliestDueDate(this.hoveredPlan))}
-            </Popover.Content>
-          </Popover>
-        </Overlay>
       </div>
     );
   }

--- a/tutor/src/screens/teacher-dashboard/task-dnd.jsx
+++ b/tutor/src/screens/teacher-dashboard/task-dnd.jsx
@@ -95,8 +95,9 @@ const CloneAssignmentLink = DragSource(ItemTypes.CloneTask, CloneTaskDrag, DragI
       className={cn('task-plan', {
         'is-dragging': props.isDragging,
         'is-editing': props.isEditing,
-      }
-      )}>
+      })}
+      title={props.toolTip}
+    >
       <GrabbyDots />
       <div>
         {props.plan.title}


### PR DESCRIPTION
It's conflicting with drag and drop.  Replace with standard browser title attribute

![image](https://user-images.githubusercontent.com/79566/65787169-f4456300-e11d-11e9-93b9-9febe98be6ea.png)
