### PR TITLE
Removed late_work_fraction_penalty from student array in scores

### DIFF
--- a/tutor/specs/factories/task-scores.js
+++ b/tutor/specs/factories/task-scores.js
@@ -15,7 +15,6 @@ Factory.define('TaskPlanPeriodStudent')
   .total_points(({ parent: { object } }) => object.question_headings.length)
   .total_fraction(1)
   .late_work_point_penalty(0)
-  .late_work_fraction_penalty(0)
   .questions(({ object: { role_id }, parent: { exercises, grades } }) => flatMap(exercises, (exercise) => (
     exercise.content.questions.map((question) => {
       const is_completed = fake.random.arrayElement([true, true, true, true, true, false])

--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -99,7 +99,6 @@ class TaskPlanScoreStudent extends BaseModel {
   @field total_points;
   @field total_fraction;
   @field late_work_point_penalty;
-  @field late_work_fraction_penalty;
   @field grades_need_publishing;
 
   @hasMany({ model: TaskPlanScoreStudentQuestion, inverseOf: 'student' }) questions;


### PR DESCRIPTION
This field was unused and ambiguous so I took it out in the backend too.