### PR TITLE
Restore student task info tooltip

### DIFF
--- a/shared/src/components/icon.js
+++ b/shared/src/components/icon.js
@@ -113,6 +113,10 @@ const Variants = {
     color: '#c2002f',
     type: 'exclamation-circle',
   },
+  info: {
+    color: '#007da4',
+    type: 'exclamation-circle',
+  },
   activity: {
     type: 'spinner',
     spin: true,

--- a/tutor/specs/screens/student-dashboard/task-progress-info.spec.js
+++ b/tutor/specs/screens/student-dashboard/task-progress-info.spec.js
@@ -21,4 +21,10 @@ describe('Task Progress Info', function() {
     expect.snapshot(<Info {...props} />).toMatchSnapshot();
   });
 
+  it('displays description in a info popover', () => {
+    props.event.description = 'this is some description';
+    const info = mount(<Info {...props} />);
+    expect(info).toHaveRendered(`Icon[variant="info"][tooltip="${props.event.description}"]`);
+    info.unmount();
+  });
 });

--- a/tutor/src/models/task-plans/student/task.js
+++ b/tutor/src/models/task-plans/student/task.js
@@ -46,7 +46,7 @@ class StudentTask extends BaseModel {
   @field completed_steps_count = 0;
   @field completed_on_time_steps_count = 0;
   @field completed_accepted_late_steps_count = 0;
-
+  @field description;
   @field({ type: 'date' }) last_worked_at;
   @field({ type: 'date' }) due_at;
   @field({ type: 'date' }) opens_at;

--- a/tutor/src/screens/student-dashboard/progress-guide.js
+++ b/tutor/src/screens/student-dashboard/progress-guide.js
@@ -87,8 +87,8 @@ class ProgressGuideCards extends React.Component {
                 by the performance forecast
               </li>
               {sections.map((section) =>
-                <li>
-                  {section.chapter_section.asString}
+                <li key={section.chapter_section.join('.')}>
+                  {section.chapter_section.join('.')}
                   {' section.title'}
                 </li>)}
             </ul>

--- a/tutor/src/screens/student-dashboard/task-progress-info.js
+++ b/tutor/src/screens/student-dashboard/task-progress-info.js
@@ -1,4 +1,5 @@
 import { React, PropTypes, styled, observer } from 'vendor';
+import { Icon } from 'shared';
 import EventInfoIcon from './event-info-icon';
 import TourAnchor from '../../components/tours/anchor';
 import Theme from '../../theme';
@@ -8,7 +9,6 @@ const Feedback = styled.div`
   justify-content: flex-start;
   align-items: center;
 `;
-
 
 const LateCaption = styled.div`
   font-size: 1.2rem;
@@ -26,6 +26,13 @@ const LateInfo = observer(({ event }) => {
 });
 
 
+const DescriptionPopoverIcon = observer(({ event }) => {
+  if (!event.description) { return null; }
+  return (
+    <Icon variant="info" tooltip={event.description} />
+  );
+});
+
 const TaskProgressInfo = observer(({ event, course }) => {
   if (event.is_deleted) { return null; }
 
@@ -40,6 +47,7 @@ const TaskProgressInfo = observer(({ event, course }) => {
           event={event}
           isCollege={course.is_college}
         />
+        <DescriptionPopoverIcon event={event} />
       </Feedback>
       <LateInfo event={event} />
     </React.Fragment>


### PR DESCRIPTION
The description used to be displayed like this but it was lost somewhere along the line

![image](https://user-images.githubusercontent.com/79566/65804186-a1cc6c80-e146-11e9-97bb-334755dc1364.png)
