### PR TITLE
prevent section select from partially going off screen

### DIFF
--- a/tutor/src/components/multi-select.jsx
+++ b/tutor/src/components/multi-select.jsx
@@ -143,7 +143,10 @@ class MultiSelect extends React.Component {
         >
           {this.props.title}
         </Dropdown.Toggle>
-        <Dropdown.Menu>
+        <Dropdown.Menu
+          flip={false}
+          popperConfig={{ modifiers: { preventOverflow: { enabled: false } } }}
+        >
           <MultiSelectWrapper
             useColumns={this.props.useColumns}
             showHelperControls={this.props.showHelperControls}

--- a/tutor/src/components/multi-select.jsx
+++ b/tutor/src/components/multi-select.jsx
@@ -145,7 +145,12 @@ class MultiSelect extends React.Component {
         </Dropdown.Toggle>
         <Dropdown.Menu
           flip={false}
-          popperConfig={{ modifiers: { preventOverflow: { enabled: false } } }}
+          popperConfig={{
+            modifiers: {
+              preventOverflow: { enabled: false },
+              hide: { enabled: false },
+            }
+          }}
         >
           <MultiSelectWrapper
             useColumns={this.props.useColumns}


### PR DESCRIPTION
This prevents popper from trying to keep the dropdown onscreen, which could cause it to partially go offscreen.

Before:

![image](https://user-images.githubusercontent.com/34174/70099324-608f8780-15e3-11ea-9531-6851c664927a.png)

After:

![image](https://user-images.githubusercontent.com/34174/70099376-86b52780-15e3-11ea-91e0-30be69b547b2.png)
