### PR TITLE
Fix media preview inner text links

### DIFF
--- a/tutor/src/components/book-page.js
+++ b/tutor/src/components/book-page.js
@@ -298,9 +298,7 @@ class BookPage extends React.Component {
     };
 
     const mediaPreview = (
-      <MediaPreview {...mediaProps}>
-        {link.innerText}
-      </MediaPreview>
+      <MediaPreview {...mediaProps} html={link.innerHTML} />
     );
 
     ReactDOM.render(mediaPreview, previewNode);

--- a/tutor/src/components/media-preview.js
+++ b/tutor/src/components/media-preview.js
@@ -56,7 +56,7 @@ class MediaPreview extends React.Component {
 
   onMouseLeave = (mouseEvent) => {
     mouseEvent.preventDefault();
-    if (this.isMouseExited(mouseEvent)) { return this.hideMedia(); }
+    if (this.isMouseExited(mouseEvent)) { this.hideMedia(); }
   };
 
   getLinkProps = (otherProps) => {
@@ -99,9 +99,9 @@ class MediaPreview extends React.Component {
   };
 
   UNSAFE_componentWillMount() {
-    const { mediaId, cnxId } = this.props;
+    const { mediaId } = this.props;
     const media = MediaStore.get(mediaId);
-    if (media != null) { return this.updateMedia(media); }
+    if (media != null) { this.updateMedia(media); }
   }
 
   checkShouldPop = () => {
@@ -113,10 +113,10 @@ class MediaPreview extends React.Component {
     if (this.state.popped) {
       if (!this.state.stick) {
         this.setState({ popped: false });
-        return this.refs.overlay.hide();
+        this.refs.overlay.hide();
       }
     } else {
-      return this.unhighlightMedia();
+      this.unhighlightMedia();
     }
   };
 
@@ -147,10 +147,10 @@ class MediaPreview extends React.Component {
     if (shouldPop) {
       if (!this.state.popped) {
         this.setState({ popped: true });
-        return this.refs.overlay.show();
+        this.refs.overlay.show();
       }
     } else {
-      return this.highlightMedia();
+      this.highlightMedia();
     }
   };
 
@@ -158,7 +158,7 @@ class MediaPreview extends React.Component {
     this.setState({ stick: true });
     if (!this.state.popped) {
       this.setState({ popped: true });
-      return this.refs.overlay.show();
+      this.refs.overlay.show();
     }
   };
 

--- a/tutor/src/components/media-preview.js
+++ b/tutor/src/components/media-preview.js
@@ -36,6 +36,7 @@ class MediaPreview extends React.Component {
     buffer: PropTypes.number,
     shouldLinkOut: PropTypes.bool,
     originalHref: PropTypes.string,
+    html: PropTypes.string,
   };
 
   state = {
@@ -172,7 +173,7 @@ class MediaPreview extends React.Component {
   };
 
   render() {
-    const { mediaId, children, bookHref, windowImpl } = this.props;
+    const { html, windowImpl } = this.props;
     const { media } = this.state;
 
     const overlayProps = this.getOverlayProps();
@@ -193,22 +194,18 @@ class MediaPreview extends React.Component {
       const content = <ArbitraryHtmlAndMath {...contentProps} html={contentHtml} />;
       const allProps = { content, overlayProps, popoverProps, windowImpl };
 
-      if (children !== '[link]') { linkText = children; }
+      if (html !== '[link]') { linkText = html; }
       if (linkText == null) { linkText = `See ${S.capitalize(media.name)}`; }
 
       return (
         <TutorPopover {...allProps} ref="overlay">
-          <a {...linkProps}>
-            {linkText}
-          </a>
+          <a {...linkProps} dangerouslySetInnerHTML={{ __html: linkText }} />
         </TutorPopover>
       );
     } else {
       linkProps = _.omit(linkProps, 'onMouseEnter', 'onMouseLeave');
       return (
-        <a {...linkProps}>
-          {children}
-        </a>
+        <a {...linkProps} dangerouslySetInnerHTML={{ __html: html }} />
       );
     }
   }

--- a/tutor/src/components/tutor-popover.js
+++ b/tutor/src/components/tutor-popover.js
@@ -87,9 +87,11 @@ class TutorPopover extends React.Component {
         ref={this.setPopoverRef}
       >
         {title && <Popover.Title>{title}</Popover.Title>}
-        <div ref="popcontent">
-          {content}
-        </div>
+        <Popover.Content>
+          <div ref="popcontent">
+            {content}
+          </div>
+        </Popover.Content>
       </Popover>
     );
 


### PR DESCRIPTION
previously this only retained the text of a media preview which would throw away <b> and other tags inside it