### PR TITLE
fix jumping to top before scrolling to MPQ steps

### DIFF
--- a/tutor/specs/screens/task/steps/__snapshots__/exercise.spec.js.snap
+++ b/tutor/specs/screens/task/steps/__snapshots__/exercise.spec.js.snap
@@ -531,6 +531,7 @@ exports[`Exercise Tasks Screen matches snapshot 1`] = `
       "onAnswerContinue": [MockFunction],
       "onAnswerSave": [MockFunction],
       "questionNumberForStep": [MockFunction],
+      "scrollToCurrentStep": [MockFunction],
       "setCurrentMultiPartStep": [MockFunction],
     }
   }

--- a/tutor/specs/screens/task/ux.spec.js
+++ b/tutor/specs/screens/task/ux.spec.js
@@ -60,7 +60,7 @@ describe('Task UX Model', () => {
     await ux.onAnswerSave(s, { id: 1 });
     expect(s.save).toHaveBeenCalled();
     expect(ux.scroller.scrollToSelector).toHaveBeenCalledWith(
-      `[data-task-step-id="${nextS.id}"]`, { immediate: true }
+      `[data-task-step-id="${nextS.id}"]`, { immediate: true, deferred: false }
     );
     group.steps.forEach(s => {
       expect(s.fetchIfNeeded).toHaveBeenCalled();
@@ -131,17 +131,22 @@ describe('Task UX Model', () => {
     expect(ux.history.push).toHaveBeenCalledWith(`/course/${ux.course.id}/task/${ux.task.id}/step/2`);
     ux.goToStep(2, false);
     expect(ux.history.push).toHaveBeenCalledTimes(1);
-
     const i = 1 + ux.steps.findIndex(s => s.type == 'two-step-intro');
     ux.steps[i+1].uid = ux.groupedSteps[i].uid = '123@4';
     const group = ux.groupedSteps[i];
     expect(group.type).toBe('mpq');
-
+    expect(ux.stepGroupInfo.grouped).toBe(true);
+    ux.stepGroupInfo.group.steps.forEach(
+      s => s.api.requestCounts.read = 1
+    );
     ux.goToStep(i + 1, false);
     expect(ux.history.push).toHaveBeenCalledTimes(1);
-    expect(ux.scroller.scrollToSelector).toHaveBeenCalledWith(
-      `[data-task-step-id="${ux.currentStep.id}"]`,
-      { deferred: true }
-    );
+    return deferred(() => {
+      expect(ux.scroller.scrollToSelector).toHaveBeenCalledWith(
+        `[data-task-step-id="${ux.currentStep.id}"]`,
+        { deferred: true, immediate: false },
+      );
+    });
+
   });
 });

--- a/tutor/src/screens/task/index.js
+++ b/tutor/src/screens/task/index.js
@@ -2,7 +2,6 @@ import {
   React, PropTypes, withRouter, observer, computed, inject, idType,
 } from 'vendor';
 import { Redirect } from 'react-router-dom';
-import { ScrollToTop } from 'shared';
 import Router from '../../helpers/router';
 import { isNil, findIndex } from 'lodash';
 import Courses, { Course } from '../../models/courses-map';
@@ -153,17 +152,15 @@ class TaskGetter extends React.Component {
     }
 
     return (
-      <ScrollToTop>
-        <div className={`task-screen task-${task.type}`}>
-          <Task
-            key={task}
-            course={this.course}
-            task={task}
-            stepIndex={this.props.params.stepIndex - 1}
-          />
-          <SpyInfo model={task} />
-        </div>
-      </ScrollToTop>
+      <div className={`task-screen task-${task.type}`}>
+        <Task
+          key={task}
+          course={this.course}
+          task={task}
+          stepIndex={this.props.params.stepIndex - 1}
+        />
+        <SpyInfo model={task} />
+      </div>
     );
   }
 


### PR DESCRIPTION
The `ScrollToTop` component jumps to the top when the path changes, like between MPQ,
and Loading must finish before scrolling