### PR TITLE
use a redirect to load the content analyst dashboard

### DIFF
--- a/tutor/src/models/user/menu.js
+++ b/tutor/src/models/user/menu.js
@@ -135,6 +135,7 @@ const ROUTES = {
   qaHome: {
     label: 'Content Analyst',
     href: '/content_analyst',
+    options: { redirect: true },
     isAllowed() { return !!User.is_content_analyst; },
   },
 


### PR DESCRIPTION
Otherwise it uses history.push and the router doesn't handle that url