### PR TITLE
allow editing templates as long as task plans are not open

### DIFF
--- a/tutor/src/models/grading/templates.js
+++ b/tutor/src/models/grading/templates.js
@@ -29,7 +29,7 @@ class GradingTemplate extends BaseModel {
   @field default_due_time = '21:00';
   @field default_due_date_offset_days = 7;
   @field default_close_date_offset_days = 7;
-  @field has_task_plans;
+  @field has_open_task_plans;
   @observable map;
 
   @observable map = {};

--- a/tutor/src/screens/grading-templates/index.js
+++ b/tutor/src/screens/grading-templates/index.js
@@ -76,7 +76,7 @@ class GradingTemplatesScreen extends React.Component {
   }
   
   @action.bound onEditTemplate(template) {
-    if (template.has_task_plans) {
+    if (template.has_open_task_plans) {
       this.editError = template;
     } else {
       this.editing = template;

--- a/tutor/src/screens/grading-templates/modals.jsx
+++ b/tutor/src/screens/grading-templates/modals.jsx
@@ -76,7 +76,7 @@ const NoEditModal = ({ onOk, template }) => {
       </StyledHeader>
       <StyledBody>
         {template.name} template cannot be edited since
-        it is currentlly in use by assignments
+        it is currently in use by assignments
         <ControlsWrapper>
           <Controls>
             <Button variant="default" size="lg" onClick={onOk}>


### PR DESCRIPTION
Replaces `has_task_plans` with `has_open_task_plans`