### PR TITLE
update assignment modal, fix closes_at & general datetime fields

### DIFF
--- a/tutor/resources/styles/components/plan-stats.scss
+++ b/tutor/resources/styles/components/plan-stats.scss
@@ -12,10 +12,6 @@
 .card.task-stats {
   border: 0;
 
-  label {
-    font-weight: bold;
-    margin-bottom: 2rem;
-  }
   .progress {
     height: 3rem;
   }

--- a/tutor/resources/styles/global/buttons.scss
+++ b/tutor/resources/styles/global/buttons.scss
@@ -3,6 +3,9 @@ $default-background: rgba(245,245,245,.4);
 $default-background-hover: rgba(255,255,255,.8);
 $primary-background: #f47642;
 $primary-background-hover: #fa804d;
+$form-action-background: #fff;
+$form-action-color: #5e6062;
+$form-action-border: #d5d5d5;
 
 .btn + .btn { margin-left: 0.5rem; }
 
@@ -140,4 +143,19 @@ $primary-background-hover: #fa804d;
     margin: 0;
     border-width: 1px;
   }
+}
+
+.btn.btn-form-action {
+  &:not(.btn-primary) {
+    background: $form-action-background;
+    color: $form-action-color;
+    border: 1px solid $form-action-border;
+  }
+
+  height: 4.8rem;
+  min-width: 12rem;
+  padding: 0 1.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/tutor/specs/components/__snapshots__/date-time-input.spec.js.snap
+++ b/tutor/specs/components/__snapshots__/date-time-input.spec.js.snap
@@ -8,7 +8,6 @@ exports[`DateTimeInput matches snapshot 1`] = `
 
 .c0 {
   position: relative;
-  display: inline-block;
 }
 
 .c1 {
@@ -30,6 +29,9 @@ exports[`DateTimeInput matches snapshot 1`] = `
 .c3.c3 {
   padding: 0;
   border-radius: 4px;
+  -webkit-flex-basis: 100%;
+  -ms-flex-preferred-size: 100%;
+  flex-basis: 100%;
 }
 
 .c3.c3 input {
@@ -68,7 +70,7 @@ exports[`DateTimeInput matches snapshot 1`] = `
   border-radius: 0 4px 4px 0;
 }
 
-<span
+<div
   className="c0"
 >
   <label
@@ -121,5 +123,5 @@ exports[`DateTimeInput matches snapshot 1`] = `
       </svg>
     </div>
   </div>
-</span>
+</div>
 `;

--- a/tutor/specs/components/__snapshots__/template-modal.spec.js.snap
+++ b/tutor/specs/components/__snapshots__/template-modal.spec.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Template Modal renders and matches snapshot 1`] = `null`;
+exports[`Template Modal renders and matches snapshot 1`] = `
+<Memo(wrappedComponent)
+  templateType="neutral"
+/>
+`;

--- a/tutor/specs/components/__snapshots__/template-modal.spec.js.snap
+++ b/tutor/specs/components/__snapshots__/template-modal.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Template Modal renders and matches snapshot 1`] = `null`;

--- a/tutor/specs/components/plan-stats/index.spec.jsx
+++ b/tutor/specs/components/plan-stats/index.spec.jsx
@@ -21,7 +21,7 @@ describe('TaskPlan stats progress bar', function() {
     const wrapper = mount(<R><Stats {...props} /></R>);
 
     expect(await axe(wrapper.html())).toHaveNoViolations();
-    wrapper.find('.nav-tabs li a').last().simulate('click');
+    wrapper.find('input[type="radio"]').last().simulate('click');
     expect(wrapper.find('.text-not-started').text()).toEqual('0'); // not NaN
   });
 

--- a/tutor/specs/components/template-modal.spec.js
+++ b/tutor/specs/components/template-modal.spec.js
@@ -1,9 +1,10 @@
+import { React } from '../helpers';
 import TemplateModal from '../../src/components/template-modal';
 
 describe('Template Modal', () => {
 
   it('renders and matches snapshot', () => {
-    expect.snapshot(<TemplateModal templateType="neutral" />).toMatchSnapshot();
+    expect(<TemplateModal templateType="neutral" />).toMatchSnapshot();
   });
 
 });

--- a/tutor/specs/components/template-modal.spec.js
+++ b/tutor/specs/components/template-modal.spec.js
@@ -1,0 +1,9 @@
+import TemplateModal from '../../src/components/template-modal';
+
+describe('Template Modal', () => {
+
+  it('renders and matches snapshot', () => {
+    expect.snapshot(<TemplateModal templateType="neutral" />).toMatchSnapshot();
+  });
+
+});

--- a/tutor/specs/integration/assignments.spec.js
+++ b/tutor/specs/integration/assignments.spec.js
@@ -119,5 +119,4 @@ context('Dashboard', () => {
     cy.get('.modal [type="submit"]').click()
     cy.get('[data-test-id="grading-templates"]').should('contain.text', 'NewTemplate')
   });
-
 });

--- a/tutor/src/components/date-time-input.js
+++ b/tutor/src/components/date-time-input.js
@@ -9,9 +9,8 @@ import 'rc-picker/assets/index.css';
 import { Icon } from 'shared';
 import { colors } from '../theme';
 
-const StyledWrapper = styled.span`
+const StyledWrapper = styled.div`
   position: relative;
-  display: inline-block;
 `;
 
 const Label = styled.label`
@@ -28,6 +27,7 @@ const StyledPicker = styled(Picker)`
   && {
     padding: 0;
     border-radius: 4px;
+    flex-basis: 100%;
 
     input {
       padding-left: 1.2rem;

--- a/tutor/src/components/plan-stats/course-bar.jsx
+++ b/tutor/src/components/plan-stats/course-bar.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { map, partial } from 'lodash';
 import { Container, Row, Col } from 'react-bootstrap';
-
 import { Icon } from 'shared';
 
 class CourseBar extends React.Component {
@@ -89,10 +88,8 @@ so it may differ from the average you see in Student Scores.\
       <Col xs={cols} className={stat.type} key={stat.type}>
         <label>
           {stat.label}
+          : <span className={`data-container-value text-${stat.type}`}>{stat.value}</span>
         </label>
-        <div className={`data-container-value text-${stat.type}`}>
-          {stat.value}
-        </div>
       </Col>
     );
   };
@@ -105,8 +102,8 @@ so it may differ from the average you see in Student Scores.\
     const statsColumns = map(stats, partial(this.renderCourseStat, partial.placeholder, cols));
 
     return (
-      <Container className="data-container" key="course-bar">
-        <Row className="stats">
+      <Container className="data-container" key="course-bar" bsPrefix=" ">
+        <Row className="stats" noGutters={true}>
           {statsColumns}
         </Row>
       </Container>

--- a/tutor/src/components/plan-stats/index.jsx
+++ b/tutor/src/components/plan-stats/index.jsx
@@ -1,17 +1,30 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import { observer } from 'mobx-react';
-import { observable, computed, action } from 'mobx';
+import { React, PropTypes, styled, observer, observable, computed, action } from 'vendor';
 import { isEmpty, find } from 'lodash';
 import { Card } from 'react-bootstrap';
-import Course from '../../models/course';
 import { SmartOverflow } from 'shared';
+import Course from '../../models/course';
 import CoursePeriodsNav from '../course-periods-nav';
 import CourseBar from './course-bar';
 import { ChaptersPerformance, PracticesPerformance } from './performances';
 import TeacherTaskPlan from '../../models/task-plans/teacher/plan';
 import LoadingScreen from 'shared/components/loading-animation';
 import NoStudents from './no-students';
+import RadioInput from  '../radio-input';
+
+const SectionWrapper = styled.div`
+  margin: 0.8rem 5rem 0 0;
+  display: inline-flex;
+`;
+
+const StatsWrapper = styled.div`
+  margin-top: 4rem;
+  font-size: 1.6rem;
+
+  section {
+    margin-top: 0.8rem;
+  }
+`;
+
 
 export default
 @observer
@@ -61,18 +74,16 @@ class Stats extends React.Component {
     if (handlePeriodSelect) { handlePeriodSelect(period); }
   }
 
-  renderWrapped(body) {
+  renderWithTabs(body) {
     return (
-      <Card className="task-stats">
-        <Card.Body>
-          <CoursePeriodsNav
-            handleSelect={this.handlePeriodSelect}
-            periods={this.course.periods}
-            course={this.course}
-          />
-          {body}
-        </Card.Body>
-      </Card>
+      <>
+        <CoursePeriodsNav
+          handleSelect={this.handlePeriodSelect}
+          periods={this.course.periods}
+          course={this.course}
+        />
+        {body}
+      </>
     );
   }
 
@@ -99,11 +110,11 @@ class Stats extends React.Component {
     const { course, stats, props: { shouldOverflowData } } = this;
 
     if (!this.period.hasEnrollments) {
-      return this.renderWrapped(<NoStudents courseId={course.id} />);
+      return this.renderWithTabs(<NoStudents courseId={course.id} />);
     }
 
     if (!this.analytics.api.hasBeenFetched) {
-      return this.renderWrapped(<LoadingScreen />);
+      return this.renderWithTabs(<LoadingScreen />);
     }
 
     courseBar = <CourseBar data={stats} type={this.props.plan.type} />;
@@ -117,26 +128,34 @@ class Stats extends React.Component {
         {this.renderSpacedPages()}
       </SmartOverflow>;
     } else {
-      dataComponent = <div className="task-stats-data">
+      dataComponent = <StatsWrapper>
+        <h6>Class progress</h6>
         <section>
           {courseBar}
         </section>
         {this.renderCurrentPages()}
         {this.renderSpacedPages()}
-      </div>;
+      </StatsWrapper>;
     }
 
     return (
-      <Card className="task-stats">
-        <Card.Body>
-          <CoursePeriodsNav
-            handleSelect={this.handlePeriodSelect}
-            periods={this.course.periods}
-            course={this.course}
-          />
-          {dataComponent}
-        </Card.Body>
-      </Card>
+      <>
+        <h6>Select section</h6>
+        {this.course.periods.map((p, i) =>
+          <SectionWrapper key={`period-${p.id}`}>
+            <RadioInput
+              id={`period-${p.id}`}
+              name={`period-${p.id}`}
+              standalone={true}
+              onChange={() => this.handlePeriodSelect(p, i)}
+              checked={this.period.id === p.id}
+              label={p.name}
+              labelSize="lg"
+            />
+          </SectionWrapper>
+        )}
+        {dataComponent}
+      </>
     );
   }
 }

--- a/tutor/src/components/template-modal.js
+++ b/tutor/src/components/template-modal.js
@@ -1,0 +1,50 @@
+import { React, PropTypes, observer, styled } from 'vendor';
+import { Modal } from 'react-bootstrap';
+import { colors } from 'theme';
+import { omit } from 'lodash';
+
+const StyledModal = styled((props) => <Modal {...omit(props, StyledModal.OmitProps)} />)`
+  .modal-dialog {
+    .modal-header {
+      padding: 1.2rem 3.2rem;
+      border-left: 0.8rem solid ${props => props.templateColors.border};
+      background-color: ${props => props.templateColors.background};
+      font-size: 1.8rem;
+      font-weight: bold;
+      border-bottom: 0;
+      border-radius: 0;
+    }
+
+    .modal-body {
+      line-height: 2rem;
+      padding: 4rem;
+    }
+
+    .close {
+      font-size: 3rem;
+      margin-top: -1.5rem;
+    }
+  }
+`;
+
+StyledModal.OmitProps = [
+  'templateType',
+  'template',
+];
+
+const TemplateModal = observer((props) => {
+  return (
+    <StyledModal
+      {...props}
+      templateColors={colors.templates[props.templateType]}
+    >
+      {props.children}
+    </StyledModal>
+  );
+});
+
+TemplateModal.propTypes = {
+  templateType: PropTypes.string.isRequired,
+};
+
+export default TemplateModal;

--- a/tutor/src/models/task-plans/teacher/tasking.js
+++ b/tutor/src/models/task-plans/teacher/tasking.js
@@ -208,8 +208,8 @@ class TaskingPlan extends BaseModel {
 
   @action setClosesDate(date) {
     this.closes_at = findLatest(
-      moment(this.due_at),
-      dateWithUnchangedTime(moment(date), moment(this.closes_at)),
+      moment(this.due_at).add(1, 'minute'),
+      date,
     ).toISOString();
   }
 

--- a/tutor/src/screens/assignments/tasking.js
+++ b/tutor/src/screens/assignments/tasking.js
@@ -51,6 +51,7 @@ class Tasking extends React.Component {
 
   @computed get plan() { return this.props.ux.plan; }
   @computed get course() { return this.props.ux.course; }
+  @computed get form() { return this.props.ux.form; }
 
   @computed get taskings() {
     if (this.props.period) {
@@ -89,16 +90,25 @@ class Tasking extends React.Component {
     return this.plan.due_date || end;
   }
 
-  @action.bound onOpensChange({ target: { value: date } }) {
-    this.taskings.forEach(t => t.setOpensDate(date));
+  @action.bound onOpensChange({ target: { value: date, name: name } }) {
+    this.taskings.forEach(t => {
+      t.setOpensDate(date);
+      this.form.setFieldValue(name, t.opens_at);
+    });
   }
 
-  @action.bound onDueChange({ target: { value: date } }) {
-    this.taskings.forEach(t => t.setDueDate(date));
+  @action.bound onDueChange({ target: { value: date, name: name } }) {
+    this.taskings.forEach(t => {
+      t.setDueDate(date);
+      this.form.setFieldValue(name, t.due_at);
+    });
   }
 
-  @action.bound onClosesChange({ target: { value: date } }) {
-    this.taskings.forEach(t => t.setClosesDate(date));
+  @action.bound onClosesChange({ target: { value: date, name: name } }) {
+    this.taskings.forEach(t => {
+      t.setClosesDate(date);
+      this.form.setFieldValue(name, t.closes_at);
+    });
   }
 
   renderDueAtError() {

--- a/tutor/src/screens/grading-templates/editors.js
+++ b/tutor/src/screens/grading-templates/editors.js
@@ -1,6 +1,6 @@
 import { React, PropTypes, action, observer, styled } from 'vendor';
 import { Button, Modal, Alert } from 'react-bootstrap';
-import { isEmpty, range, map, omit } from 'lodash';
+import { isEmpty, range, map } from 'lodash';
 import { GradingTemplate } from '../../models/grading/templates';
 import { colors, fonts } from '../../theme';
 import { Formik, Form, Field, ErrorMessage } from 'formik';
@@ -8,38 +8,17 @@ import NumberInput from '../../components/number-input';
 import RadioInput from '../../components/radio-input';
 import TimeInput from '../../components/time-input';
 import Select from '../../components/select';
+import TemplateModal from '../../components/template-modal';
 
 const propTypes = {
   template: PropTypes.instanceOf(GradingTemplate).isRequired,
 };
 
-const StyledModal = styled((props) => <Modal {...omit(props, StyledModal.OmitProps)} />)`
+const StyledTemplateModal = styled(TemplateModal)`
   .modal-dialog {
     max-width: 680px;
-
-    .modal-header {
-      border-left: 8px solid ${props => props.templateColors.border};
-      background-color: ${props => props.templateColors.background};
-      font-size: 1.8rem;
-      font-weight: bold;
-      border-bottom: 0;
-      border-radius: 0;
-    }
-
-    .modal-body {
-      line-height: 2rem;
-    }
-
-    .close {
-      font-size: 3rem;
-      margin-top: -1.5rem;
-    }
   }
 `;
-
-StyledModal.OmitProps = [
-  'templateColors',
-];
 
 const Row = styled.div`
   margin: 2.4rem 0;
@@ -363,11 +342,11 @@ class TemplateForm extends React.Component {
     const { template, onComplete } = this.props;
 
     return (
-      <StyledModal
+      <StyledTemplateModal
         show={true}
         backdrop="static"
         onHide={onComplete}
-        templateColors={colors.templates[template.task_plan_type]}
+        templateType={template.task_plan_type}
       >
         <Modal.Header closeButton>
           {template.isNew ? 'Add' : 'Edit'} {template.task_plan_type} grading template
@@ -382,7 +361,7 @@ class TemplateForm extends React.Component {
           </Formik>
         </Modal.Body>
 
-      </StyledModal>
+      </StyledTemplateModal>
     );
   }
 
@@ -521,11 +500,11 @@ const create = observer((props) => {
   const { onComplete, onCreateTypeSelection: onSelection } = props;
 
   return (
-    <StyledModal
+    <StyledTemplateModal
       show={true}
       backdrop="static"
       onHide={onComplete}
-      templateColors={colors.templates.neutral}
+      templateType="neutral"
     >
       <Modal.Header closeButton>
         Select assignment type
@@ -547,7 +526,7 @@ const create = observer((props) => {
           </Row>
         </CenteredRow>
       </Modal.Body>
-    </StyledModal>
+    </StyledTemplateModal>
   );
 
 });


### PR DESCRIPTION
Update Assignment Modal

- Use radio buttons for period toggle
- Add date time fields to change and save inline for period
- Update button styles

Update assignment DateTime fields

- Use setFieldValue in event to make sure the form visually reflects changes we made while running rules (like if the due date was set to before open date)
- Fix closes_at rule

General

- Added a btn-form-action in sass for those new big buttons we've started using.
- Made a TemplateModal component to DRY up that particular modal style

Side note: with both the above, I need to add a pass later that makes things like grading templates modal use them instead of duplicating styles.

![image](https://user-images.githubusercontent.com/34174/76267563-6e7b2700-6228-11ea-9ecd-bddcada0d06c.png)

As you can see from the below image, the metrics screen may need to be touched up now.

![image](https://user-images.githubusercontent.com/34174/76267570-73d87180-6228-11ea-8865-e9be04f13d1a.png)
