### PR TITLE
restrict access to user types other than listed

### DIFF
--- a/tutor/specs/components/__snapshots__/app.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/app.spec.jsx.snap
@@ -278,62 +278,6 @@ exports[`main Tutor App renders and matches snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    className="actions-menu dropdown"
-                    onKeyDown={[Function]}
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu and settings"
-                      className="dropdown-toggle btn btn-ox"
-                      disabled={false}
-                      id="actions-menu"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        className="svg-inline--fa fa-bars fa-w-14 ox-icon ox-icon-bars c3"
-                        data-icon="bars"
-                        data-prefix="fas"
-                        focusable="false"
-                        role="img"
-                        style={Object {}}
-                        viewBox="0 0 448 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z"
-                          fill="currentColor"
-                          style={Object {}}
-                        />
-                      </svg>
-                      <span
-                        className="control-label"
-                        title="Menu and settings"
-                      >
-                        Menu
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        className="svg-inline--fa fa-angle-down fa-w-10 ox-icon ox-icon-angle-down toggle c3"
-                        data-icon="angle-down"
-                        data-prefix="fas"
-                        focusable="false"
-                        role="img"
-                        style={Object {}}
-                        viewBox="0 0 320 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                          fill="currentColor"
-                          style={Object {}}
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                  <div
                     className="user-menu dropdown"
                     onKeyDown={[Function]}
                   >

--- a/tutor/specs/components/app.spec.jsx
+++ b/tutor/specs/components/app.spec.jsx
@@ -7,6 +7,7 @@ jest.mock('../../src/models/user', () => ({
   verifiedRoleForCourse() {
     return 'teacher';
   },
+  isAllowedSchoolType: true,
   isConfirmedFaculty: true,
   terms: {
     api: {

--- a/tutor/specs/components/my-courses.spec.jsx
+++ b/tutor/specs/components/my-courses.spec.jsx
@@ -18,7 +18,7 @@ describe('My Courses Component', function() {
   afterEach(() => {
     Courses.clear();
     User.faculty_status = '';
-    User.school_type = 'unknown_school_type';
+    User.school_type = 'college';
     User.self_reported_role = '';
   });
 
@@ -118,10 +118,23 @@ describe('My Courses Component', function() {
     wrapper.unmount();
   });
 
-  it('displays previews', () => {
-    loadTeacherUser();
-    const wrapper = mount(<C><CourseListing /></C>);
-    expect(wrapper).toHaveRendered('MyCoursesPreview MyCoursesBasic');
-    wrapper.unmount();
+  describe('non-allowed instructors', () => {
+    it('locks them out and displays message when they hve no courses', () => {
+      loadTeacherUser();
+      Courses.clear();
+      User.school_type = 'unknown_school_type';
+      const wrapper = mount(<C><CourseListing /></C>);
+      expect(wrapper).toHaveRendered('NonAllowedTeachers');
+      wrapper.unmount();
+    });
+
+    it('hides previews if they have courses', () => {
+      loadTeacherUser();
+      const wrapper = mount(<C><CourseListing /></C>);
+      expect(wrapper).toHaveRendered('MyCoursesPreview MyCoursesBasic');
+      User.school_type = 'unknown_school_type';
+      expect(wrapper).not.toHaveRendered('MyCoursesPreview MyCoursesBasic');
+      wrapper.unmount();
+    });
   });
 });

--- a/tutor/specs/models/user.spec.js
+++ b/tutor/specs/models/user.spec.js
@@ -94,12 +94,12 @@ describe('User Model', () => {
     expect(User.initials).toEqual('B S');
   });
 
-  it('detects college teachers', () => {
+  it('detects allowed teachers', () => {
     User.school_type = 'unknown_school_type';
-    expect(User.isCollegeTeacher).toBe(false);
+    expect(User.isAllowedInstructor).toBe(false);
     User.faculty_status = 'confirmed_faculty';
     User.school_type = 'college';
-    expect(User.isCollegeTeacher).toBe(true);
+    expect(User.isAllowedInstructor).toBe(true);
   });
 
 });

--- a/tutor/specs/models/user/__snapshots__/menu.spec.js.snap
+++ b/tutor/specs/models/user/__snapshots__/menu.spec.js.snap
@@ -49,6 +49,16 @@ Array [
       "courseId": 2,
     },
   },
+  Object {
+    "label": "Create a Course",
+    "name": "createNewCourse",
+    "options": Object {
+      "separator": "both",
+    },
+    "params": Object {
+      "courseId": 2,
+    },
+  },
 ]
 `;
 

--- a/tutor/specs/models/user/menu.spec.js
+++ b/tutor/specs/models/user/menu.spec.js
@@ -2,7 +2,10 @@ import { ld, Factory } from '../../helpers';
 import UserMenu from '../../../src/models/user/menu';
 import User from '../../../src/models/user';
 
-jest.mock('../../../src/models/user');
+jest.mock('../../../src/models/user', () => ({
+  isAllowedInstructor: true,
+  isConfirmedFaculty: true,
+}));
 
 describe('Current User Store', function() {
 
@@ -29,8 +32,8 @@ describe('Current User Store', function() {
     expect.snapshot(UserMenu.getRoutes(course)).toMatchSnapshot();
   });
 
-  it('hides course creation from unverified faculty', () => {
-    User.isConfirmedFaculty = false;
+  it('hides course creation from non-college faculty', () => {
+    User.isAllowedInstructor = false;
     const course = Factory.course({ is_teacher: true });
     const options = ld.map(UserMenu.getRoutes(course), 'name');
     expect(options).not.toContain('createNewCourse');

--- a/tutor/specs/screens/new-course/course-name.spec.js
+++ b/tutor/specs/screens/new-course/course-name.spec.js
@@ -2,7 +2,9 @@ import { React, Factory } from '../../helpers';
 import CourseName from '../../../src/screens/new-course/course-name';
 import BuilderUX from '../../../src/screens/new-course/ux';
 
-jest.mock('../../../src/models/user');
+jest.mock('../../../src/models/user', () => ({
+  isAllowedInstructor: true,
+}));
 
 describe('CreateCourse: entering name', function() {
 

--- a/tutor/specs/screens/new-course/course-numbers.spec.jsx
+++ b/tutor/specs/screens/new-course/course-numbers.spec.jsx
@@ -2,7 +2,9 @@ import { C, React, Factory } from '../../helpers';
 import CourseNumbers from '../../../src/screens/new-course/course-numbers';
 import BuilderUX from '../../../src/screens/new-course/ux';
 
-jest.mock('../../../src/models/user');
+jest.mock('../../../src/models/user', () => ({
+  isAllowedInstructor: true,
+}));
 
 describe('CreateCourse: entering details', function() {
 

--- a/tutor/specs/screens/new-course/index.spec.jsx
+++ b/tutor/specs/screens/new-course/index.spec.jsx
@@ -4,6 +4,7 @@ import NewCourse from '../../../src/screens/new-course';
 jest.mock('../../../src/models/loader');
 jest.mock('../../../src/models/user', () => ({
   terms_signatures_needed: false,
+  isAllowedInstructor: true,
 }));
 
 describe('NewCourse wrapper', function() {

--- a/tutor/specs/screens/new-course/select-course.spec.jsx
+++ b/tutor/specs/screens/new-course/select-course.spec.jsx
@@ -3,7 +3,9 @@ import SelectCourse from '../../../src/screens/new-course/select-course';
 import BuilderUX from '../../../src/screens/new-course/ux';
 
 
-jest.mock('../../../src/models/user');
+jest.mock('../../../src/models/user', () => ({
+  isAllowedInstructor: true,
+}));
 
 describe('CreateCourse: Selecting course subject', function() {
 

--- a/tutor/specs/screens/new-course/select-dates.spec.jsx
+++ b/tutor/specs/screens/new-course/select-dates.spec.jsx
@@ -2,7 +2,9 @@ import { React, Factory, TimeMock } from '../../helpers';
 import SelectDates from '../../../src/screens/new-course/select-dates';
 import BuilderUX from '../../../src/screens/new-course/ux';
 
-jest.mock('../../../src/models/user');
+jest.mock('../../../src/models/user', () => ({
+  isAllowedInstructor: true,
+}));
 
 describe('CreateCourse: Selecting course dates', function() {
   let ux;

--- a/tutor/specs/screens/new-course/ux.spec.js
+++ b/tutor/specs/screens/new-course/ux.spec.js
@@ -1,11 +1,14 @@
 import { Factory, TestRouter } from '../../helpers';
 import BuilderUX from '../../../src/screens/new-course/ux';
 import User from '../../../src/models/user';
+import Router from '../../../src/helpers/router';
 
 jest.mock('../../../src/helpers/router');
 jest.useFakeTimers();
 
-jest.mock('../../../src/models/user');
+jest.mock('../../../src/models/user', () => ({
+  isAllowedInstructor: true,
+}));
 
 const testRouter = new TestRouter();
 let courses;
@@ -19,7 +22,7 @@ describe('Course Builder UX Model', () => {
   let ux;
 
   beforeEach(() => {
-    User.isConfirmedFaculty = true;
+    User.isAllowedInstructor = true;
     courses = Factory.coursesMap({ is_teacher: true });
     ux = createTestUX();
     ux.courses.array[0].offering_id = ux.offerings.array[0].id;
@@ -143,6 +146,14 @@ describe('Course Builder UX Model', () => {
     ux.newCourse.offering_id = offering.id;
     ux.newCourse.offering = ux.offerings.array[1];
     expect(ux.offering).toEqual(ux.offerings.array[1]);
+  });
+
+  it('redirects to not allowed teacher page if teacher isnt allowed access', () => {
+    User.isAllowedInstructor = false;
+    ux = createTestUX();
+    Router.makePathname.mockReturnValue('/only-teacher');
+    jest.runOnlyPendingTimers();
+    expect(ux.router.history.replace).toHaveBeenCalledWith('/only-teacher');
   });
 
   describe('after course is created', function() {

--- a/tutor/specs/screens/new-course/wizard.spec.jsx
+++ b/tutor/specs/screens/new-course/wizard.spec.jsx
@@ -5,7 +5,9 @@ import Wizard from '../../../src/screens/new-course/wizard';
 import { OfferingsMap, Offering } from '../../../src/models/course/offerings';
 
 jest.mock('../../../src/helpers/router');
-jest.mock('../../../src/models/user');
+jest.mock('../../../src/models/user', () => ({
+  isAllowedInstructor: true,
+}));
 
 describe('Creating a course', function() {
 

--- a/tutor/src/components/my-courses/index.jsx
+++ b/tutor/src/components/my-courses/index.jsx
@@ -8,6 +8,7 @@ import Courses from '../../models/courses-map';
 import EmptyCourses from './empty';
 import TourRegion from '../tours/region';
 import PendingVerification from './pending-verification';
+import NonAllowedTeacher from './non-allowed-teacher';
 import { MyCoursesPast, MyCoursesCurrent, MyCoursesPreview } from './listings';
 
 export default
@@ -33,7 +34,11 @@ class MyCourses extends React.Component {
 
   render() {
     if (Courses.isEmpty) {
-      if (!User.isConfirmedFaculty) {
+      if (User.isConfirmedFaculty) {
+        if (!User.isAllowedInstructor) {
+          return <NonAllowedTeacher />;
+        }
+      } else {
         return User.isUnverifiedInstructor? <PendingVerification /> : <EmptyCourses />;
       }
     }

--- a/tutor/src/components/my-courses/non-allowed-teacher.js
+++ b/tutor/src/components/my-courses/non-allowed-teacher.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import SupportLink from '../support-email-link';
+import { Card } from 'react-bootstrap';
+import styled from 'styled-components';
+
+const ThanksButNo = styled(Card)`
+padding: 2rem;
+font-size: 2rem;
+line-height: 2.5rem;
+margin: 4rem auto;
+max-width: 800px;
+`;
+
+export default function NonAllowedTeachers() {
+  return (
+    <ThanksButNo className="non-allowed-instructors">
+      <p>
+        Thanks for your interest in OpenStax Tutor Beta! At this time, OpenStax Tutor Beta is only available to instructors and students at 2- and 4-year institutions and high schools in the United States. Unfortunately, we're not able to offer OpenStax Tutor Beta to home school, corporate or international users at this time.
+      </p>
+      <p>
+        In the meantime, we have over 50 online homework and ancillary partners that have created low-cost tools that integrate with our books. You can find those resources at <a href="https://openstax.org/partners">openstax.org/partners</a>.
+      </p>
+      <p>
+        If you think you’ve reached this page in error, please contact <SupportLink displayEmail />.
+      </p>
+    </ThanksButNo>
+  );
+}

--- a/tutor/src/models/user.js
+++ b/tutor/src/models/user.js
@@ -1,7 +1,7 @@
 import {
   BaseModel, identifiedBy, field, hasMany,
 } from 'shared/model';
-import { find, isEmpty, startsWith } from 'lodash';
+import { find, isEmpty, startsWith, includes } from 'lodash';
 import { action, computed, observable } from 'mobx';
 import UiSettings from 'shared/model/ui-settings';
 import Courses from './courses-map';
@@ -80,12 +80,12 @@ class User extends BaseModel {
     return this.faculty_status === 'confirmed_faculty';
   }
 
-  @computed get isCollegeTeacher() {
-    return this.isConfirmedFaculty && this.school_type === 'college';
+  @computed get isAllowedInstructor() {
+    return this.isConfirmedFaculty && includes(['college', 'high_school', 'k12_school'], this.school_type);
   }
 
   @computed get canViewPreviewCourses() {
-    return this.isConfirmedFaculty;
+    return this.isAllowedInstructor;
   }
 
   @computed get isProbablyTeacher() {

--- a/tutor/src/models/user/menu.js
+++ b/tutor/src/models/user/menu.js
@@ -87,7 +87,7 @@ const ROUTES = {
     label: 'Create a Course',
     isAllowed(course) {
       return Boolean(
-        User.isConfirmedFaculty && (!course || !course.currentRole.isTeacherStudent)
+        User.isAllowedInstructor && (!course || !course.currentRole.isTeacherStudent)
       );
     },
     options({ course }) {
@@ -106,7 +106,7 @@ const ROUTES = {
       key: 'cloneCourse', separator: 'after',
     },
     isAllowed(course) {
-      return !!(course && !course.is_preview && !course.is_concept_coach && User.isConfirmedFaculty); },
+      return !!(course && !course.is_preview && User.isAllowedInstructor); },
   },
   customer_service: {
     label: 'Customer Service',

--- a/tutor/src/routes.js
+++ b/tutor/src/routes.js
@@ -1,6 +1,7 @@
 import { loadAsync } from './helpers/async-component';
 import { memoize } from 'lodash';
 import { getConditionalHandlers } from './helpers/conditional-handlers';
+import NonAllowedTeacher from './components/my-courses/non-allowed-teacher';
 
 const r = (i, n) => memoize(loadAsync(i, n));
 
@@ -10,6 +11,8 @@ const getRoutes = (router) => {
   return [
     { path: '/dashboard', name: 'myCourses',
       renderer: r(() => import('./components/my-courses'), 'Courses Listing') },
+    { path: '/non-allowed-instructors', name: 'nonAllowedTeacher',
+      renderer: () => NonAllowedTeacher },
     { path: '/enroll/start/:enrollmentCode', name: 'createEnrollmentChange',
       renderer: r(() => import('./components/enroll'), 'Course Enrollment') },
     { path: '/new-course/offering/:appearanceCode?', name: 'createNewCourseFromOffering',

--- a/tutor/src/screens/new-course/ux.js
+++ b/tutor/src/screens/new-course/ux.js
@@ -2,7 +2,7 @@ import {
   BaseModel, identifiedBy,
 } from 'shared/model';
 import {
-  invoke, filter, result, isEmpty, pick, values, every, find,
+  invoke, filter, result, isEmpty, pick, values, every, delay, find,
 } from 'lodash';
 import { readonly } from 'core-decorators';
 import { when, observable, computed, action, observe } from 'mobx';
@@ -10,6 +10,8 @@ import Course from '../../models/course';
 import Courses from '../../models/courses-map';
 import Offerings from '../../models/course/offerings';
 import CreateCourse from '../../models/course/create';
+import Router from '../../helpers/router';
+import User from '../../models/user';
 
 export default
 @identifiedBy('course/builder-ux')
@@ -41,6 +43,15 @@ class CourseBuilderUX extends BaseModel {
     this.offerings = offerings;
     this.courses = courses;
     this.newCourse = new CreateCourse({ courses, offerings });
+    if (!User.isAllowedInstructor) {
+      delay(() => // use delay in case we're called from a React constructor
+        router.history.replace(
+          Router.makePathname('nonAllowedTeacher')
+        )
+      );
+      this.currentStageIndex = 0;
+      return;
+    }
 
     invoke(this.offerings.fetch(), 'then', this.onOfferingsAvailable);
 


### PR DESCRIPTION
Only college, high_school and k12 should be given instructor access

Salesforce has a few others like "general" that shouldn't be able to teach

<img width="918" alt="image" src="https://user-images.githubusercontent.com/79566/80151111-1fdadf80-857f-11ea-811f-357c79cd28d4.png">
