### PR TITLE
allow new unsaved assignments to set url when past open

### DIFF
--- a/tutor/src/screens/assignment-edit/ux.js
+++ b/tutor/src/screens/assignment-edit/ux.js
@@ -471,6 +471,6 @@ export default class AssignmentUX {
   }
 
   @computed get canEditSettings() {
-    return every(this.plan.tasking_plans, ['isPastOpen', false]);
+    return this.plan.isNew || every(this.plan.tasking_plans, ['isPastOpen', false]);
   }
 }


### PR DESCRIPTION
This preserves the existing constraint while allowing the url to also be changed while creating a new, unsaved assignment that has an open date in the past.

Both screenshots are while creating a new assignment.

Before:

![image](https://user-images.githubusercontent.com/34174/85040061-42334880-b13d-11ea-860e-fb01478fb42e.png)

After:

![image](https://user-images.githubusercontent.com/34174/85039951-1e700280-b13d-11ea-825f-7e27b8a12a8b.png)
