### PR TITLE
Sections sometimes lack ids, use alternate key

### DIFF
--- a/tutor/src/components/book-menu/menu.jsx
+++ b/tutor/src/components/book-menu/menu.jsx
@@ -111,8 +111,8 @@ const Branch = ({ node, ux, ...props }) => {
               </div>
             </Summary>
             <Ol>
-              {map(node.children, child => (
-                <Node key={child.id} {...props} ux={ux} node={child} />
+              {map(node.children, (child, i) => (
+                <Node key={i} {...props} ux={ux} node={child} />
               ))}
             </Ol>
           </Details>
@@ -209,11 +209,11 @@ class BookMenu extends React.Component {
 
     return (
       <StyledMenu ref={this.menuWrapper} className={cn('book-menu', className )}>
-        {map(book.children, child => (
+        {map(book.children, (child, i) => (
           <Node
             ux={this.ux}
             node={child}
-            key={child.id}
+            key={i}
             pageLinkProps={pageLinkProps}
           />
         ))}

--- a/tutor/src/components/sections-chooser.jsx
+++ b/tutor/src/components/sections-chooser.jsx
@@ -150,8 +150,8 @@ class ChapterAccordion extends React.Component {
         </ChapterHeading>
         <Collapse in={this.expanded}>
           <div className="sections">
-            {chapter.children.assignable.map((section) =>
-              <Section key={section.cnx_id} {...this.props} section={section} />)}
+            {chapter.children.assignable.map((section, i) =>
+              <Section key={i} {...this.props} section={section} />)}
           </div>
         </Collapse>
       </ChapterWrapper>


### PR DESCRIPTION
With the new TOC the chapters do not have ids since they're not stored as a db record

Needed to go along with: https://github.com/openstax/tutor-server/pull/1966