### PR TITLE
use sans serif font for figures

### DIFF
--- a/tutor/resources/styles/mixins/figures.scss
+++ b/tutor/resources/styles/mixins/figures.scss
@@ -1,6 +1,7 @@
 @mixin tutor-figure-title() {
   .os-title-label,
   .os-number {
+    @include tutor-sans-font();
     font-weight: 800;
   }
 }


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/79566/67899040-7a930180-fb2f-11e9-88ab-0a12f3078750.png)




after:
![image](https://user-images.githubusercontent.com/79566/67899022-736bf380-fb2f-11e9-88f7-831cab21effe.png)
