### PR TITLE
add delete confirmation to templates

### DIFF
--- a/tutor/specs/screens/grading-templates/__snapshots__/delete-modal.spec.jsx.snap
+++ b/tutor/specs/screens/grading-templates/__snapshots__/delete-modal.spec.jsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Delete Modal matches snapshot 1`] = `
+<DeleteModal
+  onCancel={[MockFunction]}
+  onDelete={[MockFunction]}
+  template={
+    GradingTemplate {
+      "auto_grading_feedback_on": true,
+      "completion_weight": 0.08,
+      "correctness_weight": 0.53,
+      "default_close_date_offset_days": 1,
+      "default_due_date_offset_days": 1,
+      "default_due_time": "17:00",
+      "default_open_time": "07:00",
+      "id": 1,
+      "late_work_immediate_penalty": false,
+      "late_work_per_day_penalty": true,
+      "manual_grading_feedback_on": true,
+      "map": undefined,
+      "name": "Default Reading",
+      "task_plan_type": "reading",
+    }
+  }
+/>
+`;

--- a/tutor/specs/screens/grading-templates/delete-modal.spec.jsx
+++ b/tutor/specs/screens/grading-templates/delete-modal.spec.jsx
@@ -1,0 +1,28 @@
+import { React, Factory } from '../../helpers';
+import DeleteModal from '../../../src/screens/grading-templates/delete-modal';
+
+describe('Delete Modal', function() {
+  let props;
+
+  beforeEach(() => {
+    props = {
+      template: Factory.gradingTemplate({ task_plan_type: 'reading' }),
+      onDelete: jest.fn(),
+      onCancel: jest.fn(),
+    };
+  });
+
+  it('matches snapshot', () => {
+    expect(<DeleteModal {...props} />).toMatchSnapshot();
+  });
+
+  it('deletes and cancels', () => {
+    const modal = shallow(<DeleteModal {...props} />);
+
+    modal.find('.cancel').simulate('click');
+    expect(props.onCancel).toHaveBeenCalled();
+
+    modal.find('.delete').simulate('click');
+    expect(props.onDelete).toHaveBeenCalledWith(props.template);
+  });
+});

--- a/tutor/src/screens/grading-templates/delete-modal.jsx
+++ b/tutor/src/screens/grading-templates/delete-modal.jsx
@@ -1,0 +1,69 @@
+import { React, PropTypes, action, observer, styled } from 'vendor';
+import { Button, Modal } from 'react-bootstrap';
+import { GradingTemplate } from '../../models/grading/templates';
+
+const StyledHeader = styled(Modal.Header)`
+  font-weight: bold;
+
+  .close {
+    font-size: 3rem;
+  }
+`;
+
+const StyledBody = styled(Modal.Body)`
+  font-size: 1.6rem;
+  line-height: 2.5rem;
+`;
+
+const ControlsWrapper = styled.div`
+  margin-top: 3rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+`;
+
+const Controls = styled.div`
+  .btn + .btn {
+    margin-left: 1.5rem;
+  }
+`;
+
+
+export default class DeleteModal extends React.Component {
+  static propTypes = {
+    onDelete: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    template: PropTypes.instanceOf(GradingTemplate).isRequired,
+  };
+
+  render () {
+    const { template, onDelete, onCancel } = this.props;
+
+    return (
+      <Modal
+        show={true}
+        onHide={onCancel}
+        backdrop="static"
+      >
+        <StyledHeader closeButton>
+          Delete tempate?
+        </StyledHeader>
+        <StyledBody>
+          Are you sure you want to permanently
+          delete <strong>{template.name}</strong> template?
+          You can't undo this action.
+          <ControlsWrapper>
+            <Controls>
+              <Button className="delete" variant="default" size="lg" onClick={() => onDelete(template)}>
+                Delete
+              </Button>
+              <Button className="cancel" variant="primary" size="lg" onClick={onCancel}>
+                Cancel
+              </Button>
+            </Controls>
+          </ControlsWrapper>
+        </StyledBody>
+      </Modal>
+    );
+  }
+}

--- a/tutor/src/screens/grading-templates/index.js
+++ b/tutor/src/screens/grading-templates/index.js
@@ -7,6 +7,7 @@ import Theme from '../../theme';
 import Loading from 'shared/components/loading-animation';
 import { GradingTemplates } from '../../models/grading/templates';
 import Card from './card';
+import DeleteModal from './delete-modal';
 import { ScrollToTop } from 'shared';
 import CoursePage from '../../components/course-page';
 import * as EDIT_TYPES from './editors';
@@ -34,6 +35,7 @@ class GradingTemplatesScreen extends React.Component {
   }
 
   @observable editing = null;
+  @observable deleting = null;
 
   constructor(props) {
     super(props);
@@ -56,8 +58,17 @@ class GradingTemplatesScreen extends React.Component {
     this.editing = template;
   }
 
+  @action.bound onConfirmDelete(template) {
+    this.deleting = template;
+  }
+
+  @action.bound onDeleteComplete() {
+    this.deleting = null;
+  }
+
   @action.bound onDeleteTemplate(template) {
     template.remove();
+    this.onDeleteComplete();
   }
 
   @action.bound onAdd() {
@@ -87,6 +98,16 @@ class GradingTemplatesScreen extends React.Component {
       }
     }
 
+    if (this.deleting) {
+      modal = (
+        <DeleteModal
+          onDelete={this.onDeleteTemplate}
+          onCancel={this.onDeleteComplete}
+          template={this.deleting}
+        />
+      );
+    }
+
     return (
       <Container fluid={true}>
         {modal}
@@ -101,7 +122,7 @@ class GradingTemplatesScreen extends React.Component {
               key={template.id}
               template={template}
               onEdit={this.onEditTemplate}
-              onDelete={this.onDeleteTemplate}
+              onDelete={this.onConfirmDelete}
             />))}
         </Row>
       </Container>


### PR DESCRIPTION
- Moves delete callback into a modal confirmation
- Makes edit modal close button match the others

![image](https://user-images.githubusercontent.com/34174/72458451-7a44f280-377d-11ea-9052-51cc2b554f89.png)

