### PR TITLE
Retry loading tasks that start with a placeholder step (practice tasks)

### DIFF
--- a/tutor/specs/screens/task/__snapshots__/breadcrumbs.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/breadcrumbs.spec.js.snap
@@ -13,6 +13,7 @@ exports[`Homework Breadcrumbs Component matches snapshot 1`] = `
         "due_at": 2017-10-17T12:00:00.000Z,
         "feedback_at": undefined,
         "id": 1,
+        "isLoading": false,
         "is_deleted": undefined,
         "spy": Object {},
         "steps": Array [

--- a/tutor/specs/screens/task/__snapshots__/external.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/external.spec.js.snap
@@ -12,6 +12,7 @@ exports[`Tasks External URL Screen matches snapshot 1`] = `
           "due_at": 2017-10-17T12:00:00.000Z,
           "feedback_at": undefined,
           "id": 1,
+          "isLoading": false,
           "is_deleted": undefined,
           "spy": Object {},
           "steps": Array [

--- a/tutor/specs/screens/task/__snapshots__/homework.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/homework.spec.js.snap
@@ -12,6 +12,7 @@ exports[`Reading Tasks Screen matches snapshot 1`] = `
           "due_at": 2017-10-17T12:00:00.000Z,
           "feedback_at": undefined,
           "id": 1,
+          "isLoading": false,
           "is_deleted": undefined,
           "spy": Object {},
           "steps": Array [

--- a/tutor/specs/screens/task/__snapshots__/milestones.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/milestones.spec.js.snap
@@ -13,6 +13,7 @@ exports[`Reading Milestones Component matches snapshot 1`] = `
         "due_at": 2017-10-17T12:00:00.000Z,
         "feedback_at": undefined,
         "id": 1,
+        "isLoading": false,
         "is_deleted": undefined,
         "spy": Object {},
         "steps": Array [

--- a/tutor/specs/screens/task/__snapshots__/progress.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/progress.spec.js.snap
@@ -11,6 +11,7 @@ exports[`Reading Progress Component matches snapshot 1`] = `
         "due_at": 2017-10-17T12:00:00.000Z,
         "feedback_at": undefined,
         "id": 1,
+        "isLoading": false,
         "is_deleted": undefined,
         "spy": Object {},
         "steps": Array [

--- a/tutor/specs/screens/task/__snapshots__/reading.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/reading.spec.js.snap
@@ -12,6 +12,7 @@ exports[`Reading Tasks Screen matches snapshot 1`] = `
           "due_at": 2017-10-17T12:00:00.000Z,
           "feedback_at": undefined,
           "id": 1,
+          "isLoading": false,
           "is_deleted": undefined,
           "spy": Object {},
           "steps": Array [

--- a/tutor/specs/screens/task/__snapshots__/task-info.spec.js.snap
+++ b/tutor/specs/screens/task/__snapshots__/task-info.spec.js.snap
@@ -9,6 +9,7 @@ exports[`Tasks Info matches snapshot 1`] = `
       "due_at": 2017-10-17T12:00:00.000Z,
       "feedback_at": undefined,
       "id": 1,
+      "isLoading": false,
       "is_deleted": undefined,
       "spy": Object {},
       "steps": Array [

--- a/tutor/specs/screens/task/index.spec.js
+++ b/tutor/specs/screens/task/index.spec.js
@@ -14,6 +14,7 @@ describe('Tasks Screen', () => {
     Object.assign(task, {
       id: 1,
       type: 'reading',
+      isLoaded: true,
       tasksMap: { course },
       api: observable({
         hasErrors: false,
@@ -37,12 +38,13 @@ describe('Tasks Screen', () => {
   });
 
   it('renders and fetches', () => {
+    task.isLoaded = false;
     task.api.isFetchedOrFetching = false;
     task.api.isPending = true;
     task.api.hasBeenFetched = false;
     props.params.stepIndex = 1;
     const t = mount(<C><Task {...props} /></C>);
-    expect(task.fetch).toHaveBeenCalled();
+    expect(task.load).toHaveBeenCalled();
     expect(t).toHaveRendered('ContentLoader');
     t.unmount();
   });

--- a/tutor/specs/screens/task/steps/__snapshots__/exercise-free-response.spec.js.snap
+++ b/tutor/specs/screens/task/steps/__snapshots__/exercise-free-response.spec.js.snap
@@ -491,6 +491,7 @@ exports[`Exercise Free Response matches snapshot 1`] = `
           "due_at": 2017-10-17T12:00:00.000Z,
           "feedback_at": undefined,
           "id": 1,
+          "isLoading": false,
           "is_deleted": undefined,
           "spy": Object {},
           "steps": Array [
@@ -515,6 +516,7 @@ exports[`Exercise Free Response matches snapshot 1`] = `
           "due_at": 2017-10-17T12:00:00.000Z,
           "feedback_at": undefined,
           "id": 1,
+          "isLoading": false,
           "is_deleted": undefined,
           "spy": Object {},
           "steps": Array [

--- a/tutor/specs/screens/task/steps/__snapshots__/exercise.spec.js.snap
+++ b/tutor/specs/screens/task/steps/__snapshots__/exercise.spec.js.snap
@@ -188,6 +188,7 @@ exports[`Exercise Tasks Screen matches snapshot 1`] = `
         "due_at": 2017-10-17T12:00:00.000Z,
         "feedback_at": undefined,
         "id": 1,
+        "isLoading": false,
         "is_deleted": undefined,
         "spy": Object {},
         "steps": Array [
@@ -515,6 +516,7 @@ exports[`Exercise Tasks Screen matches snapshot 1`] = `
           "due_at": 2017-10-17T12:00:00.000Z,
           "feedback_at": undefined,
           "id": 1,
+          "isLoading": false,
           "is_deleted": undefined,
           "spy": Object {},
           "steps": Array [

--- a/tutor/specs/screens/task/steps/__snapshots__/failure.spec.js.snap
+++ b/tutor/specs/screens/task/steps/__snapshots__/failure.spec.js.snap
@@ -31,6 +31,7 @@ exports[`Task Failure matches snapshot 1`] = `
       "due_at": undefined,
       "feedback_at": undefined,
       "id": 4321,
+      "isLoading": false,
       "is_deleted": undefined,
       "spy": Object {},
       "steps": Array [],

--- a/tutor/specs/screens/task/steps/__snapshots__/nudge-message.spec.js.snap
+++ b/tutor/specs/screens/task/steps/__snapshots__/nudge-message.spec.js.snap
@@ -314,6 +314,7 @@ exports[`Free Response Nudge Messages matches snapshot 1`] = `
         "due_at": 2017-10-17T12:00:00.000Z,
         "feedback_at": undefined,
         "id": 1,
+        "isLoading": false,
         "is_deleted": undefined,
         "spy": Object {},
         "steps": Array [
@@ -653,6 +654,7 @@ exports[`Free Response Nudge Messages matches snapshot 2`] = `
         "due_at": 2017-10-17T12:00:00.000Z,
         "feedback_at": undefined,
         "id": 1,
+        "isLoading": false,
         "is_deleted": undefined,
         "spy": Object {},
         "steps": Array [
@@ -996,6 +998,7 @@ exports[`Free Response Nudge Messages matches snapshot 3`] = `
         "due_at": 2017-10-17T12:00:00.000Z,
         "feedback_at": undefined,
         "id": 1,
+        "isLoading": false,
         "is_deleted": undefined,
         "spy": Object {},
         "steps": Array [
@@ -1339,6 +1342,7 @@ exports[`Free Response Nudge Messages matches snapshot 4`] = `
         "due_at": 2017-10-17T12:00:00.000Z,
         "feedback_at": undefined,
         "id": 1,
+        "isLoading": false,
         "is_deleted": undefined,
         "spy": Object {},
         "steps": Array [
@@ -1682,6 +1686,7 @@ exports[`Free Response Nudge Messages matches snapshot 5`] = `
         "due_at": 2017-10-17T12:00:00.000Z,
         "feedback_at": undefined,
         "id": 1,
+        "isLoading": false,
         "is_deleted": undefined,
         "spy": Object {},
         "steps": Array [

--- a/tutor/src/screens/task/index.js
+++ b/tutor/src/screens/task/index.js
@@ -99,7 +99,7 @@ class TaskGetter extends React.Component {
   constructor(props) {
     super(props);
     if (!this.task.api.isFetchedOrFetching) {
-      this.task.fetch();
+      this.task.load();
     }
   }
 
@@ -113,7 +113,7 @@ class TaskGetter extends React.Component {
       return <Failure task={task} />;
     }
 
-    if (!task.api.hasBeenFetched) {
+    if (!task.isLoaded) {
       return <StepCard><PendingLoad /></StepCard>;
     }
 


### PR DESCRIPTION
This moves the wait for practice tasks from the BE to the FE so the unicorn workers don't stay busy while waiting.

Goes with https://github.com/openstax/tutor-server/pull/1970