### PR TITLE
Fix NaN after granting extension

### DIFF
--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -7,7 +7,7 @@ import {
   get, some, reduce, every, uniq,
 } from 'lodash';
 import DroppedQuestion from './dropped_question';
-import S from '../../../helpers/string';
+import S, { UNWORKED } from '../../../helpers/string';
 
 @identifiedBy('task-plan/scores/student-question')
 class TaskPlanScoreStudentQuestion extends BaseModel {
@@ -73,9 +73,8 @@ class TaskPlanScoreStudentQuestion extends BaseModel {
 
   @computed get displayValue() {
     const { dropped } = this.questionHeading || {};
-    const pending = '---';
 
-    if (this.needs_grading) { return pending; }
+    if (this.needs_grading) { return UNWORKED; }
 
     if (dropped && this.is_completed) {
       return S.numberWithOneDecimalPlace(
@@ -85,7 +84,7 @@ class TaskPlanScoreStudentQuestion extends BaseModel {
 
     if (!isNil(this.gradedPoints)) { return S.numberWithOneDecimalPlace(this.gradedPoints); }
 
-    return pending;
+    return UNWORKED;
   }
 }
 
@@ -229,7 +228,7 @@ class TaskPlanScoreHeading extends BaseModel {
 
   @computed get humanCorrectResponses() {
     const { correct, completed } = this.responseStats;
-    return `${this.gradedStats.remaining > 0 ? '---' : correct} / ${completed}`;
+    return `${this.gradedStats.remaining > 0 ? UNWORKED : correct} / ${completed}`;
   }
 }
 

--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -4,7 +4,7 @@ import {
 import Exercises from '../../exercises';
 import {
   filter, sum, sumBy, find, isNil, isEmpty, compact, sortBy,
-  get, some, reduce, every, uniq,
+  get, some, reduce, every, uniq, isNumber,
 } from 'lodash';
 import DroppedQuestion from './dropped_question';
 import S, { UNWORKED } from '../../../helpers/string';
@@ -122,6 +122,13 @@ class TaskPlanScoreStudent extends BaseModel {
     return this.tasking.scores.taskPlan.extensions.find(ex => ex.role_id == this.role_id);
   }
 
+  @computed get humanTotalFraction() {
+    return isNumber(this.total_fraction) ? `${S.asPercent(this.total_fraction)}%` : UNWORKED;
+  }
+
+  @computed get humanTotalPoints() {
+    return isNumber(this.total_points) ? S.numberWithOneDecimalPlace(this.total_points) : UNWORKED;
+  }
 }
 
 

--- a/tutor/src/screens/assignment-review/homework-scores.js
+++ b/tutor/src/screens/assignment-review/homework-scores.js
@@ -168,9 +168,7 @@ const StudentCell = observer(({ ux, student, striped }) => (
       </NameWrapper>
 
       <Total>
-        {ux.displayTotalInPercent ?
-          `${S.asPercent(student.total_fraction || 0)}%` :
-          S.numberWithOneDecimalPlace(student.total_points)}
+        {ux.displayTotalInPercent ? student.humanTotalFraction : student.humanTotalPoints}
       </Total>
       <LateWork>
         {student.late_work_point_penalty ? `-${S.numberWithOneDecimalPlace(student.late_work_point_penalty)}` : '0'}


### PR DESCRIPTION
In cases were the BE doesn't send `total_points` and `total_fraction` (due to extension or not due yet) we need to display `---`.

![image](https://user-images.githubusercontent.com/34174/85166202-ceb43880-b21b-11ea-86fc-264ffad54152.png)
