### PR TITLE
add a 1.5 seconds delay before a step can be advanced

### DIFF
--- a/tutor/specs/screens/task/__snapshots__/breadcrumbs.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/breadcrumbs.spec.js.snap
@@ -1937,6 +1937,7 @@ exports[`Homework Breadcrumbs Component matches snapshot 1`] = `
         "push": [MockFunction],
         "replace": [MockFunction],
       },
+      "isLocked": false,
       "viewedInfoSteps": Array [],
       "window": [Window],
     }

--- a/tutor/specs/screens/task/__snapshots__/external.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/external.spec.js.snap
@@ -176,6 +176,7 @@ exports[`Tasks External URL Screen matches snapshot 1`] = `
           "push": [MockFunction],
           "replace": [MockFunction],
         },
+        "isLocked": false,
         "viewedInfoSteps": Array [],
         "window": [Window],
       }

--- a/tutor/specs/screens/task/__snapshots__/homework.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/homework.spec.js.snap
@@ -1068,6 +1068,7 @@ exports[`Reading Tasks Screen matches snapshot 1`] = `
         "history": Object {
           "push": [Function],
         },
+        "isLocked": false,
         "viewedInfoSteps": Array [],
         "window": [Window],
       }

--- a/tutor/specs/screens/task/__snapshots__/milestones.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/milestones.spec.js.snap
@@ -737,6 +737,7 @@ exports[`Reading Milestones Component matches snapshot 1`] = `
         "year": 2017,
       },
       "history": undefined,
+      "isLocked": false,
       "viewedInfoSteps": Array [],
       "window": [Window],
     }

--- a/tutor/specs/screens/task/__snapshots__/progress.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/progress.spec.js.snap
@@ -366,6 +366,7 @@ exports[`Reading Progress Component matches snapshot 1`] = `
         "year": 2017,
       },
       "history": undefined,
+      "isLocked": false,
       "viewedInfoSteps": Array [],
       "window": [Window],
     }

--- a/tutor/specs/screens/task/__snapshots__/reading.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/reading.spec.js.snap
@@ -738,6 +738,7 @@ exports[`Reading Tasks Screen matches snapshot 1`] = `
         "history": Object {
           "push": [Function],
         },
+        "isLocked": false,
         "viewedInfoSteps": Array [],
         "window": [Window],
       }

--- a/tutor/specs/screens/task/steps/__snapshots__/exercise-free-response.spec.js.snap
+++ b/tutor/specs/screens/task/steps/__snapshots__/exercise-free-response.spec.js.snap
@@ -838,6 +838,7 @@ exports[`Exercise Free Response matches snapshot 1`] = `
           "push": [MockFunction],
           "replace": [MockFunction],
         },
+        "isLocked": false,
         "viewedInfoSteps": Array [],
         "window": [Window],
       }

--- a/tutor/specs/screens/task/ux.spec.js
+++ b/tutor/specs/screens/task/ux.spec.js
@@ -150,6 +150,18 @@ describe('Task UX Model', () => {
         { deferred: true, immediate: false },
       );
     });
+  });
 
+  it('locks going forward repeatedly', () => {
+    jest.useFakeTimers();
+    expect(ux.nextStep.is_completed).toBe(false);
+    ux.currentStep.is_completed = true;
+    expect(ux.isLocked).toBe(false);
+    ux.goForward();
+    expect(ux.isLocked).toBeTruthy();
+    expect(ux.canGoForward).toBe(false);
+    jest.runAllTimers();
+    expect(ux.isLocked).toBe(false);
+    expect(ux.canGoForward).toBe(true);
   });
 });


### PR DESCRIPTION
This stops keyboard arrows or clicking on next arrow from rapidly skipping all the reading steps