### PR TITLE
Only fetch task if needed, wait for finish before step navigation

### DIFF
--- a/tutor/specs/screens/task/index.spec.js
+++ b/tutor/specs/screens/task/index.spec.js
@@ -37,6 +37,8 @@ describe('Tasks Screen', () => {
   });
 
   it('renders and fetches', () => {
+    task.api.isFetchedOrFetching = false;
+    task.api.isPending = true;
     task.api.hasBeenFetched = false;
     props.params.stepIndex = 1;
     const t = mount(<C><Task {...props} /></C>);

--- a/tutor/src/screens/task/index.js
+++ b/tutor/src/screens/task/index.js
@@ -122,7 +122,9 @@ class TaskGetter extends React.Component {
 
   constructor(props) {
     super(props);
-    this.task.fetch();
+    if (!this.task.api.isFetchedOrFetching) {
+      this.task.fetch();
+    }
   }
 
   render() {

--- a/tutor/src/screens/task/ux.js
+++ b/tutor/src/screens/task/ux.js
@@ -26,12 +26,13 @@ export default class TaskUX {
     this.course = course || task.tasksMap.course;
     this.becomeStudentIfNeeded();
     CenterControls.currentTaskStep = this.currentStep;
-    observe(this, 'currentStep', this.onStepChange, true);
     when(
-      () => !this.task.api.isPendingInitialFetch,
-      () => this.goToStep(stepIndex)
+      () => !this.task.api.isPending,
+      () => {
+        observe(this, 'currentStep', this.onStepChange, true);
+        this.goToStep(stepIndex);
+      }
     );
-
   }
 
   @lazyGetter scroller = new ScrollTo({ windowImpl: this.window });


### PR DESCRIPTION
Previously we'd fetch the task every time it the task UI loaded, even if we'd fetched it before.  In that case the steps would already be loaded but we'd reload the task.

Doing so would cause a race between the task loading and the current step.  if the step loaded first, the task would reset it when it loaded, leaving the UI in a loading state.

this fixes the step load to only occurs after the task is finished loading, but also changes the task to only load if it wasn't already fetched.  I don't see any reason that we need to load it every time.
