### PR TITLE
remove drop cap style from paragraphs

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -63,7 +63,6 @@
   section:not(.references) h1 + p:first-of-type,
   [data-type="document-title"] ~ p:first-of-type {
     margin-top: 2rem;
-    @include tutor-reading-first-letter();
   }
 
   // prevent larger images from pushing out past their container.

--- a/tutor/resources/styles/book-content/mixins.scss
+++ b/tutor/resources/styles/book-content/mixins.scss
@@ -21,26 +21,6 @@
   text-transform: capitalize;
 }
 
-@mixin tutor-reading-first-letter($letter-color: $tutor-book-secondary) {
-  &::first-letter {
-    color: $openstax-book-drop-cap-color;
-    float: left;
-    @include tutor-sans-font(10.8rem, .7em); //setting line-height in em to scale on browser zoom
-    font-weight: 600;
-    margin: .1em .08em 0 -.06em; //best combination on line-height and margin to look good in chrome and ff
-  }
-
-  // use clearfix hack to ensure the paragraph's first-leter does not flow into the following block
-  &:after {
-    content: " ";
-    display: table;
-  }
-  &:after {
-    clear: both;
-  }
-
-}
-
 @mixin book-content-subtitle($subtitle-color: $tutor-book-secondary) {
   color: $subtitle-color;
   font-weight: 400;

--- a/tutor/resources/styles/variables/book-content.scss
+++ b/tutor/resources/styles/variables/book-content.scss
@@ -20,7 +20,6 @@ $openstax-book-default-fg: $openstax-book-neutral-neutral-darker-green;
 $openstax-book-default-bg: $openstax-book-gray;
 $openstax-book-default-accent: $openstax-book-gray-accent;
 $openstax-book-default-fg-inverse: $openstax-gold;
-$openstax-book-drop-cap-color: $tutor-gray;
 $openstax-book-text-on-dark-labels: #fff;
 
 // NOTE:


### PR DESCRIPTION
Before:
<img width="756" alt="after" src="https://user-images.githubusercontent.com/34174/68493266-06c4b900-0201-11ea-98d7-c8a314baa868.png">

After:
<img width="750" alt="before" src="https://user-images.githubusercontent.com/34174/68493258-03c9c880-0201-11ea-96b4-6e6d8685078f.png">