### PR TITLE
move reading milestones into a modal

### DIFF
--- a/tutor/resources/styles/components/notes/summary-page.scss
+++ b/tutor/resources/styles/components/notes/summary-page.scss
@@ -5,35 +5,10 @@
 }
 
 .modal-dialog.notes-modal {
-  margin: 40px auto 24px;
-  height: calc(100% - 64px);
-  width: calc(100% - 48px);
-  max-width: $tutor-max-panel-width;
-  justify-content: center;
-
-  .modal-header {
-    background-color: $tutor-dark-blue;
-
-    &, .close {
-      color: $tutor-white;
-    }
-
-    .close {
-      opacity: 1;
-      text-shadow: none;
-      font-size: 2.75rem;
-      margin-top: -1.75rem;
-    }
-  }
-
-  .modal-content {
-    // Fix white background showing behind rounded header corners
-    background: transparent;
-  }
+  @include tutor-modal-v2;
 
   .modal-body {
     padding: 0;
-    background-color: $tutor-neutral-light;
   }
 
   .modal-scroll-btn {

--- a/tutor/resources/styles/mixins/tutor-modal.scss
+++ b/tutor/resources/styles/mixins/tutor-modal.scss
@@ -51,3 +51,37 @@
 
 
 }
+
+// Expects to be placed at .modal-dialog level
+@mixin tutor-modal-v2() {
+  margin: 40px auto 24px;
+  height: calc(100% - 64px);
+  width: calc(100% - 48px);
+  max-width: $tutor-max-panel-width;
+  justify-content: center;
+
+  .modal-header {
+    background-color: $tutor-dark-blue;
+
+    &, .close {
+      color: $tutor-white;
+    }
+
+    .close {
+      opacity: 1;
+      text-shadow: none;
+      font-size: 2.75rem;
+      margin-top: -1.75rem;
+    }
+  }
+
+  .modal-content {
+    // Fix white background showing behind rounded header corners
+    background: transparent;
+  }
+
+  .modal-body {
+    padding: 3rem;
+    background-color: $tutor-neutral-light;
+  }
+}

--- a/tutor/specs/screens/task/progress.spec.js
+++ b/tutor/specs/screens/task/progress.spec.js
@@ -28,15 +28,4 @@ describe('Reading Progress Component', () => {
     expect(<Progress {...props}><p>hi</p></Progress>).toMatchSnapshot();
   });
 
-  it('pages through steps', () => {
-    const pr = mount(<Progress {...props}><p>hi</p></Progress>);
-    expect(pr).toHaveRendered('a.paging-control.prev[disabled=true]');
-    expect(pr).toHaveRendered('a.paging-control.next[disabled=false]');
-    pr.find('a.paging-control.next').simulate('click');
-    pr.find('a.paging-control.next').simulate('click');
-    expect(pr).toHaveRendered('a.paging-control.next[disabled=true]');
-    expect(pr).toHaveRendered('a.paging-control.prev[disabled=false]');
-    pr.unmount();
-  });
-
 });

--- a/tutor/specs/screens/task/reading.spec.js
+++ b/tutor/specs/screens/task/reading.spec.js
@@ -95,4 +95,15 @@ describe('Reading Tasks Screen', () => {
     r.unmount();
   });
 
+  it('pages through steps', () => {
+    const pr = mount(<C><Reading {...props} /></C>);
+    expect(pr).toHaveRendered('a.paging-control.prev[disabled=true]');
+    expect(pr).toHaveRendered('a.paging-control.next[disabled=false]');
+    pr.find('a.paging-control.next').simulate('click');
+    pr.find('a.paging-control.next').simulate('click');
+    expect(pr).toHaveRendered('a.paging-control.next[disabled=true]');
+    expect(pr).toHaveRendered('a.paging-control.prev[disabled=false]');
+    pr.unmount();
+  });
+
 });

--- a/tutor/src/screens/task/milestones.js
+++ b/tutor/src/screens/task/milestones.js
@@ -53,6 +53,7 @@ class Milestone extends React.Component {
   }
 }
 
