### PR TITLE
use sans-serif font for table cells

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -215,6 +215,9 @@
           background: $tutor-neutral-darker;
         }
       }
+      td {
+        font-family: $tutor-sans-font-face;
+      }
     }
   }
 }

--- a/tutor/resources/styles/global/typography.scss
+++ b/tutor/resources/styles/global/typography.scss
@@ -17,11 +17,12 @@
 $caption-font-color: #646464;
 $html-font-size: 10px;
 $tutor-default-font-face: "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$tutor-sans-font-face: $tutor-default-font-face;
 $tutor-neutral-light-font-face: "HelveticaNeue-Light", "Helvetica Neue Light", $tutor-default-font-face;
 
 
 @mixin tutor-sans-font($size: 1.5rem, $line-height: 2.25rem) {
-  font-family: $tutor-default-font-face;
+  font-family: $tutor-sans-font-face;
   font-weight: 400;
   font-style: normal;
   font-size: $size;


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/79566/67900884-694bf400-fb33-11e9-994f-045bc2612998.png)






after:

![image](https://user-images.githubusercontent.com/79566/67900858-5df8c880-fb33-11e9-8509-40d7687317b7.png)
