### PR TITLE
limit width of 1st column on "text tables"

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -143,6 +143,7 @@
 
   table {
     font-family: $tutor-sans-font-face;
+    width: 100%;
     caption {
       caption-side: bottom;
       font-style: italic;
@@ -205,6 +206,12 @@
         li::before{
           background: $tutor-neutral-darker;
         }
+      }
+    }
+
+    &.tutor-textheavy {
+      td:first-child {
+        max-width: 300px;
       }
     }
   }


### PR DESCRIPTION
Content has added a 'tutor-textheavy' class to identify them

Fixes https://github.com/openstax/tutor/issues/777

before:
<img width="869" alt="image" src="https://user-images.githubusercontent.com/79566/86164028-bd4e1480-bad6-11ea-8d48-837683e8d737.png">



after:
<img width="872" alt="image" src="https://user-images.githubusercontent.com/79566/86164054-c808a980-bad6-11ea-8fc6-d966a21b25e1.png">
