### PR TITLE
Improve highlighter popup tool

### DIFF
--- a/tutor/resources/styles/components/notes/note.scss
+++ b/tutor/resources/styles/components/notes/note.scss
@@ -55,7 +55,6 @@
         position: absolute;
         top: 8px;
         bottom: 8px;
-        left: 49.5%;
       }
     }
     .annotate {

--- a/tutor/resources/styles/components/notes/note.scss
+++ b/tutor/resources/styles/components/notes/note.scss
@@ -42,10 +42,27 @@
     @include tutor-shadow(subtle);
     display: flex;
     align-items: center;
+    border-radius: 2px;
     > * {
       background-color: $tutor-gray;
     }
+    .highlight {
+      border-radius: 2px 0 0 2px;
+
+      &::after {
+        content: " ";
+        border-right: 1px solid #404345;
+        position: absolute;
+        top: 8px;
+        bottom: 8px;
+        left: 49.5%;
+      }
+    }
+    .annotate {
+      border-radius: 0 2px 2px 0;
+    }
     .highlight, .annotate {
+      padding: 0;
       svg {
         width: 48px;
         height: 48px;

--- a/tutor/src/components/notes/inline-controls.jsx
+++ b/tutor/src/components/notes/inline-controls.jsx
@@ -10,10 +10,11 @@ const InlineControls = observer(({ windowImpl, pendingHighlight, annotate, paren
   if (!pendingHighlight || !pendingHighlight.range) { return null; }
 
   const rect = getRangeRect(windowImpl, pendingHighlight.range);
+  const firstLineRect = pendingHighlight.range.getClientRects()[0];
 
   const style = {
-    top: `${(rect.top - parentRect.top) - 48}px`,
-    right: `${parentRect.right - rect.right - 40}px`,
+    top: `${(rect.top - parentRect.top) - 55}px`,
+    left: `${((firstLineRect.left + firstLineRect.right) / 2) - parentRect.left - 64}px`,
   };
 
   return (

--- a/tutor/src/components/notes/inline-controls.jsx
+++ b/tutor/src/components/notes/inline-controls.jsx
@@ -14,7 +14,7 @@ const InlineControls = observer(({ windowImpl, pendingHighlight, annotate, paren
 
   const style = {
     top: `${(rect.top - parentRect.top) - 55}px`,
-    left: `${((firstLineRect.left + firstLineRect.right) / 2) - parentRect.left - 64}px`,
+    left: `${((firstLineRect.left + firstLineRect.right) / 2) - parentRect.left - 48}px`,
   };
 
   return (


### PR DESCRIPTION
- Changes the width and adds a dividing border to match the design comp
- Centers the tool over the first (or only) highlighted line by using getClientRects to position itself.

Before:

![image](https://user-images.githubusercontent.com/34174/70673379-3ff4ac80-1c37-11ea-9fde-a7100c432b5e.png)

After:

![image](https://user-images.githubusercontent.com/34174/70675857-38d19c80-1c3f-11ea-9347-e0f747453ab2.png)
