### PR TITLE
Support rendering html component without router context

### DIFF
--- a/shared/specs/components/__snapshots__/html.spec.js.snap
+++ b/shared/specs/components/__snapshots__/html.spec.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Arbitrary Html Component renders html 1`] = `"<div history=\\"[object Object]\\" location=\\"[object Object]\\" match=\\"[object Object]\\" class=\\"openstax-has-html html\\"><span>a test phrase</span></div>"`;
+exports[`Arbitrary Html Component renders html 1`] = `"<div class=\\"openstax-has-html html\\"><span>a test phrase</span></div>"`;
 
-exports[`Arbitrary Html Component renders using span when block is false 1`] = `"<span history=\\"[object Object]\\" location=\\"[object Object]\\" match=\\"[object Object]\\" class=\\"openstax-has-html html\\"><span>a test phrase</span></span>"`;
+exports[`Arbitrary Html Component renders using span when block is false 1`] = `"<span class=\\"openstax-has-html html\\"><span>a test phrase</span></span>"`;

--- a/shared/specs/components/html.spec.js
+++ b/shared/specs/components/html.spec.js
@@ -16,17 +16,26 @@ describe('Arbitrary Html Component', function() {
   it('renders html', () => {
     const html = mount(<R><Html {...props} /></R>);
     expect(html.html()).toMatchSnapshot();
+    html.unmount();
   });
 
   it('calls math processing function when rendered', () => {
-    mount(<R><Html {...props} /></R>);
+    const html = mount(<R><Html {...props} /></R>);
     expect(props.processHtmlAndMath).toHaveBeenCalled();
+    html.unmount();
   });
 
   it('renders using span when block is false', function() {
     props.block = false;
     const html = mount(<R><Html {...props} /></R>);
     expect(html.html()).toMatchSnapshot();
+    html.unmount();
+  });
+
+  it('renders without router context', function() {
+    props.html='<span>this <a href="/course/1">is a link</a></span>';
+    const html = mount(<Html {...props} />);
+    html.unmount();
   });
 
 });

--- a/shared/src/components/html.js
+++ b/shared/src/components/html.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { omit } from 'lodash';
-import { withRouter } from 'react-router';
+import { __RouterContext as RouterContext } from 'react-router';
 import classnames from 'classnames';
 import { typesetMath } from '../helpers/mathjax';
 import { wrapFrames } from '../helpers/html-videos';
@@ -12,7 +12,7 @@ const isExternalLink = (a) => {
   return ('A' == a.tagName && a.origin !== window.location.origin);
 };
 
-@withRouter
+
 class ArbitraryHtmlAndMath extends React.Component {
 
   static defaultProps = {
@@ -29,6 +29,8 @@ class ArbitraryHtmlAndMath extends React.Component {
     windowImpl: PropTypes.object,
     history: PropTypes.object,
   };
+
+  static contextType = RouterContext;
 
   componentDidMount() { return this.updateDOMNode(); }
 
@@ -68,8 +70,8 @@ class ArbitraryHtmlAndMath extends React.Component {
   };
 
   onClick = (ev) => {
-    if (isExternalLink(ev.target)) {
-      this.props.history.push(ev.target.pathname + ev.target.hash);
+    if (!isExternalLink(ev.target) && this.context.history) {
+      this.context.history.push(ev.target.pathname + ev.target.hash);
       ev.preventDefault();
     }
   }


### PR DESCRIPTION
The media previews were rendered using reactdom and lack the context of their parent

https://github.com/openstax/tutor-js/blob/master/tutor/src/components/book-page.js#L305