### PR TITLE
add indicators to questions step footer

### DIFF
--- a/tutor/specs/integration/assignments.spec.js
+++ b/tutor/specs/integration/assignments.spec.js
@@ -48,7 +48,7 @@ context('Dashboard', () => {
 
   });
 
-  it('increases and decreases selections', () => {
+  it('increases selections', () => {
     cy.visit('/course/2/assignment/homework/new')
     cy.disableTours()
     fillDetails()
@@ -62,20 +62,6 @@ context('Dashboard', () => {
 
     cy.get('[data-test-id="selection-count"]').should('contain.text', '1')
     cy.get('[data-test-id="selection-count-footer"]').should('contain.text', '1')
-    cy.get('[data-test-id="tutor-count"]').should('contain.text', '3')
-    cy.get('[data-test-id="tutor-count-footer"]').should('contain.text', '3')
-    cy.get('[data-test-id="total-count"]').should('contain.text', '4')
-    cy.get('[data-test-id="total-count-footer"]').should('contain.text', '4')
-
-    cy.get('[data-test-id="increase-button').click()
-
-    cy.get('[data-test-id="tutor-count"]').should('contain.text', '4')
-    cy.get('[data-test-id="tutor-count-footer"]').should('contain.text', '4')
-    cy.get('[data-test-id="total-count"]').should('contain.text', '5')
-    cy.get('[data-test-id="total-count-footer"]').should('contain.text', '5')
-
-    cy.get('[data-test-id="decrease-button').click()
-
     cy.get('[data-test-id="tutor-count"]').should('contain.text', '3')
     cy.get('[data-test-id="tutor-count-footer"]').should('contain.text', '3')
     cy.get('[data-test-id="total-count"]').should('contain.text', '4')

--- a/tutor/specs/integration/assignments.spec.js
+++ b/tutor/specs/integration/assignments.spec.js
@@ -48,4 +48,38 @@ context('Dashboard', () => {
 
   });
 
+  it('increases and decreases selections', () => {
+    cy.visit('/course/2/assignment/homework/new')
+    cy.disableTours()
+    fillDetails()
+    cy.get('.controls .btn-primary').click()
+    cy.get('.chapter-checkbox .btn').first().click()
+    cy.get('.controls .btn-primary').click()
+    cy.get('[data-test-id="selection-count"]').should('contain.text', '0')
+    cy.get('[data-test-id="selection-count-footer"]').should('contain.text', '0')
+
+    cy.get('.action.include:first').click({ force: true })
+
+    cy.get('[data-test-id="selection-count"]').should('contain.text', '1')
+    cy.get('[data-test-id="selection-count-footer"]').should('contain.text', '1')
+    cy.get('[data-test-id="tutor-count"]').should('contain.text', '3')
+    cy.get('[data-test-id="tutor-count-footer"]').should('contain.text', '3')
+    cy.get('[data-test-id="total-count"]').should('contain.text', '4')
+    cy.get('[data-test-id="total-count-footer"]').should('contain.text', '4')
+
+    cy.get('[data-test-id="increase-button').click()
+
+    cy.get('[data-test-id="tutor-count"]').should('contain.text', '4')
+    cy.get('[data-test-id="tutor-count-footer"]').should('contain.text', '4')
+    cy.get('[data-test-id="total-count"]').should('contain.text', '5')
+    cy.get('[data-test-id="total-count-footer"]').should('contain.text', '5')
+
+    cy.get('[data-test-id="decrease-button').click()
+
+    cy.get('[data-test-id="tutor-count"]').should('contain.text', '3')
+    cy.get('[data-test-id="tutor-count-footer"]').should('contain.text', '3')
+    cy.get('[data-test-id="total-count"]').should('contain.text', '4')
+    cy.get('[data-test-id="total-count-footer"]').should('contain.text', '4')
+  });
+
 });

--- a/tutor/src/screens/assignments/builder.js
+++ b/tutor/src/screens/assignments/builder.js
@@ -99,7 +99,7 @@ TextInput.propTypes = {
   name: PropTypes.string.isRequired,
 };
 
-const AssignmentBuilder = observer(({ ux, children, title }) => {
+const AssignmentBuilder = observer(({ ux, children, title, middleControls }) => {
   return (
     <ScrollToTop>
       <FormWrapper>
@@ -113,7 +113,7 @@ const AssignmentBuilder = observer(({ ux, children, title }) => {
           {children}
         </BodyWrapper>
       </FormWrapper>
-      <Controls ux={ux} />
+      <Controls ux={ux} middleControls={middleControls} />
     </ScrollToTop>
   );
 });
@@ -122,6 +122,7 @@ AssignmentBuilder.propTypes = {
   ux: PropTypes.object.isRequired,
   children: PropTypes.node.isRequired,
   title: PropTypes.string.isRequired,
+  middleControls: PropTypes.node,
 };
 
 export { AssignmentBuilder, Row, SplitRow, HintText, Label, TextInput, Setting, Body };

--- a/tutor/src/screens/assignments/controls.js
+++ b/tutor/src/screens/assignments/controls.js
@@ -12,6 +12,10 @@ const Footer = styled.div`
   padding: .8rem 2.4rem;
   background: ${colors.neutral.bright};
   box-shadow: 0 -1px 2px rgba(0,0,0,0.19);
+
+  .btn, .btn.btn-plain {
+    padding: 0.6rem 2rem;
+  }
 `;
 
 const FooterInner = styled.div`
@@ -20,7 +24,7 @@ const FooterInner = styled.div`
   display: flex;
 `;
 
-const Spacer = styled.div`
+const Middle = styled.div`
   flex: 1;
 `;
 
@@ -28,24 +32,19 @@ const LeftButton = styled(Button).attrs({
   variant: 'plain',
 })`
   &.btn.btn-plain {
-    background-color: ${colors.neutral.white};
+    background: #fff;
     color: ${colors.neutral.dark};
     border: 1px solid ${colors.neutral.pale};
-    padding: 1rem 2rem;
     min-width: 10rem;
   }
 `;
 
-const PrimaryButton = styled(Button).attrs({
-  variant: 'primary',
-})`
-  &.btn {
-    padding: 1rem 2rem;
-  }
+const RightButton = styled(Button)`
+  min-width: 16rem;
 `;
 
 
-const Controls = observer(({ ux: {
+const Controls = observer(({ middleControls, ux: {
   onPublishClick, onSaveAsDraftClick, onCancel, steps: {
     isFirst, isLast, goForward, goBackward, canGoForward,
   } } }) => {
@@ -54,12 +53,12 @@ const Controls = observer(({ ux: {
 
   if (isLast) {
     rightButtons = [
-      <Button key="draft" variant="secondary" onClick={onSaveAsDraftClick}>Save as Draft</Button>,
-      <PrimaryButton key="publish" onClick={onPublishClick}>Publish</PrimaryButton>,
+      <RightButton key="draft" variant="secondary" onClick={onSaveAsDraftClick}>Save as Draft</RightButton>,
+      <RightButton key="publish" variant="primary" onClick={onPublishClick}>Publish</RightButton>,
     ];
   } else {
     rightButtons = [
-      <PrimaryButton key="forward" disabled={!canGoForward} onClick={goForward}>Save & Continue</PrimaryButton>,
+      <RightButton key="forward" variant="primary" disabled={!canGoForward} onClick={goForward}>Save & Continue</RightButton>,
     ];
   }
 
@@ -69,7 +68,9 @@ const Controls = observer(({ ux: {
         <LeftButton onClick={isFirst ? onCancel : goBackward}>
           {isFirst ? 'Cancel' : 'Back'}
         </LeftButton>
-        <Spacer />
+        <Middle>
+          {middleControls}
+        </Middle>
         {rightButtons}
       </FooterInner>
     </Footer>

--- a/tutor/src/screens/assignments/homework/exercise-controls.jsx
+++ b/tutor/src/screens/assignments/homework/exercise-controls.jsx
@@ -185,6 +185,7 @@ class ExerciseControls extends React.Component {
         disabled={!ux.canIncreaseTutorExercises}
         onClick={ux.increaseTutorSelection}
         variant="plain"
+        data-test-id="increase-button"
       >
         <Icon
           type="plus"
@@ -202,6 +203,7 @@ class ExerciseControls extends React.Component {
         disabled={!ux.canDecreaseTutorExercises}
         onClick={ux.decreaseTutorSelection}
         variant="plain"
+        data-test-id="decrease-button"
       >
         <Icon
           type="minus"
@@ -212,7 +214,7 @@ class ExerciseControls extends React.Component {
   }
 
   render() {
-    const { ux: { numExerciseSteps, numTutorSelections } } = this.props;
+    const { ux: { numExerciseSteps, numTutorSelections, totalSelections } } = this.props;
 
     return (
       <Wrapper>
@@ -229,7 +231,7 @@ class ExerciseControls extends React.Component {
                 <Columns>
                   <Counter>
                     <Title>MCQs</Title>
-                    {numExerciseSteps}
+                    <span data-test-id="selection-count">{numExerciseSteps}</span>
                   </Counter>
                   <Counter variant="plus">
                     +
@@ -247,7 +249,7 @@ class ExerciseControls extends React.Component {
                     <SelectionsTooltip />
                     <Columns>
                       {this.renderDecreaseButton()}
-                      <Counter>
+                      <Counter data-test-id="tutor-count">
                         {numTutorSelections}
                       </Counter>
                       {this.renderIncreaseButton()}
@@ -257,8 +259,8 @@ class ExerciseControls extends React.Component {
               </Indicator>
               <Indicator>
                 Total
-                <Counter>
-                  {numExerciseSteps + numTutorSelections}
+                <Counter data-test-id="total-count">
+                  {totalSelections}
                 </Counter>
               </Indicator>
               {this.renderExplanation()}

--- a/tutor/src/screens/assignments/questions.js
+++ b/tutor/src/screens/assignments/questions.js
@@ -1,7 +1,67 @@
-import { React, PropTypes } from 'vendor';
+import { React, PropTypes, observer, styled } from 'vendor';
 import { AssignmentBuilder } from './builder';
 import ChooseExercises from './homework/choose-exercises';
 import sharedExercises from '../../models/exercises';
+import { colors } from '../../theme';
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`;
+
+const Item = styled.div`
+  display: flex;
+  padding: 1rem 2.5rem;
+
+  &:not(:last-child) {
+    border-right: 1px solid ${colors.neutral.pale};
+  }
+`;
+
+const Value = styled.div`
+  font-size: 1.8rem;
+  font-weight: bold;
+  margin-left: 1rem;
+`;
+
+const Indicator = ({ title, value, testId }) => {
+  return (
+    <Item>
+      <span>{title}</span>
+      <Value data-test-id={testId}>{value}</Value>
+    </Item>
+  );
+};
+
+Indicator.propTypes = {
+  title: PropTypes.string.isRequired,
+  value: PropTypes.number.isRequired,
+  testId: PropTypes.string,
+};
+
+const Indicators = observer(({ ux }) => {
+  return (
+    <Wrapper>
+      <Indicator
+        title="My selections"
+        value={ux.numExerciseSteps}
+        testId="selection-count-footer"
+      />
+      <Indicator
+        title="OpenStax Tutor selections"
+        value={ux.numTutorSelections}
+        testId="tutor-count-footer"
+      />
+      <Indicator
+        title="Total"
+        value={ux.totalSelections}
+        testId="total-count-footer"
+      />
+    </Wrapper>
+  );
+});
 
 const Questions = ({ ux }) => {
 
@@ -9,6 +69,7 @@ const Questions = ({ ux }) => {
     <AssignmentBuilder
       title="Select Questions"
       ux={ux}
+      middleControls={<Indicators ux={ux} />}
     >
       <ChooseExercises
         ux={ux}

--- a/tutor/src/screens/assignments/ux.js
+++ b/tutor/src/screens/assignments/ux.js
@@ -218,6 +218,10 @@ export default class AssignmentUX {
     );
   }
 
+  @computed get totalSelections() {
+    return this.numExerciseSteps + this.numTutorSelections;
+  }
+
   @computed get gradingTemplate() {
     return (
       this.course.gradingTemplates.array.find(t => t.id == this.form.values.grading_template_id)


### PR DESCRIPTION
Adds the indicators from the top toolbar into the footer toolbar, and makes the buttons match the specs.

![image](https://user-images.githubusercontent.com/34174/73990404-da066780-48fd-11ea-97f6-e7ff0f318ed5.png)

![image](https://user-images.githubusercontent.com/34174/73990417-e68ac000-48fd-11ea-8d5c-09529702cd5b.png)
