### PR TITLE
fix aria label interpolation

### DIFF
--- a/tutor/src/screens/performance-forecast/section.js
+++ b/tutor/src/screens/performance-forecast/section.js
@@ -20,7 +20,7 @@ const PerformanceForecastSection = (props) => {
       </h4>
       <ProgressBar
         {...props}
-        ariaLabel={`cs.asString ${section.title}`} />
+        ariaLabel={`${cs.asString} ${section.title}`} />
       <Statistics
         courseId={courseId}
         roleId={roleId}


### PR DESCRIPTION
This fixes the value being passed to the ProgressBar component from
including a literal "cs.asString" to instead interpolating the value.

Ex: "Practice - cs.asString" becomes "Practice - 3.2 Vector Addition"