### PR TITLE
fix displaying available points icon/value

### DIFF
--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -325,7 +325,7 @@ const Overview = observer(({ ux, ux: { scores } }) => (
       </Row>
       <Row>
         <Header>
-          Available Points <AvailablePoints value={(scores.hasEqualTutorQuestions && scores.questionsInfo.totalPoints) || false} />
+          Available Points <AvailablePoints value={(scores.hasEqualTutorQuestions && scores.availablePoints) || false} />
         </Header>
         {scores.question_headings.map((h, i) => <Cell key={i}>{S.numberWithOneDecimalPlace(h.points)}</Cell>)}
       </Row>


### PR DESCRIPTION
Fixes not sending `availablePoints` when there were equal number of questions, causing the icon to be displayed instead of the points.

![image](https://user-images.githubusercontent.com/34174/83659343-3f9af580-a578-11ea-8799-1c4a3db5f915.png)

![image](https://user-images.githubusercontent.com/34174/83659364-44f84000-a578-11ea-89db-3f00c227f2ce.png)
