### PR TITLE
Add custom checkbox and tweaks to details page

### DIFF
--- a/tutor/specs/components/__snapshots__/checkbox-input.spec.js.snap
+++ b/tutor/specs/components/__snapshots__/checkbox-input.spec.js.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckboxInput matches snapshot 1`] = `
+.c2 {
+  margin-right: 0.5rem;
+  margin-left: 0.5rem;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c1 {
+  opacity: 0;
+}
+
+.c1 + label {
+  margin-left: 1rem;
+}
+
+.c1.c1 + label svg {
+  border: 0;
+  content: "";
+  left: 0;
+  top: 0;
+  margin: 0;
+  position: absolute;
+  height: 1.6rem;
+  width: 1.6rem;
+}
+
+.c1:focus + label svg {
+  box-shadow: 0 0 4px 0 rgba(13,192,220,0.5);
+}
+
+<span
+  className="c0"
+>
+  <input
+    checked={false}
+    className="c1"
+    id="input_1"
+    label="Input 1"
+    name="input_1"
+    onBlur={[Function]}
+    onChange={[Function]}
+    type="checkbox"
+  />
+  <label
+    htmlFor="input_1"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-square fa-w-14 fa-lg ox-icon ox-icon-square c2"
+      color="#5E6062"
+      data-icon="square"
+      data-prefix="far"
+      data-variant="checkSquare"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zm-6 400H54c-3.3 0-6-2.7-6-6V86c0-3.3 2.7-6 6-6h340c3.3 0 6 2.7 6 6v340c0 3.3-2.7 6-6 6z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Input 1
+  </label>
+</span>
+`;

--- a/tutor/specs/components/checkbox-input.spec.js
+++ b/tutor/specs/components/checkbox-input.spec.js
@@ -1,0 +1,18 @@
+import CheckboxInput from '../../src/components/checkbox-input';
+import { Formik as F } from 'formik';
+
+describe('CheckboxInput', () => {
+  let props;
+
+  beforeEach(() => {
+    props = {
+      name: 'input_1',
+      label: 'Input 1',
+      id: 'input_1',
+    };
+  });
+
+  it('matches snapshot', () => {
+    expect.snapshot(<F><CheckboxInput {...props} /></F>).toMatchSnapshot();
+  });
+});

--- a/tutor/src/components/checkbox-input.js
+++ b/tutor/src/components/checkbox-input.js
@@ -1,0 +1,61 @@
+import { React, PropTypes, observer, styled } from 'vendor';
+import Theme from '../theme';
+import { uniqueId } from 'lodash';
+import { useField } from 'formik';
+import { Icon } from 'shared';
+
+const StyledWrapper = styled.span`
+  position: relative;
+`;
+
+const StyledCheckboxInput = styled.input.attrs( () => ({
+  type: 'checkbox',
+}))`
+  opacity: 0;
+
+  & + label {
+    margin-left: 1rem;
+    ${props => props.labelSize === 'lg' && 'font-size: 1.6rem;'}
+  }
+
+  && + label svg {
+    border: 0;
+    content: "";
+    left: 0;
+    top: 0;
+    margin: 0;
+    position: absolute;
+    height: 1.6rem;
+    width: 1.6rem;
+  }
+
+  &:focus + label svg {
+    box-shadow: 0 0 4px 0 ${Theme.colors.forms.borders.focusShadow};
+  }
+`;
+
+const CheckboxInput = observer((props) => {
+  const [field] = useField({ type: 'checkbox', ...props });
+  const id = props.id || uniqueId(props.name);
+
+  return (
+    <StyledWrapper>
+      <StyledCheckboxInput
+        {...field}
+        {...props}
+        id={id}
+      />
+      <label htmlFor={id}>
+        <Icon variant={props.checked ? 'checkedSquare' : 'checkSquare'} size="lg" />
+        {props.label}
+      </label>
+    </StyledWrapper>
+  );
+});
+
+CheckboxInput.propTypes = {
+  name: PropTypes.string,
+  labelSize: PropTypes.string,
+};
+
+export default CheckboxInput;

--- a/tutor/src/components/radio-input.jsx
+++ b/tutor/src/components/radio-input.jsx
@@ -14,6 +14,7 @@ const StyledRadioInput = styled.input.attrs( () => ({
 
   & + label {
     margin-left: 1.4rem;
+    ${props => props.labelSize === 'lg' && 'font-size: 1.6rem;'}
   }
 
   & + label::before {
@@ -71,6 +72,7 @@ const RadioInput = observer((props) => {
 
 RadioInput.propTypes = {
   name: PropTypes.string.isRequired,
+  labelSize: PropTypes.string,
 };
 
 export default RadioInput;

--- a/tutor/src/screens/assignments/details.js
+++ b/tutor/src/screens/assignments/details.js
@@ -1,6 +1,6 @@
 import { React, PropTypes, styled, observer } from 'vendor';
 import { isEmpty } from 'lodash';
-import { AssignmentBuilder, SplitRow, Label, HintText, TextInput, Setting, Body } from './builder';
+import { AssignmentBuilder, SplitRow, Label, HintText, TextInput, Body } from './builder';
 import Select from '../../components/select';
 import RadioInput from '../../components/radio-input';
 import PreviewTooltip from './preview-tooltip';
@@ -22,6 +22,18 @@ const FullWidthCol = styled.div`
   flex-basis: auto;
 `;
 
+const SectionRow = styled.div`
+  margin-bottom: 2rem;
+`;
+
+const StyledTextInput = styled(TextInput)`
+  max-width: 48rem;
+`;
+
+const StyledSelect = styled(Select)`
+  min-width: 24rem;
+`;
+
 const Details = observer(({ ux }) => {
   return (
     <AssignmentBuilder
@@ -34,7 +46,7 @@ const Details = observer(({ ux }) => {
             Assignment name
             <HintText>(This will show on the student dashboard)</HintText>
           </RowLabel>
-          <TextInput
+          <StyledTextInput
             name="title"
             validate={isRequired}
           />
@@ -56,9 +68,9 @@ const Details = observer(({ ux }) => {
             <HintText>(Apply a pre-set submission and grading policy template)</HintText>
           </RowLabel>
           <div>
-            <Select name="grading_template_id">
+            <StyledSelect name="grading_template_id">
               {ux.gradingTemplates.map(t => <option key={t.id} value={t.id}>{t.name}</option>)}
-            </Select>
+            </StyledSelect>
             <PreviewTooltip template={ux.gradingTemplate} />
           </div>
         </SplitRow>
@@ -76,27 +88,29 @@ const Details = observer(({ ux }) => {
           </RowLabel>
 
           <FullWidthCol>
-            <Setting>
+            <SectionRow>
               <RadioInput
                 name="assignto"
                 value="all"
                 label="All sections"
+                labelSize="lg"
                 checked={!ux.isShowingPeriodTaskings}
                 onChange={ux.togglePeriodTaskingsEnabled}
               />
               {!ux.isShowingPeriodTaskings && <Tasking ux={ux} />}
-            </Setting>
+            </SectionRow>
 
-            <Setting>
+            <SectionRow>
               <RadioInput
                 name="assignto"
                 value="periods"
                 label="Select sections"
+                labelSize="lg"
                 checked={ux.isShowingPeriodTaskings}
                 onChange={ux.togglePeriodTaskingsEnabled}
               />
               {ux.isShowingPeriodTaskings && ux.course.periods.map(p => <Tasking key={p.id} period={p} ux={ux} />)}
-            </Setting>
+            </SectionRow>
           </FullWidthCol>
         </SplitRow>
 

--- a/tutor/src/screens/assignments/tasking.js
+++ b/tutor/src/screens/assignments/tasking.js
@@ -9,9 +9,11 @@ import { findEarliest, findLatest } from '../../helpers/dates';
 import Time from '../../models/time';
 import DateTime from '../../components/date-time-input';
 import NewTooltip from './new-tooltip';
+import CheckboxInput from '../../components/checkbox-input';
 
-const StyledTasking = styled(Row)`
+const StyledTasking = styled.div`
   min-height: 7rem;
+  margin-top: 0.5rem;
   padding: 0.5rem 0 0 2.7rem;
 
   .react-datepicker-wrapper {
@@ -24,12 +26,10 @@ const StyledCantEditExplanation = styled(Col)`
   font-size: 1.2rem;
 `;
 
-const StyledSelection = styled(Col)`
-  display: flex;
-  align-items: center;
-
-  label {
-    margin-left: 0.5rem;
+const StyledInner = styled.div`
+  &:not([data-period-id="all"]) {
+    margin-top: 0.5rem;
+    padding-left: 2.2rem;
   }
 `;
 
@@ -131,46 +131,39 @@ class Tasking extends React.Component {
     if (!period) { return null; }
 
     return (
-      <StyledSelection sm={4} md={3}>
-        <input
-          id={`period-toggle-${period.id}`}
-          disabled={!plan.isEditable}
-          type="checkbox"
-          data-period-id={period.id}
-          onChange={ux.togglePeriodTasking}
-          checked={!!plan.tasking_plans.forPeriod(period)}
-        />
-        <label className="period" htmlFor={`period-toggle-${period.id}`}>
-          {period.name}
-        </label>
-      </StyledSelection>
+      <CheckboxInput
+        id={`period-toggle-${period.id}`}
+        disabled={!plan.isEditable}
+        label={period.name}
+        labelSize="lg"
+        data-period-id={period.id}
+        checked={!!plan.tasking_plans.forPeriod(period)}
+        onChange={ux.togglePeriodTasking}
+      />
     );
   }
 
   render() {
     const tasking = this.taskings.length ? this.taskings[0] : null;
     const { period } = this.props;
-    const mainSizes = period ? { sm: 8, md: 9 } : { sm: 12 };
     const type = period ? `period-${period.id}` : 'combined';
 
     return (
       <StyledTasking className="tasking">
         {this.renderSelectionCheckbox()}
-        <Col
-          {...mainSizes}
-
+        <StyledInner
           data-tasking-type={type}
           data-period-id={period ? period.id : 'all'}
         >
           {tasking && this.renderDateTimeInputs(tasking, type)}
-        </Col>
+        </StyledInner>
       </StyledTasking>
     );
   }
 
   renderDateTimeInputs(tasking) {
     const index = this.props.ux.plan.tasking_plans.indexOf(tasking);
-    const format = 'MMM D hh:mm a';
+    const format = 'MMM D hh:mm A';
 
     return (
       <Row className="tasking-date-time">


### PR DESCRIPTION
- Adds an orange checkbox (CheckboxInput) that can be used anywhere and should be accessible. 
- Fixes some alignment things with rendering period + date time fields

![image](https://user-images.githubusercontent.com/34174/74578242-588b8680-4f48-11ea-8a21-4d8888d83f4f.png)
