### PR TITLE
Student dash fixes

### DIFF
--- a/tutor/src/screens/student-dashboard/status-legend.js
+++ b/tutor/src/screens/student-dashboard/status-legend.js
@@ -1,9 +1,8 @@
 import { React, styled } from 'vendor';
-import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Icon } from 'shared';
+import { colors } from 'theme';
 import { EIcon } from '../../components/icons/extension';
-import Theme from '../../theme';
 
 const Wrapper = styled.div`
   display: flex;
@@ -33,29 +32,23 @@ const StyledEIcon = styled(EIcon)`
   line-height: 1.2rem;
 `;
 
-const StatusIconLegend = props => {
-  if (isEmpty(props.tasks)) {
-    return null;
-  }
+const StatusIconLegend = () => (
+  <Wrapper>
+    <span>
+      <Icon color={colors.warning} type="exclamation-circle" /> Due soon
+    </span>
+    <span>
+      <Icon color={colors.danger} type="clock" /> Late
+    </span>
+    <span>
+      <StyledEIcon /> Extension
+    </span>
+    <span>
+      <Icon variant="circledStar" /> Provisional score. Final scores will be available when published by your instructor.
+    </span>
 
-  return (
-    <Wrapper>
-      <span>
-        <Icon color={Theme.colors.warning} type="exclamation-circle" /> Due soon
-      </span>
-      <span>
-        <Icon color={Theme.colors.danger} type="clock" /> Late
-      </span>
-      <span>
-        <StyledEIcon /> Extension
-      </span>
-      <span>
-        <Icon variant="circledStar" /> Provisional score. Final scores will be available when published by your instructor.
-      </span>
-
-    </Wrapper>
-  );
-};
+  </Wrapper>
+);
 
 StatusIconLegend.propTypes = {
   tasks: PropTypes.oneOfType([

--- a/tutor/src/screens/student-dashboard/task-info.js
+++ b/tutor/src/screens/student-dashboard/task-info.js
@@ -1,5 +1,6 @@
 import { React, PropTypes, styled, observer } from 'vendor';
 import { Icon } from 'shared';
+import { isNumber } from 'lodash';
 import EventInfoIcon from './event-info-icon';
 import TourAnchor from '../../components/tours/anchor';
 
@@ -37,7 +38,7 @@ const TaskScore = observer(({ event }) => {
   return (
     <Feedback>
       {event.humanScore}
-      {event.is_provisional_score && <Icon variant="circledStar" />}
+      {isNumber(event.score) && event.is_provisional_score && <Icon variant="circledStar" />}
     </Feedback>
   );
 });


### PR DESCRIPTION
- Always display the legend
- Make sure score is set when displaying provisional icon, because sometimes it's true from the backend for new, unworked assignments.