+@observer
 class Milestones extends React.Component {
 
   static propTypes = {

--- a/tutor/src/screens/task/progress.js
+++ b/tutor/src/screens/task/progress.js
@@ -40,7 +40,7 @@ class ProgressCard extends React.Component {
           closeButton={true}
           closeLabel={'Close'}
         >
-          <Modal.Title>Overview</Modal.Title>
+          <Modal.Title>Assignment Overview</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           {this.renderMilestones()}

--- a/tutor/src/screens/task/progress.js
+++ b/tutor/src/screens/task/progress.js
@@ -1,9 +1,8 @@
 import { React, PropTypes, observer, action, cn } from 'vendor';
-import Overlay from '../../components/obscured-page/overlay';
-import PagingNavigation from '../../components/paging-navigation';
 import { Milestones } from './milestones';
 import UX from './ux';
 import MilestonesToggle from './reading-milestones-toggle';
+import { Modal } from 'react-bootstrap';
 
 export default
 @observer
@@ -11,7 +10,6 @@ class ProgressCard extends React.Component {
 
   static propTypes = {
     ux: PropTypes.instanceOf(UX).isRequired,
-    children: PropTypes.node.isRequired,
   }
 
   @action.bound closeMilestones() {
@@ -31,26 +29,24 @@ class ProgressCard extends React.Component {
   }
 
   render() {
-    const { ux, children } = this.props;
-
     return (
-      <PagingNavigation
-        className={cn('progress-panel')}
-        enableKeys={!this.showMilestones}
-        isForwardEnabled={ux.canGoForward}
-        isBackwardEnabled={ux.canGoBackward}
-        onForwardNavigation={ux.goForward}
-        onBackwardNavigation={ux.goBackward}
-        titles={ux.relatedStepTitles}
+      <Modal
+        dialogClassName={cn('task-milestones', 'openstax-wrapper')}
+        show={MilestonesToggle.isActive}
+        onHide={this.closeMilestones}
+        scrollable={true}
       >
-        <Overlay
-          id="task-milestones"
-          visible={MilestonesToggle.isActive}
-          renderer={this.renderMilestones}
-          onHide={this.closeMilestones}
-        />
-        {children}
-      </PagingNavigation>
+        <Modal.Header
+          closeButton={true}
+          closeLabel={'Close'}
+        >
+          <Modal.Title>Overview</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {this.renderMilestones()}
+        </Modal.Body>
+      </Modal>
+
     );
   }
 }

--- a/tutor/src/screens/task/reading.js
+++ b/tutor/src/screens/task/reading.js
@@ -1,10 +1,9 @@
-import { React, PropTypes, styled, observer } from 'vendor';
+import { React, PropTypes, styled, observer, cn } from 'vendor';
 import ProgressCard from './progress';
 import UX from './ux';
 import { TaskStep } from './step';
-import ObscuredPage from '../../components/obscured-page';
 import ReadingNavbar from './reading-navbar';
-
+import PagingNavigation from '../../components/paging-navigation';
 
 const StyledReading = styled.div`
 
@@ -23,16 +22,23 @@ class ReadingTask extends React.Component {
 
     return (
       <StyledReading className="reading-task">
-        <ProgressCard ux={ux}>
-          <ReadingNavbar ux={ux} />
-          <ObscuredPage>
-            <TaskStep
-              ux={ux}
-              step={ux.currentGroupedStep}
-              windowImpl={windowImpl}
-            />
-          </ObscuredPage>
-        </ProgressCard>
+        <ReadingNavbar ux={ux} />
+        <PagingNavigation
+          className={cn('progress-panel')}
+          enableKeys={true}
+          isForwardEnabled={ux.canGoForward}
+          isBackwardEnabled={ux.canGoBackward}
+          onForwardNavigation={ux.goForward}
+          onBackwardNavigation={ux.goBackward}
+          titles={ux.relatedStepTitles}
+        >
+          <ProgressCard ux={ux} />
+          <TaskStep
+            ux={ux}
+            step={ux.currentGroupedStep}
+            windowImpl={windowImpl}
+          />
+        </PagingNavigation>
       </StyledReading>
     );
   }

--- a/tutor/src/screens/task/styles/milestones.scss
+++ b/tutor/src/screens/task/styles/milestones.scss
@@ -15,16 +15,12 @@ $milestone-icon-size: 60px;
   }
 }
 
-.overlay.task-milestones {
-  padding-top: $openstax-navbar-height;
-  background: $tutor-neutral-light;
-  .milestones-wrapper {
-    margin: 110px 50px 50px;
-    width: 100%;
-    .milestones {
-      display: flex;
-      flex-wrap: wrap;
-    }
+.modal-dialog.task-milestones {
+  @include tutor-modal-v2;
+
+  .milestones {
+    display: flex;
+    flex-wrap: wrap;
   }
 }
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/34174/70489783-8a4c2100-1ab1-11ea-9fcc-89151686d900.png)

After:

![image](https://user-images.githubusercontent.com/34174/70491019-d351a480-1ab4-11ea-984f-13589981190e.png)

- Observes Milestones so we can pass index changes to Milestone
- Hoists PagingNavigation up to ReadingTask since the Overlay isn't used anymore
- Consolidates the new modal style into a mixin so it can be phased in
  and eventually removed when it becomes the base style.