### PR TITLE
set "cloned_from_id" property when cloning an assignment

### DIFF
--- a/tutor/specs/models/task-plans/teacher/plan.spec.js
+++ b/tutor/specs/models/task-plans/teacher/plan.spec.js
@@ -55,24 +55,32 @@ describe('CourseCalendar Header', function() {
     expect(onDelete).toHaveBeenCalledWith(plan.id);
   });
 
-  it('clones with attributes', () => {
-    expect(plan.clonedAttributes).toMatchObject({
-      ...ld.pick(plan, 'title', 'description', 'settings', 'type', 'ecosystem_id'),
+  describe('cloning', () => {
+    it('sets cloned_from_id', () => {
+      const newPlan = plan.createClone({ course: plan.course });
+      expect(newPlan.dataForSave).toMatchObject({
+        cloned_from_id: plan.id,
+      });
+    });
+
+    it('includes attributes', () => {
+      expect(plan.clonedAttributes).toMatchObject({
+        ...ld.pick(plan, 'title', 'description', 'settings', 'type', 'ecosystem_id'),
+      });
+    });
+
+    it('copies tasking times', () => {
+      plan.tasking_plans[0].opens_at = '2015-01-12T03:30:00.000Z';
+      expect(plan.clonedAttributes.tasking_plans[0].opens_at).toEqual(
+        plan.tasking_plans[0].opens_at
+      );
+      const newPlan = new plan.constructor({});
+      newPlan.update(plan.serialize());
+      expect(newPlan.tasking_plans[0].opens_at).toEqual(
+        plan.tasking_plans[0].opens_at
+      );
     });
   });
-
-  it('copies tasking times', () => {
-    plan.tasking_plans[0].opens_at = '2015-01-12T03:30:00.000Z';
-    expect(plan.clonedAttributes.tasking_plans[0].opens_at).toEqual(
-      plan.tasking_plans[0].opens_at
-    );
-    const newPlan = new plan.constructor({});
-    newPlan.update(plan.serialize());
-    expect(newPlan.tasking_plans[0].opens_at).toEqual(
-      plan.tasking_plans[0].opens_at
-    );
-  });
-
   it('calculates duration', () => {
     plan.tasking_plans[0].opens_at = '2015-01-01T03:30:00.000Z';
     plan.tasking_plans[0].due_at = '2015-01-30T03:30:00.000Z';

--- a/tutor/src/models/task-plans/teacher/plan.js
+++ b/tutor/src/models/task-plans/teacher/plan.js
@@ -294,6 +294,7 @@ class TeacherTaskPlan extends BaseModel {
   @action createClone({ course }) {
     return new TeacherTaskPlan({
       ...this.clonedAttributes,
+      cloned_from_id: this.id,
       tasking_plans: course.periods.active.map(period => ({
         target_id: period.id,
         target_type: 'period',
@@ -305,7 +306,7 @@ class TeacherTaskPlan extends BaseModel {
   @computed get dataForSave() {
     return extend(
       this.clonedAttributes,
-      pick(this, 'is_publish_requested'),
+      pick(this, 'is_publish_requested', 'cloned_from_id'),
       { tasking_plans: map(this.tasking_plans, 'dataForSave') },
     );
   }


### PR DESCRIPTION
This wasn't being set at all but it wasn't noticed since clones would still succeed if the ecosystem hadn't changed