### PR TITLE
Set book content headings to be sans serif

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -115,6 +115,11 @@
     display: none;
   }
 
+  [data-type="title"] {
+    font-family: $tutor-sans-font-face;
+  }
+
+
   .os-glossary-container {
     margin-top: 2rem;
     margin-bottom: 1rem;

--- a/tutor/resources/styles/global/typography.scss
+++ b/tutor/resources/styles/global/typography.scss
@@ -17,6 +17,7 @@
 $caption-font-color: #646464;
 $html-font-size: 10px;
 $tutor-default-font-face: "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$tutor-sans-font-face: $tutor-default-font-face;
 $tutor-neutral-light-font-face: "HelveticaNeue-Light", "Helvetica Neue Light", $tutor-default-font-face;
 
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/79566/67897714-f8094280-fb2c-11e9-98ba-7bc803c82453.png)



after:
![image](https://user-images.githubusercontent.com/79566/67897701-ede74400-fb2c-11e9-8abf-160e10fa1839.png)
