### PR TITLE
Wrm assignment edit fixes

### DIFF
--- a/tutor/src/components/date-time-input.js
+++ b/tutor/src/components/date-time-input.js
@@ -80,7 +80,7 @@ const DateTimeInput = (assignedProps) => useObserver(() => {
     field.onChange(ev);
     props.onChange && props.onChange(ev);
   };
-  
+
   return (
     <StyledWrapper className={cn('date-time-input', props.className)}>
       <LabelWrapper>

--- a/tutor/src/models/task-plans/teacher/tasking.js
+++ b/tutor/src/models/task-plans/teacher/tasking.js
@@ -27,6 +27,11 @@ class TaskingPlan extends BaseModel {
   @field due_at;
   @field closes_at;
 
+  constructor(attrs) {
+    super(attrs);
+    this.originalDueAt = this.due_at;
+  }
+
   get course() {
     return get(this.plan, 'course');
   }
@@ -90,14 +95,22 @@ class TaskingPlan extends BaseModel {
     return moment(this.opens_at).isBefore(Time.now);
   }
 
+  @computed get isBeforeDue() {
+    return moment(this.due_at).isAfter(Time.now);
+  }
+
   @computed get isValid() {
     return Boolean(
       this.target_id &&
         this.target_type &&
         this.opens_at &&
         this.due_at &&
-        moment(this.due_at).isAfter(Time.now)
+        ((this.isNew || this.dueAtChanged) ? this.isBeforeDue : true)
     );
+  }
+
+  @computed get dueAtChanged() {
+    return !moment(this.originalDueAt).isSame(this.due_at);
   }
 
   @action async persistTime(type) {

--- a/tutor/src/screens/assignment-edit/details-body.js
+++ b/tutor/src/screens/assignment-edit/details-body.js
@@ -245,7 +245,7 @@ const DetailsBody = observer(({ ux }) => {
               checked={ux.isShowingPeriodTaskings}
               onChange={ux.togglePeriodTaskingsEnabled}
             />
-            {ux.isShowingPeriodTaskings && ux.course.periods.map(p => <Tasking key={p.id} period={p} ux={ux} />)}
+            {ux.isShowingPeriodTaskings && ux.course.periods.active.map(p => <Tasking key={p.id} period={p} ux={ux} />)}
           </SectionRow>
         </FullWidthCol>
       </SplitRow>

--- a/tutor/src/screens/assignment-edit/ux.js
+++ b/tutor/src/screens/assignment-edit/ux.js
@@ -115,7 +115,7 @@ export default class AssignmentUX {
     }
 
     observe(this.plan, 'grading_template_id', this.onGradingTemplateUpdate);
-    
+
     if (this.canSelectTemplates) {
       // once templates is loaded, select ones of the correct type
       await gradingTemplates.ensureLoaded();
@@ -135,7 +135,7 @@ export default class AssignmentUX {
     this.isShowingPeriodTaskings = !(this.canSelectAllSections && this.plan.areTaskingDatesSame);
 
     this.scroller = new ScrollTo({ windowImpl });
-    
+
     // don't setup additional helpers until fully initialized
     this.validations = new Validations(this);
     this.steps = new StepUX(this, step);

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -1,5 +1,5 @@
 import { React, observable, action, computed } from 'vendor';
-import { first, pick, sortBy, filter, sumBy, get, find, cloneDeep } from 'lodash';
+import { first, pick, sortBy, filter, sumBy, get, find } from 'lodash';
 import ScrollTo from '../../helpers/scroll-to';
 import DropQuestion from '../../models/task-plans/teacher/dropped_question';
 import EditUX from '../assignment-edit/ux';
@@ -239,7 +239,7 @@ export default class AssignmentReviewUX {
 
     await this.editUX.initialize({
       ...this.params,
-      plan: cloneDeep(this.taskPlan),
+      id: this.taskPlan.id,
       history,
       course: this.course,
     });

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -1,5 +1,5 @@
 import { React, observable, action, computed } from 'vendor';
-import { first, pick, sortBy, filter, sumBy, get, find } from 'lodash';
+import { first, pick, sortBy, filter, sumBy, get, find, cloneDeep } from 'lodash';
 import ScrollTo from '../../helpers/scroll-to';
 import DropQuestion from '../../models/task-plans/teacher/dropped_question';
 import EditUX from '../assignment-edit/ux';
@@ -239,7 +239,7 @@ export default class AssignmentReviewUX {
 
     await this.editUX.initialize({
       ...this.params,
-      plan: this.taskPlan,
+      plan: cloneDeep(this.taskPlan),
       history,
       course: this.course,
     });


### PR DESCRIPTION
- Set originalDueAt when initializing a tasking plan, and check it when validating an existing record. This allows the assignment edit form to save things like name/description while considering the due date as untouched. If they change the due date during edit, normal validation will still occur.

- Only render active periods to be selected in the assignment builder.

- Deep clone the task plan when opening the assignment edit modal. This is to prevent the UI from immediately reflecting potentially temp changes because of computed values.