### PR TITLE
Wrm assignment review details

### DIFF
--- a/tutor/src/models/task-plans/teacher/plan.js
+++ b/tutor/src/models/task-plans/teacher/plan.js
@@ -109,13 +109,15 @@ class TeacherTaskPlan extends BaseModel {
     );
     if (this.isNew) {
       Object.assign(this.settings, this.defaultSettings);
+
+      // Apply updated grading template settings to tasking plans whenever it changes.
+      // Skip doing this on existing plans so set dates aren't affected.
+      observe(this, 'grading_template_id', ({ oldValue, newValue }) => {
+        const previousTemplate = this.course.gradingTemplates.get(oldValue);
+        const currentTemplate = this.course.gradingTemplates.get(newValue);
+        this.tasking_plans.forEach(tp => tp.onGradingTemplateUpdate({ previousTemplate, currentTemplate }));
+      });
     }
-    // apply updated grading template settings to the tasking plans whenever it changes
-    observe(this, 'grading_template_id', ({ oldValue, newValue }) => {
-      const previousTemplate = this.course.gradingTemplates.get(oldValue);
-      const currentTemplate = this.course.gradingTemplates.get(newValue);
-      this.tasking_plans.forEach(tp => tp.onGradingTemplateUpdate({ previousTemplate, currentTemplate }));
-    });
   }
 
   @computed get defaultSettings() {

--- a/tutor/src/models/task-plans/teacher/tasking.js
+++ b/tutor/src/models/task-plans/teacher/tasking.js
@@ -29,6 +29,11 @@ class TaskingPlan extends BaseModel {
     return get(this.plan, 'course');
   }
 
+  get period() {
+    if (this.target_type !== 'period') { return null; }
+    return this.course.periods.find(p => p.id == this.target_id);
+  }
+
   opensAtForTemplate(template) {
     const [ hour, minute ] = template.default_open_time.split(':');
     const defaultOpensAt = moment(Time.now).add(1, 'day').hour(hour).minute(minute).startOf('minute');

--- a/tutor/src/screens/assignment-edit/confirm-template-modal.js
+++ b/tutor/src/screens/assignment-edit/confirm-template-modal.js
@@ -27,15 +27,9 @@ const Controls = styled.div`
   }
 `;
 
-const StyledModal = styled(Modal)`
-  .stacked-modal-backdrop {
-    z-index: 1050;
-  }
-`;
-
 const ConfirmTemplateModal = observer(({ onConfirm, onCancel }) => {
   return (
-    <StyledModal
+    <Modal
       show={true}
       onHide={onCancel}
       backdrop="static"
@@ -68,7 +62,7 @@ const ConfirmTemplateModal = observer(({ onConfirm, onCancel }) => {
           </Controls>
         </ControlsWrapper>
       </StyledBody>
-    </StyledModal>
+    </Modal>
   );
 });
 

--- a/tutor/src/screens/assignment-review/details.js
+++ b/tutor/src/screens/assignment-review/details.js
@@ -269,7 +269,7 @@ const Details = observer(({ ux, ux: {
                   <PlanDates
                     plan={plan}
                     title={ux.areTaskingDatesSame ? 'All sections' : plan.period.name}
-                    key={plan.id}
+                    key={plan.period.id}
                   />
                 )}
               </Item>

--- a/tutor/src/screens/assignment-review/details.js
+++ b/tutor/src/screens/assignment-review/details.js
@@ -190,10 +190,33 @@ const TemplateInfo = ({ template }) => useObserver(() => {
   );
 });
 
-const Details = observer(({ ux, ux: {
-  scores, planScores, taskingPlan, isDisplayingConfirmDelete, isDisplayingEditAssignment, editUX,
-} }) => {
+const PlanDates = observer(({ plan, title }) => {
   const format = 'MMM D, h:mm a';
+
+  return (
+    <>
+      <div>{title}</div>
+      <dl>
+        <div>
+          <dt>Open date</dt>
+          <dd>{moment(plan.opens_at).format(format)}</dd>
+        </div>
+        <div>
+          <dt>Due date</dt>
+          <dd>{moment(plan.due_at).format(format)}</dd>
+        </div>
+        <div>
+          <dt>Close date</dt>
+          <dd>{moment(plan.closes_at).format(format)}</dd>
+        </div>
+      </dl>
+    </>
+  );
+});
+
+const Details = observer(({ ux, ux: {
+  scores, planScores, isDisplayingConfirmDelete, isDisplayingEditAssignment, editUX, taskingPlanDetails,
+} }) => {
 
   if (!editUX) { return <Loading />; }
 
@@ -242,25 +265,14 @@ const Details = observer(({ ux, ux: {
             <Row>
               <Title>Assigned to</Title>
               <Item>
-                All sections
+                {taskingPlanDetails.map(plan =>
+                  <PlanDates
+                    plan={plan}
+                    title={ux.areTaskingDatesSame ? 'All sections' : plan.period.name}
+                    key={plan.id}
+                  />
+                )}
               </Item>
-            </Row>
-            <Row>
-              <Title></Title>
-              <dl>
-                <div>
-                  <dt>Open date</dt>
-                  <dd>{moment(taskingPlan.opens_at).format(format)}</dd>
-                </div>
-                <div>
-                  <dt>Due date</dt>
-                  <dd>{moment(taskingPlan.due_at).format(format)}</dd>
-                </div>
-                <div>
-                  <dt>Close date</dt>
-                  <dd>{moment(taskingPlan.closes_at).format(format)}</dd>
-                </div>
-              </dl>
             </Row>
           </Table>
         </Section>
@@ -273,7 +285,7 @@ const Details = observer(({ ux, ux: {
             <StyledTutorLink
               className="btn btn-standard btn-primary btn-new-flag btn-inline"
               to="gradeAssignment"
-              params={{ id: ux.planId, periodId: taskingPlan.target_id, courseId: ux.course.id }}
+              params={{ id: ux.planId, periodId: ux.selectedPeriodId, courseId: ux.course.id }}
             >
               <span className="flag">72 New</span>
               <span>Grade answers</span>

--- a/tutor/src/screens/assignment-review/details.js
+++ b/tutor/src/screens/assignment-review/details.js
@@ -191,9 +191,11 @@ const TemplateInfo = ({ template }) => useObserver(() => {
 });
 
 const Details = observer(({ ux, ux: {
-  scores, planScores, taskingPlan, isDisplayingConfirmDelete, isDisplayingEditAssignment,
+  scores, planScores, taskingPlan, isDisplayingConfirmDelete, isDisplayingEditAssignment, editUX,
 } }) => {
   const format = 'MMM D, h:mm a';
+
+  if (!editUX) { return <Loading /> }
 
   return (
     <DetailsWrapper>

--- a/tutor/src/screens/assignment-review/details.js
+++ b/tutor/src/screens/assignment-review/details.js
@@ -218,7 +218,7 @@ const Details = observer(({ ux, ux: {
   scores, planScores, isDisplayingConfirmDelete, isDisplayingEditAssignment, editUX, taskingPlanDetails,
 } }) => {
 
-  if (!editUX) { return <Loading />; }
+  if (!ux || !editUX) { return <Loading />; }
 
   return (
     <DetailsWrapper>

--- a/tutor/src/screens/assignment-review/details.js
+++ b/tutor/src/screens/assignment-review/details.js
@@ -195,7 +195,7 @@ const Details = observer(({ ux, ux: {
 } }) => {
   const format = 'MMM D, h:mm a';
 
-  if (!editUX) { return <Loading /> }
+  if (!editUX) { return <Loading />; }
 
   return (
     <DetailsWrapper>

--- a/tutor/src/screens/assignment-review/styles.scss
+++ b/tutor/src/screens/assignment-review/styles.scss
@@ -1,1 +1,5 @@
 @import '../screen-styles';
+
+.stacked-modal-backdrop {
+  z-index: 1050;
+}

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -15,6 +15,7 @@ export default class AssignmentReviewUX {
   @observable isDisplayingDropQuestions = false;
   @observable isDisplayingConfirmDelete = false;
   @observable isDisplayingEditAssignment = false;
+  @observable editUX;
 
   freeResponseQuestions = observable.map();
   pendingExtensions = observable.map();

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -1,5 +1,5 @@
 import { React, observable, action, computed } from 'vendor';
-import { first } from 'lodash';
+import { first, pick, sortBy } from 'lodash';
 import ScrollTo from '../../helpers/scroll-to';
 import TaskPlanScores from '../../models/task-plans/teacher/scores';
 import DropQuestion from '../../models/task-plans/teacher/dropped_question';
@@ -62,7 +62,11 @@ export default class AssignmentReviewUX {
   }
 
   @computed get taskingPlan() {
-    return this.planScores.tasking_plans.forPeriod(this.selectedPeriod);
+    return this.taskingPlans.forPeriod(this.selectedPeriod);
+  }
+
+  @computed get taskingPlans() {
+    return this.planScores.taskPlan.tasking_plans;
   }
 
   @computed get sortedStudents() {
@@ -165,6 +169,17 @@ export default class AssignmentReviewUX {
     return Boolean(
       this.editUX.validations.isValid
     );
+  }
+
+  @computed get areTaskingDatesSame() {
+    return Boolean(
+      this.planScores.taskPlan.areTaskingDatesSame
+    );
+  }
+
+  @computed get taskingPlanDetails() {
+    return this.areTaskingDatesSame ?
+      [first(this.taskingPlans)] : sortBy(this.taskingPlans, tp => tp.period.name);
   }
 
 }

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -150,7 +150,8 @@ export default class AssignmentReviewUX {
 
   @action.bound async onSavePlan() {
     await this.editUX.savePlan();
-    Object.assign(this.planScores, this.editUX.plan);
+    Object.assign(this.planScores, pick(this.editUX.plan, ['title', 'description']));
+    this.planScores.grading_template = this.editUX.plan.gradingTemplate;
     this.isDisplayingEditAssignment = false;
   }
 


### PR DESCRIPTION
- Fix z-index — the style wasn't actually getting used, this fixes making sure the modal backdrop displays on top of the 1st modal.

- Wait to render events that need planScores & editUX until it's ready

- Fix some recursion that was happening with the latest changes by hand picking and assigning values we pull from the edited plan.

- Only update tasking plan dates if the plan is new

- Break out "Assigned to" dates by period if they are different

![image](https://user-images.githubusercontent.com/34174/81086868-e6bf3b00-8ead-11ea-9cf8-b973e80261c4.png)

![image](https://user-images.githubusercontent.com/34174/81086885-ec1c8580-8ead-11ea-8669-7e43a69b7962.png)
