### PR TITLE
reset summary and selection when deleting last note in a page

### DIFF
--- a/tutor/src/components/notes/summary-page.jsx
+++ b/tutor/src/components/notes/summary-page.jsx
@@ -80,6 +80,9 @@ class NoteSummaryPage extends React.Component {
 
   @action.bound onDelete(note) {
     this.props.onDelete(note);
+    this.selectedPages.remove(
+      this.selectedPages.find(s => s.uuid == note.page.uuid)
+    );
     this.prepareFocus();
   }
 

--- a/tutor/src/components/notes/summary-page.jsx
+++ b/tutor/src/components/notes/summary-page.jsx
@@ -80,9 +80,11 @@ class NoteSummaryPage extends React.Component {
 
   @action.bound onDelete(note) {
     this.props.onDelete(note);
-    this.selectedPages.remove(
-      this.selectedPages.find(s => s.uuid == note.page.uuid)
-    );
+    if (note.page.isEmpty) {
+      this.selectedPages.remove(
+        this.selectedPages.find(s => s.uuid == note.page.uuid)
+      );
+    }
     this.prepareFocus();
   }
 

--- a/tutor/src/models/notes.js
+++ b/tutor/src/models/notes.js
@@ -119,10 +119,8 @@ class Notes extends BaseModel {
 
   @action onNoteDeleted(note, page) {
     if (page.isEmpty) {
-      const section = this.pages.get(page.uuid);
-      if (section) {
-        this.pages.remove(section);
-      }
+      this.pages.delete(page.uuid);
+      this.summary.remove(this.summary.find(s => s.uuid == page.uuid));
     }
   }
 


### PR DESCRIPTION
When the last note in a section is removed, we need to remove it from the summary and selected sections lists