### PR TITLE
fix selectedSection prop check

### DIFF
--- a/tutor/src/components/exercises/details.jsx
+++ b/tutor/src/components/exercises/details.jsx
@@ -46,6 +46,9 @@ class ExerciseDetails extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
+    if (!this.props.selectedSection) {
+      return;
+    }
     if (!this.props.selectedSection.eq(prevProps.selectedSection)) {
       const index = this.exercises.findIndex(
         ex => ex.page.chapter_section.eq(this.props.selectedSection)


### PR DESCRIPTION
A particular render case doesn't pass the selectedSection prop, so
it's undefined when this equality check is run. This commit returns
early from componentDidUpdate if it's not present.