### PR TITLE
Submission overview changes

### DIFF
--- a/tutor/src/screens/assignment-grade/ux.js
+++ b/tutor/src/screens/assignment-grade/ux.js
@@ -1,5 +1,5 @@
 import { observable, action, computed } from 'vendor';
-import { first, filter, isEmpty, findIndex, some } from 'lodash';
+import { first, filter, isEmpty, findIndex } from 'lodash';
 import Courses from '../../models/courses-map';
 import ScrollTo from '../../helpers/scroll-to';
 import Grade from '../../models/task-plans/teacher/grade';

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -323,9 +323,7 @@ const StyledTooltip = styled(Tooltip)`
 `;
 
 const GradingBlock = observer(({ ux }) => {
-  const { taskPlan } = ux.planScores;
-
-  if (!taskPlan.canGrade) { return null; }
+  if (!ux.canDisplayGradingButton) { return null; }
 
   return (
     <Toolbar>

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -216,9 +216,8 @@ const WRQFreeResponse = observer(({ info }) => {
   const responses = info.responses.map((response, i) => {
     const student = response.student;
     return response.free_response && (
-      <ResponseWrapper key={`response-wrapper-${i}`} wrq={true}>
+      <ResponseWrapper key={i} wrq={true}>
         <StyledQuestionFreeResponse
-          key={i}
           data-student-id={student.id}
           wrq={true}
           longResponse={response.free_response.length > 2000}
@@ -339,7 +338,7 @@ const GradingBlock = observer(({ ux }) => {
         }}
       >
         {ux.gradeableQuestionCount > 0 &&
-          <span class="flag">{ux.gradeableQuestionCount} NEW</span>}
+          <span className="flag">{ux.gradeableQuestionCount} NEW</span>}
         <span>Grade answers</span>
       </GradeButton>
     </Toolbar>

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -200,6 +200,15 @@ const StyledStickyTable = styled(StickyTable)`
     border: 1px solid ${colors.neutral.pale};
   }
 
+  .sticky-table-cell {
+    &:not(:last-child) {
+      border-right: 1px solid ${colors.neutral.pale};
+    }
+    &:not(:first-child) {
+      text-align: center;
+    }
+  }
+
   .sticky-table-cell, .sticky-table-row {
     vertical-align: middle;
     padding: 0 1.6rem;

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -329,6 +329,10 @@ export default class AssignmentReviewUX {
     return Boolean(this.planScores.isHomework && this.scores);
   }
 
+  @computed get canDisplayGradingButton() {
+    return Boolean(this.taskingPlan.isPastDue && this.scores.hasAnyResponses);
+  }
+
   @computed get isReadingOrHomework() {
     return Boolean(['reading', 'homework'].includes(this.planScores.type));
   }


### PR DESCRIPTION
- Render graded response block to expanded question responses
- Add border to table cells
- Tweak some grade button styles, and only render them when the assignment is past due

I think there's still an issue to look into where the grade buttons are displaying with 0 remaining.

![image](https://user-images.githubusercontent.com/34174/83929212-71ae8200-a747-11ea-8c26-56b52b5c8644.png)
