### PR TITLE
Grade responses fixes

### DIFF
--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -55,6 +55,7 @@ QuestionHeader.propTypes = {
 
 const QuestionFooter = observer(({ ux, info }) => {
   if (info.question.isMultipleChoice) { return null; }
+  const displayingFlag = !ux.scores.hasFinishedGrading && info.remaining > 0;
 
   return (<Footer>
     <strong>
@@ -76,9 +77,9 @@ const QuestionFooter = observer(({ ux, info }) => {
           periodId: ux.selectedPeriod.id,
           questionId: `${info.id}`,
         }}
-        displayingFlag={!ux.scores.hasFinishedGrading}
+        displayingFlag={displayingFlag}
       >
-        {!ux.scores.hasFinishedGrading && <span className="flag">{info.remaining} NEW</span>}
+        {displayingFlag && <span className="flag">{info.remaining} NEW</span>}
         <span>{ux.scores.hasFinishedGrading ? 'Regrade' : 'Grade Answers' }</span>
       </GradeButton>
     }

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -238,10 +238,10 @@ const WRQFreeResponse = observer(({ info }) => {
           </div>
           <div className="grade">
             {response.needs_grading && 'Not graded'}
-            {!isNaN(response.published_points) &&
+            {!isNaN(response.grader_points) &&
               <div>
-                <h3>{response.published_points}</h3>
-                {response.published_comments}
+                <h3>{response.grader_points}</h3>
+                {response.grader_comments}
               </div>}
           </div>
         </StyledQuestionFreeResponse>


### PR DESCRIPTION
- Fix the Grade Answers flag displaying "0 NEW" when there aren't any remaining. (Long-term, maybe it should display the "Regrade" link instead, but the documentation needs to be double-checked.)

- Use `grader_points` and `grader_comments` instead of `published_points` and `published_comments` in the Submission Overview responses.

![image](https://user-images.githubusercontent.com/34174/85095338-f10b6f00-b1a5-11ea-8118-a3203471763b.png)
