### PR TITLE
Fix highlighter dropdown rendering issues in chrome and firefox

### DIFF
--- a/tutor/resources/styles/components/multi-select.scss
+++ b/tutor/resources/styles/components/multi-select.scss
@@ -17,6 +17,7 @@
 
     &.dropdown-item {
       padding: 0.75rem;
+      transform: translateZ(0);
     }
 
     .title {


### PR DESCRIPTION
The will-change property being added by the dropdown library causes stange rendering behavior. Adding `transform: translateZ(0)` forces hardware acceleration on and somehow fixes the bug.

#### In Chrome, the last element in the left column gets cut off and partially rendered in the second column.

Chrome before:
![chrome-01-before](https://user-images.githubusercontent.com/34174/69684834-db4e2500-106e-11ea-9c90-655b6592b832.png)

Chrome after:
![chrome-02-after](https://user-images.githubusercontent.com/34174/69684835-db4e2500-106e-11ea-89f2-e8e61d12b10b.png)

#### In Firefox, typography line height gets affected, causing descenders like `j` and `g` to be cut off.

Firefox before:
<img width="966" alt="firefox-01-before" src="https://user-images.githubusercontent.com/34174/69684844-e739e700-106e-11ea-96c9-fa8c20a2f0c4.png">

Firefox after:
<img width="963" alt="firefox-02-after" src="https://user-images.githubusercontent.com/34174/69684845-e739e700-106e-11ea-8db1-228ff2747315.png">
