### PR TITLE
fix not displaying only active assigned periods

### DIFF
--- a/tutor/specs/integration/assignment-review.spec.js
+++ b/tutor/specs/integration/assignment-review.spec.js
@@ -11,8 +11,6 @@ context('Assignment Review', () => {
   it('loads and views feedback', () => {
     cy.contains('Submission Overview').click();
     cy.getTestElement('overview').should('exist');
-    cy.getTestElement('student-free-responses').should('not.exist');
-    cy.get('.homework-questions .ox-icon-caret-right').first().click()
     cy.getTestElement('student-free-responses').should('exist');
   });
 

--- a/tutor/specs/screens/teacher-dashboard/plan-details.spec.jsx
+++ b/tutor/specs/screens/teacher-dashboard/plan-details.spec.jsx
@@ -36,6 +36,7 @@ describe('Plan Details Component', function() {
 
   it('renders no students enrolled', () => {
     plan.is_published = true;
+    plan.analytics = { api: { hasBeenFetched: true } };
     course.periods[0].num_enrolled_students = 0;
     return renderModal(props).then((m) => {
       expect(m.textContent).toContain('No students enrolled');

--- a/tutor/src/components/course-period-select.js
+++ b/tutor/src/components/course-period-select.js
@@ -25,6 +25,7 @@ const StyledDropdownToggle = styled(Dropdown.Toggle)`
 const CoursePeriodSelect = observer(({ course, periods, period, onChange }) => {
   const items = periods || course.periods.active;
   const choices = without(items, period);
+  if (!period) { return null; }
 
   const onSelect = (periodId) => {
     const period = find(items, { id: periodId });

--- a/tutor/src/components/plan-stats/index.jsx
+++ b/tutor/src/components/plan-stats/index.jsx
@@ -11,19 +11,18 @@ import NoStudents from './no-students';
 import RadioInput from  '../radio-input';
 
 const SectionWrapper = styled.div`
-  margin: 0.8rem 5rem 0 0;
+  margin: 0.8rem 5rem 2rem 0;
   display: inline-flex;
 `;
 
 const StatsWrapper = styled.div`
-  margin-top: 4rem;
+  margin-top: 2rem;
   font-size: 1.6rem;
 
   section {
     margin-top: 0.8rem;
   }
 `;
-
 
 export default
 @observer
@@ -54,7 +53,11 @@ class Stats extends React.Component {
   }
 
   @computed get period() {
-    return this.course.periods.sorted[this.currentPeriodIndex];
+    return this.periods[this.currentPeriodIndex];
+  }
+
+  @computed get periods() {
+    return this.props.plan.activeAssignedPeriods;
   }
 
   @computed get stats() {
@@ -108,12 +111,8 @@ class Stats extends React.Component {
     let courseBar, dataComponent;
     const { course, stats, props: { shouldOverflowData } } = this;
 
-    if (!this.period.hasEnrollments) {
-      return this.renderWithTabs(<NoStudents courseId={course.id} />);
-    }
-
     if (!this.analytics.api.hasBeenFetched) {
-      return this.renderWithTabs(<LoadingScreen />);
+      return <LoadingScreen />;
     }
 
     courseBar = <CourseBar data={stats} type={this.props.plan.type} />;
@@ -138,7 +137,7 @@ class Stats extends React.Component {
     return (
       <>
         <h6>Select section</h6>
-        {this.course.periods.map((p, i) =>
+        {this.periods.map((p, i) =>
           <SectionWrapper key={`period-${p.id}`}>
             <RadioInput
               id={`period-${p.id}`}
@@ -151,7 +150,8 @@ class Stats extends React.Component {
             />
           </SectionWrapper>
         )}
-        {dataComponent}
+        {!this.period.hasEnrollments && <NoStudents courseId={course.id} />}
+        {this.period.hasEnrollments && dataComponent}
       </>
     );
   }

--- a/tutor/src/models/task-plans/teacher/plan.js
+++ b/tutor/src/models/task-plans/teacher/plan.js
@@ -4,7 +4,7 @@ import {
 import { action, computed, observable, createAtom, toJS } from 'mobx';
 import Exercises from '../../exercises';
 import {
-  first, last, map, flatMap, find, get, pick, extend, every, isEmpty, compact, findIndex,
+  first, last, map, flatMap, find, get, pick, extend, every, isEmpty, compact, findIndex, filter, includes,
 } from 'lodash';
 import isUrl from 'validator/lib/isURL';
 import { lazyInitialize } from 'core-decorators';
@@ -111,7 +111,7 @@ class TeacherTaskPlan extends BaseModel {
     if (this.isNew && !this.isClone) {
       Object.assign(this.settings, this.defaultSettings);
     }
-    
+
   }
 
   @computed get defaultSettings() {
@@ -431,6 +431,13 @@ class TeacherTaskPlan extends BaseModel {
         dropped_questions: toJS(this.dropped_questions),
       },
     };
+  }
+
+  @computed get activeAssignedPeriods() {
+    const ids = compact(this.tasking_plans.map(tp => tp.target_type == 'period' && tp.target_id));
+    return filter(
+      this.course.periods.sorted, p => includes(ids, p.id)
+    );
   }
 
   // called from api

--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -2,7 +2,7 @@ import {
   BaseModel, identifiedBy, field, identifier, hasMany, belongsTo, computed,
 } from 'shared/model';
 import Exercises from '../../exercises';
-import { filter, sum, sumBy, find, isNil, isEmpty, compact, sortBy, get, includes } from 'lodash';
+import { filter, sum, sumBy, find, isNil, isEmpty, compact, sortBy, get } from 'lodash';
 import DroppedQuestion from './dropped_question';
 import S from '../../../helpers/string';
 
@@ -365,12 +365,5 @@ class TaskPlanScores extends BaseModel {
 
   get course() {
     return this.taskPlan.course;
-  }
-
-  @computed get periods() {
-    const ids = this.tasking_plans.map(tp => tp.period_id);
-    return filter(
-      this.taskPlan.course.periods.active, p => includes(ids, p.id)
-    );
   }
 }

--- a/tutor/src/screens/assignment-grade/index.js
+++ b/tutor/src/screens/assignment-grade/index.js
@@ -73,7 +73,7 @@ class AssignmentGrading extends React.Component {
             />
             <CoursePeriodSelect
               period={ux.selectedPeriod}
-              periods={ux.planScores.periods}
+              periods={ux.assignedPeriods}
               course={ux.course}
               onChange={ux.setSelectedPeriod}
             />

--- a/tutor/src/screens/assignment-grade/ux.js
+++ b/tutor/src/screens/assignment-grade/ux.js
@@ -60,6 +60,10 @@ export default class AssignmentGradingUX {
     return this.planScores.tasking_plans.find(tp => this.selectedPeriod.id == tp.period_id);
   }
 
+  @computed get assignedPeriods() {
+    return this.planScores.taskPlan.activeAssignedPeriods;
+  }
+
   @computed get completedResponses() {
     return filter(this.selectedHeading.studentResponses, sr => sr.grader_points !== undefined);
   }

--- a/tutor/src/screens/assignment-review/index.js
+++ b/tutor/src/screens/assignment-review/index.js
@@ -96,7 +96,8 @@ class AssignmentReview extends React.Component {
 
   render() {
     const {
-      isScoresReady, course, planScores, selectedPeriod, setSelectedPeriod, scores: taskPlanScores, isReadingOrHomework,
+      isScoresReady, course, planScores, assignedPeriods, selectedPeriod, setSelectedPeriod,
+      scores: taskPlanScores, isReadingOrHomework,
     } = this.ux;
 
     if (!isScoresReady) {
@@ -126,7 +127,7 @@ class AssignmentReview extends React.Component {
               />
               <CoursePeriodSelect
                 period={selectedPeriod}
-                periods={planScores.periods}
+                periods={assignedPeriods}
                 course={course}
                 onChange={setSelectedPeriod}
               />

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -41,7 +41,6 @@ export default class AssignmentReviewUX {
     this.scroller = new ScrollTo({ windowImpl });
     this.planScores = scores;
     this.course = course;
-    this.selectedPeriod = first(course.periods.active);
     this.onCompleteDelete = onCompleteDelete;
     this.onEditAssignedQuestions = onEditAssignedQuestions;
     this.onTabSelection = onTabSelection;
@@ -49,9 +48,9 @@ export default class AssignmentReviewUX {
     await this.planScores.fetch();
     await this.planScores.taskPlan.fetch();
     await this.planScores.taskPlan.analytics.fetch();
-
     await this.planScores.ensureExercisesLoaded();
 
+    this.selectedPeriod = first(this.assignedPeriods);
     this.exercisesHaveBeenFetched = true;
     this.freeResponseQuestions.set(get(this.scores, 'questionsInfo[0].id'), true);
   }
@@ -65,6 +64,7 @@ export default class AssignmentReviewUX {
   }
 
   @computed get scores() {
+    if (!this.selectedPeriod) { return null; }
     return this.planScores.tasking_plans.find(tp => this.selectedPeriod.id == tp.period_id);
   }
 
@@ -74,6 +74,10 @@ export default class AssignmentReviewUX {
 
   @computed get taskPlan() {
     return this.planScores.taskPlan;
+  }
+
+  @computed get assignedPeriods() {
+    return this.planScores.taskPlan.activeAssignedPeriods;
   }
 
   // methods relating to sorting and filtering scores table
@@ -131,7 +135,7 @@ export default class AssignmentReviewUX {
       this.pendingExtensions.set(s.role_id, checked);
     });
   }
-  
+
   @action.bound cancelDisplayingGrantExtension() {
     this.pendingExtensions.clear();
     this.isDisplayingGrantExtension = false;

--- a/tutor/src/screens/teacher-dashboard/plan-details.jsx
+++ b/tutor/src/screens/teacher-dashboard/plan-details.jsx
@@ -172,7 +172,7 @@ class CoursePlanDetails extends React.Component {
   }
 
   @computed get tasking() {
-    const periodId = this.selectedPeriodId || this.props.course.periods[0].id;
+    const periodId = this.selectedPeriodId || this.props.plan.activeAssignedPeriods[0].id;
 
     return this.props.plan.tasking_plans.find(t =>
       t.target_id == periodId && t.target_type === 'period'


### PR DESCRIPTION
- Consolidates some of the period options to only provide active periods that were assigned to.
- Fixes an issue with assignment review getting period data from scores api instead of the task plan api, which now allows the selector to render when a period doesn't have students.
- Fixes several period-selector issues with the plan stats/details modal that shows when you click a plan on the calendar.

![image](https://user-images.githubusercontent.com/34174/83820919-c76d2680-a682-11ea-9627-45a6e2095a92.png)

![image](https://user-images.githubusercontent.com/34174/83821002-d227bb80-a682-11ea-94d4-8a74bb7da4bc.png)
