### PR TITLE
Fix double title render and some small visual fixes

### DIFF
--- a/tutor/specs/components/__snapshots__/course-breadcrumb.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/course-breadcrumb.spec.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Course Breadcrumb renders and matches snapshot 1`] = `
-.c2 {
+.c3 {
   margin-right: 0.5rem;
   margin-left: 0.5rem;
 }
@@ -21,55 +21,74 @@ exports[`Course Breadcrumb renders and matches snapshot 1`] = `
 }
 
 .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
   color: #cdcdcd;
   margin: 0 0.8rem;
   margin-top: 2px;
 }
 
-.c1 svg {
+.c2 svg {
   margin: 0;
 }
 
-.c3 {
+.c4 {
   max-width: 1200px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: #5e6062;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  max-width: 100%;
+  margin-top: 1rem;
+  font-size: 3.6rem;
+  font-weight: bold;
+  line-height: initial;
+  color: #424242;
 }
 
 <div
   className="c0"
 >
-  <a
-    href="/course/1"
-    onClick={[Function]}
+  <div
+    className="c1"
   >
-    College Physics
-    <span
-      className="sc-fznyAO c1"
+    <a
+      href="/course/1"
+      onClick={[Function]}
     >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-angle-right fa-w-8 c2 ox-icon ox-icon-angle-right"
-        data-icon="angle-right"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={Object {}}
-        viewBox="0 0 256 512"
-        xmlns="http://www.w3.org/2000/svg"
+      College Physics
+      <span
+        className="sc-fznKkj c2"
       >
-        <path
-          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-          fill="currentColor"
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-angle-right fa-w-8 c3 ox-icon ox-icon-angle-right"
+          data-icon="angle-right"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
           style={Object {}}
-        />
-      </svg>
-    </span>
-  </a>
+          viewBox="0 0 256 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+      </span>
+    </a>
+  </div>
   <h2
-    className="sc-fzpans c3"
+    className="sc-fzpans c4"
   >
     Current Task
   </h2>

--- a/tutor/src/components/course-breadcrumb.jsx
+++ b/tutor/src/components/course-breadcrumb.jsx
@@ -11,6 +11,11 @@ const Wrapper = styled.div`
   line-height: 2.5rem;
   margin: 2rem 0;
   max-width: 1200px;
+  ${props => props.noBottomMargin && 'margin-bottom: 0;'}
+`;
+
+const Links = styled.div`
+  display: flex;
 `;
 
 const Divider = styled.span`
@@ -24,43 +29,42 @@ const AngleDivider = styled(Divider)`
 `;
 
 const TaskTitle = styled(TruncatedText)`
-  color: ${Theme.colors.neutral.grayblue};
-
-  ${props => props.titleSize === 'lg' && css`
-    max-width: 100%;
-    margin-top: 1rem;
-    font-size: 3.6rem;
-    font-weight: bold;
-    line-height: initial;
-    color: ${Theme.colors.neutral.darker};
-  `}
+  flex: 1;
+  max-width: 100%;
+  margin-top: 1rem;
+  font-size: 3.6rem;
+  font-weight: bold;
+  line-height: initial;
+  color: ${Theme.colors.neutral.darker};
 `;
 
-const CourseBreadcrumb = ({ course, currentTitle, titleSize, plan }) => {
+const CourseBreadcrumb = ({ course, currentTitle, titleSize, plan, noBottomMargin }) => {
   return (
-    <Wrapper>
-      <TutorLink to="dashboard" params={{ courseId: course.id }}>
-        {course.name}
-        <AngleDivider>
-          <Icon type="angle-right" />
-        </AngleDivider>
-      </TutorLink>
+    <Wrapper noBottomMargin={noBottomMargin}>
+      <Links>
+        <TutorLink to="dashboard" params={{ courseId: course.id }}>
+          {course.name}
+          <AngleDivider>
+            <Icon type="angle-right" />
+          </AngleDivider>
+        </TutorLink>
 
-      {
-        plan &&
-          <>
-            <TutorLink
-              to="reviewAssignment"
-              params={{ courseId: course.id, id: plan.id }}
-            >
-              <TruncatedText>{plan.title}</TruncatedText>
-            </TutorLink>
-            <AngleDivider>
-              <Icon type="angle-right" />
-            </AngleDivider>
-          </>
-      }
-      <TaskTitle as="h2" titleSize={titleSize}>{currentTitle}</TaskTitle>
+        {
+          plan &&
+            <>
+              <TutorLink
+                to="reviewAssignment"
+                params={{ courseId: course.id, id: plan.id }}
+              >
+                <TruncatedText>{plan.title}</TruncatedText>
+              </TutorLink>
+              <AngleDivider>
+                <Icon type="angle-right" />
+              </AngleDivider>
+            </>
+        }
+      </Links>
+      <TaskTitle as="h2">{currentTitle}</TaskTitle>
     </Wrapper>
   );
 };

--- a/tutor/src/screens/assignment-grade/index.js
+++ b/tutor/src/screens/assignment-grade/index.js
@@ -18,13 +18,6 @@ const Heading = styled.div`
   margin-bottom: 20px;
 `;
 
-const Title = styled.h1`
-  font-weight: bold;
-  font-size: 3.5rem;
-  line-height: 4.5rem;
-  margin: 0;
-`;
-
 const BodyBackground = styled.div`
   padding: 4rem;
   background-color: ${colors.neutral.bright};
@@ -62,14 +55,14 @@ class AssignmentGrading extends React.Component {
 
   render() {
     const { ux } = this;
-    
+
     if (!ux.isExercisesReady) {
       return <LoadingScreen message="Loading Assignment…" />;
     }
     return (
       <BackgroundWrapper>
         <ScrollToTop>
-          <div>    
+          <Heading>
             <CourseBreadcrumb
               course={ux.course}
               plan={{
@@ -78,16 +71,13 @@ class AssignmentGrading extends React.Component {
               }}
               currentTitle="Grade Answers"
             />
-            <Heading>
-              <Title>Grade Answers</Title>
-              <CoursePeriodSelect
-                period={ux.selectedPeriod}
-                periods={ux.planScores.periods}
-                course={ux.course}
-                onChange={ux.setSelectedPeriod}
-              />
-            </Heading>
-          </div>
+            <CoursePeriodSelect
+              period={ux.selectedPeriod}
+              periods={ux.planScores.periods}
+              course={ux.course}
+              onChange={ux.setSelectedPeriod}
+            />
+          </Heading>
           <QuestionsBar ux={ux} />
           <BodyBackground>
             <Question

--- a/tutor/src/screens/assignment-review/index.js
+++ b/tutor/src/screens/assignment-review/index.js
@@ -118,7 +118,6 @@ class AssignmentReview extends React.Component {
               <CourseBreadcrumb
                 course={course}
                 currentTitle={planScores.title}
-                titleSize="lg"
               />
               <CoursePeriodSelect
                 period={selectedPeriod}

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -231,7 +231,7 @@ const Right = styled.div`
   align-items: center;
   font-size: 1.6rem;
   .btn {
-    margin-left: 2rem;
+    margin-left: 1.6rem;
   }
 `;
 

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -26,6 +26,7 @@ const Footer = styled.div`
 
 const StyledIcon = styled(Icon)`
   font-size: 2.7rem;
+  flex-shrink: 0;
   &&:hover {
     box-shadow: none;
   }

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -226,7 +226,12 @@ const Center = styled.div`
 `;
 
 const Right = styled.div`
-
+  display: flex;
+  align-items: center;
+  font-size: 1.6rem;
+  .btn {
+    margin-left: 2rem;
+  }
 `;
 
 const GradeButton = styled(TutorLink).attrs({
@@ -256,9 +261,9 @@ const GradingBlock = observer(({ ux }) => {
   return (
     <Toolbar>
       <Center>
-        This assignment is now open for grading.
       </Center>
       <Right>
+        This assignment is now open for grading.
         <GradeButton
           to="gradeAssignment"
           params={{

--- a/tutor/src/screens/grading-templates/index.js
+++ b/tutor/src/screens/grading-templates/index.js
@@ -13,6 +13,19 @@ import CoursePage from '../../components/course-page';
 import * as EDIT_TYPES from './editors';
 import CourseBreadcrumb from '../../components/course-breadcrumb';
 
+const Heading = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 20px;
+  border-bottom: 1px solid ${Theme.colors.neutral.pale};
+  padding-bottom: 1.6rem;
+  > :first-child {
+    margin: 0;
+    h2 { margin-bottom: 0; }
+  }
+`;
+
 const Instructions = styled.p`
   font-size: 1.6rem;
   line-height: 2.5rem;
@@ -109,26 +122,22 @@ class GradingTemplatesScreen extends React.Component {
     return null;
   }
 
-  titleControls() {
-    return <Button onClick={this.onAdd} size="lg">Add new template</Button>;
-  }
-
-  titleBreadcrumbs() {
-    return <CourseBreadcrumb course={this.course} currentTitle="Grading templates" />;
-  }
-
   render() {
     return (
       <ScrollToTop>
         <Templates
           course={this.course}
-          title="Grading templates"
-          titleControls={this.titleControls()}
-          titleBreadcrumbs={this.titleBreadcrumbs()}
           titleAppearance="light"
         >
           <Container fluid={true}>
-            {this.modal}         
+            {this.modal}
+            <Heading>
+              <CourseBreadcrumb
+                course={this.course}
+                currentTitle="Grading templates"
+              />
+              <Button onClick={this.onAdd} size="lg">Add new template</Button>
+            </Heading>
             <Row>
               <Col>
                 <Instructions>

--- a/tutor/src/screens/teacher-gradebook/index.js
+++ b/tutor/src/screens/teacher-gradebook/index.js
@@ -12,7 +12,7 @@ import './styles.scss';
 import UX from './ux';
 
 const titleBreadcrumbs = (course) => {
-  return <CourseBreadcrumb course={course} currentTitle="Gradebook" />;
+  return <CourseBreadcrumb course={course} currentTitle="Gradebook" noBottomMargin />;
 };
 
 const titleControls = (ux) => {
@@ -39,7 +39,7 @@ const TeacherGradeBook = ({ ux: propsUX, ...props }) => {
       <BackgroundWrapper>
         <CoursePage
           course={ux.course}
-          title="Gradebook"
+          title=""
           className="course-scores-report"
           titleBreadcrumbs={titleBreadcrumbs(ux.course)}
           titleAppearance="light"


### PR DESCRIPTION
Consolidates these pages to use the breadcrumb for the title exclusively, and removes the size option since it's not really used.

Also moves the "This assignment is now open for grading." text to be aligned with the Grade button.

![image](https://user-images.githubusercontent.com/34174/83564883-4cfda480-a4d2-11ea-8346-dfa6a5f51d05.png)


![image](https://user-images.githubusercontent.com/34174/83564861-41aa7900-a4d2-11ea-8c37-6bf43e560780.png)

![image](https://user-images.githubusercontent.com/34174/83564899-52f38580-a4d2-11ea-9929-ace26cf6b3b9.png)

![image](https://user-images.githubusercontent.com/34174/83564912-58e96680-a4d2-11ea-93e1-92616000122e.png)

![image](https://user-images.githubusercontent.com/34174/83564956-6868af80-a4d2-11ea-9aa6-dca3cbc82efb.png)

![image](https://user-images.githubusercontent.com/34174/83565136-b2519580-a4d2-11ea-91d9-171e3657e8d1.png)
