### PR TITLE
WRM Assignment Review Tooltips

### DIFF
--- a/shared/src/components/icon.js
+++ b/shared/src/components/icon.js
@@ -128,6 +128,10 @@ const Variants = {
     color: '#007da4',
     type: 'exclamation-circle',
   },
+  infoCircle: {
+    color: '#f47641',
+    type: 'info-circle',
+  },
   activity: {
     type: 'spinner',
     spin: true,

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -1,6 +1,6 @@
 import { React, PropTypes, styled, useObserver } from 'vendor';
 import { StickyTable, Row, Cell } from 'react-sticky-table';
-import { Button } from 'react-bootstrap';
+import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import ExerciseType from './exercise-type';
 import S from '../../helpers/string';
 import { Icon } from 'shared';
@@ -116,6 +116,35 @@ const GradeButton = styled(Button)`
   }
 `;
 
+const StyledTooltip = styled(Tooltip)`
+  max-width: 30rem;
+  &.tooltip.show { opacity: 1; }
+
+  .tooltip-inner {
+    padding: 2.2rem 1.6rem;
+    text-align: left;
+  }
+`;
+
+const AvailablePoints = ({ value }) => {
+  if (!value) { return (
+    <OverlayTrigger
+      placement="right"
+      overlay={
+        <StyledTooltip>
+          Students received different numbers of Tutor-selected questions. This can happen when questions aren’t
+          available, a student works an assignment late, or a student hasn’t started the assignment.
+        </StyledTooltip>
+      }
+    >
+      <Icon variant="infoCircle" />
+    </OverlayTrigger>
+  )};
+  return (
+    <strong>({S.numberWithOneDecimalPlace(value)})</strong>
+  );
+}
+
 const Overview = ({ ux, ux: { scores } }) => {
   return useObserver(() => (
     <Wrapper data-test-id="overview">
@@ -140,7 +169,9 @@ const Overview = ({ ux, ux: { scores } }) => {
           {scores.question_headings.map((h, i) => <Cell key={i}>{h.type}</Cell>)}
         </Row>
         <Row>
-          <Header>Available Points</Header>
+          <Header>
+            Available Points <AvailablePoints value={scores.hasEqualTutorQuestions && scores.questionsInfo.totalPoints} />
+          </Header>
           {scores.question_headings.map((h, i) => <Cell key={i}>{S.numberWithOneDecimalPlace(h.points)}</Cell>)}
         </Row>
         <Row>

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -127,23 +127,31 @@ const StyledTooltip = styled(Tooltip)`
 `;
 
 const AvailablePoints = ({ value }) => {
-  if (!value) { return (
-    <OverlayTrigger
-      placement="right"
-      overlay={
-        <StyledTooltip>
-          Students received different numbers of Tutor-selected questions. This can happen when questions aren’t
-          available, a student works an assignment late, or a student hasn’t started the assignment.
-        </StyledTooltip>
-      }
-    >
-      <Icon variant="infoCircle" />
-    </OverlayTrigger>
-  )};
+  if (!value) {
+    return (
+      <OverlayTrigger
+        placement="right"
+        overlay={
+          <StyledTooltip>
+            Students received different numbers of Tutor-selected questions. This can happen when questions aren’t
+            available, a student works an assignment late, or a student hasn’t started the assignment.
+          </StyledTooltip>
+        }
+      >
+        <Icon variant="infoCircle" />
+      </OverlayTrigger>
+    );
+  }
   return (
     <strong>({S.numberWithOneDecimalPlace(value)})</strong>
   );
-}
+};
+AvailablePoints.propTypes = {
+  value: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+};
 
 const Overview = ({ ux, ux: { scores } }) => {
   return useObserver(() => (

--- a/tutor/src/screens/assignment-review/scores.js
+++ b/tutor/src/screens/assignment-review/scores.js
@@ -1,6 +1,6 @@
 import { React, PropTypes, styled, useObserver, css } from 'vendor';
 import { StickyTable, Row, Cell as TableCell } from 'react-sticky-table';
-import { Button } from 'react-bootstrap';
+import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { Icon } from 'shared';
 import { colors } from 'theme';
 import S from '../../helpers/string';
@@ -81,7 +81,6 @@ const HeadingBottom = styled.div`
   font-size: 1rem;
   background: #fff;
   position: relative;
-  ${props => props.isDropped && blueTriangleCSS};
 `;
 
 const ColumnHeading = styled.div`
@@ -108,7 +107,6 @@ const LateWork = styled.div`
   ${centeredCSS}
   align-self: stretch;
   position: relative;
-  ${props => props.hasExtension && greenTriangleCSS}
 `;
 
 const Total = styled.div`
@@ -123,34 +121,6 @@ const isTroubleCSS = css`
   border-color: ${colors.danger};
   border-top: 1px solid ${colors.danger};
   border-bottom: 1px solid ${colors.danger};
-`;
-
-const triangleCSS = css`
-  &::after {
-    content: "";
-    width: 0;
-    height: 0;
-    position: absolute;
-    top: 0;
-    right: 0;
-    border-style: solid;
-    border-width: 0 1rem 1rem 0;
-    border-color: transparent #000 transparent transparent;
-  }
-`;
-
-const greenTriangleCSS = css`
-  ${triangleCSS}
-  &::after {
-    border-color: transparent ${colors.assignments.scores.extension} transparent transparent;
-  }
-`;
-
-const blueTriangleCSS = css`
-  ${triangleCSS}
-  &::after {
-    border-color: transparent ${colors.assignments.scores.dropped} transparent transparent;
-  }
 `;
 
 const Result = styled.div`
@@ -195,6 +165,42 @@ const ToolbarButton = styled(Button)`
   && {
     border: 1px solid ${colors.neutral.pale};
   }
+`;
+
+const CornerTriangle = ({ color, tooltip }) => {
+  return (
+    <OverlayTrigger
+      placement="right"
+      overlay={
+        <Tooltip>
+          {tooltip}
+        </Tooltip>
+      }
+    >
+      <StyledTriangle color={color} />
+    </OverlayTrigger>
+  );
+};
+CornerTriangle.propTypes = {
+  color: PropTypes.string.isRequired,
+  tooltip: PropTypes.string.isRequired,
+};
+
+const StyledTriangle = styled.div`
+  height: 0;
+  width: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+  border-style: solid;
+  border-width: 0 1rem 1rem 0;
+  border-color: transparent #000 transparent transparent;
+  ${props => props.color === 'green' && css`
+    border-color: transparent ${colors.assignments.scores.extension} transparent transparent;
+  `}
+  ${props => props.color === 'blue' && css`
+    border-color: transparent ${colors.assignments.scores.dropped} transparent transparent;
+  `}
 `;
 
 const StudentColumnHeader = () => {
@@ -258,8 +264,8 @@ const StudentCell = ({ student, striped }) => {
         <Total>
           {S.numberWithOneDecimalPlace(student.total_points)}
         </Total>
-
-        <LateWork hasExtension={false}>
+        <LateWork>
+          {false && <CornerTriangle color="green" tooltip="Student was granted an extension" />}
           {student.late_work_penalty ? `-${S.numberWithOneDecimalPlace(student.late_work_penalty)}` : '0'}
         </LateWork>
       </CellContents>
@@ -277,7 +283,8 @@ const AssignmentHeading = ({ heading }) => {
         <HeadingMiddle>
           {heading.type}
         </HeadingMiddle>
-        <HeadingBottom isDropped={false}>
+        <HeadingBottom>
+          {false && <CornerTriangle color="blue" tooltip="Dropped" />}
           {S.numberWithOneDecimalPlace(heading.points)}
         </HeadingBottom>
       </ColumnHeading>


### PR DESCRIPTION
Added the available points text using some quite rudimentary addition, I need to go over the logic for real and put it into UX.

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/34174/77388455-699c9400-6d4d-11ea-9e63-62ecb9d0f1b7.png">

Added the state for if this can't be calculated due to different student question counts... as above,  not sure about the logic of this yet.

<img width="1149" alt="image" src="https://user-images.githubusercontent.com/34174/77388437-57baf100-6d4d-11ea-908b-b4aaf6384366.png">

Refactored the existing score table triangles so they can support having tooltips. Added some placeholder text for now.

<img width="1137" alt="Screen Shot 2020-03-23 at 9 25 42 PM" src="https://user-images.githubusercontent.com/34174/77388377-27735280-6d4d-11ea-95a5-300f70d6d6ca.png">
