### PR TITLE
Fix note deletion throwing error

### DIFF
--- a/shared/src/model/api.js
+++ b/shared/src/model/api.js
@@ -19,6 +19,10 @@ export default class ModelApi {
     return this.requestsInProgress.size > 0;
   }
 
+  @computed get isDeleted() {
+    return this.requestCounts.delete > 0;
+  }
+
   @computed get isPendingInitialFetch() {
     return this.isPending && !this.hasBeenFetched;
   }

--- a/tutor/src/components/notes/edit-box.jsx
+++ b/tutor/src/components/notes/edit-box.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { defer } from 'lodash';
 import { observer } from 'mobx-react';
-import { action, observable } from 'mobx';
+import { action, observable, computed } from 'mobx';
 import cn from 'classnames';
 import { Icon } from 'shared';
 import { Form } from 'react-bootstrap';
@@ -38,7 +38,7 @@ class EditBox extends React.Component {
   }
 
   componentWillUnmount() {
-    if (!this.props.note.api.isDeleted && (this.annotation !== this.props.note.annotation)) {
+    if (!this.isDeleted && (this.annotation !== this.props.note.annotation)) {
       this.props.note.annotation = this.annotation;
       this.props.note.save();
     }
@@ -61,6 +61,10 @@ class EditBox extends React.Component {
 
   @action.bound goNext() {
     this.props.goToNote(this.props.next);
+  }
+
+  @computed get isDeleted() {
+    return this.props.note.api.isDeleted;
   }
 
   renderWarning() {

--- a/tutor/src/components/notes/edit-box.jsx
+++ b/tutor/src/components/notes/edit-box.jsx
@@ -23,12 +23,14 @@ class EditBox extends React.Component {
 
   @action.bound onDelete() {
     this.props.note.destroy().then(() => {
+      this.isDeleted = true;
       this.props.onHide();
       this.props.onDelete(this.props.note);
     });
   }
 
   @observable annotation = this.props.note ? this.props.note.annotation : '';
+  isDeleted = false;
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.note !== this.props.note) {
@@ -38,7 +40,7 @@ class EditBox extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.annotation !== this.props.note.annotation) {
+    if (!this.isDeleted && (this.annotation !== this.props.note.annotation)) {
       this.props.note.annotation = this.annotation;
       this.props.note.save();
     }

--- a/tutor/src/components/notes/edit-box.jsx
+++ b/tutor/src/components/notes/edit-box.jsx
@@ -23,14 +23,12 @@ class EditBox extends React.Component {
 
   @action.bound onDelete() {
     this.props.note.destroy().then(() => {
-      this.isDeleted = true;
       this.props.onHide();
       this.props.onDelete(this.props.note);
     });
   }
 
   @observable annotation = this.props.note ? this.props.note.annotation : '';
-  isDeleted = false;
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.note !== this.props.note) {
@@ -40,7 +38,7 @@ class EditBox extends React.Component {
   }
 
   componentWillUnmount() {
-    if (!this.isDeleted && (this.annotation !== this.props.note.annotation)) {
+    if (!this.props.note.api.isDeleted && (this.annotation !== this.props.note.annotation)) {
       this.props.note.annotation = this.annotation;
       this.props.note.save();
     }


### PR DESCRIPTION
If you changed the annotation in the textbox of an existing note, and then click Delete, an error would be thrown because the note would be deleted, but during unmounting, the annotation text would be different, firing off an update. This fixes the issue by checking the api for a deletion request (thanks @nathanstitt!)