### PR TITLE
Don't allow table columns to be less than 300px

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -170,6 +170,7 @@
     }
     td,
     th {
+      min-width: 300px;
       .MathJax_Display {
         display: inline!important;
         text-align: left!important;

--- a/tutor/src/components/notes.js
+++ b/tutor/src/components/notes.js
@@ -35,15 +35,21 @@ class NotesWidgetWrapper extends React.Component {
     page: PropTypes.instanceOf(Page).isRequired,
   };
 
+  get canAnnotate() {
+    return Boolean(this.props.course && this.props.course.canAnnotate);
+  }
+
   constructor(props) {
     super(props);
-    props.course.notes.ensurePageExists(props.page);
+    if (this.canAnnotate) {
+      props.course.notes.ensurePageExists(props.page);
+    }
   }
 
   render() {
     const { course, page } = this.props;
 
-    if (!course || !course.canAnnotate) { return this.props.children; }
+    if (!this.canAnnotate) { return this.props.children; }
 
     return (
       <NotesWidget


### PR DESCRIPTION
fixes cases where the columns would get very narrow.  This was caused by the right column having `<br/>` tags inserted in the content which caused the computed line length to be very short

before:
![image](https://user-images.githubusercontent.com/79566/71698382-f6543900-2d80-11ea-8bab-f333ac46b1ef.png)


After looks like:
![image](https://user-images.githubusercontent.com/79566/71698338-d3c22000-2d80-11ea-93e4-2992bc81d603.png)
