### PR TITLE
Submission Overview changes

### DIFF
--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -206,6 +206,16 @@ class TaskPlanScoreHeading extends BaseModel {
   @computed get averageGradedPoints() {
     return this.responseStats.averageGradedPoints;
   }
+
+  @computed get isTrouble() {
+    const { correct, completed } = this.responseStats;
+    return completed > 0 &&  correct / completed < 0.5;
+  }
+
+  @computed get humanCorrectResponses() {
+    const { correct, completed } = this.responseStats;
+    return `${this.gradedStats.remaining > 0 ? '---' : correct} / ${completed}`;
+  }
 }
 
 @identifiedBy('task-plan/scores/tasking')

--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -209,7 +209,8 @@ class TaskPlanScoreHeading extends BaseModel {
 
   @computed get isTrouble() {
     const { correct, completed } = this.responseStats;
-    return completed > 0 && correct / completed < 0.5;
+    const remaining = this.gradedStats.remaining > 0;
+    return !remaining && completed > 0 && correct / completed < 0.5;
   }
 
   @computed get humanCorrectResponses() {

--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -209,7 +209,7 @@ class TaskPlanScoreHeading extends BaseModel {
 
   @computed get isTrouble() {
     const { correct, completed } = this.responseStats;
-    return completed > 0 &&  correct / completed < 0.5;
+    return completed > 0 && correct / completed < 0.5;
   }
 
   @computed get humanCorrectResponses() {

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -376,9 +376,10 @@ const Overview = observer(({ ux, ux: { scores } }) => (
         <Header>Question Number</Header>
         {scores.question_headings.map((h, i) =>
           <Header key={i} center={true}>
-            <StyledButton variant="link" onClick={() => ux.scrollToQuestion(h.question_id, i)}>
-              {h.title}
-            </StyledButton>
+            {h.isCore ?
+              <StyledButton variant="link" onClick={() => ux.scrollToQuestion(h.question_id, i)}>
+                {h.title}
+              </StyledButton> : h.title}
           </Header>)}
       </Row>
       <Row>

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -372,6 +372,12 @@ const StyledButton = styled(Button)`
   && { text-decoration: underline; }
 `;
 
+const StyledCell = styled(Cell)`
+  ${props => props.isTrouble && css`
+    background: ${colors.states.trouble};
+  `}
+`;
+
 const Overview = observer(({ ux, ux: { scores } }) => (
   <Wrapper data-test-id="overview">
     <GradingBlock ux={ux}/>
@@ -398,9 +404,9 @@ const Overview = observer(({ ux, ux: { scores } }) => (
       <Row>
         <Header>Correct Responses</Header>
         {scores.question_headings.map((h, i) => (
-          <Cell key={i}>
-            {h.gradedStats.remaining > 0 ? '---' : h.responseStats.correct} / {h.responseStats.completed}
-          </Cell>
+          <StyledCell key={i} isTrouble={h.isTrouble}>
+            {h.humanCorrectResponses}
+          </StyledCell>
         ))}
       </Row>
     </StyledStickyTable>

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -1,7 +1,7 @@
 import { React, PropTypes, styled, css, observer, cn } from 'vendor';
 import { StickyTable, Row, Cell } from 'react-sticky-table';
 import TutorLink from '../../components/link';
-import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { Button, Tooltip } from 'react-bootstrap';
 import S from '../../helpers/string';
 import { Icon, ArbitraryHtmlAndMath } from 'shared';
 import HomeworkQuestions, { ExerciseNumber } from '../../components/homework-questions';
@@ -309,16 +309,6 @@ const GradeButton = styled(TutorLink)`
     padding: 1.5rem 2.1rem 1.5rem;
     line-height: 1.9rem;
     ${props => props.displayingFlag && 'padding-left: 1.1rem;'}
-  }
-`;
-
-const StyledTooltip = styled(Tooltip)`
-  max-width: 30rem;
-  &.tooltip.show { opacity: 1; }
-
-  .tooltip-inner {
-    padding: 2.2rem 1.6rem;
-    text-align: left;
   }
 `;
 

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -5,6 +5,7 @@ import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import S from '../../helpers/string';
 import { Icon, ArbitraryHtmlAndMath } from 'shared';
 import HomeworkQuestions, { ExerciseNumber } from '../../components/homework-questions';
+import InfoIcon from '../../components/icons/info';
 import { colors } from 'theme';
 import Loading from 'shared/components/loading-animation';
 import { isEmpty, compact } from 'lodash';
@@ -348,17 +349,11 @@ const GradingBlock = observer(({ ux }) => {
 const AvailablePoints = ({ value }) => {
   if (!value) {
     return (
-      <OverlayTrigger
-        placement="right"
-        overlay={
-          <StyledTooltip>
-            Students received different numbers of Tutor-selected questions. This can happen when questions aren’t
-            available, a student works an assignment late, or a student hasn’t started the assignment.
-          </StyledTooltip>
-        }
-      >
-        <Icon variant="infoCircle" />
-      </OverlayTrigger>
+      <InfoIcon
+        color="#f36a31"
+        tooltip="Students received different numbers of Tutor-selected questions.  This can happen when questions aren’t
+        available, a student works an assignment late, or a student hasn’t started the assignment."
+      />
     );
   }
   return (

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -1,7 +1,7 @@
 import { React, PropTypes, styled, css, observer, cn } from 'vendor';
 import { StickyTable, Row, Cell } from 'react-sticky-table';
 import TutorLink from '../../components/link';
-import { Button, Tooltip } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import S from '../../helpers/string';
 import { Icon, ArbitraryHtmlAndMath } from 'shared';
 import HomeworkQuestions, { ExerciseNumber } from '../../components/homework-questions';


### PR DESCRIPTION
Some bug fixes in Submission Overview:

- Make the response cell background red if less than 50% of responses are correct
- Use the same Available Points info icon used in the Scores table
- Don't link to Tutor-assigned questions. Question headings for these are returned from the backend as placeholders, so we don't have a question id to link to
![image](https://user-images.githubusercontent.com/34174/84094185-0a940600-a9b1-11ea-89c3-1576226cc7bb.png)

