### PR TITLE
fix small label issues and edit/delete buttons not unfocusing when cl…

### DIFF
--- a/tutor/specs/screens/grading-templates/__snapshots__/card.spec.js.snap
+++ b/tutor/specs/screens/grading-templates/__snapshots__/card.spec.js.snap
@@ -40,6 +40,10 @@ exports[`Grading Templates Card matches snapshot for homework 1`] = `
   justify-content: space-between;
 }
 
+.c1 .card-header .btn:not(.btn-link):focus {
+  box-shadow: none;
+}
+
 .c1 .card-header .btn-link {
   color: #424242;
   padding: 0;
@@ -256,6 +260,10 @@ exports[`Grading Templates Card matches snapshot for reading 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+}
+
+.c1 .card-header .btn:not(.btn-link):focus {
+  box-shadow: none;
 }
 
 .c1 .card-header .btn-link {

--- a/tutor/src/screens/grading-templates/card.js
+++ b/tutor/src/screens/grading-templates/card.js
@@ -24,6 +24,11 @@ const CardWrapper = styled.div`
     align-items: center;
     justify-content: space-between;
 
+    /** Fix issue when clicking on the edit or delete button will stay on focus after the modal is closed  */
+    & .btn:not(.btn-link):focus {
+      box-shadow: none;
+    }
+
     .btn-link {
       color: ${Theme.colors.neutral.darker};
       padding: 0;
@@ -59,8 +64,8 @@ const StyledCol = styled(Col)`
 
 const toPerc = (n) => `${Math.round(n * 100)}%`;
 
-const gradedExplanation = (tmpl) => {
-  switch (tmpl.auto_grading_feedback_on) {
+const gradedExplanation = (gradingType) => {
+  switch (gradingType) {
     case 'publish':
       return 'After I publish the scores';
     case 'grade':
@@ -68,7 +73,7 @@ const gradedExplanation = (tmpl) => {
     case 'answer':
       return 'Immediately after student answers';
     case 'due':
-      return 'After assignment is due';
+      return 'After the due date';
     default:
       return 'invalid value';
   }
@@ -174,10 +179,12 @@ const HomeworkCard = ({ template, ...cardProps }) => {
       <SectionTitle>SHOW SCORES & FEEDBACK TO STUDENTS</SectionTitle>
 
       <SettingName>For auto-graded questions:</SettingName>
-      <SettingValue>{gradedExplanation(template)}</SettingValue>
+      <SettingValue>{gradedExplanation(template.
+        auto_grading_feedback_on)}</SettingValue>
 
       <SettingName>For manually-graded questions:</SettingName>
-      <SettingValue>{gradedExplanation(template)}</SettingValue>
+      <SettingValue>{gradedExplanation(template.
+        manual_grading_feedback_on)}</SettingValue>
     </CardInfo>
   );
 };


### PR DESCRIPTION
- On the OS HW card, The scores and feedback settings are not syncing with the template properly. The setting for ‘For manually-graded questions’ is displaying the selection made for ‘For auto-graded questions’

- The HW template says “After the due date” but the preview card shows “After assignment is due”. The card should also display “After the due date” if that option is selected.

-  The hover state doesn’t go away. To repeat: Click on delete/edit. Click cancel on the modal that opens. On the card, the button is still in the hover state. You have to click on it or somewhere else to remove the hover state