### PR TITLE
add left padding to blockquote

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -18,6 +18,11 @@
     }
   }
 
+  blockquote {
+    padding-left: 2rem;
+    border-left: 0.5rem solid $tutor-neutral;
+  }
+
   section {
     clear: both;
     &:not(.learning-objectives) {

--- a/tutor/resources/styles/book-content/theming-mixins.scss
+++ b/tutor/resources/styles/book-content/theming-mixins.scss
@@ -27,7 +27,7 @@
 
 @mixin tutor-book-theme-quote($border-color) {
   blockquote {
-    border-left: 0.5rem solid $border-color;
+    border-left-color: $border-color;
   }
 }
 


### PR DESCRIPTION
otherwise the border is pressed right up to the text

Somehow this rule was lost in https://github.com/openstax/tutor-js/pull/2740