### PR TITLE
Confirm changing template

### DIFF
--- a/tutor/scripts/test-server/backend/grading-templates.js
+++ b/tutor/scripts/test-server/backend/grading-templates.js
@@ -2,9 +2,11 @@ const Factory = require('object-factory-bot');
 const { times, fromPairs } = require('lodash');
 require('../../../specs/factories/grading-template');
 
-const TEMPLATES = times(2, (i) => Factory.create('GradingTemplate', {
+let TEMPLATES = times(2, (i) => Factory.create('GradingTemplate', {
   task_plan_type: i ? 'reading' : 'homework',
 }));
+
+TEMPLATES.push(Factory.create('GradingTemplate', { task_plan_type: 'homework', name: 'Second Homework' }));
 
 const TEMPLATES_MAP = fromPairs(TEMPLATES.map(t => [t.id, t]));
 

--- a/tutor/specs/integration/assignment-review.spec.js
+++ b/tutor/specs/integration/assignment-review.spec.js
@@ -46,4 +46,14 @@ context('Assignment Review', () => {
     cy.location('pathname').should('include', '/course/1/t/month');
   });
 
+  it.only('can update details', () => {
+    cy.server();
+    cy.route('GET', '/api/courses/1/grading_templates*').as('getGradingTemplates');
+    cy.wait('@getGradingTemplates');
+    cy.getTestElement('edit-assignment').click();
+    cy.getTestElement('edit-assignment-name').clear().type('Update');
+    cy.getTestElement('confirm-save-assignment').click();
+    cy.getTestElement('assignment-name').should('have.text', 'Update');
+  });
+
 });

--- a/tutor/specs/integration/assignment-review.spec.js
+++ b/tutor/specs/integration/assignment-review.spec.js
@@ -46,7 +46,7 @@ context('Assignment Review', () => {
     cy.location('pathname').should('include', '/course/1/t/month');
   });
 
-  it.only('can update details', () => {
+  it('can update details', () => {
     cy.server();
     cy.route('GET', '/api/courses/1/grading_templates*').as('getGradingTemplates');
     cy.wait('@getGradingTemplates');
@@ -54,6 +54,25 @@ context('Assignment Review', () => {
     cy.getTestElement('edit-assignment-name').clear().type('Update');
     cy.getTestElement('confirm-save-assignment').click();
     cy.getTestElement('assignment-name').should('have.text', 'Update');
+  });
+
+  it('requires confirmation when changing grading template', () => {
+    cy.server();
+    cy.route('GET', '/api/courses/1/grading_templates*').as('getGradingTemplates');
+    cy.wait('@getGradingTemplates');
+
+    // Can change
+    cy.getTestElement('edit-assignment').click();
+    cy.getTestElement('grading-templates').click();
+    cy.getTestElement('Second Homework').click();
+    cy.getTestElement('confirm-change-template').click();
+    cy.getTestElement('selected-grading-template').should('have.text', 'Second Homework');
+
+    // Can cancel
+    cy.getTestElement('grading-templates').click();
+    cy.getTestElement('Default Homework').click();
+    cy.getTestElement('cancel-confirm-change-template').click();
+    cy.getTestElement('selected-grading-template').should('have.text', 'Second Homework');
   });
 
 });

--- a/tutor/src/screens/assignment-edit/confirm-template-modal.js
+++ b/tutor/src/screens/assignment-edit/confirm-template-modal.js
@@ -1,0 +1,80 @@
+import { React, PropTypes, styled, observer } from 'vendor';
+import { Button, Modal } from 'react-bootstrap';
+
+const StyledHeader = styled(Modal.Header)`
+  font-weight: bold;
+
+  .close {
+    font-size: 3rem;
+  }
+`;
+
+const StyledBody = styled(Modal.Body)`
+  font-size: 1.6rem;
+  line-height: 2.5rem;
+`;
+
+const ControlsWrapper = styled.div`
+  margin-top: 3rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+`;
+
+const Controls = styled.div`
+  .btn + .btn {
+    margin-left: 1.5rem;
+  }
+`;
+
+const StyledModal = styled(Modal)`
+  .stacked-modal-backdrop {
+    z-index: 1050;
+  }
+`;
+
+const ConfirmTemplateModal = observer(({ onConfirm, onCancel }) => {
+  return (
+    <StyledModal
+      show={true}
+      onHide={onCancel}
+      backdrop="static"
+      backdropClassName="stacked-modal-backdrop"
+    >
+      <StyledHeader closeButton>
+        Change grading template?
+      </StyledHeader>
+      <StyledBody>
+        <p>Changing the grading template applied to an assignment may
+        affect the existing grades and assignment dates for the class.</p>
+        <p>Do you still wish to continue?</p>
+        <ControlsWrapper>
+          <Controls>
+            <Button
+              data-test-id="cancel-confirm-change-template"
+              variant="default"
+              className="btn-standard btn-inline"
+              onClick={onCancel}
+            >
+              No
+            </Button>
+            <Button
+              data-test-id="confirm-change-template"
+              className="btn-standard btn-inline"
+              onClick={onConfirm}
+            >
+              Continue
+            </Button>
+          </Controls>
+        </ControlsWrapper>
+      </StyledBody>
+    </StyledModal>
+  );
+});
+
+ConfirmTemplateModal.propTypes = {
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+export default ConfirmTemplateModal;

--- a/tutor/src/screens/assignment-edit/details-body.js
+++ b/tutor/src/screens/assignment-edit/details-body.js
@@ -4,6 +4,7 @@ import RadioInput from '../../components/radio-input';
 import PreviewTooltip from './preview-tooltip';
 import NewTooltip from './new-tooltip';
 import Tasking from './tasking';
+import ConfirmTemplateModal from './confirm-template-modal';
 import { OverlayTrigger, Tooltip, Dropdown } from 'react-bootstrap';
 import ChangeTimezone from './change-timezone';
 import { colors } from '../../theme';
@@ -115,7 +116,7 @@ const TemplateField = observer(({ ux }) => {
       </RowLabel>
       <div>
         <StyledDropdown data-test-id="grading-templates">
-          <StyledToggle variant="outline">
+          <StyledToggle variant="outline" data-test-id="selected-grading-template">
             {ux.gradingTemplate.name}
           </StyledToggle>
           <StyledMenu>
@@ -124,17 +125,15 @@ const TemplateField = observer(({ ux }) => {
                 key={t.id}
                 value={t.id}
                 eventKey={t.id}
-                onSelect={k => {
-                  ux.form.setFieldValue('grading_template_id', k);
-                  ux.plan.grading_template_id = k;
-                }}
+                onSelect={k => ux.onSelectTemplate(k)}
                 data-test-id={`${t.name}`}
               >
                 {t.name}
               </Dropdown.Item>)}
-            <StyledAddItem as="button" onClick={ux.onShowAddTemplate} data-test-id="add-template">
-              + Add new template
-            </StyledAddItem>
+            {ux.canAddTemplate &&
+              <StyledAddItem as="button" onClick={ux.onShowAddTemplate} data-test-id="add-template">
+                + Add new template
+              </StyledAddItem>}
           </StyledMenu>
         </StyledDropdown>
         <PreviewTooltip template={ux.gradingTemplate} />
@@ -232,6 +231,11 @@ const DetailsBody = observer(({ ux }) => {
         </FullWidthCol>
       </SplitRow>
       {ux.isShowingAddTemplate && <EditModal ux={ux} />}
+      {ux.isShowingConfirmTemplate &&
+        <ConfirmTemplateModal
+          onConfirm={ux.onConfirmTemplate}
+          onCancel={ux.onCancelConfirmTemplate}
+        />}
     </Body>
   );
 });

--- a/tutor/src/screens/assignment-edit/ux.js
+++ b/tutor/src/screens/assignment-edit/ux.js
@@ -332,7 +332,7 @@ export default class AssignmentUX {
     await this.saveAndCopyPlan();
   }
 
-  @action.bound async savePlan(){
+  @action.bound async savePlan() {
     this.plan.update(omit(this.form.values, 'tasking_plans'));
     this.plan.is_draft = false;
     if (!this.plan.is_published) {

--- a/tutor/src/screens/assignment-edit/ux.js
+++ b/tutor/src/screens/assignment-edit/ux.js
@@ -22,6 +22,7 @@ export default class AssignmentUX {
   @observable isShowingExerciseReview = false;
   @observable isShowingPeriodTaskings;
   @observable isShowingAddTemplate = false;
+  @observable isShowingConfirmTemplate = false;
   @observable exercises;
   @observable isReady = false;
   @observable sourcePlanId;
@@ -90,7 +91,7 @@ export default class AssignmentUX {
 
     observe(this.plan, ({ name, object }) => {
       // Change the ux dates when the template of the plan is changed
-      if(name === 'grading_template_id' && object && object.tasking_plans)
+      if(name === 'grading_template_id' && this.plan.isNew && object && object.tasking_plans)
         object.tasking_plans.forEach((t, index) => {
           if(this.form){
             this.form.setFieldValue(`tasking_plans[${index}].due_at`, t.due_at);
@@ -147,6 +148,11 @@ export default class AssignmentUX {
     return TEMPLATEABLE_TYPES.includes(this.plan.type);
   }
 
+  @computed get canAddTemplate() {
+    // Prevent showing add template modal when editing in review
+    return this.plan.isNew;
+  }
+
   @computed get canInputExternalUrl() {
     return this.plan.type === 'external';
   }
@@ -193,6 +199,29 @@ export default class AssignmentUX {
 
   @action.bound onCancel() {
     this.onComplete();
+  }
+
+  @action.bound onSelectTemplate(templateId) {
+    if (this.plan.isNew) {
+      this.setTemplateId(templateId);
+    } else {
+      this.newTemplateId = templateId;
+      this.isShowingConfirmTemplate = true;
+    }
+  }
+
+  @action.bound onConfirmTemplate() {
+    this.setTemplateId(this.newTemplateId);
+    this.isShowingConfirmTemplate = false;
+  }
+
+  @action.bound onCancelConfirmTemplate() {
+    this.isShowingConfirmTemplate = false;
+  }
+
+  @action.bound setTemplateId(templateId) {
+    this.form.setFieldValue('grading_template_id', templateId);
+    this.plan.grading_template_id = templateId;
   }
 
   get formValues() {

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -145,7 +145,7 @@ export default class AssignmentReviewUX {
 
   @action.bound async onSavePlan() {
     await this.editUX.savePlan();
-    await this.planScores.fetch();
+    Object.assign(this.planScores, this.editUX.plan);
     this.isDisplayingEditAssignment = false;
   }
 


### PR DESCRIPTION
- Adds a confirmation modal when changing grading template on an existing assignment
- Skip updating date times on an existing assignment when changing templates
- Assign updated plan values to `planScores` so we don't have to refetch (helps load + tests.)
- Don't allow adding a new template when editing existing assignment

![image](https://user-images.githubusercontent.com/34174/80828538-4cec4b00-8b9a-11ea-98af-fbf1acb47409.png)
