### PR TITLE
add available points in student task progress header

### DIFF
--- a/tutor/src/components/task-progress.js
+++ b/tutor/src/components/task-progress.js
@@ -1,7 +1,8 @@
 import { React, PropTypes, observer, cn, styled } from 'vendor';
 import { StickyTable, Row, Cell } from 'react-sticky-table';
-import { map } from 'lodash';
+import { map, sumBy } from 'lodash';
 import { colors } from 'theme';
+import S from '../../src/helpers/string';
 
 const StyledStickyTable = styled(StickyTable)`
   padding-bottom: 5px;
@@ -133,26 +134,13 @@ class TaskProgress extends React.Component {
             steps.map((step, stepIndex) => {
               if(!step.isInfo) {
                 progressIndex += 1;
-                return <Cell key={stepIndex}>{progressIndex}</Cell>;
+                return <Cell key={stepIndex}>{S.numberWithOneDecimalPlace(step.available_points)}</Cell>;
               }
               return <Cell key={stepIndex}></Cell>;
             })
           }
-          <Cell>1000</Cell>
+          <Cell>{S.numberWithOneDecimalPlace(sumBy(steps, s => s.available_points))}</Cell>
         </Row>
-        {/* <Row>
-          <Cell>Points Scored</Cell>
-          {
-            range(100).map((step, stepIndex) => {
-              if(!step.isInfo) {
-                progressIndex += 1;
-                return <Cell key={stepIndex}>{progressIndex}</Cell>;
-              }
-              return <Cell key={stepIndex}></Cell>;
-            })
-          }
-          <Cell>1000</Cell>
-        </Row> */}
       </StyledStickyTable>
     );
     

--- a/tutor/src/models/student-tasks/step.js
+++ b/tutor/src/models/student-tasks/step.js
@@ -73,6 +73,9 @@ class StudentTaskStep extends BaseModel {
   @identifier id;
   @field uid;
   @field preview;
+  @field available_points;
+  @field grader_points;
+  @field grader_comments;
   @field type;
   @field is_completed;
   @field answer_id;

--- a/tutor/src/screens/task/step/card.js
+++ b/tutor/src/screens/task/step/card.js
@@ -2,6 +2,7 @@ import { React, PropTypes, cn, observer, styled } from 'vendor';
 import { colors } from 'theme';
 import { SpyInfo } from './spy-info';
 import Step from '../../../models/student-tasks/step';
+import S from '../../../helpers/string';
 
 const InnerStepCard = styled.div`
   display: flex;
@@ -43,13 +44,13 @@ const StepCardQuestion = styled.div`
 
 LoadingCard.displayName = 'LoadingCard';
 
-const StepCard = ({ questionNumber, stepType, isHomework, unpadded, className, children, ...otherProps }) => (
+const StepCard = ({ questionNumber, stepType, isHomework, availablePoints, unpadded, className, children, ...otherProps }) => (
   <OuterStepCard {...otherProps}>
     <InnerStepCard className={className}>
       {questionNumber && isHomework && stepType === 'exercise' &&
       <StepCardHeader>
         <div>Question {questionNumber}</div>
-        <div>2.0 Points</div>
+        <div>{S.numberWithOneDecimalPlace(availablePoints)} Points</div>
       </StepCardHeader>
       }
       <StepCardQuestion unpadded={unpadded}>{children}</StepCardQuestion>
@@ -63,6 +64,7 @@ StepCard.propTypes = {
   questionNumber: PropTypes.number,
   stepType: PropTypes.string,
   isHomework: PropTypes.string,
+  availablePoints: PropTypes.number,
 };
 
 
@@ -73,6 +75,7 @@ const TaskStepCard = observer(({ step, questionNumber, children, className, ...o
     stepType={step.type}
     isHomework={step.task.type}
     data-task-step-id={step.id}
+    availablePoints={step.available_points}
     className={cn(`${step.type}-step`, className)}
   >
     {children}


### PR DESCRIPTION
Add the available points in the task header progress table and question card.

![Screenshot from 2020-05-29 16-18-58](https://user-images.githubusercontent.com/3774774/83301740-2553c700-a1c8-11ea-959a-c0769cc301dc.png)
