### PR TITLE
Delete modal in assignment review

### DIFF
--- a/tutor/resources/styles/global/buttons.scss
+++ b/tutor/resources/styles/global/buttons.scss
@@ -3,9 +3,6 @@ $default-background: rgba(245,245,245,.4);
 $default-background-hover: rgba(255,255,255,.8);
 $primary-background: #f47642;
 $primary-background-hover: #fa804d;
-$form-action-background: #fff;
-$form-action-color: #5e6062;
-$form-action-border: #d5d5d5;
 
 .btn + .btn { margin-left: 0.5rem; }
 
@@ -145,19 +142,27 @@ $form-action-border: #d5d5d5;
   }
 }
 
-.btn.btn-form-action {
-  &:not(.btn-primary) {
-    background: $form-action-background;
-    color: $form-action-color;
-    border: 1px solid $form-action-border;
-  }
-
+.btn.btn-standard {
   height: 4.8rem;
   min-width: 12rem;
   padding: 0 1.6rem;
   display: flex;
   align-items: center;
   justify-content: center;
+
+  &:not(.btn-primary) {
+    background: #fff;
+    color: #5e6062;
+    border: 1px solid #d5d5d5;
+  }
+
+  &.btn-icon {
+    min-width: 5.5rem;
+  }
+
+  &.btn-inline {
+    display: inline-flex;
+  }
 }
 
 .btn-new-flag {

--- a/tutor/scripts/test-server/backend/task-plans.js
+++ b/tutor/scripts/test-server/backend/task-plans.js
@@ -70,10 +70,16 @@ module.exports = {
     return res.json(plan);
   },
 
+  delete(req, res) {
+    const plan = planForId(req.params.id);
+    return res.json(plan);
+  },
+
   route(server) {
     server.get('/api/plans/:id', this.get);
-    server.get('/api/courses/:courseId/plans/past*', this.getPast);
     server.patch('/api/plans/:id', this.update);
+    server.delete('/api/plans/:id', this.delete);
+    server.get('/api/courses/:courseId/plans/past*', this.getPast);
     server.get('/api/plans/:id/scores', this.getScores);
     server.get('/api/plans/:id/stats', this.getStats);
     server.get('/api/plans/:id/review', this.getStats);

--- a/tutor/specs/integration/assignment-review.spec.js
+++ b/tutor/specs/integration/assignment-review.spec.js
@@ -32,13 +32,18 @@ context('Assignment Review', () => {
       cy.getTestElement('drop-questions-btn').click()
       cy.get(`[data-question-id=${questionId}] input[type="checkbox"]`).should('be.checked')
     })
-
-  })
+  });
 
   it('can render grading template preview', () => {
     cy.getTestElement('grading-template-card').should('not.exist');
     cy.getTestElement('preview-card-trigger').click();
     cy.getTestElement('grading-template-card').should('exist');
+  });
+
+  it('can delete assignment', () => {
+    cy.getTestElement('delete-assignment').click();
+    cy.getTestElement('confirm-delete-assignment').click();
+    cy.location('pathname').should('include', '/course/1/t/month');
   });
 
 });

--- a/tutor/src/screens/assignment-review/delete-modal.js
+++ b/tutor/src/screens/assignment-review/delete-modal.js
@@ -1,0 +1,72 @@
+import { React, PropTypes, styled, observer } from 'vendor';
+import { Button, Modal } from 'react-bootstrap';
+
+const StyledHeader = styled(Modal.Header)`
+  font-weight: bold;
+
+  .close {
+    font-size: 3rem;
+  }
+`;
+
+const StyledBody = styled(Modal.Body)`
+  font-size: 1.6rem;
+  line-height: 2.5rem;
+`;
+
+const ControlsWrapper = styled.div`
+  margin-top: 3rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+`;
+
+const Controls = styled.div`
+  .btn + .btn {
+    margin-left: 1.5rem;
+  }
+`;
+
+const DeleteModal = observer(({ ux: { onConfirmDelete, onCancelDelete } }) => {
+  return (
+    <Modal
+      show={true}
+      onHide={onCancelDelete}
+      backdrop="static"
+    >
+      <StyledHeader closeButton>
+        Delete assignment?
+      </StyledHeader>
+      <StyledBody>
+        <p>Some students may have started work on this assignment. Are you sure you want to permanently
+        delete this assignment?</p>
+        <p>You can't undo this action.</p>
+        <ControlsWrapper>
+          <Controls>
+            <Button
+              data-test-id="confirm-delete-assignment"
+              variant="default"
+              className="btn-standard btn-inline"
+              onClick={onConfirmDelete}
+            >
+              Delete
+            </Button>
+            <Button
+              data-test-id="cancel-delete-assignment"
+              className="btn-standard btn-inline"
+              onClick={onCancelDelete}
+            >
+              Cancel
+            </Button>
+          </Controls>
+        </ControlsWrapper>
+      </StyledBody>
+    </Modal>
+  );
+});
+
+DeleteModal.propTypes = {
+  ux: PropTypes.object.isRequired,
+};
+
+export default DeleteModal;

