### PR TITLE
fix formik deprecation warning by switching render approach

### DIFF
--- a/tutor/src/screens/teacher-dashboard/plan-details.jsx
+++ b/tutor/src/screens/teacher-dashboard/plan-details.jsx
@@ -231,37 +231,37 @@ class CoursePlanDetails extends React.Component {
         <Formik
           enableReinitialize
           initialValues={this.tasking}
-          render={({ setFieldValue }) => (
-            <Row className="tasking-date-time">
-              <Col xs={12} md={4} className="opens-at">
-                <DateTime
-                  label="Open date & time"
-                  name="opens_at"
-                  onChange={e => this.onOpensChange(e, setFieldValue)}
-                  format={format}
-                />
-                {!this.tasking.canEditOpensAt && <CantEditExplanation />}
-              </Col>
-              <Col xs={12} md={4} className="due-at">
-                <DateTime
-                  label="Due date & time"
-                  name="due_at"
-                  onChange={e => this.onDueChange(e, setFieldValue)}
-                  format={format}
-                />
-                {this.renderDueAtError()}
-              </Col>
-              <Col xs={12} md={4} className="closes-at">
-                <DateTime
-                  label="Close date & time"
-                  name="closes_at"
-                  onChange={e => this.onClosesChange(e, setFieldValue)}
-                  format={format}
-                />
-              </Col>
-            </Row>
-          )}
-        />
+        >
+        {(setFieldValue) => (
+          <Row className="tasking-date-time">
+            <Col xs={12} md={4} className="opens-at">
+              <DateTime
+                label="Open date & time"
+                name="opens_at"
+                onChange={e => this.onOpensChange(e, setFieldValue)}
+                format={format}
+              />
+              {!this.tasking.canEditOpensAt && <CantEditExplanation />}
+            </Col>
+            <Col xs={12} md={4} className="due-at">
+              <DateTime
+                label="Due date & time"
+                name="due_at"
+                onChange={e => this.onDueChange(e, setFieldValue)}
+                format={format}
+              />
+              {this.renderDueAtError()}
+            </Col>
+            <Col xs={12} md={4} className="closes-at">
+              <DateTime
+                label="Close date & time"
+                name="closes_at"
+                onChange={e => this.onClosesChange(e, setFieldValue)}
+                format={format}
+              />
+            </Col>
+          </Row>)}
+        </Formik>
       </DateFieldsWrapper>
     );
   }


### PR DESCRIPTION
Using render is deprecated, so I switched it to a child callback function.

`Warning: <Formik render> has been deprecated and will be removed in future versions of Formik. Please use a child callback function instead. To get rid of this warning, replace <Formik render={(props) => …} /> with <Formik>{(props) => …}</Formik> tiny-warning.esm.js:11 `