### PR TITLE
Put exercise questions back into columns

### DIFF
--- a/tutor/src/screens/assignments/homework/add-exercises.jsx
+++ b/tutor/src/screens/assignments/homework/add-exercises.jsx
@@ -6,10 +6,38 @@ import ExerciseDetails from '../../../components/exercises/details';
 import ExerciseCards from '../../../components/exercises/cards';
 import TourRegion from '../../../components/tours/region';
 import { Body } from '../builder';
-import { colors } from '../../../theme';
+import { colors, breakpoints } from '../../../theme';
 
 const StyledBody = styled(Body)`
   background: ${colors.neutral.lighter};
+
+  .exercise-sections:not(:first-child) {
+    padding-top: 5rem;
+  }
+
+  .exercises {
+    column-width: 45rem;
+  }
+
+  @media ${breakpoints.mdUp} {
+    .card {
+      margin: 5px;
+    }
+  }
+
+  .exercise-card {
+    page-break-inside: avoid;
+    break-inside: avoid;
+    display: inline-block;
+    width: 100%;
+
+    .selected-mask {
+      background-color: ${colors.exercises.selected};
+    }
+    .controls-overlay {
+      background-color: ${colors.exercises.hovered};
+    }
+  }
 `;
 
 @observer

--- a/tutor/src/theme.js
+++ b/tutor/src/theme.js
@@ -30,6 +30,7 @@ const colorDefinitions = {
   warning:       '#f4d019', // yellow
   danger:        '#c2002f', // dark red
   teal:          '#0C9372',
+  highlight:     '#d2f7fc', // light blue
 };
 
 const tasks = {
@@ -95,6 +96,11 @@ export const colors = {
       border: neutral.dark,
     },
   },
+
+  exercises: {
+    selected: colorDefinitions.highlight,
+    hovered:  'rgba(241, 241, 241, 0.4)',
+  },
 };
 
 export const fonts = {
@@ -124,6 +130,17 @@ export const navbars = {
   bottom: {
     height: '50px',
   },
+};
+
+export const breakpoints = {
+  xsDown: '(max-width: 575.98px)',
+  smDown: '(max-width: 767.98px)',
+  mdDown: '(max-width: 991.98px)',
+  lgDown: '(max-width: 1199.98px)',
+  smUp: '(min-width: 576px)',
+  mdUp: '(min-width: 768px)',
+  lgUp: '(min-width: 992px)',
+  xlUp: '(min-width: 1200px)',
 };
 
 const TutorTheme = {


### PR DESCRIPTION
I pulled over styles from the sass files into styled components — after the switch, we could eventually apply them directly to the exercise card components, but for now it uses the descendant class names. A little fragile but keeps from cloning the card component classes.

Also copied Bootstrap v4's default breakpoints into Theme to maintain an existing margin rule & set it up for future use.

![image](https://user-images.githubusercontent.com/34174/74074582-9d04a880-49c3-11ea-9896-b25ec9472b66.png)

![image](https://user-images.githubusercontent.com/34174/74074592-a55ce380-49c3-11ea-923a-8354639dca80.png)
