### PR TITLE
dashboard modal tweaks

### DIFF
--- a/tutor/scripts/test-server/backend/dashboard.js
+++ b/tutor/scripts/test-server/backend/dashboard.js
@@ -32,11 +32,27 @@ module.exports = {
     } else {
       let days = -50;
 
-      data.plans = range(1, 25).map(id => omit(Factory.create('TeacherTaskPlan', {
+      const defaultPlans = range(1, 25).map(id => omit(Factory.create('TeacherTaskPlan', {
         id, course, now,
         title: TITLES[id],
         days_ago: (days+=id),
       }), 'course'));
+
+      // Match due_at day offset to render day before + day after current day
+      const planSettings = [
+        { id: 26, type: 'homework', days_ago: 4 },
+        { id: 27, type: 'homework', days_ago: 2 },
+        { id: 28, type: 'event',    days_ago: 2 },
+        { id: 29, type: 'external', days_ago: 2 },
+        { id: 30, type: 'reading',  days_ago: 2 },
+      ];
+
+      const setPlans = planSettings.map(s => Factory.create('TeacherTaskPlan', {
+        ...s, course, now,
+        title: TITLES[s.id],
+      }));
+
+      data.plans = [...defaultPlans, ...setPlans]
 
       data.tasks = [];
     }

--- a/tutor/scripts/test-server/backend/task-plans.js
+++ b/tutor/scripts/test-server/backend/task-plans.js
@@ -24,8 +24,7 @@ let PLANS = {};
 const planForId = (id, attrs = {}) => (
   PLANS[id] || (PLANS[id] = Factory.create('TeacherTaskPlan', Object.assign(attrs, {
     id,
-
-    type: fake.random.arrayElement(['reading', 'homework']),
+    type: attrs['type'] || fake.random.arrayElement(['reading', 'homework']),
   })))
 );
 
@@ -58,7 +57,7 @@ module.exports = {
 
   getScores(req, res) {
     const course = getCourse(req.query.course_id);
-    const plan = planForId(req.params.id, { course: course });
+    const plan = planForId(req.params.id, { course: course, type: 'homework' });
     const exercises = times(8).map((id) => getExercise(id));
     const scores = Factory.create('TaskPlanScores', { task_plan: plan, course, exercises });
     res.json(scores);

--- a/tutor/scripts/test-server/backend/task-plans.js
+++ b/tutor/scripts/test-server/backend/task-plans.js
@@ -58,7 +58,7 @@ module.exports = {
 
   getScores(req, res) {
     const course = getCourse(req.query.course_id);
-    const plan = planForId(req.params.id);
+    const plan = planForId(req.params.id, { course: course });
     const exercises = times(8).map((id) => getExercise(id));
     const scores = Factory.create('TaskPlanScores', { task_plan: plan, course, exercises });
     res.json(scores);

--- a/tutor/specs/integration/assignment-review.spec.js
+++ b/tutor/specs/integration/assignment-review.spec.js
@@ -6,6 +6,7 @@ context('Assignment Review', () => {
   });
 
   it('loads and views feedback', () => {
+    cy.contains('Submission Overview').click();
     cy.getTestElement('overview').should('exist');
     cy.getTestElement('student-free-responses').should('not.exist');
     cy.get('.homework-questions .ox-icon-caret-right').first().click()

--- a/tutor/specs/integration/course.spec.js
+++ b/tutor/specs/integration/course.spec.js
@@ -1,0 +1,33 @@
+context('Course', () => {
+  beforeEach(() => {
+    cy.visit('/course/1');
+    cy.disableTours();
+  });
+
+  it('only displays Grade Answers button on Homework type', () => {
+    cy.get('.event.type-external label').first().click();
+    cy.getTestElement('gradeAnswers').should('not.exist');
+    cy.get('.modal-header .close').click();
+
+    cy.get('.event.type-event label').first().click();
+    cy.getTestElement('gradeAnswers').should('not.exist');
+    cy.get('.modal-header .close').click();
+
+    cy.get('.event.type-reading label').first().click();
+    cy.getTestElement('gradeAnswers').should('not.exist');
+    cy.get('.modal-header .close').click();
+
+    cy.get('.event.type-homework label').first().click();
+    cy.getTestElement('gradeAnswers').should('exist');
+    cy.get('.modal-header .close').click();
+
+    // Check upcoming assignment
+    cy.get('.upcoming .event.type-homework label').first().click();
+    cy.getTestElement('gradeAnswers').should('exist').should('have.class', 'disabled');
+    cy.get('.modal-header .close').click();
+
+    // Check past due assignment
+    cy.get('.past .event.type-homework label').first().click();
+    cy.getTestElement('gradeAnswers').should('exist').should('not.have.class', 'disabled');
+  });
+});

--- a/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
+++ b/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
@@ -91,6 +91,7 @@ exports[`Student Dashboard displays as loading 1`] = `
               role="tab"
             >
               <a
+                data-test-id="this-week-tab"
                 href="#"
                 onClick={[Function]}
               >
@@ -105,6 +106,7 @@ exports[`Student Dashboard displays as loading 1`] = `
               role="tab"
             >
               <a
+                data-test-id="all-past-work-tab"
                 href="#"
                 onClick={[Function]}
               >
@@ -574,6 +576,7 @@ exports[`Student Dashboard matches snapshot 1`] = `
               role="tab"
             >
               <a
+                data-test-id="this-week-tab"
                 href="#"
                 onClick={[Function]}
               >
@@ -588,6 +591,7 @@ exports[`Student Dashboard matches snapshot 1`] = `
               role="tab"
             >
               <a
+                data-test-id="all-past-work-tab"
                 href="#"
                 onClick={[Function]}
               >

--- a/tutor/specs/screens/teacher-dashboard/plan-details.spec.jsx
+++ b/tutor/specs/screens/teacher-dashboard/plan-details.spec.jsx
@@ -46,7 +46,7 @@ describe('Plan Details Component', function() {
     plan.is_published = true;
     plan.type = 'event';
     return renderModal(props).then((m) => {
-      expect(m.textContent).toContain('Edit Event');
+      expect(m.textContent).toContain('View assignment');
       expect(m.textContent).not.toContain('assignment link');
     });
   });

--- a/tutor/src/components/plan-stats/index.jsx
+++ b/tutor/src/components/plan-stats/index.jsx
@@ -133,8 +133,6 @@ class Stats extends React.Component {
         <section>
           {courseBar}
         </section>
-        {this.renderCurrentPages()}
-        {this.renderSpacedPages()}
       </StatsWrapper>;
     }
 

--- a/tutor/src/components/template-modal.js
+++ b/tutor/src/components/template-modal.js
@@ -20,6 +20,10 @@ const StyledModal = styled((props) => <Modal {...omit(props, StyledModal.OmitPro
       padding: 4rem;
     }
 
+    .modal-footer {
+      padding: 0 4rem 4rem;
+    }
+
     .close {
       font-size: 3rem;
       margin-top: -1.5rem;

--- a/tutor/src/helpers/string.js
+++ b/tutor/src/helpers/string.js
@@ -39,7 +39,7 @@ export default {
   },
 
   dasherize(string) {
-    return string
+    return String(string)
       .replace(/[A-Z]/g, (char, index) => (index !== 0 ? '-' : '') + char.toLowerCase())
       .replace(/[-_\s]+/g, '-');
   },

--- a/tutor/src/routes.js
+++ b/tutor/src/routes.js
@@ -66,7 +66,7 @@ const getRoutes = (router) => {
           path: 'assignment/review/:id', name: 'reviewAssignment',
           renderer: r(() => import('./screens/assignment-review'), 'Assignment Review') },
         {
-          path: 'assignment/grade/:id', name: 'gradeAssignment',
+          path: 'assignment/grade/:id/:periodId?', name: 'gradeAssignment',
           renderer: r(() => import('./screens/assignment-grade'), 'Assignment Grader') },
         {
           path: 'gradebook', name: 'viewGradebook',

--- a/tutor/src/screens/assignment-grade/ux.js
+++ b/tutor/src/screens/assignment-grade/ux.js
@@ -19,13 +19,14 @@ export default class AssignmentGradingUX {
   }
 
   @action async initialize({
-    id, courseId, scores, course,
+    id, periodId, courseId, scores, course,
     windowImpl = window,
   }) {
 
     this.scroller = new ScrollTo({ windowImpl });
     this.course = course || Courses.get(courseId);
-    this.selectedPeriod = first(this.course.periods.active);
+    this.selectedPeriod = this.course.periods.active.find(p => p.id == periodId) ||
+      first(this.course.periods.active);
     this.planScores = scores || new TaskPlanScores({ id, course: this.course });
     this.setQuestionIndex(0);
 

--- a/tutor/src/screens/assignment-review/details.js
+++ b/tutor/src/screens/assignment-review/details.js
@@ -222,7 +222,7 @@ const Details = observer(({ ux, ux: { scores, planScores, taskingPlan } }) => {
             <StyledTutorLink
               className="btn btn-form-action btn-primary btn-new-flag"
               to='gradeAssignment'
-              params={{ id: ux.planId, courseId: ux.course.id }}
+              params={{ id: ux.planId, periodId: taskingPlan.target_id, courseId: ux.course.id }}
             >
               <span className="flag">72 New</span>
               <span>Grade answers</span>

--- a/tutor/src/screens/assignment-review/index.js
+++ b/tutor/src/screens/assignment-review/index.js
@@ -52,7 +52,7 @@ class AssignmentReview extends React.Component {
     history: PropTypes.object.isRequired,
   }
 
-  @observable tabIndex = 1;
+  @observable tabIndex = 0;
 
   @action.bound onTabSelection(tabIndex) {
     this.tabIndex = tabIndex;
@@ -85,7 +85,7 @@ class AssignmentReview extends React.Component {
       return <LoadingScreen message="Loading Assignment…" />;
     }
 
-    const Tab = AvailableTabs[this.tabIndex] || Overview;
+    const Tab = AvailableTabs[this.tabIndex] || Details;
 
     return (
       <BackgroundWrapper>

--- a/tutor/src/screens/teacher-dashboard/plan-details.jsx
+++ b/tutor/src/screens/teacher-dashboard/plan-details.jsx
@@ -3,7 +3,7 @@ import {
   computed, observable, action, styled,
 } from 'vendor';
 import Course from '../../models/course';
-import { Modal, Row, Col, Alert } from 'react-bootstrap';
+import { Modal, Row, Col, Alert, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import TourContext from '../../models/tour/context';
 import TourRegion from '../../components/tours/region';
 import Stats from '../../components/plan-stats';
@@ -17,6 +17,7 @@ import moment from 'moment';
 import Time from '../../models/time';
 import { Formik } from 'formik';
 import TemplateModal from '../../components/template-modal';
+import cn from 'classnames';
 
 const StyledAlert = styled(Alert)`
   margin-top: 0.5rem;
@@ -103,15 +104,30 @@ class CoursePlanDetails extends React.Component {
   }
 
   @computed get gradeAnswersButton() {
-    if (this.props.plan.type === 'event'){ return null; }
+    const { plan, course } = this.props;
+    // TODO: Check plan for gradeable anwers. For now just use Homework as the
+    // check until we have practical dev/test data
+    if (!plan.isHomework) { return null; }
     return (
-      <TutorLink
-        className="btn btn-form-action btn-primary"
-        to='gradeAssignment'
-        params={{ id: this.props.plan.id, courseId: this.props.course.id }}
+      <OverlayTrigger
+        placement="top"
+        overlay={
+          <Tooltip>
+            {!this.tasking.isPastDue && "Assignment will be available for grading after the due date."}
+          </Tooltip>
+        }
       >
-        Grade answers
-      </TutorLink>
+        <span>
+          <TutorLink
+            className={cn("btn btn-form-action btn-primary", { 'disabled': !this.tasking.isPastDue }) }
+            to="gradeAssignment"
+            data-test-id="gradeAnswers"
+            params={{ id: plan.id, periodId: this.tasking.target_id, courseId: course.id }}
+          >
+            Grade answers
+          </TutorLink>
+        </span>
+      </OverlayTrigger>
     );
   }
 

--- a/tutor/src/screens/teacher-dashboard/plan-details.jsx
+++ b/tutor/src/screens/teacher-dashboard/plan-details.jsx
@@ -42,6 +42,10 @@ const StyledTemplateModal = styled(TemplateModal)`
   h6 {
     font-weight: bold;
   }
+
+  .modal-footer {
+    justify-content: flex-start;
+  }
 `;
 
 
@@ -123,19 +127,8 @@ class CoursePlanDetails extends React.Component {
           to={plan.isExternal ? 'viewGradebook' : 'reviewAssignment'}
           params={this.linkParams}
         >
-          {plan.isExternal ? 'View Scores' : 'Review Metrics'}
+          View assignment
         </TutorLink>
-
-        <TutorLink
-          className="btn btn-form-action"
-          to="editAssignment"
-          params={this.linkParams}
-        >
-          {plan.isEditable ? 'Edit' : 'View'}
-          {' '}
-          {plan.type === 'event' ? 'Event' : 'Assignment'}
-        </TutorLink>
-
         {this.assignmentLinksButton}
         {this.gradeAnswersButton}
       </div>

--- a/tutor/src/screens/teacher-dashboard/plan-details.jsx
+++ b/tutor/src/screens/teacher-dashboard/plan-details.jsx
@@ -224,7 +224,7 @@ class CoursePlanDetails extends React.Component {
           enableReinitialize
           initialValues={this.tasking}
         >
-          {(setFieldValue) => (
+          {({ setFieldValue }) => (
             <Row className="tasking-date-time">
               <Col xs={12} md={4} className="opens-at">
                 <DateTime


### PR DESCRIPTION
- All assignment types use a singular "View assignment" button that goes to the Details tab
- Metrics (question performance bars) aren't needed

Note: does not yet include logic to decide if the Grade button should be shown based on WRM question presence

![image](https://user-images.githubusercontent.com/34174/78073713-4332b600-7356-11ea-9198-43c7e8af7a7a.png)