### PR TITLE
insert value prop before first MPQ

### DIFF
--- a/tutor/specs/screens/task/ux-task-manipulations.spec.js
+++ b/tutor/specs/screens/task/ux-task-manipulations.spec.js
@@ -12,6 +12,16 @@ describe('Task Manipulations', () => {
     return { task, steps: task.steps };
   }
 
+  it('inserts two-step before MPQ', () => {
+    const t = createTask({ type: 'homework' });
+    t.steps.forEach(s => s.formats = []);
+    t.steps[7].formats = ['free-response'];
+    t.steps[7].uid = t.steps[6].uid;
+    const { steps } = M.insertValueProp(t);
+    expect(steps[6]).toMatchObject({ type: 'two-step-intro' });
+    expect(steps.length).toEqual(11);
+  });
+
   it('insertIndividiualReview', () => {
     const t = createTask({ type: 'reading' });
     t.steps[7].labels = ['review'];
@@ -42,4 +52,5 @@ describe('Task Manipulations', () => {
     const { steps } = M.insertEnd(t);
     expect(steps[steps.length - 1]).toMatchObject({ type: 'end' });
   });
+
 });

--- a/tutor/src/models/student-tasks/step-group.js
+++ b/tutor/src/models/student-tasks/step-group.js
@@ -14,6 +14,10 @@ class StudentTaskStepGroup extends BaseModel {
   @readonly isGrouped = true;
   @readonly type = 'mpq';
 
+  static key(s) {
+    return `${s.type}.${s.uid || s.id}`;
+  }
+
   constructor(attrs) {
     super(attrs);
     this.steps.forEach((s) => s.multiPartGroup = this);

--- a/tutor/src/screens/task/ux-task-manipulations.js
+++ b/tutor/src/screens/task/ux-task-manipulations.js
@@ -2,11 +2,16 @@ import { without, findIndex, forEach } from 'lodash';
 import { insert } from '../../helpers/immutable';
 import UiSettings from 'shared/model/ui-settings';
 import InfoStep from '../../models/student-tasks/info-step';
+import StepGroup from '../../models/student-tasks/step-group';
 
 function insertBeforeMatch(type, task, steps, match) {
   const cleanSteps = without(steps, { type });
-  const index = findIndex(cleanSteps, match);
+  let index = findIndex(cleanSteps, match);
   if (-1 !== index) {
+    const key = StepGroup.key(cleanSteps[index]);
+    while(key && index > 0 && StepGroup.key(cleanSteps[index - 1]) === key) {
+      index--;
+    }
     return insert(cleanSteps, index, new InfoStep({ task, type }));
   }
   return steps;

--- a/tutor/src/screens/task/ux.js
+++ b/tutor/src/screens/task/ux.js
@@ -70,9 +70,10 @@ export default class TaskUX {
 
   @computed get groupedSteps() {
     const { steps } = this.manipulated;
+
     if (this.task.isHomework) {
       return map(
-        groupBy(steps, s => `${s.type}.${s.uid || s.id}`),
+        groupBy(steps, StepGroup.key),
         (steps, uid) => steps.length > 1 ?
           new StepGroup({ steps, uid }) : steps[0]
       );


### PR DESCRIPTION
occasionally only one of the steps in a MPQ will trigger display of a value-prop card.  When that happens the value prop card is displayed after the MPQ but it's breadcrumb would be correct.

This changes the value-prop insertion so that it happens before the first MPQ