### PR TITLE
make drop questions button async

### DIFF
--- a/tutor/src/screens/assignment-review/drop-questions.js
+++ b/tutor/src/screens/assignment-review/drop-questions.js
@@ -1,6 +1,7 @@
 import { React, PropTypes, observer, styled, css } from 'vendor';
 import { Modal, Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { colors } from 'theme';
+import { AsyncButton } from 'shared';
 import OXQuestionPreview from '../../components/question-preview';
 import { StickyTable, Row, Cell } from 'react-sticky-table';
 import S from '../../helpers/string';
@@ -317,13 +318,15 @@ const DropQuestion = observer(({ ux }) => {
             data-test-id="cancel-btn"
             onClick={ux.cancelDisplayingDropQuestions}
           >Cancel</Button>
-          <Button
+          <AsyncButton
             variant="primary"
             className="btn-standard"
             data-test-id="save-btn"
-            disabled={!ux.canSubmitDroppedQuestions}
+            disabled={!ux.canSubmitDroppedQuestions || ux.isDroppedQuestionsSaving}
+            isWaiting={ux.isDroppedQuestionsSaving}
+            waitingText="Dropping…"
             onClick={ux.saveDropQuestions}
-          >Save</Button>
+          >Save</AsyncButton>
         </Modal.Footer>
       </DropQuestionsModal>
     </>

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -212,6 +212,10 @@ export default class AssignmentReviewUX {
     );
   }
 
+  @computed get isDroppedQuestionsSaving() {
+    return this.taskPlan.api.isPending;
+  }
+
   @action.bound onDelete() {
     this.isDisplayingConfirmDelete = true;
   }


### PR DESCRIPTION
Might fix a bug on tutor-dev and is a good idea anyway.

Second api conditional on disabled to ensure it gets disabled while submitting to prevent double clicks... normally the isWaiting logic inside the component takes care of it, but didn't seem to be working in this case 🤔