### PR TITLE
Hook up question type filters

### DIFF
--- a/shared/specs/factories/exercise.js
+++ b/shared/specs/factories/exercise.js
@@ -114,6 +114,28 @@ Factory.define('ExerciseQuestion')
   ])
   .community_solutions(() => []);
 
+Factory.define('OpenEndedExerciseQuestion')
+  .id(sequence)
+  .is_answer_order_important(false)
+  .stimulus_html(({ object }) => [][object.id % 1])
+  .stem_html(({ object }) => [
+    'In the context of cell biology, what do we mean by "form follows function?" What are at least two examples of this concept?',
+  ][ object.id % 1 ])
+  .answers(() => [])
+  .hints(() => [])
+  .formats(() => [
+    'free-response',
+  ])
+  .combo_choices(() => [])
+  .collaborator_solutions(() => [
+    {
+      'attachments': [],
+      'solution_type': 'detailed',
+      'content_html': 'four',
+    },
+  ])
+  .community_solutions(() => []);
+
 Factory.define('Exercise')
   .tags([
     'type:conceptual',
@@ -140,3 +162,29 @@ Factory.define('Exercise')
   .questions(reference('ExerciseQuestion', { count: ({ multipart }) => multipart ? 3: 1 }) )
   .versions(({ object }) => [object.version])
   .attachments(reference('ExerciseAttachment', { count: 2 }));
+
+Factory.define('OpenEndedExercise')
+  .tags([
+    'type:conceptual',
+    'requires-context:true',
+    'filter-type:test-prep',
+    'blooms:4',
+    'time:medium',
+    'dok:3',
+    'lo:stax-phys:1-2-1',
+    'book:stax-phys',
+    'context-cnxmod:',
+    'context-cnxfeature:one-1',
+  ])
+  .nickname(fake.internet.domainWord)
+  .uuid(uuid)
+  .group_uuid(uuid)
+  .number(sequence)
+  .version(1)
+  .uid(({ object }) => `${object.number}@${object.version}`)
+  .authors(reference('ExerciseUser', { count: 1 }))
+  .copyright_holders(reference('ExerciseUser', { count: 1 }))
+  .derived_from(() => [])
+  .is_vocab(false)
+  .questions(reference('OpenEndedExerciseQuestion', { count: ({ multipart }) => multipart ? 3: 1 }) )
+  .versions(({ object }) => [object.version]);

--- a/tutor/scripts/test-server/backend/exercises.js
+++ b/tutor/scripts/test-server/backend/exercises.js
@@ -1,5 +1,5 @@
 const Factory = require('object-factory-bot');
-const { partial, find, range, flatMap } = require('lodash');
+const { partial, find, range, flatMap, concat } = require('lodash');
 const Readings = require('./readings');
 require('../../../specs/factories/exercise');
 
@@ -28,9 +28,14 @@ module.exports = {
       const pg = findPage(pgId, book);
       // eslint-disable-next-line
       if (!pg){ console.warn(`Unable to find page id ${pgId} in book id ${req.params.ecosystemId}`); }
-      return range(8).map(() => Factory.create('TutorExercise', {
-        page_uuid: pg ? pg.uuid : undefined,
-      }));
+      return concat(
+        range(8).map(() => Factory.create('TutorExercise', {
+          page_uuid: pg ? pg.uuid : undefined,
+        })),
+        range(4).map(() => Factory.create('OpenEndedTutorExercise', {
+          page_uuid: pg ? pg.uuid : undefined,
+        })),
+      );
     });
     res.json({
       total_count: exercises.length,

--- a/tutor/specs/factories/exercise.js
+++ b/tutor/specs/factories/exercise.js
@@ -21,3 +21,21 @@ Factory.define('TutorExercise')
     `https://exercises.openstax.org/exercises/${object.content.uid}`
   )
   .question_stats(() => []);
+
+Factory.define('OpenEndedTutorExercise')
+  .id(sequence)
+  .content(reference('OpenEndedExercise'))
+  .has_interactive(() => fake.random.arrayElement([true, false, false, false]))
+  .has_video(() => fake.random.arrayElement([true, false, false]))
+  .is_excluded(false)
+  .page_uuid(uuid)
+  .pool_types(() => [
+    fake.random.arrayElement(['homework_core', 'reading_dynamic' ]),
+  ])
+  .tags(({ object }) =>
+    object.content.tags.map(t => ({ id: t, type: first(t.split(':')), is_visible: true })),
+  )
+  .url(({ object }) =>
+    `https://exercises.openstax.org/exercises/${object.content.uid}`
+  )
+  .question_stats(() => []);

--- a/tutor/specs/integration/assignments.spec.js
+++ b/tutor/specs/integration/assignments.spec.js
@@ -16,6 +16,7 @@ context('Dashboard', () => {
     cy.get('.heading').should('contain.text', 'STEP 2')
     cy.get('.controls .btn-primary').should('be.disabled')
     cy.get('.chapter[data-is-expanded="false"]').first().click()
+    cy.get('[data-chapter-section="2.1"]').click();
     cy.get('[data-chapter-section="2.2"]').click();
     cy.get('.controls .btn-primary').should('not.be.disabled')
 
@@ -75,6 +76,19 @@ context('Dashboard', () => {
     cy.get('[data-test-id="tutor-count-footer"]').should('contain.text', '3')
     cy.get('[data-test-id="total-count"]').should('contain.text', '4')
     cy.get('[data-test-id="total-count-footer"]').should('contain.text', '4')
+  });
+
+  it('filters question types', () => {
+    cy.visit('/course/2/assignment/homework/new')
+    cy.disableTours()
+    fillDetails()
+    cy.get('.controls .btn-primary').click()
+    cy.get('.chapter-checkbox .btn').first().click()
+    cy.get('.controls .btn-primary').click()
+    cy.get('[name="filter"][value="oe"]').click({ force: true })
+    cy.get('[data-section]').should('not.contain.text', 'Multiple Choice Questions')
+    cy.get('[name="filter"][value="mc"]').click({ force: true })
+    cy.get('[data-section]').should('not.contain.text', 'Written Response Questions')
   });
 
 });

--- a/tutor/src/screens/assignments/homework/add-exercises.jsx
+++ b/tutor/src/screens/assignments/homework/add-exercises.jsx
@@ -3,41 +3,13 @@ import Loading from 'shared/components/loading-animation';
 import ExerciseHelpers from '../../../helpers/exercise';
 import ExerciseControls from './exercise-controls';
 import ExerciseDetails from '../../../components/exercises/details';
-import ExerciseCards from '../../../components/exercises/cards';
+import ExerciseCards from './cards';
 import TourRegion from '../../../components/tours/region';
 import { Body } from '../builder';
-import { colors, breakpoints } from '../../../theme';
+import { colors } from '../../../theme';
 
 const StyledBody = styled(Body)`
   background: ${colors.neutral.lighter};
-
-  .exercise-sections:not(:first-child) {
-    padding-top: 5rem;
-  }
-
-  .exercises {
-    column-width: 45rem;
-  }
-
-  @media ${breakpoints.mdUp} {
-    .card {
-      margin: 5px;
-    }
-  }
-
-  .exercise-card {
-    page-break-inside: avoid;
-    break-inside: avoid;
-    display: inline-block;
-    width: 100%;
-
-    .selected-mask {
-      background-color: ${colors.exercises.selected};
-    }
-    .controls-overlay {
-      background-color: ${colors.exercises.hovered};
-    }
-  }
 `;
 
 @observer
@@ -168,7 +140,9 @@ class AddExercises extends React.Component {
           {...sharedProps}
           topScrollOffset={110}
           focusedExercise={this.focusedExercise}
-          onShowDetailsViewClick={this.onShowDetailsViewClick} />
+          onShowDetailsViewClick={this.onShowDetailsViewClick}
+          filter={ux.activeFilter}
+        />
       );
     }
 

--- a/tutor/src/screens/assignments/homework/cards.js
+++ b/tutor/src/screens/assignments/homework/cards.js
@@ -1,0 +1,222 @@
+import {
+  React, PropTypes, observer, ArrayOrMobxType, styled, computed,
+} from 'vendor';
+import { map, isEmpty } from 'lodash';
+import ChapterSection from '../../../components/chapter-section';
+import ExercisePreview from '../../../components/exercises/preview';
+import BookPartTitle from '../../../components/book-part-title';
+import ScrollTo from '../../../helpers/scroll-to';
+import { ExercisesMap } from '../../../models/exercises';
+import Exercise from '../../../models/exercises/exercise';
+import Book from '../../../models/reference-book';
+import NoExercisesFound from '../../../components/exercises/no-exercises-found';
+import { colors, breakpoints } from '../../../theme';
+
+const Wrapper = styled.div`
+  &:not(:first-child) {
+    padding-top: 5rem;
+  }
+
+  @media ${breakpoints.mdUp} {
+    .card {
+      margin: 5px;
+    }
+  }
+
+  .exercise-card {
+    page-break-inside: avoid;
+    break-inside: avoid;
+    display: inline-block;
+    width: 100%;
+
+    .selected-mask {
+      background-color: ${colors.exercises.selected};
+    }
+    .controls-overlay {
+      background-color: ${colors.exercises.hovered};
+    }
+  }
+`;
+
+const Columns = styled.div`
+  column-width: 45rem;
+
+  @media ${breakpoints.mdUp} {
+    margin-left: -0.5rem;
+  }
+
+  padding-bottom: 1.6rem;
+`;
+
+const SectionLabel = styled.label`
+  font-size: 2.8rem;
+  font-weight: bold;
+  line-height: 3.5rem;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: baseline;
+  margin: 1.6rem 0;
+`;
+
+const Title = styled.div`
+  font-size: 1.8rem;
+  font-weight: bold;
+  margin-right: 1.6rem;
+`;
+
+const HintText = styled.div`
+  color: ${colors.neutral.thin}
+`;
+
+const Exercises = observer(({ id, exercises, title, hintText, ...previewProps }) => {
+  if (isEmpty(exercises)) { return null; }
+
+  return (
+    <div key={id}>
+      <Header>
+        <Title>{title}</Title>
+        <HintText>{hintText}</HintText>
+      </Header>
+      <Columns>
+        {map(exercises, (exercise) =>
+          <ExercisePreview key={exercise.id} {...previewProps} exercise={exercise} />)}
+      </Columns>
+    </div>
+  );
+});
+
+Exercises.propTypes = {
+  id: PropTypes.string,
+  exercises: PropTypes.array,
+  title: PropTypes.string.isRequired,
+  hintText: PropTypes.string.isRequired,
+};
+
+@observer
+class SectionsExercises extends React.Component {
+  static propTypes = {
+    pageId:                 PropTypes.string.isRequired,
+    book:                   PropTypes.instanceOf(Book).isRequired,
+    exercises:              PropTypes.instanceOf(ExercisesMap).isRequired,
+    onShowDetailsViewClick: PropTypes.func.isRequired,
+    onExerciseToggle:       PropTypes.func.isRequired,
+    getExerciseIsSelected:  PropTypes.func.isRequired,
+    getExerciseActions:     PropTypes.func.isRequired,
+    filter:                 PropTypes.string,
+  };
+
+  @computed get showMultipleChoice() {
+    return this.props.filter != 'oe';
+  }
+
+  @computed get showOpenEnded() {
+    return this.props.filter != 'mc';
+  }
+
+  render() {
+    const { pageId, book, exercises, ...previewProps } = this.props;
+    const page = book.pages.byId.get(pageId);
+    const pageExercises = exercises.byPageId[pageId];
+    if (isEmpty(pageExercises)) { return null; }
+
+    let mcExercises, oeExercises = [];
+
+    if (this.showMultipleChoice) {
+      mcExercises = pageExercises.filter(e => e.content.questions[0].isMultipleChoice);
+    }
+
+    if (this.showOpenEnded) {
+      oeExercises = pageExercises.filter(e => e.content.questions[0].isOpenEnded);
+    }
+
+    if (isEmpty(mcExercises) && isEmpty(oeExercises)) { return null; }
+
+    // IMPORTANT: the 'data-section' attribute is used as a scroll-to target and must be present
+    return (
+      <Wrapper data-section={page.chapter_section.asString}>
+        <SectionLabel>
+          <ChapterSection chapterSection={page.chapter_section} />
+          {' '}
+          <BookPartTitle title={page.title} />
+        </SectionLabel>
+        <Exercises
+          title="Multiple Choice Questions"
+          hintText="(MCQs are auto-graded by Tutor)"
+          exercises={mcExercises}
+          id={`mc-${pageId}`}
+          {...previewProps}
+        />
+        <Exercises
+          title="Written Response Questions"
+          hintText="(WRQs have to be manually graded by the teacher)"
+          exercises={oeExercises}
+          id={`oe-${pageId}`}
+          {...previewProps}
+        />
+      </Wrapper>
+    );
+  }
+}
+
+
+export default
+@observer
+class ExerciseCards extends React.Component {
+
+  static propTypes = {
+    pageIds:                ArrayOrMobxType.isRequired,
+    book:                   PropTypes.instanceOf(Book).isRequired,
+    exercises:              PropTypes.instanceOf(ExercisesMap).isRequired,
+    onExerciseToggle:       PropTypes.func.isRequired,
+    getExerciseIsSelected:  PropTypes.func.isRequired,
+    getExerciseActions:     PropTypes.func.isRequired,
+    onShowDetailsViewClick: PropTypes.func.isRequired,
+    focusedExercise:        PropTypes.instanceOf(Exercise),
+    topScrollOffset:        PropTypes.number,
+    windowImpl:             PropTypes.object,
+  };
+
+  static defaultProps = {
+    topScrollOffset: 110,
+  };
+
+  scroller = new ScrollTo({
+    windowImpl: this.props.windowImpl,
+    onAfterScroll: this.onAfterScroll,
+  });
+
+  componentDidMount() {
+    if (this.props.focusedExercise) {
+      this.scroller.scrollToSelector(`[data-exercise-id="${this.props.focusedExercise.content.uid}"]`, { immediate: true });
+    } else {
+      this.scroller.scrollToSelector('[data-section]');
+    }
+  }
+
+  onAfterScroll = (el) => {
+    if (this.props.focusedExercise) { el.focus(); }
+  }
+
+  render() {
+    const { pageIds, exercises, ...sectionProps } = this.props;
+
+    if (exercises.noneForPageIds(pageIds)) {
+      return <NoExercisesFound />;
+    }
+
+    let sections = map(pageIds, pageId => (
+      <SectionsExercises
+        key={pageId}
+        exercises={exercises}
+        pageId={pageId}
+        {...sectionProps}
+      />
+    ));
+
+    return (
+      <div className="exercise-cards">{sections}</div>
+    );
+  }
+}

--- a/tutor/src/screens/assignments/homework/exercise-controls.jsx
+++ b/tutor/src/screens/assignments/homework/exercise-controls.jsx
@@ -214,7 +214,7 @@ class ExerciseControls extends React.Component {
   }
 
   render() {
-    const { ux: { numExerciseSteps, numTutorSelections, totalSelections } } = this.props;
+    const { ux, ux: { numExerciseSteps, numTutorSelections, totalSelections } } = this.props;
 
     return (
       <Wrapper>
@@ -269,10 +269,15 @@ class ExerciseControls extends React.Component {
         </Columns>
         <Filter>
           <strong>Filter</strong>
-          <ToggleButtonGroup type="radio" name="options" defaultValue={1}>
-            <StyledToggleButton variant="plain" value={1}>All questions</StyledToggleButton>
-            <StyledToggleButton variant="plain" value={2}>Multiple-choice questions only</StyledToggleButton>
-            <StyledToggleButton variant="plain" value={3}>Written-response questions only</StyledToggleButton>
+          <ToggleButtonGroup
+            type="radio"
+            name="filter"
+            value={ux.activeFilter}
+            onChange={ux.onChangeFilter}
+          >
+            <StyledToggleButton variant="plain" value="all">All questions</StyledToggleButton>
+            <StyledToggleButton variant="plain" value="mc">Multiple-choice questions only</StyledToggleButton>
+            <StyledToggleButton variant="plain" value="oe">Written-response questions only</StyledToggleButton>
           </ToggleButtonGroup>
         </Filter>
       </Wrapper>

--- a/tutor/src/screens/assignments/ux.js
+++ b/tutor/src/screens/assignments/ux.js
@@ -19,6 +19,7 @@ export default class AssignmentUX {
   @observable isReady = false;
   @observable sourcePlanId;
   @observable form;
+  @observable activeFilter = 'all';
 
   constructor(attrs = null) {
     if (attrs) { this.initialize(attrs); }
@@ -307,6 +308,10 @@ export default class AssignmentUX {
       const destPlan = this.course.teacherTaskPlans.withPlanId(this.plan.id);
       destPlan.update(this.plan.serialize());
     });
+  }
+
+  @action.bound onChangeFilter(value) {
+    this.activeFilter = value;
   }
 
 }


### PR DESCRIPTION
Adds filtering for All / Multiple Choice / Written Response (Open Ended) question types to the assignment builder.

Due to multipart questions, the only reliable method I could find was to check the type of the first question in the list. As far as I can tell, it's not likely a multipart will ever contain mixed types, but if there's a better way let me know.

Example of narrowing it down to WR only:
![image](https://user-images.githubusercontent.com/34174/74304064-bdf53280-4d10-11ea-9719-8850bda5fdbb.png)

With All or Multiple Choice selected, you'll always see MC at the top:
![image](https://user-images.githubusercontent.com/34174/74303885-2ee81a80-4d10-11ea-9e05-2f8dca8a39e6.png)
