### PR TITLE
Fix some visual things

### DIFF
--- a/shared/src/components/question/answer.jsx
+++ b/shared/src/components/question/answer.jsx
@@ -185,7 +185,7 @@ class Answer extends React.Component {
     let body = '';
     if (type === 'teacher-review') {
       body = (
-        <>
+        <div className="review-wrapper">
           <div className={cn('review-count', { 'green': isCorrect, 'red': !isCorrect })}>
             {selectedCount}
             <span className={cn('letter', { 'green': isCorrect, 'red': !isCorrect })}>
@@ -199,7 +199,7 @@ class Answer extends React.Component {
               html={answer.content_html} />
             {feedback}
           </div>
-        </>
+        </div>
       );
     } else {
       body = (

--- a/tutor/src/components/homework-questions.js
+++ b/tutor/src/components/homework-questions.js
@@ -54,9 +54,17 @@ const Body = styled.div`
       }
 
       .answer-answer {
-        margin: 0 0 1.2rem 1.5rem;
+        margin: 0.25rem 0 0;
         font-size: 1.6rem;
       }
+    }
+
+    .review-wrapper {
+      margin-bottom: 1.2rem;
+      display: flex;
+      align-items: center;
+
+      .answer-answer { margin: 0; }
     }
 
     .review-count {
@@ -67,6 +75,7 @@ const Body = styled.div`
       border-radius: 25%/50%;
       min-width: 5.6rem;
       padding: 0.1rem;
+      margin-right: 1.6rem;
       font-weight: bold;
 
       .selected-count {

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -92,7 +92,9 @@ QuestionHeader.propTypes = {
 };
 
 const StyledQuestionFreeResponse = styled.div`
-  margin-bottom: 1.6rem;
+  &:not(:last-child) {
+    margin-bottom: 1.6rem;
+  }
   display: flex;
   align-items: stretch;
   > * {
@@ -106,6 +108,7 @@ const StyledQuestionFreeResponse = styled.div`
     overflow-wrap: break-word;
     text-align: right;
     font-weight: normal;
+    line-height: 2.5rem;
     color: ${colors.neutral.thin};
   }
   .resp {
@@ -115,7 +118,7 @@ const StyledQuestionFreeResponse = styled.div`
     line-height: 2.5rem;
     white-space: pre-wrap;
   }
-  &:not(:only-child) .resp {
+  &:not(:only-child):not(:last-child) .resp {
     border-bottom: 1px solid ${colors.neutral.light};
   }
 

--- a/tutor/src/screens/assignment-review/table-elements.js
+++ b/tutor/src/screens/assignment-review/table-elements.js
@@ -9,6 +9,10 @@ const StyledStickyTable = styled(StickyTable)`
   .sticky-table-row:last-child .sticky-table-cell {
     border-bottom: 1px solid ${colors.neutral.pale};
   }
+
+  .sticky-table-cell {
+    vertical-align: middle;
+  }
 `;
 
 const Cell = styled(TableCell)`


### PR DESCRIPTION
- Fix the alignment of preview letter and answer

Before: 

![image](https://user-images.githubusercontent.com/34174/84981691-f30ff800-b0e9-11ea-9005-68f389a5e2a3.png)


After:

![image](https://user-images.githubusercontent.com/34174/84981643-d1167580-b0e9-11ea-898b-31436705c06c.png)

- Fix the student name in response to match baseline of response text.
- Don't render bottom border and margin for the last response.

Before:

![image](https://user-images.githubusercontent.com/34174/84981390-43d32100-b0e9-11ea-84a0-a18448205eb4.png)

After:

![image](https://user-images.githubusercontent.com/34174/84981542-99a7c900-b0e9-11ea-944e-350274e87d09.png)


- Improve the alignment and margins of the response letters

Before:

![image](https://user-images.githubusercontent.com/34174/84981750-12a72080-b0ea-11ea-903b-365fa765af0f.png)

After:

![image](https://user-images.githubusercontent.com/34174/84981602-bcd27880-b0e9-11ea-9eaa-957a8066bb7e.png)


- Fix a regression with the scores table cells not being vertically-aligned due to a strange render issue with child flex box not being allowed to stretch to full-heigth inside the `display: table-cell`. `vertical-align: middle` doesn't seem like it should be needed and isn't ideal, but seems safe and gets it working quickly.

Before:

![image](https://user-images.githubusercontent.com/34174/84981423-58afb480-b0e9-11ea-89e9-346392fa9f94.png)


After:
![image](https://user-images.githubusercontent.com/34174/84981302-11c1bf00-b0e9-11ea-91a5-71e9a70a96d8.png)
