### PR TITLE
show message when grading template cannot be updated

### DIFF
--- a/tutor/src/components/error-monitoring/handlers.jsx
+++ b/tutor/src/components/error-monitoring/handlers.jsx
@@ -180,6 +180,29 @@ const ERROR_HANDLERS = {
     );
   },
 
+  base_cannot_be_changed_because_this_template_is_assigned_to_one_or_more_task_plans() {
+    return {
+      className: 'error',
+      title: 'Template cannot be updated',
+      body: (
+        <div className="template-del-failure">
+          <p className="lead">
+            Templated cannot be updated because this template is assigned to one or more assignments.
+          </p>
+        </div>
+      ),
+      buttons: [
+        <Button
+          key="ok"
+          onClick={hideModal}
+          variant="primary"
+        >
+          OK
+        </Button>,
+      ],
+    };
+  },
+
   // Payment overdue: don't render the error dialog because we want to display the modal instead
   payment_overdue() {
     return null;

--- a/tutor/src/components/error-monitoring/handlers.jsx
+++ b/tutor/src/components/error-monitoring/handlers.jsx
@@ -180,7 +180,7 @@ const ERROR_HANDLERS = {
     );
   },
 
-  base_cannot_be_changed_because_this_template_is_assigned_to_one_or_more_task_plans() {
+  base_cannot_be_changed_because_this_template_is_assigned_to_one_or_more_open_task_plans() {
     return {
       className: 'error',
       title: 'Template cannot be updated',


### PR DESCRIPTION
Message will start showing after BE PR is merged

Note that this is only a fallback for if the PATCH is sent... it won't prevent the modal from loading. A future PR will prevent the modal from loading by checking for open tasks in the FE.

![image](https://user-images.githubusercontent.com/34174/84099786-3e762800-a9bf-11ea-81b6-8e7ad4a25b1b.png)
