### PR TITLE
use break-word css rule

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -72,7 +72,7 @@
     max-width: 100%;
   }
   a {
-    word-break: break-all;
+    overflow-wrap: break-word;
   }
 
   @include tutor-figure();


### PR DESCRIPTION
Fixes links that would break anywhere, not just on spaces:
![image](https://user-images.githubusercontent.com/79566/68496167-53b38a00-0217-11ea-8a78-d2640bb80958.png)


after:
![image](https://user-images.githubusercontent.com/79566/68496133-40a0ba00-0217-11ea-951e-6d98bcecae62.png)


