### PR TITLE
Fix no course message when task fails to load due to connection issues

### DIFF
--- a/tutor/src/screens/task/index.js
+++ b/tutor/src/screens/task/index.js
@@ -126,9 +126,10 @@ class TaskGetter extends React.Component {
   }
 
   render() {
-    if (!this.course || this.task.api.hasErrors) {
+    if (!this.course) {
       return <CourseNotFoundWarning area="assignment" />;
     }
+
     const { task } = this;
     if (!task || (task.api && task.api.hasErrors)) {
       return <Failure task={task} />;


### PR DESCRIPTION
I still haven't figured out how to fix the loading forever bug.