### PR TITLE
fix edit external url

### DIFF
--- a/tutor/specs/integration/assignment-edit.spec.js
+++ b/tutor/specs/integration/assignment-edit.spec.js
@@ -10,7 +10,7 @@ context('Assignment Edit', () => {
     cy.get('input[name="title"]').type('test assignment #1')
     cy.get('.controls .btn-primary').should('not.be.disabled')
   }
-  const addTemplate = ({ name, dueDateOffsetDays = '1', dueTimeHour = '5', 
+  const addTemplate = ({ name, dueDateOffsetDays = '1', dueTimeHour = '5',
     dueTimeMinutes = '30', closesDateOffsetDays = '30', isAM = false, doSelect = false }) => {
     cy.get('[data-test-id="grading-templates"]').click()
     cy.get('[data-test-id="add-template"]').click()
@@ -41,7 +41,7 @@ context('Assignment Edit', () => {
     ).blur()
     cy.get('[aria-invalid][data-target="description"]').should('contain.text', 'Cannot be longer')
   })
-  
+
   it('loads and advances homework', () => {
     cy.visit('/course/2/assignment/edit/homework/new')
     cy.disableTours();
@@ -141,7 +141,7 @@ context('Assignment Edit', () => {
     cy.visit('/course/2/assignment/edit/external/new')
     cy.disableTours()
     cy.get('.heading').should('not.contain.text', 'STEP 1')
-    cy.get('[name="external_url"').type('url')
+    cy.get('[name="settings.external_url"').type('url')
   });
 
   it('can add a new template', () => {
@@ -253,7 +253,7 @@ context('Assignment Edit', () => {
     // force update the open date
     cy.get('input[name="tasking_plans[0].opens_at"]').clear({ force: true }).type(typedOpenDate, { force: true })
     // After opening the closes date time picker modal, it gets the two OK buttons
-    cy.get('.oxdt-ok button').last().click({ force: true })  
+    cy.get('.oxdt-ok button').last().click({ force: true })
     // after changing the open date, no dates should be changed because the interval between open/due/close date has changed
     cy.get('input[name="tasking_plans[0].closes_at"]').then(d => {
       expect(d[0].defaultValue).eq(currentClosesDate)

--- a/tutor/src/components/error-monitoring/handlers.jsx
+++ b/tutor/src/components/error-monitoring/handlers.jsx
@@ -185,6 +185,29 @@ const ERROR_HANDLERS = {
     return null;
   },
 
+  settings_cannot_be_updated_after_open() {
+    return {
+      className: 'error',
+      title: 'Settings cannot be changed after assignment is open',
+      body: (
+        <div className="template-del-failure">
+          <p className="lead">
+            Assignment settings cannot be changed after the assignment is open.
+          </p>
+        </div>
+      ),
+      buttons: [
+        <Button
+          key="ok"
+          onClick={hideModal}
+          variant="primary"
+        >
+          OK
+        </Button>,
+      ],
+    };
+  },
+
   // The default error dialog that's displayed when we have no idea what's going on
   default(error, message, context) {
     if (context == null) { context = {}; }

--- a/tutor/src/screens/assignment-edit/builder.js
+++ b/tutor/src/screens/assignment-edit/builder.js
@@ -2,6 +2,7 @@ import { React, PropTypes, styled, observer } from 'vendor';
 import { ScrollToTop } from 'shared';
 import { colors, fonts } from 'theme';
 import { ErrorMessage, Field } from 'formik';
+import { Popover } from 'react-bootstrap';
 import Controls from './controls';
 
 const Header = styled.div`
@@ -74,6 +75,13 @@ const TextInputError = styled.div.attrs({
   margin: 1rem 0;
 `;
 
+const GreyPopover = styled(Popover)`
+  &.popover {
+    padding: 2rem;
+    background-color: #f4f5f4;
+  }
+`;
+
 // don't pass hasError onto Field, it'll set it on the DOM
 // eslint-disable-next-line no-unused-vars
 const StyledTextInput = styled(Field).withConfig({
@@ -144,4 +152,7 @@ AssignmentBuilder.propTypes = {
   middleControls: PropTypes.node,
 };
 
-export { AssignmentBuilder, Row, SplitRow, HintText, Label, TextInput, TextArea, Setting, Body };
+export {
+  AssignmentBuilder, Row, SplitRow, HintText, Label, TextInput, TextArea,
+  Setting, Body, GreyPopover,
+};

--- a/tutor/src/screens/assignment-edit/details-body.js
+++ b/tutor/src/screens/assignment-edit/details-body.js
@@ -1,5 +1,7 @@
 import { React, PropTypes, styled, observer, useRef, useEffect } from 'vendor';
-import { SplitRow, Label, HintText, TextInput, TextArea, Body } from './builder';
+import {
+  SplitRow, Label, HintText, TextInput, TextArea, Body, GreyPopover,
+} from './builder';
 import RadioInput from '../../components/radio-input';
 import PreviewTooltip from './preview-tooltip';
 import NewTooltip from './new-tooltip';
@@ -35,7 +37,9 @@ const SectionRow = styled.div`
 `;
 
 const StyledTextInput = styled(TextInput)`
-
+  &[disabled] {
+    background: ${colors.neutral.bright};
+  }
 `;
 
 const StyledDropdown = styled(Dropdown)`
@@ -156,14 +160,28 @@ TemplateField.propTypes = {
 };
 
 const ExternalUrlField = observer(({ ux }) => {
+  const input = (
+    <StyledTextInput
+      name="settings.external_url"
+      validate={isValidUrl}
+      disabled={!ux.canEditSettings}
+    />
+  );
+
+  const disabledInput = (
+    <OverlayTrigger
+      trigger="hover"
+      placement="bottom"
+      overlay={<GreyPopover>Cannot be edited after assignment is open</GreyPopover>}
+    >
+      {input}
+    </OverlayTrigger>
+  );
+
   return (
     <SplitRow>
       <RowLabel htmlFor="externalUrl">Assignment URL</RowLabel>
-      <StyledTextInput
-        name="external_url"
-        defaultValue={ux.plan.settings.external_url}
-        validate={isValidUrl}
-      />
+      {ux.canEditSettings ? input : disabledInput}
     </SplitRow>
   );
 });

--- a/tutor/src/screens/assignment-edit/tasking.js
+++ b/tutor/src/screens/assignment-edit/tasking.js
@@ -3,13 +3,14 @@ import {
 } from 'vendor';
 import moment from 'moment';
 import { Icon } from 'shared';
-import { Row, Col, Alert, Popover, OverlayTrigger } from 'react-bootstrap';
+import { Row, Col, Alert, OverlayTrigger } from 'react-bootstrap';
 import { compact } from 'lodash';
 import { findEarliest, findLatest } from '../../helpers/dates';
 import Time from '../../models/time';
 import DateTime from '../../components/date-time-input';
 import NewTooltip from './new-tooltip';
 import CheckboxInput from '../../components/checkbox-input';
+import { GreyPopover } from './builder';
 
 const StyledTasking = styled.div`
   min-height: 7rem;
@@ -31,14 +32,6 @@ const StyledInner = styled.div`
 
 const StyledAlert = styled(Alert)`
 `;
-
-const GreyPopover = styled(Popover)`
-&.popover {
-padding: 2rem;
-background-color: #f4f5f4;
-}
-`;
-
 
 @observer
 class Tasking extends React.Component {
@@ -106,7 +99,7 @@ class Tasking extends React.Component {
         }
         else
           this.props.ux.setDidUserChangeDatesManually(true);
-      } 
+      }
     });
   }
 
@@ -248,7 +241,7 @@ class Tasking extends React.Component {
   }
 }
 
-const OpensDateTime = observer(({ index, disabled, tasking, onChange }) => {   
+const OpensDateTime = observer(({ index, disabled, tasking, onChange }) => {
   const input = (
     <DateTime
       label="Open date & Time"

--- a/tutor/src/screens/assignment-edit/ux.js
+++ b/tutor/src/screens/assignment-edit/ux.js
@@ -3,7 +3,7 @@ import Router from '../../helpers/router';
 import { runInAction, observe } from 'mobx';
 import ScrollTo from '../../helpers/scroll-to';
 import {
-  filter, isEmpty, compact, map, get, first, difference, flatMap, omit, pick, extend,
+  filter, isEmpty, compact, map, get, first, difference, flatMap, omit, pick, extend, every,
 } from 'lodash';
 import Exercises from '../../models/exercises';
 import TaskPlan, { SELECTION_COUNTS } from '../../models/task-plans/teacher/plan';
@@ -407,7 +407,7 @@ export default class AssignmentUX {
   @action saveFormToPlan() {
     this.plan.update(omit(this.form.values, 'tasking_plans', 'settings'));
     if (this.plan.isExternal) {
-      this.plan.settings.external_url = this.form.values.external_url;
+      this.plan.settings.external_url = this.form.values.settings.external_url;
     }
   }
 
@@ -468,5 +468,9 @@ export default class AssignmentUX {
     if (!(this.plan.isClone && this.plan.isHomework)) { return false; }
     const clonedFrom = this.course.pastTaskPlans.get(this.plan.cloned_from_id);
     return Boolean(clonedFrom && clonedFrom.duration.start.isBefore(WRM_START_DATE));
+  }
+
+  @computed get canEditSettings() {
+    return every(this.plan.tasking_plans, ['isPastOpen', false]);
   }
 }


### PR DESCRIPTION
- Let formik handle setting the field (name="settings.external_url") via initialValues to prevent uncontrolled/controlled swap issue
- Block the field from being edited once a tasking plan is open.
- Add a handler for the unlikely case someone tries to update the plan when a tasking plan is open, but the front end didn't block it