### PR TITLE
Wrm scores fixes

### DIFF
--- a/shared/src/components/icon.js
+++ b/shared/src/components/icon.js
@@ -157,6 +157,18 @@ const Variants = {
     color: 'white',
     withCircle: true,
   },
+  droppedFullCredit: {
+    color: '#83AD51',
+    type: 'check',
+  },
+  droppedZeroCredit: {
+    color: '#B23238',
+    type: 'close',
+  },
+  toggleOrder: {
+    color: '#027EB5',
+    type: 'exchange-alt',
+  },
 };
 
 
@@ -214,7 +226,7 @@ class Icon extends React.Component {
         }
       });
     }
-    
+
     let icon = (
       <IconWrapper
         data-variant={variant}

--- a/tutor/specs/integration/assignment-review.spec.js
+++ b/tutor/specs/integration/assignment-review.spec.js
@@ -64,7 +64,6 @@ context('Assignment Review', () => {
     cy.location('pathname').should('include', '/course/1/t/month');
   });
 
-  
   it('can update details', () => {
     cy.server();
     cy.route('GET', '/api/courses/1/grading_templates*').as('getGradingTemplates');
@@ -96,15 +95,19 @@ context('Assignment Review', () => {
     cy.getTestElement('grading-block').should('not.exist');
     cy.getTestElement('questions-block').should('not.exist');
 
+
     cy.visit('/course/1/assignment/review/2');
+    cy.server();
+    cy.route('GET', '/api/plans/*').as('taskPlan');
+    cy.wait('@taskPlan');
     cy.getTestElement('grading-block').should('exist');
     cy.getTestElement('questions-block').should('exist');
 
-    cy.visit('/course/1/assignment/review/3');
+    cy.visit('/course/1/assignment/review/4');
     cy.getTestElement('grading-block').should('not.exist');
     cy.getTestElement('questions-block').should('not.exist');
 
-    cy.visit('/course/1/assignment/review/4');
+    cy.visit('/course/1/assignment/review/5');
     cy.getTestElement('grading-block').should('not.exist');
     cy.getTestElement('questions-block').should('not.exist');
   });

--- a/tutor/specs/integration/assignment-review.spec.js
+++ b/tutor/specs/integration/assignment-review.spec.js
@@ -3,6 +3,9 @@ context('Assignment Review', () => {
   beforeEach(() => {
     cy.visit('/course/1/assignment/review/2')
     cy.disableTours();
+    cy.server();
+    cy.route('GET', '/api/plans/*').as('taskPlan');
+    cy.wait('@taskPlan');
   });
 
   it('loads and views feedback', () => {

--- a/tutor/src/components/icons/extension.js
+++ b/tutor/src/components/icons/extension.js
@@ -5,8 +5,6 @@ const GreenCircle = styled.div`
   display: inline-block;
   width: 1.4rem;
   height: 1.4rem;
-  position: absolute;
-  right: 1rem;
   background: #009670;
   color: #fff;
   font-size: 0.9rem;
@@ -20,8 +18,9 @@ const ExtensionIcon = () => (
     placement="right"
     overlay={<Tooltip>Student was granted an extension</Tooltip>}
   >
-    <GreenCircle>E</GreenCircle>
+    <GreenCircle className="extension-icon">E</GreenCircle>
   </OverlayTrigger>
 );
 
+export { GreenCircle };
 export default ExtensionIcon;

--- a/tutor/src/components/icons/extension.js
+++ b/tutor/src/components/icons/extension.js
@@ -1,0 +1,27 @@
+import { React, styled } from 'vendor';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+
+const GreenCircle = styled.div`
+  display: inline-block;
+  width: 1.4rem;
+  height: 1.4rem;
+  position: absolute;
+  right: 1rem;
+  background: #009670;
+  color: #fff;
+  font-size: 0.9rem;
+  line-height: 1.4rem;
+  border-radius: 50%;
+  text-align: center;
+`;
+
+const ExtensionIcon = () => (
+  <OverlayTrigger
+    placement="right"
+    overlay={<Tooltip>Student was granted an extension</Tooltip>}
+  >
+    <GreenCircle>E</GreenCircle>
+  </OverlayTrigger>
+);
+
+export default ExtensionIcon;

--- a/tutor/src/helpers/background-wrapper.js
+++ b/tutor/src/helpers/background-wrapper.js
@@ -11,6 +11,7 @@ const BackgroundWrapper = styled.div`
 
 const ContentWrapper = styled.div`
   max-width: 1200px;
+  min-width: 1100px;
   margin: 0 auto;
 `;
 

--- a/tutor/src/helpers/background-wrapper.js
+++ b/tutor/src/helpers/background-wrapper.js
@@ -9,4 +9,9 @@ const BackgroundWrapper = styled.div`
   padding: 0 2.4rem;
 `;
 
-export { BackgroundWrapper };
+const ContentWrapper = styled.div`
+  max-width: 1200px;
+  margin: 0 auto;
+`;
+
+export { BackgroundWrapper, ContentWrapper };

--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -143,6 +143,10 @@ class TaskPlanScoresTasking extends BaseModel {
   } }) question_headings;
   @hasMany({ model: TaskPlanScoreStudent, inverseOf: 'tasking' }) students;
 
+  @computed get availablePoints() {
+    return sumBy(this.question_headings, 'points');
+  }
+
   // this returns all of the quesions that were assigned
   // this is trickier than just using the index from headings because tutor assigned questions
   // will be in different order and different students will get different ones

--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -45,7 +45,7 @@ class TaskPlanScoreStudentQuestion extends BaseModel {
   }
 
   @computed get isTrouble() {
-    return this.is_completed && this.points <= 0.5;
+    return this.is_completed && (this.points / this.availablePoints) < 0.5;
   }
 }
 

--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -43,6 +43,10 @@ class TaskPlanScoreStudentQuestion extends BaseModel {
   @computed get isManuallyGraded() {
     return !isNil(this.grader_points);
   }
+
+  @computed get isTrouble() {
+    return this.is_completed && this.points <= 0.5;
+  }
 }
 
 @identifiedBy('task-plan/scores/student')
@@ -65,6 +69,10 @@ class TaskPlanScoreStudent extends BaseModel {
   @computed get name() {
     return `${this.last_name}, ${this.first_name}`;
   }
+
+  @computed get reversedName() {
+    return `${this.first_name} ${this.last_name}`;
+  }
 }
 
 
@@ -80,6 +88,10 @@ class TaskPlanScoreHeading extends BaseModel {
 
   @computed get isCore() {
     return 'Tutor' !== this.type;
+  }
+
+  @computed get displayType() {
+    return this.type === 'FR' ? 'WRQ' : this.type;
   }
 
   @computed get index() {
@@ -124,6 +136,12 @@ class TaskPlanScoreHeading extends BaseModel {
       remaining,
       complete: remaining == 0,
     };
+  }
+
+  @computed get displayPoints() {
+    const { dropped } = this;
+    return dropped ?
+      (dropped.drop_method == 'zeroed' ? 0 : this.points_without_dropping) : this.points;
   }
 
 }

--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -4,13 +4,14 @@ import {
 import Exercises from '../../exercises';
 import { filter, sumBy, find, isNil, compact } from 'lodash';
 import DroppedQuestion from './dropped_question';
+import S from '../../../helpers/string';
 
 @identifiedBy('task-plan/scores/student-question')
 class TaskPlanScoreStudentQuestion extends BaseModel {
   @identifier question_id;
   @field exercise_id;
   @field is_completed = false;
-  @field points = 0;
+  @field points;
   @field selected_answer_id;
   @field free_response;
   @field task_step_id;
@@ -45,7 +46,24 @@ class TaskPlanScoreStudentQuestion extends BaseModel {
   }
 
   @computed get isTrouble() {
-    return this.is_completed && (this.points / this.availablePoints) < 0.5;
+    return !isNil(this.gradedPoints) && (this.gradedPoints / this.availablePoints) < 0.5;
+  }
+
+  @computed get displayValue() {
+    const { dropped } = this.questionHeading;
+    const pending = '---';
+
+    if (this.needs_grading) { return pending; }
+
+    if (dropped && this.is_completed) {
+      return S.numberWithOneDecimalPlace(
+        dropped.drop_method == 'full_credit' ? this.availablePoints : 0
+      );
+    }
+
+    if (!isNil(this.gradedPoints)) { return S.numberWithOneDecimalPlace(this.gradedPoints); }
+
+    return pending;
   }
 }
 

--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -108,10 +108,6 @@ class TaskPlanScoreHeading extends BaseModel {
     return 'Tutor' !== this.type;
   }
 
-  @computed get displayType() {
-    return this.type === 'FR' ? 'WRQ' : this.type;
-  }
-
   @computed get index() {
     return this.tasking && this.tasking.question_headings.indexOf(this);
   }

--- a/tutor/src/screens/assignment-edit/index.js
+++ b/tutor/src/screens/assignment-edit/index.js
@@ -7,7 +7,7 @@ import LoadingScreen from 'shared/components/loading-animation';
 import { Formik } from 'formik';
 import { withRouter } from 'react-router';
 import UX from './ux';
-import { BackgroundWrapper } from '../../helpers/background-wrapper';
+import { BackgroundWrapper, ContentWrapper } from '../../helpers/background-wrapper';
 import CourseBreadcrumb from '../../components/course-breadcrumb';
 
 import './styles.scss';
@@ -68,7 +68,7 @@ class AssignmentBuilder extends React.Component {
     }
 
     return (
-      <StyledBackgroundWrapper>
+      <BackgroundWrapper>
         <ScrollToTop>
           <TourRegion
             className="assignment-builder"
@@ -76,16 +76,18 @@ class AssignmentBuilder extends React.Component {
             otherTours={[`${ux.plan.type}-assignment-editor-super`]}
             courseId={ux.course.id}
           >
-            <CourseBreadcrumb course={this.ux.course} currentTitle={`Add ${ux.plan.type}`} />
-            <Formik
-              initialValues={ux.formValues}
-              validateOnMount={true}
-            >
-              {ux.renderStep}
-            </Formik>
+            <ContentWrapper>
+              <CourseBreadcrumb course={this.ux.course} currentTitle={`Add ${ux.plan.type}`} />
+              <Formik
+                initialValues={ux.formValues}
+                validateOnMount={true}
+              >
+                {ux.renderStep}
+              </Formik>
+            </ContentWrapper>
           </TourRegion>
         </ScrollToTop>
-      </StyledBackgroundWrapper>
+      </BackgroundWrapper>
     );
   }
 }

--- a/tutor/src/screens/assignment-edit/index.js
+++ b/tutor/src/screens/assignment-edit/index.js
@@ -12,13 +12,6 @@ import CourseBreadcrumb from '../../components/course-breadcrumb';
 
 import './styles.scss';
 
-const StyledBackgroundWrapper = styled(BackgroundWrapper)`
-  > * {
-    max-width: 1200px;
-    margin: 0 auto;
-  }
-`;
-
 @withRouter
 @observer
 class AssignmentBuilder extends React.Component {

--- a/tutor/src/screens/assignment-edit/index.js
+++ b/tutor/src/screens/assignment-edit/index.js
@@ -1,4 +1,4 @@
-import { React, PropTypes, observer, styled } from 'vendor';
+import { React, PropTypes, observer } from 'vendor';
 import { ScrollToTop } from 'shared';
 import TourRegion from '../../components/tours/region';
 import Courses from '../../models/courses-map';

--- a/tutor/src/screens/assignment-review/drop-questions.js
+++ b/tutor/src/screens/assignment-review/drop-questions.js
@@ -1,5 +1,4 @@
 import { React, PropTypes, observer, styled, css } from 'vendor';
-import { ToolbarButton } from 'primitives';
 import { Modal, Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { colors } from 'theme';
 import OXQuestionPreview from '../../components/question-preview';
@@ -277,12 +276,14 @@ const DropQuestion = observer(({ ux }) => {
         placement="bottom"
         overlay={<Tooltip>Select and drop question(s) from assignment</Tooltip>}
       >
-        <ToolbarButton
+        <Button
+          variant="light"
+          className="btn-standard"
           data-test-id="drop-questions-btn"
           onClick={() => ux.isDisplayingDropQuestions=true}
         >
           Drop questions
-        </ToolbarButton>
+        </Button>
       </OverlayTrigger>
       <DropQuestionsModal
         show={ux.isDisplayingDropQuestions}

--- a/tutor/src/screens/assignment-review/grant-extension.js
+++ b/tutor/src/screens/assignment-review/grant-extension.js
@@ -1,5 +1,4 @@
 import { React, PropTypes, observer, styled, moment } from 'vendor';
-import { ToolbarButton } from 'primitives';
 import { Modal, Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import DateTime from '../../components/date-time-input';
 import { Formik, Form } from 'formik';
@@ -53,7 +52,13 @@ const GrantExtension = observer(({ ux }) => {
         placement="bottom"
         overlay={<Tooltip>Select and grant time extension to student(s)</Tooltip>}
       >
-        <ToolbarButton onClick={() => ux.isDisplayingGrantExtension=true}>Grant Extension</ToolbarButton>
+        <Button
+          variant="light"
+          className="btn-standard"
+          onClick={() => ux.isDisplayingGrantExtension=true}
+        >
+          Grant Extension
+        </Button>
       </OverlayTrigger>
       <Formik
         onSubmit={ux.saveDisplayingGrantExtension}

--- a/tutor/src/screens/assignment-review/index.js
+++ b/tutor/src/screens/assignment-review/index.js
@@ -11,7 +11,7 @@ import Details from './details';
 import Overview from './overview';
 import Scores from './scores';
 import CourseBreadcrumb from '../../components/course-breadcrumb';
-import { BackgroundWrapper } from '../../helpers/background-wrapper';
+import { BackgroundWrapper, ContentWrapper } from '../../helpers/background-wrapper';
 
 import './styles.scss';
 
@@ -113,21 +113,23 @@ class AssignmentReview extends React.Component {
     return (
       <BackgroundWrapper>
         <ScrollToTop>
-          <Heading>
-            <CourseBreadcrumb
-              course={course}
-              currentTitle={planScores.title}
-              titleSize="lg"
+          <ContentWrapper>
+            <Heading>
+              <CourseBreadcrumb
+                course={course}
+                currentTitle={planScores.title}
+                titleSize="lg"
+              />
+              <CoursePeriodSelect period={selectedPeriod} course={course} onChange={setSelectedPeriod} />
+            </Heading>
+            <StyledTabs
+              selectedIndex={this.tabIndex}
+              params={this.props.params}
+              onSelect={this.onTabSelection}
+              tabs={AvailableTabs.map(t => t.title)}
             />
-            <CoursePeriodSelect period={selectedPeriod} course={course} onChange={setSelectedPeriod} />
-          </Heading>
-          <StyledTabs
-            selectedIndex={this.tabIndex}
-            params={this.props.params}
-            onSelect={this.onTabSelection}
-            tabs={AvailableTabs.map(t => t.title)}
-          />
-          <Tab ux={this.ux} />
+            <Tab ux={this.ux} />
+          </ContentWrapper>
         </ScrollToTop>
       </BackgroundWrapper>
     );

--- a/tutor/src/screens/assignment-review/scores.js
+++ b/tutor/src/screens/assignment-review/scores.js
@@ -119,6 +119,11 @@ const LateWork = styled.div`
   ${centeredCSS}
   align-self: stretch;
   position: relative;
+
+  .extension-icon {
+    position: absolute;
+    right: 1rem;
+  }
 `;
 
 const Total = styled.div`
@@ -172,7 +177,6 @@ const Definition = styled.dd`
   margin: 0;
   color: ${colors.neutral.thin};
 `;
-
 
 const CornerTriangle = ({ color, tooltip }) => {
   return (

--- a/tutor/src/screens/assignment-review/scores.js
+++ b/tutor/src/screens/assignment-review/scores.js
@@ -361,7 +361,7 @@ const ResultDisplay = observer(({ result }) => {
 
 const TaskResult = observer(({ result, striped }) => (
   <Cell striped={striped}>
-    <Result isTrouble={result.is_completed && result.isTrouble}>
+    <Result isTrouble={result.isTrouble}>
       <ResultDisplay result={result} />
     </Result>
   </Cell>

--- a/tutor/src/screens/assignment-review/scores.js
+++ b/tutor/src/screens/assignment-review/scores.js
@@ -164,8 +164,8 @@ const Term = styled.dt`
   width: 5.6rem;
   height: 2.8rem;
   margin-right: 1.1rem;
-  font-size: 1.6rem;
-  line-height: 1.8rem;
+  font-size: 1.4rem;
+  line-height: 2.4rem;
 `;
 
 const Definition = styled.dd`
@@ -342,27 +342,10 @@ const AssignmentHeading = observer(({ ux, heading }) => (
   </Cell>
 ));
 
-const ResultDisplay = observer(({ result }) => {
-  const { dropped } = result.questionHeading;
-  const pending = '---';
-
-  if (result.is_completed) {
-    if (dropped) {
-      return (
-        <Icon variant={result.points > 0 ? 'droppedFullCredit' : 'droppedZeroCredit'} />
-      );
-    }
-    return S.numberWithOneDecimalPlace(result.points);
-  } else {
-    return pending;
-  }
-});
-
-
 const TaskResult = observer(({ result, striped }) => (
   <Cell striped={striped}>
     <Result isTrouble={result.isTrouble}>
-      <ResultDisplay result={result} />
+      {result.displayValue}
     </Result>
   </Cell>
 ));
@@ -441,7 +424,7 @@ const Scores = observer(({ ux }) => {
       <DefinitionsWrapper>
         <Term variant="trouble" aria-label="Less than 50%"></Term>
         <Definition>Scores less than 50% of question's point value</Definition>
-        <Term aria-label="Unattempted">&hellip;</Term>
+        <Term aria-label="Unattempted">---</Term>
         <Definition>Unattempted question or ungraded responses</Definition>
       </DefinitionsWrapper>
     </>

--- a/tutor/src/screens/assignment-review/scores.js
+++ b/tutor/src/screens/assignment-review/scores.js
@@ -5,6 +5,7 @@ import { Icon } from 'shared';
 import LoadingScreen from 'shared/components/loading-animation';
 import { colors } from 'theme';
 import S from '../../helpers/string';
+import ExtensionIcon from '../../components/icons/extension';
 import SortIcon from '../../components/icons/sort';
 import SearchInput from '../../components/search-input';
 import GrantExtension from './grant-extension';
@@ -209,29 +210,6 @@ const StyledTriangle = styled.div`
   `}
 `;
 
-const GreenCircle = styled.div`
-  display: inline-block;
-  width: 1.4rem;
-  height: 1.4rem;
-  position: absolute;
-  right: 1rem;
-  background: #009670;
-  color: #fff;
-  font-size: 0.9rem;
-  line-height: 1.4rem;
-  border-radius: 50%;
-  text-align: center;
-`;
-
-const ExtensionCircle = () => (
-  <OverlayTrigger
-    placement="right"
-    overlay={<Tooltip>Student was granted an extension</Tooltip>}
-  >
-    <GreenCircle>E</GreenCircle>
-  </OverlayTrigger>
-);
-
 const OrderIcon = styled(Icon)`
   &&.btn {
     transition: none;
@@ -335,7 +313,7 @@ const StudentCell = observer(({ ux, student, striped }) => (
       </Total>
       <LateWork>
         {student.late_work_penalty ? `-${S.numberWithOneDecimalPlace(student.late_work_penalty)}` : '0'}
-        {ux.wasGrantedExtension(student.role_id) && <ExtensionCircle />}
+        {ux.wasGrantedExtension(student.role_id) && <ExtensionIcon />}
       </LateWork>
     </CellContents>
   </Cell>

--- a/tutor/src/screens/assignment-review/scores.js
+++ b/tutor/src/screens/assignment-review/scores.js
@@ -332,7 +332,7 @@ const AssignmentHeading = observer(({ ux, heading }) => (
         <SortIcon sort={ux.sortForColumn(heading.index, 'question')} />
       </HeadingTop>
       <HeadingMiddle>
-        {heading.displayType}
+        {heading.type}
       </HeadingMiddle>
       <HeadingBottom>
         {heading.dropped &&

--- a/tutor/src/screens/assignment-review/scores.js
+++ b/tutor/src/screens/assignment-review/scores.js
@@ -232,7 +232,7 @@ const StudentColumnHeader = observer(({ ux }) => (
           </SplitCell>
         </HeadingMiddle>
         <HeadingBottom>
-          {20.0}
+          {S.numberWithOneDecimalPlace(ux.scores.availablePoints)}
         </HeadingBottom>
       </ColumnHeading>
       <ColumnHeading>
@@ -240,10 +240,10 @@ const StudentColumnHeader = observer(({ ux }) => (
           Late work
         </HeadingTop>
         <HeadingMiddle>
-          Per day
+          {S.capitalize(ux.planScores.grading_template.late_work_penalty_applied)}
         </HeadingMiddle>
         <HeadingBottom>
-          {-10.0}
+          {S.asPercent(ux.planScores.grading_template.late_work_penalty)}%
         </HeadingBottom>
       </ColumnHeading>
     </CellContents>

--- a/tutor/src/screens/assignment-review/scores.js
+++ b/tutor/src/screens/assignment-review/scores.js
@@ -464,7 +464,7 @@ const Scores = observer(({ ux }) => {
         <Term variant="trouble" aria-label="Less than 50%"></Term>
         <Definition>Scores less than 50% of question's point value</Definition>
         <Term aria-label="Unattempted">&hellip;</Term>
-        <Definition>Unattempted question of ungraded responses</Definition>
+        <Definition>Unattempted question or ungraded responses</Definition>
       </DefinitionsWrapper>
     </>
   );

--- a/tutor/src/screens/assignment-review/scores.js
+++ b/tutor/src/screens/assignment-review/scores.js
@@ -2,6 +2,7 @@ import { React, PropTypes, styled, observer, css } from 'vendor';
 import { StickyTable, Row, Cell as TableCell } from 'react-sticky-table';
 import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { Icon } from 'shared';
+import LoadingScreen from 'shared/components/loading-animation';
 import { colors } from 'theme';
 import S from '../../helpers/string';
 import SortIcon from '../../components/icons/sort';
@@ -69,6 +70,7 @@ const HeadingTop = styled.div`
   padding-top: 1.2rem;
   align-self: stretch;
   font-weight: bold;
+  cursor: pointer;
 `;
 
 const HeadingMiddle = styled.div`
@@ -105,6 +107,10 @@ const ColumnHeading = styled.div`
 const SplitCell = styled.div`
   ${centeredCSS}
   flex: 1.0;
+  font-size: 1.4rem;
+  ${props => props.variant != 'active' && `color: ${colors.link};`}
+  ${props => props.variant == 'divider' && `color: ${colors.neutral.pale};`}
+  ${props => props.variant != 'divider' && 'cursor: pointer;'}
 `;
 
 const LateWork = styled.div`
@@ -122,7 +128,7 @@ const Total = styled.div`
 `;
 
 const isTroubleCSS = css`
-  background-color: ${colors.states.trouble}
+  background-color: ${colors.states.trouble};
   border-color: ${colors.danger};
   border-top: 1px solid ${colors.danger};
   border-bottom: 1px solid ${colors.danger};
@@ -203,31 +209,92 @@ const StyledTriangle = styled.div`
   `}
 `;
 
+const GreenCircle = styled.div`
+  display: inline-block;
+  width: 1.4rem;
+  height: 1.4rem;
+  position: absolute;
+  right: 1rem;
+  background: #009670;
+  color: #fff;
+  font-size: 0.9rem;
+  line-height: 1.4rem;
+  border-radius: 50%;
+  text-align: center;
+`;
+
+const ExtensionCircle = () => (
+  <OverlayTrigger
+    placement="right"
+    overlay={<Tooltip>Student was granted an extension</Tooltip>}
+  >
+    <GreenCircle>E</GreenCircle>
+  </OverlayTrigger>
+);
+
+const OrderIcon = styled(Icon)`
+  &&.btn {
+    transition: none;
+    font-size: 1.2rem;
+    line-height: 1.2rem;
+
+    &:hover, &:focus {
+      box-shadow: none;
+    }
+  }
+`;
+
 const StudentColumnHeader = observer(({ ux }) => (
   <Cell leftBorder={true}>
     <CellContents>
-      <ColumnHeading first={true} onClick={() => ux.changeRowSortingOrder(0, 'name')}>
-        <HeadingTop>
+      <ColumnHeading first={true}>
+        <HeadingTop
+          onClick={() => ux.changeRowSortingOrder(0, 'name')}
+          aria-label="Sort by student name"
+          role="button"
+        >
           Student Name
           <SortIcon sort={ux.sortForColumn(0, 'name')} />
         </HeadingTop>
         <HeadingMiddle>
-          Lastname, Firstname <Icon type="exchange-alt" />
+          {ux.nameOrderHeader}
+          <OrderIcon
+            variant="toggleOrder"
+            onClick={ux.toggleNameOrder}
+            aria-label="Toggle firstname lastname order"
+          />
         </HeadingMiddle>
         <HeadingBottom>
           Available Points
         </HeadingBottom>
       </ColumnHeading>
-      <ColumnHeading onClick={() => ux.changeRowSortingOrder(0, 'total')}>
-        <HeadingTop>
+      <ColumnHeading>
+        <HeadingTop
+          onClick={() => ux.changeRowSortingOrder(0, 'total')}
+          aria-label="Sort by student total"
+          role="button"
+        >
           Total
           <SortIcon sort={ux.sortForColumn(0, 'total')} />
         </HeadingTop>
         <HeadingMiddle>
-          <SplitCell>
+          <SplitCell
+            variant={!ux.displayTotalInPercent ? 'active' : ''}
+            onClick={() => ux.displayTotalInPercent = false}
+            aria-label="Display total in points"
+            role="button"
+          >
             #
           </SplitCell>
-          <SplitCell>
+          <SplitCell variant="divider">
+            |
+          </SplitCell>
+          <SplitCell
+            variant={ux.displayTotalInPercent ? 'active' : ''}
+            onClick={() => ux.displayTotalInPercent = true}
+            aria-label="Display total in percent"
+            role="button"
+          >
             %
           </SplitCell>
         </HeadingMiddle>
@@ -243,7 +310,7 @@ const StudentColumnHeader = observer(({ ux }) => (
           {S.capitalize(ux.planScores.grading_template.late_work_penalty_applied)}
         </HeadingMiddle>
         <HeadingBottom>
-          {S.asPercent(ux.planScores.grading_template.late_work_penalty)}%
+          -{S.asPercent(ux.planScores.grading_template.late_work_penalty)}%
         </HeadingBottom>
       </ColumnHeading>
     </CellContents>
@@ -251,22 +318,24 @@ const StudentColumnHeader = observer(({ ux }) => (
 ));
 
 
-const StudentCell = observer(({ student, striped }) => (
+const StudentCell = observer(({ ux, student, striped }) => (
   <Cell striped={striped}>
     <CellContents>
 
       <Heading first={true}>
         <StyledButton variant="link">
-          {student.name}
+          {ux.reverseNameOrder ? student.reversedName : student.name}
         </StyledButton>
       </Heading>
 
       <Total>
-        {S.numberWithOneDecimalPlace(student.total_points)}
+        {ux.displayTotalInPercent ?
+          `${S.asPercent(student.total_fraction || 0)}%` :
+          S.numberWithOneDecimalPlace(student.total_points)}
       </Total>
       <LateWork>
-        {false && <CornerTriangle color="green" tooltip="Student was granted an extension" />}
         {student.late_work_penalty ? `-${S.numberWithOneDecimalPlace(student.late_work_penalty)}` : '0'}
+        {ux.wasGrantedExtension(student.role_id) && <ExtensionCircle />}
       </LateWork>
     </CellContents>
   </Cell>
@@ -281,21 +350,41 @@ const AssignmentHeading = observer(({ ux, heading }) => (
         <SortIcon sort={ux.sortForColumn(heading.index, 'question')} />
       </HeadingTop>
       <HeadingMiddle>
-        {heading.type}
+        {heading.displayType}
       </HeadingMiddle>
       <HeadingBottom>
-        {false && <CornerTriangle color="blue" tooltip="Dropped" />}
-        {S.numberWithOneDecimalPlace(heading.points)}
+        {heading.dropped &&
+          <CornerTriangle color="blue"
+            tooltip={heading.dropped.drop_method == 'zeroed' ?
+              'Points changed to 0' : 'Full credit given to all students'}
+          />}
+        {S.numberWithOneDecimalPlace(heading.displayPoints)}
       </HeadingBottom>
     </ColumnHeading>
   </Cell>
 ));
 
+const ResultDisplay = observer(({ result }) => {
+  const { dropped } = result.questionHeading;
+  const pending = '---';
+
+  if (result.is_completed) {
+    if (dropped) {
+      return (
+        <Icon variant={result.points > 0 ? 'droppedFullCredit' : 'droppedZeroCredit'} />
+      );
+    }
+    return S.numberWithOneDecimalPlace(result.points);
+  } else {
+    return pending;
+  }
+});
+
 
 const TaskResult = observer(({ result, striped }) => (
   <Cell striped={striped}>
-    <Result isTrouble={false}>
-      {result.is_completed ? S.numberWithOneDecimalPlace(result.points) : '…'}
+    <Result isTrouble={result.is_completed && result.isTrouble}>
+      <ResultDisplay result={result} />
     </Result>
   </Cell>
 ));
@@ -315,7 +404,7 @@ const ControlGroup = styled.div`
     width: 25.6rem;
 
     input {
-      height: 100%;
+      height: 3.8rem;
     }
   }
 
@@ -324,7 +413,8 @@ const ControlGroup = styled.div`
       margin-left: 1.6rem;
     }
     .btn:not(.btn-icon) {
-      padding: 0.5rem 3.3rem 0.75rem;
+      height: 4rem;
+      min-width: 17rem;
     }
   }
 `;
@@ -350,6 +440,10 @@ TableHeader.propTypes = {
 const Scores = observer(({ ux }) => {
   const { scores } = ux;
 
+  if (!ux.isExercisesReady) {
+    return <LoadingScreen message="Loading Assignment…" />;
+  }
+
   return (
     <>
       <TableHeader ux={ux} />
@@ -360,9 +454,9 @@ const Scores = observer(({ ux }) => {
         </Row>
         {ux.sortedStudents.map((student,sIndex) => (
           <Row key={sIndex}>
-            <StudentCell student={student} striped={0 === sIndex % 2} />
+            <StudentCell ux={ux} student={student} striped={0 === sIndex % 2} />
             {student.questions.map((result, i) => (
-              <TaskResult key={i} index={i} result={result} striped={0 === sIndex % 2} />
+              <TaskResult key={i} index={i} ux={ux} result={result} striped={0 === sIndex % 2} />
             ))}
           </Row>))}
       </StyledStickyTable>

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -141,7 +141,9 @@ export default class AssignmentReviewUX {
   }
 
   wasGrantedExtension(role_id) {
-    return Boolean(this.taskPlan.extensions.find(e => e.role_id == role_id));
+    return Boolean(
+      this.taskPlan.extensions.length > 0 && this.taskPlan.extensions.find(e => e.role_id == role_id)
+    );
   }
 
   // methods relating to droppping questions

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -19,6 +19,8 @@ export default class AssignmentReviewUX {
   @observable editablePlan;
   @observable rowSort = { key: 0, asc: true, dataType: 'name' };
   @observable searchingMatcher = null;
+  @observable reverseNameOrder = false;
+  @observable displayTotalInPercent = false;
 
   freeResponseQuestions = observable.map();
   pendingExtensions = observable.map();
@@ -71,13 +73,14 @@ export default class AssignmentReviewUX {
     return this.planScores.taskPlan;
   }
 
+  // methods relating to sorting and filtering scores table
+
   @computed get sortedStudents() {
     const students = rowDataSorter(this.scores.students, this.rowSort);
     if (!this.searchingMatcher) {
       return students;
     }
     return filter(students, s => s.name.match(this.searchingMatcher));
-
   }
 
   @action.bound changeRowSortingOrder(key, dataType) {
@@ -94,6 +97,13 @@ export default class AssignmentReviewUX {
     return (this.rowSort.key === sortKey) && (this.rowSort.dataType === dataType) ? this.rowSort : false;
   }
 
+  @action.bound toggleNameOrder() {
+    this.reverseNameOrder = !this.reverseNameOrder;
+  }
+
+  @computed get nameOrderHeader() {
+    return this.reverseNameOrder ? 'Firstname Lastname' : 'Lastname, Firstname';
+  }
 
   isShowingFreeResponseForQuestion(question) {
     return Boolean(this.freeResponseQuestions.get(question.id));
@@ -129,6 +139,9 @@ export default class AssignmentReviewUX {
     this.cancelDisplayingGrantExtension();
   }
 
+  wasGrantedExtension(role_id) {
+    return Boolean(this.taskPlan.extensions.find(e => e.role_id == role_id));
+  }
 
   // methods relating to droppping questions
 

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -46,6 +46,7 @@ export default class AssignmentReviewUX {
     this.onTabSelection = onTabSelection;
 
     await this.planScores.fetch();
+    await this.planScores.taskPlan.fetch();
     await this.planScores.taskPlan.analytics.fetch();
 
     await this.planScores.ensureExercisesLoaded();


### PR DESCRIPTION
- Display when a student has been granted an extension
- Add a ContentWrapper to start adding min/max width layout requirements
- Display points or dashes based if the question has been graded, has been completed, was not completed before the due date, etc. Regarding the past due date, the BE will send 0 for `points` after the due date if the question wasn't answered, so we don't have to manually check for due dates, just `points`/`gradedPoints` presence.
- Add name order toggle
- Fix displaying "FR" displaying instead of "WRQ"
- Fix many places real values weren't being displayed yet

![image](https://user-images.githubusercontent.com/34174/82950949-2d5aff00-9f5b-11ea-8d80-d4c603f04847.png)