### PR TITLE
set entire table font to use sans serif font stack

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -147,6 +147,7 @@
   .os-table { margin-top: 2rem; }
 
   table {
+    font-family: $tutor-sans-font-face;
     caption {
       caption-side: bottom;
       font-style: italic;
@@ -209,9 +210,6 @@
         li::before{
           background: $tutor-neutral-darker;
         }
-      }
-      td {
-        font-family: $tutor-sans-font-face;
       }
     }
   }


### PR DESCRIPTION
Previously only the body was sans, but we also want the headers as well

before:
![image](https://user-images.githubusercontent.com/79566/69449255-1aebd880-0d20-11ea-8b1e-1c16a14d5a92.png)



after:
![image](https://user-images.githubusercontent.com/79566/69449229-0ad3f900-0d20-11ea-9acc-1e379c0aa4ae.png)