--- a/tutor/src/screens/assignment-review/details.js
+++ b/tutor/src/screens/assignment-review/details.js
@@ -9,6 +9,7 @@ import HomeworkQuestions, { ExerciseNumber } from '../../components/homework-que
 import S from '../../helpers/string';
 import { isEmpty } from 'lodash';
 import PreviewTooltip from '../assignment-edit/preview-tooltip';
+import DeleteModal from './delete-modal';
 
 const DetailsWrapper = styled.div`
 
@@ -88,6 +89,15 @@ const Header = styled.div`
 
 const Controls = styled.div`
   align-self: flex-end;
+  display: flex;
+  .btn.btn-icon {
+    min-width: 0;
+    width: 5.5rem;
+    height: 4rem;
+  }
+  .btn + .btn {
+    margin-left: 1.6rem;
+  }
 `;
 
 const Title = styled.div`
@@ -105,10 +115,10 @@ const StyledHomeworkQuestions = styled(HomeworkQuestions)`
 `;
 
 const StyledTutorLink = styled(TutorLink)`
-  &.btn.btn-form-action {
-    display: inline-flex;
-  }
   margin-bottom: 2.5rem;
+  &.btn.btn-standard {
+    min-width: 16.7rem;
+  }
 `;
 
 const QuestionHeader = ({ styleVariant, label, info }) => useObserver(() => {
@@ -179,8 +189,9 @@ const TemplateInfo = ({ template }) => useObserver(() => {
   );
 });
 
-
-const Details = observer(({ ux, ux: { scores, planScores, taskingPlan } }) => {
+const Details = observer(({ ux, ux: {
+  scores, planScores, taskingPlan, isDisplayingConfirmDelete,
+} }) => {
   const format = 'MMM D, h:mm a';
 
   return (
@@ -190,12 +201,16 @@ const Details = observer(({ ux, ux: { scores, planScores, taskingPlan } }) => {
           <Header>
             <h6>Details</h6>
             <Controls>
-              <Button variant="icon">
+              <button className="btn btn-standard btn-icon">
                 <Icon type="edit" />
-              </Button>
-              <Button variant="icon">
+              </button>
+              <button
+                className="btn btn-standard btn-icon"
+                onClick={ux.onDelete}
+                data-test-id="delete-assignment"
+              >
                 <Icon type="trash" />
-              </Button>
+              </button>
             </Controls>
           </Header>
           <Table>
@@ -249,8 +264,8 @@ const Details = observer(({ ux, ux: { scores, planScores, taskingPlan } }) => {
           <div>
             <p>This assignment is now open for grading.</p>
             <StyledTutorLink
-              className="btn btn-form-action btn-primary btn-new-flag"
-              to='gradeAssignment'
+              className="btn btn-standard btn-primary btn-new-flag btn-inline"
+              to="gradeAssignment"
               params={{ id: ux.planId, periodId: taskingPlan.target_id, courseId: ux.course.id }}
             >
               <span className="flag">72 New</span>
@@ -259,11 +274,17 @@ const Details = observer(({ ux, ux: { scores, planScores, taskingPlan } }) => {
           </div>
           <div>
             <p>View scores for auto-graded questions</p>
-            <button className="btn btn-form-action btn-light">View scores</button>
+            <StyledTutorLink
+              className="btn btn-standard btn-inline"
+              to=""
+            >
+              View scores
+            </StyledTutorLink>
           </div>
         </Section>
       </Top>
       {scores && <Questions ux={ux} questionsInfo={scores.questionsInfo} />}
+      {isDisplayingConfirmDelete && <DeleteModal ux={ux} />}
     </DetailsWrapper>
   );
 

--- a/tutor/src/screens/assignment-review/index.js
+++ b/tutor/src/screens/assignment-review/index.js
@@ -74,8 +74,18 @@ class AssignmentReview extends React.Component {
       ...props.params,
       history: props.history,
       course,
-      onComplete: this.onComplete,
+      onCompleteDelete: this.onCompleteDelete,
     });
+  }
+
+  @action.bound onCompleteDelete() {
+    const { ux } = this;
+    this.props.history.push(
+      Router.makePathname('calendarByDate', {
+        courseId: ux.course.id,
+        date: ux.planScores.taskPlan.dateRanges.opens.start.format('YYYY-MM-DD'),
+      }),
+    );
   }
 
   render() {

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -172,7 +172,7 @@ const Right = styled.div`
 
 const GradeButton = styled(TutorLink).attrs({
   to: 'gradeAssignment',
-  className: 'btn btn-form-action btn-primary btn-new-flag',
+  className: 'btn btn-standard btn-primary btn-new-flag',
 })`
   && {
     padding: 1.2rem 2.1rem 1.6rem 1.1rem;

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -11,6 +11,7 @@ export default class AssignmentReviewUX {
   @observable exercisesHaveBeenFetched = false;
   @observable isDisplayingGrantExtension = false;
   @observable isDisplayingDropQuestions = false;
+  @observable isDisplayingConfirmDelete = false;
 
   freeResponseQuestions = observable.map();
   pendingExtensions = observable.map();
@@ -21,13 +22,14 @@ export default class AssignmentReviewUX {
   }
 
   @action async initialize({
-    id, scores, course,
+    id, scores, course, onCompleteDelete,
     windowImpl = window,
   }) {
     this.scroller = new ScrollTo({ windowImpl });
     this.planScores = scores || new TaskPlanScores({ id, course });
     this.course = course;
     this.selectedPeriod = first(course.periods.active);
+    this.onCompleteDelete = onCompleteDelete;
 
     await this.planScores.fetch();
 
@@ -107,6 +109,19 @@ export default class AssignmentReviewUX {
 
   droppedQuestionRecord(heading) {
     return heading.dropped || this.pendingDroppedQuestions.get(heading.question_id);
+  }
+
+  @action.bound onDelete() {
+    this.isDisplayingConfirmDelete = true;
+  }
+
+  @action.bound async onConfirmDelete() {
+    await this.planScores.taskPlan.destroy();
+    this.onCompleteDelete();
+  }
+
+  @action.bound onCancelDelete() {
+    this.isDisplayingConfirmDelete = false;
   }
 
 }

--- a/tutor/src/screens/teacher-dashboard/plan-details.jsx
+++ b/tutor/src/screens/teacher-dashboard/plan-details.jsx
@@ -97,7 +97,7 @@ class CoursePlanDetails extends React.Component {
   @computed get assignmentLinksButton() {
     if (this.props.plan.type === 'event'){ return null; }
     return (
-      <button className="btn btn-form-action" onClick={this.onShowAssignmentLinks}>
+      <button className="btn btn-standard" onClick={this.onShowAssignmentLinks}>
         Get assignment link
       </button>
     );
@@ -119,7 +119,7 @@ class CoursePlanDetails extends React.Component {
       >
         <span>
           <TutorLink
-            className={cn('btn btn-form-action btn-primary', { 'disabled': !this.tasking.isPastDue }) }
+            className={cn("btn btn-standard btn-primary", { 'disabled': !this.tasking.isPastDue }) }
             to="gradeAssignment"
             data-test-id="gradeAnswers"
             params={{ id: plan.id, periodId: this.tasking.target_id, courseId: course.id }}
@@ -139,7 +139,7 @@ class CoursePlanDetails extends React.Component {
       <div className="modal-footer">
         <TutorLink
           disabled={!plan.isPublished}
-          className="btn btn-form-action"
+          className="btn btn-standard"
           to={plan.isExternal ? 'viewGradebook' : 'reviewAssignment'}
           params={this.linkParams}
         >


### PR DESCRIPTION
- Add delete assignment modal
- Rename `btn-form-action` to `btn-standard`. I didn't realize at first how much we'd be using these new button styles outside of forms, so I'm taking the time now to settle on this naming ("default" is already in use.) Should be generic enough and allow us to continue phasing in the new styles without overriding the existing "default" buttons.

![image](https://user-images.githubusercontent.com/34174/80150227-db464880-856c-11ea-9ec2-fa03a806c200.png)
