### PR TITLE
Wrm 930 date time picker style

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "prop-types": "^15.7.2",
     "qs": "6.8.0",
     "rc-input-number": "^4.5.1",
-    "rc-picker": "^0.0.1-rc.2",
+    "rc-picker": "^1.4.12",
     "react": "16.9.0",
     "react-addons-pure-render-mixin": "15.6.2",
     "react-apexcharts": "^1.3.3",

--- a/tutor/resources/styles/components/date-time-input.scss
+++ b/tutor/resources/styles/components/date-time-input.scss
@@ -47,7 +47,7 @@
 
   > button {
     min-width: 1.6em;
-    font-size: 14px;
+    font-size: 18px;
 
     &:hover {
       color: rgba(0, 0, 0, 0.65);

--- a/tutor/resources/styles/components/date-time-input.scss
+++ b/tutor/resources/styles/components/date-time-input.scss
@@ -880,6 +880,17 @@ tr > .oxdt-cell-in-view {
   &:not(:first-child) {
     border-left: 1px solid #f0f0f0;
   }
+  // first-child is the hours column
+  // reverse the order from 12 to 1
+  &:first-child {
+    display: flex;
+    flex-direction: column-reverse;
+
+    // somehow the default order is 12, 1, 2, ... so keep the first item as order 1
+    li:first-child {
+      order: 1;
+    }
+  }
 }
 
 .oxdt-time-panel-column-active {

--- a/tutor/specs/components/__snapshots__/date-time-input.spec.js.snap
+++ b/tutor/specs/components/__snapshots__/date-time-input.spec.js.snap
@@ -84,11 +84,13 @@ exports[`DateTimeInput matches snapshot 1`] = `
   >
     <div
       className="oxdt c3"
+      onMouseUp={[Function]}
     >
       <div
         className="oxdt-input"
       >
         <input
+          id="dte1"
           name="dte"
           onBlur={[Function]}
           onChange={[Function]}
@@ -97,6 +99,7 @@ exports[`DateTimeInput matches snapshot 1`] = `
           onMouseDown={[Function]}
           readOnly={true}
           size={21}
+          title=""
           value=""
         />
       </div>

--- a/tutor/specs/components/date-time-input.spec.js
+++ b/tutor/specs/components/date-time-input.spec.js
@@ -1,6 +1,7 @@
 import { TimeMock } from '../helpers';
 import DateTimeInput from '../../src/components/date-time-input';
 import { Formik as F } from 'formik';
+import { last } from 'lodash';
 
 describe('DateTimeInput', () => {
   let props;
@@ -23,17 +24,21 @@ describe('DateTimeInput', () => {
     const dt = mount(<F initialValues={{
       dte: new Date(),
     }}><DateTimeInput {...props} /></F>);
-
     dt.find('input').simulate('mouseDown')
     dt.find('td[title="2020-02-15"]').simulate('click')
+    
+    //Note for hour selection:
+    //the order in the browser is different from what jest simulates. There is CSS that reorders the flow of the hour options
+    //Browser: 12, 11, 10, ...., 1
+    //Jest: 12, 1, 2, ...., 11
     dt.find('.oxdt-time-panel-column').at(0).find('.oxdt-time-panel-cell').last().simulate('click')
+    // last cell now is 59
     dt.find('.oxdt-time-panel-column').at(1).find('.oxdt-time-panel-cell').last().simulate('click')
     dt.find('.oxdt-time-panel-column').at(2).find('.oxdt-time-panel-cell').last().simulate('click')
-    expect(dt.find('input').instance().value).toEqual('2020-02-15 23:50:00')
-
+    expect(dt.find('input').instance().value).toEqual('2020-02-15 23:59:00')
     dt.find('.oxdt-ok button').simulate('click')
     expect(props.onChange).toHaveBeenCalled()
-    expect(props.onChange.mock.calls[0][0].target.value.toISOString()).toEqual('2020-02-16T05:50:00.000Z')
+    expect(last(props.onChange.mock.calls)[0].target.value.toISOString()).toEqual('2020-02-16T05:59:00.000Z')
 
     dt.unmount();
   });

--- a/tutor/specs/integration/assignment-edit.spec.js
+++ b/tutor/specs/integration/assignment-edit.spec.js
@@ -174,7 +174,7 @@ context('Assignment Edit', () => {
     });
   })
 
-  it.only('updates due and closes date manually, select a grading a template, but due and closes date is not updated', () => {
+  it('updates due and closes date manually, select a grading a template, but due and closes date is not updated', () => {
     const templateName = 'Template to not update date'
     const typedDueDate = 'Jun 10 | 05:00 PM'
     const typedClosesDate = 'Jun 22 | 05:00 PM'

--- a/tutor/specs/integration/assignment-edit.spec.js
+++ b/tutor/specs/integration/assignment-edit.spec.js
@@ -2,6 +2,8 @@ import { range } from 'lodash';
 import moment from 'moment-timezone';
 
 context('Assignment Edit', () => {
+  const format = 'MMM D | hh:mm A';
+
   const fillDetails = () => {
     cy.get('.heading').should('contain.text', 'STEP 1')
     cy.get('.controls .btn-primary').should('be.disabled')
@@ -150,11 +152,11 @@ context('Assignment Edit', () => {
       let updatedDueDate;
       // Due date should change
       cy.get('input[name="tasking_plans[0].due_at"]').then(d => {
-        const dueDate = moment(d[0].defaultValue).toISOString();
+        const dueDate = moment(d[0].defaultValue, format).toISOString();
         updatedDueDate = dueDate;
         // Compute the due date from the open date
         const hour = isAM ? parseInt(dueTimeHour, 10) : parseInt(dueTimeHour, 10) + 12
-        const expectedDueDate = moment(openDate)
+        const expectedDueDate = moment(openDate, format)
           .add(parseInt(dueDateOffsetDays, 10), 'days')
           .set({ hour, minutes: parseInt(dueTimeMinutes, 10) })
           .toISOString();
@@ -162,7 +164,7 @@ context('Assignment Edit', () => {
       })
       // Closes date should change
       cy.get('input[name="tasking_plans[0].closes_at"]').then(c => {
-        const closesDate = moment(c[0].defaultValue).toISOString();
+        const closesDate = moment(c[0].defaultValue, format).toISOString();
         // Compute the closes date from the due date
         const expectedDueDate = moment(updatedDueDate)
           .add(parseInt(closesDateOffsetDays, 10), 'days')
@@ -172,10 +174,10 @@ context('Assignment Edit', () => {
     });
   })
 
-  it('updates due and closes date manually, select a grading a template, but due and closes date is not updated', () => {
+  it.only('updates due and closes date manually, select a grading a template, but due and closes date is not updated', () => {
     const templateName = 'Template to not update date'
-    const typedDueDate = 'Jun 10 05:00 PM'
-    const typedClosesDate = 'Jun 22 05:00 PM'
+    const typedDueDate = 'Jun 10 | 05:00 PM'
+    const typedClosesDate = 'Jun 22 | 05:00 PM'
     cy.visit('/course/2/assignment/edit/homework/new')
     cy.disableTours()
     // force update the closes date
@@ -184,8 +186,8 @@ context('Assignment Edit', () => {
     addTemplate({ name: templateName, doSelect: true })
     // after adding and selecting the template, closes date should not be updated
     cy.get('input[name="tasking_plans[0].closes_at"]').then(c => {
-      const closesDate = moment(c[0].defaultValue).toISOString();
-      expect(closesDate).eq(moment(typedClosesDate).toISOString())
+      const closesDate = moment(c[0].defaultValue, format).toISOString();
+      expect(closesDate).eq(moment(typedClosesDate, format).toISOString())
     })
     // force update the due date
     cy.get('input[name="tasking_plans[0].due_at"]').clear({ force: true }).type(typedDueDate, { force: true })
@@ -195,8 +197,8 @@ context('Assignment Edit', () => {
     cy.get('[data-test-id="Default Homework"]').click()
     // after selecting the first template, due date should not be updated
     cy.get('input[name="tasking_plans[0].due_at"]').then(d => {
-      const dueDate = moment(d[0].defaultValue).toISOString();
-      expect(dueDate).eq(moment(typedDueDate).toISOString())
+      const dueDate = moment(d[0].defaultValue, format).toISOString();
+      expect(dueDate).eq(moment(typedDueDate, format).toISOString())
     })
   })
 });

--- a/tutor/src/components/date-time-input.js
+++ b/tutor/src/components/date-time-input.js
@@ -79,6 +79,7 @@ const DateTimeInput = (props) => useObserver(() => {
             showSecond: false,
             use12Hours: true,
             minuteStep: 10,
+            format: 'hh:mm A',
           }}
           {...field}
           {...props}

--- a/tutor/src/components/date-time-input.js
+++ b/tutor/src/components/date-time-input.js
@@ -1,7 +1,7 @@
 import { React, styled, PropTypes, useObserver, cn } from 'vendor';
 import { useField } from 'formik';
 import Picker from 'rc-picker';
-import { uniqueId } from 'lodash';
+import { uniqueId, range } from 'lodash';
 import moment from 'moment';
 import locale from 'rc-picker/lib/locale/en_US';
 import generateConfig from 'rc-picker/lib/generate/moment';
@@ -63,7 +63,6 @@ const DateTimeInput = (props) => useObserver(() => {
   const [field, meta] = useField({ type: 'text', ...props });
   const id = props.id || uniqueId(props.name);
   const LabelWrapper = props.labelWrapper || React.Fragment;
-
   return (
     <StyledWrapper className={cn('date-time-input', props.className)}>
       <LabelWrapper>
@@ -78,8 +77,17 @@ const DateTimeInput = (props) => useObserver(() => {
           showTime={{
             showSecond: false,
             use12Hours: true,
-            minuteStep: 10,
-            format: 'hh:mm A',
+            hideDisabledOptions: true,
+            format: props.timeFormat || 'hh:mm A',
+          }}
+          //Reference: https://github.com/react-component/picker/blob/master/src/interface.ts#L84
+          //Showing minutes step of 10, and 1 and 59
+          disabledTime={() => {
+            return {
+              disabledMinutes() {
+                return range(1, 60, 1).filter(f => f % 10 !== 0 && f !== 1 && f !== 59);
+              },
+            };
           }}
           {...field}
           {...props}

--- a/tutor/src/components/date-time-input.js
+++ b/tutor/src/components/date-time-input.js
@@ -84,7 +84,7 @@ const DateTimeInput = (props) => useObserver(() => {
           {...field}
           {...props}
           value={field.value ? moment(field.value) : null}
-          onChange={dt => {
+          onSelect={dt => {
             const ev = { target: { name: field.name, value: dt } };
             field.onChange(ev);
             props.onChange && props.onChange(ev);

--- a/tutor/src/components/date-time-input.js
+++ b/tutor/src/components/date-time-input.js
@@ -63,6 +63,13 @@ const DateTimeInput = (props) => useObserver(() => {
   const [field, meta] = useField({ type: 'text', ...props });
   const id = props.id || uniqueId(props.name);
   const LabelWrapper = props.labelWrapper || React.Fragment;
+
+  const onUpdateDate = dt => {
+    const ev = { target: { name: field.name, value: dt } };
+    field.onChange(ev);
+    props.onChange && props.onChange(ev);
+  };
+  
   return (
     <StyledWrapper className={cn('date-time-input', props.className)}>
       <LabelWrapper>
@@ -92,11 +99,8 @@ const DateTimeInput = (props) => useObserver(() => {
           {...field}
           {...props}
           value={field.value ? moment(field.value) : null}
-          onSelect={dt => {
-            const ev = { target: { name: field.name, value: dt } };
-            field.onChange(ev);
-            props.onChange && props.onChange(ev);
-          }}
+          onSelect={onUpdateDate}
+          onChange={onUpdateDate}
           prefixCls="oxdt"
           id={id}
           autoFocus={props.autoFocus}

--- a/tutor/src/screens/assignment-edit/details-body.js
+++ b/tutor/src/screens/assignment-edit/details-body.js
@@ -206,8 +206,7 @@ const DetailsBody = observer(({ ux }) => {
               <ChangeTimezone course={ux.course} />
             </OverlayTrigger>
             <HintText>
-              (To immediately open an assignment, set
-              Open Date to today's date & current time.)
+              (To immediately open an assignment, select ‘Now’ in the calendar.)
             </HintText>
           </HintText>
         </RowLabel>

--- a/tutor/src/screens/assignment-edit/tasking.js
+++ b/tutor/src/screens/assignment-edit/tasking.js
@@ -168,7 +168,7 @@ class Tasking extends React.Component {
   renderDateTimeInputs(tasking) {
     const { ux, period, ux: { plan } } = this.props;
     const index = this.props.ux.plan.tasking_plans.indexOf(tasking);
-    const format = 'MMM D hh:mm A';
+    const format = 'MMM D | hh:mm A';
 
     return (
       <Row className="tasking-date-time">

--- a/tutor/src/screens/assignment-edit/tasking.js
+++ b/tutor/src/screens/assignment-edit/tasking.js
@@ -169,6 +169,7 @@ class Tasking extends React.Component {
     const { ux, period, ux: { plan } } = this.props;
     const index = this.props.ux.plan.tasking_plans.indexOf(tasking);
     const format = 'MMM D | hh:mm A';
+    const timeFormat = 'hh:mm A';
 
     return (
       <Row className="tasking-date-time">
@@ -178,6 +179,7 @@ class Tasking extends React.Component {
             name={`tasking_plans[${index}].opens_at`}
             onChange={this.onOpensChange}
             format={format}
+            timeFormat={timeFormat}
             autoFocus={period && plan.tasking_plans.forPeriod(period)}
           />
           {!tasking.canEditOpensAt && <CantEditExplanation />}
@@ -188,6 +190,7 @@ class Tasking extends React.Component {
             name={`tasking_plans[${index}].due_at`}
             onChange={this.onDueChange}
             format={format}
+            timeFormat={timeFormat}
           />
           {this.renderDueAtError()}
         </Col>
@@ -198,6 +201,7 @@ class Tasking extends React.Component {
             name={`tasking_plans[${index}].closes_at`}
             onChange={this.onClosesChange}
             format={format}
+            timeFormat={timeFormat}
           />
         </Col>
       </Row>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3430,15 +3430,20 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0, core-js@^2.6.5:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.8.tgz#dc3a1e633a04267944e0cb850d3880f340248139"
-  integrity sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg==
+core-js@^2.4.0:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
 core-js@^2.4.1:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+
+core-js@^2.6.5:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.8.tgz#dc3a1e633a04267944e0cb850d3880f340248139"
+  integrity sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg==
 
 core-js@^3.0.0:
   version "3.1.2"
@@ -3812,11 +3817,6 @@ dateformat@3.0.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-dayjs@^1.8.18:
-  version "1.8.19"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.19.tgz#5117dc390d8f8e586d53891dbff3fa308f51abfe"
-  integrity sha512-7kqOoj3oQSmqbvtvGFLU5iYqies+SqUiEGNT0UtUPPxcPYgY1BrkXR0Cq2R9HYSimBXN+xHkEN4Hi399W+Ovlg==
-
 dayz@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/dayz/-/dayz-2.6.0.tgz#81e9ecb8bcd90e44b64e8a0961c0c0f139454636"
@@ -4099,9 +4099,9 @@ doctrine@^3.0.0:
     esutils "^2.0.2"
 
 dom-align@^1.7.0:
-  version "1.10.4"
-  resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.10.4.tgz#862ae4de0d11d6495c1c8ee1b195427e7caa727d"
-  integrity sha512-wytDzaru67AmqFOY4B9GUb/hrwWagezoYYK97D/vpK+ezg+cnuZO0Q2gltUPa7KfNmIqfRIYVCF8UhRDEHAmgQ==
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.11.1.tgz#7592be99a660a36cdedc1d6eeb22b8109d758cae"
+  integrity sha512-hN42DmUgtweBx0iBjDLO4WtKOMcK8yBmPx/fgdsgQadLuzPu/8co3oLdK5yMmeM/vnUd3yDyV6qV8/NzxBexQg==
 
 dom-helpers@^3.4.0:
   version "3.4.0"
@@ -8260,10 +8260,15 @@ moment-timezone@0.5.23:
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.24.0, "moment@>= 2.9.0", moment@^2.24.0:
+moment@2.24.0, "moment@>= 2.9.0":
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
+moment@^2.24.0:
+  version "2.25.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.25.3.tgz#252ff41319cf41e47761a1a88cab30edfe9808c0"
+  integrity sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg==
 
 moo@^0.4.3:
   version "0.4.3"
@@ -9692,9 +9697,9 @@ rc-align@^3.0.0-rc.0:
     resize-observer-polyfill "^1.5.1"
 
 rc-animate@^2.10.2:
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-2.10.2.tgz#217fdc76ff26cbf425a5caf87cc8a36ba4598456"
-  integrity sha512-cE/A7piAzoWFSgUD69NmmMraqCeqVBa51UErod8NS3LUEqWfppSVagHfa0qHAlwPVPiIBg3emRONyny3eiH0Dg==
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-2.11.1.tgz#2666eeb6f1f2a495a13b2af09e236712278fdb2c"
+  integrity sha512-1NyuCGFJG/0Y+9RKh5y/i/AalUCA51opyyS/jO2seELpgymZm2u9QV3xwODwEuzkmeQ1BDPxMLmYLcTJedPlkQ==
   dependencies:
     babel-runtime "6.x"
     classnames "^2.2.6"
@@ -9715,37 +9720,37 @@ rc-input-number@^4.5.1:
     rc-util "^4.5.1"
     rmc-feedback "^2.0.0"
 
-rc-picker@^0.0.1-rc.2:
-  version "0.0.1-rc.2"
-  resolved "https://registry.yarnpkg.com/rc-picker/-/rc-picker-0.0.1-rc.2.tgz#2c281962f439ffcfb53481a10da23f4c6d936873"
-  integrity sha512-8uoLX5xh+2rHF+kUs09JIsCDDhKBER8seCYwzLDAKheqkfdjDymQ/Ll6wzsG6lK51hy8lB4T3wsPfngRTztQkg==
+rc-picker@^1.4.12:
+  version "1.4.12"
+  resolved "https://registry.yarnpkg.com/rc-picker/-/rc-picker-1.4.12.tgz#7c0fa932f6d9bd004e6b8c41a23c7905457f9909"
+  integrity sha512-WQlni3k0cMj6NU8tv0t2cKsWa4aIA51vm+D5PNlwdorh/qKZMBzXyr45l2Sd8zAQSHJ1bBatf31X2+ZCk5dZ4Q==
   dependencies:
     classnames "^2.2.1"
-    dayjs "^1.8.18"
     moment "^2.24.0"
-    rc-trigger "^4.0.0-alpha.6"
+    rc-trigger "^4.0.0"
     rc-util "^4.17.0"
+    shallowequal "^1.1.0"
 
-rc-trigger@^4.0.0-alpha.6:
-  version "4.0.0-rc.4"
-  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-4.0.0-rc.4.tgz#e0a7f9d4510018dd4b83b5fd5d5dca009ae2f806"
-  integrity sha512-WMeQsN0b6qHtmU8dABcc81XVHUhem6PCx3fLaaFpDVQdOfIBA3Hjkp3KFirqEhjInp5Y7+EMo6YTkBcShJqfQg==
+rc-trigger@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-4.0.2.tgz#42fe7bdb6a5b34035e20fa9ebfad69ec948b56be"
+  integrity sha512-to5S1NhK10rWHIgQpoQdwIhuDc2Ok4R4/dh5NLrDt6C+gqkohsdBCYiPk97Z+NwGhRU8N+dbf251bivX8DkzQg==
   dependencies:
     classnames "^2.2.6"
     prop-types "15.x"
     raf "^3.4.1"
     rc-align "^3.0.0-rc.0"
     rc-animate "^2.10.2"
-    rc-util "^4.15.2"
+    rc-util "^4.20.0"
 
-rc-util@^4.12.0, rc-util@^4.15.2, rc-util@^4.15.3, rc-util@^4.17.0:
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.19.0.tgz#f3b5e3a02cc0a667d127784068e1236c095dbcbf"
-  integrity sha512-mptALlLwpeczS3nrv83DbwJNeupolbuvlIEjcvimSiWI8NUBjpF0HgG3kWp1RymiuiRCNm9yhaXqDz0a99dpgQ==
+rc-util@^4.12.0, rc-util@^4.15.3, rc-util@^4.17.0, rc-util@^4.20.0:
+  version "4.20.5"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.20.5.tgz#f7c77569e971ae6a8ad56f899cadd22275398325"
+  integrity sha512-f67s4Dt1quBYhrVPq5QMKmK3eS2hN1NNIAyhaiG0HmvqiGYAXMQ7SP2AlGqv750vnzhJs38JklbkWT1/wjhFPg==
   dependencies:
     add-dom-event-listener "^1.1.0"
-    babel-runtime "6.x"
     prop-types "^15.5.10"
+    react-is "^16.12.0"
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.1.0"
 
@@ -9910,12 +9915,17 @@ react-input-autosize@^2.2.1:
   dependencies:
     prop-types "^15.5.8"
 
+react-is@^16.12.0, react-is@^16.8.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.4, react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-is@^16.6.0, react-is@^16.8.1, react-is@^16.9.0:
+react-is@^16.6.0, react-is@^16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==


### PR DESCRIPTION
1. The vertical separator between date and time is missing.
2. The time preview in top left should show the exact time being set.
3. It should show AM/PM instead of seconds
4. Add 01 and 59 also to the seconds option
5. Show the hours in a reverse order 12, 11, 10, 09 - preferred times since preferred due time are 9, 10, 11, 12 etc.
6. The arrows next to the month should be bigger at least 12 /16 px.
7. The confirmation button ‘Okay’ on the date and time modal is easy to miss and makes me wonder if we even need it.
8. The new D&T picker has a ‘now’ option, Update the helper text below ‘Assign’ to reflect that. New helper text-"To immediately open an assignment, select ‘now’ in the calendar."

![Screenshot from 2020-05-06 15-07-46](https://user-images.githubusercontent.com/3774774/81217932-6252e200-8fab-11ea-8261-e59cbf562e62.png)
