### PR TITLE
advance immediately if step cannot be updated

### DIFF
--- a/tutor/src/screens/task/response-validation-ux.js
+++ b/tutor/src/screens/task/response-validation-ux.js
@@ -50,7 +50,7 @@ class ResponseValidationUX {
   }
 
   @action.bound async onSave() {
-    if (!this.validator.isEnabled) {
+    if (!this.validator.isEnabled || !this.step.can_be_updated) {
       this.step.beginRecordingAnswer({ free_response: this.initialResponse });
       this.taskUX.onFreeResponseComplete(this.step);
       return;


### PR DESCRIPTION
Fixes case where the response would be re-validated when the student was reviewing past work