### PR TITLE
Hide tabs for external and event types

### DIFF
--- a/tutor/specs/integration/assignment-review.spec.js
+++ b/tutor/specs/integration/assignment-review.spec.js
@@ -118,4 +118,25 @@ context('Assignment Review', () => {
     cy.getTestElement('edit-assigned-questions').click();
     cy.location('pathname').should('include', '/course/1/assignment/edit/homework/2/points');
   });
+
+  it('hides overview and scores tabs if not reading or homework', () => {
+    // Homework
+    cy.getTestElement('submission-overview-tab').should('exist');
+    cy.getTestElement('assignment-scores-tab').should('exist');
+
+    // Reading
+    cy.visit('/course/1/assignment/review/1');
+    cy.getTestElement('submission-overview-tab').should('exist');
+    cy.getTestElement('assignment-scores-tab').should('exist');
+
+    // External
+    cy.visit('/course/1/assignment/review/3');
+    cy.getTestElement('submission-overview-tab').should('not.exist');
+    cy.getTestElement('assignment-scores-tab').should('not.exist');
+
+    // Event
+    cy.visit('/course/1/assignment/review/4');
+    cy.getTestElement('submission-overview-tab').should('not.exist');
+    cy.getTestElement('assignment-scores-tab').should('not.exist');
+  });
 });

--- a/tutor/src/screens/assignment-review/details.js
+++ b/tutor/src/screens/assignment-review/details.js
@@ -272,7 +272,7 @@ const Details = observer(({ ux, ux: { editUX } }) => {
                 {planScores.description}
               </Item>
             </Row>
-            {ux.canDisplayAssignmentSettings &&
+            {ux.isReadingOrHomework &&
               <Row>
                 <Title>Assignment settings</Title>
                 <Item>

--- a/tutor/src/screens/assignment-review/index.js
+++ b/tutor/src/screens/assignment-review/index.js
@@ -93,7 +93,10 @@ class AssignmentReview extends React.Component {
   }
 
   render() {
-    const { isScoresReady, course, planScores, selectedPeriod, setSelectedPeriod } = this.ux;
+    const {
+      isScoresReady, course, planScores, selectedPeriod, setSelectedPeriod,
+      canDisplaySubmissionAndScoresTabs,
+    } = this.ux;
 
     if (!isScoresReady) {
       return <LoadingScreen message="Loading Assignment…" />;
@@ -101,7 +104,7 @@ class AssignmentReview extends React.Component {
 
     const AvailableTabs = [Details];
     // there are no scores if no students have enrolled
-    if (this.ux.scores) {
+    if (canDisplaySubmissionAndScoresTabs && this.ux.scores) {
       AvailableTabs.push(Overview, Scores);
     }
 

--- a/tutor/src/screens/assignment-review/index.js
+++ b/tutor/src/screens/assignment-review/index.js
@@ -95,7 +95,6 @@ class AssignmentReview extends React.Component {
   render() {
     const {
       isScoresReady, course, planScores, selectedPeriod, setSelectedPeriod,
-      canDisplaySubmissionAndScoresTabs,
     } = this.ux;
 
     if (!isScoresReady) {
@@ -104,7 +103,7 @@ class AssignmentReview extends React.Component {
 
     const AvailableTabs = [Details];
     // there are no scores if no students have enrolled
-    if (canDisplaySubmissionAndScoresTabs && this.ux.scores) {
+    if (this.ux.isReadingOrHomework && this.ux.scores) {
       AvailableTabs.push(Overview, Scores);
     }
 

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -254,4 +254,8 @@ export default class AssignmentReviewUX {
     return Boolean(['reading', 'homework'].includes(this.planScores.type));
   }
 
+  @computed get canDisplaySubmissionAndScoresTabs() {
+    return Boolean(['reading', 'homework'].includes(this.planScores.type));
+  }
+
 }

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -250,11 +250,7 @@ export default class AssignmentReviewUX {
     return Boolean(this.planScores.isHomework);
   }
 
-  @computed get canDisplayAssignmentSettings() {
-    return Boolean(['reading', 'homework'].includes(this.planScores.type));
-  }
-
-  @computed get canDisplaySubmissionAndScoresTabs() {
+  @computed get isReadingOrHomework() {
     return Boolean(['reading', 'homework'].includes(this.planScores.type));
   }
 

--- a/tutor/src/screens/teacher-dashboard/plan-details.jsx
+++ b/tutor/src/screens/teacher-dashboard/plan-details.jsx
@@ -140,7 +140,7 @@ class CoursePlanDetails extends React.Component {
         <TutorLink
           disabled={!plan.isPublished}
           className="btn btn-standard"
-          to={plan.isExternal ? 'viewGradebook' : 'reviewAssignment'}
+          to={'reviewAssignment'}
           params={this.linkParams}
         >
           View assignment


### PR DESCRIPTION
- Don't render Submission and Scores tabs for External and Event types
- Fix an issue with External type in the modal not going to assignment review 

![image](https://user-images.githubusercontent.com/34174/81833093-23b1b000-94f4-11ea-853c-ff2496ad72e4.png)
