### PR TITLE
decrease polling interval for new assignments

### DIFF
--- a/tutor/specs/models/task-plans/student.spec.js
+++ b/tutor/specs/models/task-plans/student.spec.js
@@ -55,7 +55,7 @@ describe('Student Tasks Model', () => {
     expect(tasks.fetch).toHaveBeenCalledTimes(1);
     jest.runOnlyPendingTimers();
     expect(tasks.fetch).toHaveBeenCalledTimes(2);
-    expect(setTimeout).toHaveBeenCalledWith(tasks.fetchTaskPeriodically, 1000 * 60 * 60 * 4);
+    expect(setTimeout).toHaveBeenCalledWith(tasks.fetchTaskPeriodically, 1000 * 60 * 60);
     jest.runOnlyPendingTimers();
     expect(tasks.fetch).toHaveBeenCalledTimes(3);
     tasks.stopFetching();
@@ -69,7 +69,7 @@ describe('Student Tasks Model', () => {
     tasks.all_tasks_are_ready = false;
     tasks.startFetching();
     expect(tasks.isPendingTaskLoading).toEqual(true);
-    expect(setTimeout).toHaveBeenCalledWith(tasks.fetchTaskPeriodically, 60000);
+    expect(setTimeout).toHaveBeenCalledWith(tasks.fetchTaskPeriodically, 10000);
   });
 
   it('tests if the last published plan is present', () => {

--- a/tutor/specs/screens/student-dashboard/dashboard.spec.jsx
+++ b/tutor/specs/screens/student-dashboard/dashboard.spec.jsx
@@ -38,16 +38,10 @@ describe('Student Dashboard', () => {
     expect.snapshot(<Router><Dashboard {...props} /></Router>).toMatchSnapshot();
   });
 
-  it('fetches on mount', () => {
-    const dash = mount(<Router><Dashboard {...props} /></Router>);
-    expect(props.course.studentTaskPlans.fetch).toHaveBeenCalled();
-    dash.unmount();
-  });
-
   it('logs when Biglearn times out', () => {
     props.course.studentTaskPlans.all_tasks_are_ready = false;
     const tp = props.course.studentTaskPlans;
-    tp.api.requestCounts.read = 10;
+    tp.api.requestCounts.read = 30;
     expect(tp.taskReadinessTimedOut).toBe(true);
     tp.startFetching();
     tp.stopFetching();

--- a/tutor/src/models/task-plans/student.js
+++ b/tutor/src/models/task-plans/student.js
@@ -8,7 +8,7 @@ import ResearchSurveys from '../research-surveys';
 import Time from '../time';
 import Raven from '../app/raven';
 
-const MAX_POLLING_ATTEMPTS = 10;
+const MAX_POLLING_ATTEMPTS = 30;
 const POLL_SECONDS = 30;
 const WEEK_FORMAT = 'GGGGWW';
 const FETCH_INITIAL_TASKS_INTERVAL = 1000 * 10; // every 10 seconds

--- a/tutor/src/models/task-plans/student.js
+++ b/tutor/src/models/task-plans/student.js
@@ -11,8 +11,8 @@ import Raven from '../app/raven';
 const MAX_POLLING_ATTEMPTS = 10;
 const POLL_SECONDS = 30;
 const WEEK_FORMAT = 'GGGGWW';
-const FETCH_INITIAL_TASKS_INTERVAL = 1000 * 60; // every minute;
-const REFRESH_TASKS_INTERVAL = 1000 * 60 * 60 * 4; // every 4 hours
+const FETCH_INITIAL_TASKS_INTERVAL = 1000 * 10; // every 10 seconds
+const REFRESH_TASKS_INTERVAL = 1000 * 60 * 60; // every hour
 
 export
 class StudentTaskPlans extends Map {

--- a/tutor/src/models/task-plans/student.js
+++ b/tutor/src/models/task-plans/student.js
@@ -89,13 +89,13 @@ class StudentTaskPlans extends Map {
     if (
       this.isPendingTaskLoading &&
       this.taskReadinessTimedOut &&
-      this.api.requestCounts.read % 10 == 0
+      this.api.requestCounts.read % MAX_POLLING_ATTEMPTS == 0
     ) {
       Raven.log(`Dashboard loading timed out waiting on Biglearn after ${
         this.api.requestCounts.read} attempts.`);
-    }
-    else if (!this.isPendingTaskLoading) {
-      this.api.reset();
+    } else if (!this.isPendingTaskLoading) {
+      // reset our read count so it's ready to poll again if needed
+      this.api.requestCounts.read = 1;
     }
 
     return this.fetch().then(() => {

--- a/tutor/src/screens/student-dashboard/dashboard.jsx
+++ b/tutor/src/screens/student-dashboard/dashboard.jsx
@@ -1,5 +1,4 @@
 import { React, PropTypes, action, observable, observer, withRouter } from 'vendor';
-import { get } from 'lodash';
 import { Row, Col, Card } from 'react-bootstrap';
 import { includes } from 'lodash';
 import UpcomingCard from './upcoming-panel';
@@ -8,7 +7,6 @@ import ThisWeekCard from './this-week-panel';
 import ProgressGuideShell from './progress-guide';
 import BrowseTheBook from '../../components/buttons/browse-the-book';
 import CourseTitleBanner from '../../components/course-title-banner';
-
 import Course from '../../models/course';
 import Tabs from '../../components/tabs';
 import { NotificationsBar } from 'shared';
@@ -36,14 +34,6 @@ class StudentDashboard extends React.Component {
       this.tabIndex = tabIndex;
     } else {
       ev.preventDefault();
-    }
-  }
-
-  componentDidMount() {
-    const { course } = this.props;
-    const role = course.currentRole;
-    if (role.isStudentLike && !get(course.userStudentRecord, 'mustPayImmediately')) {
-      this.props.course.studentTaskPlans.fetch();
     }
   }
 


### PR DESCRIPTION
sets to 10 secs for "fast polling" state and 1 hour for regular checks

fast polling is enabled for:
 * freshly enrolled students
 * instructors who've just made an assignment then went into student view