### PR TITLE
add reading content to flux media store

### DIFF
--- a/tutor/src/models/student-tasks/step.js
+++ b/tutor/src/models/student-tasks/step.js
@@ -10,6 +10,7 @@ import RelatedContent from '../related-content';
 import ReferenceBookNode from '../reference-book/node';
 import lazyGetter from 'shared/helpers/lazy-getter';
 import { extractCnxId } from '../../helpers/content';
+import { MediaActions } from '../../flux/media';
 
 class TaskStepContent extends BaseModel {
   update(data) {
@@ -246,6 +247,9 @@ class StudentTaskStep extends BaseModel {
       throw new Error(`Attempted to set content on unknown step type ${this.type}`);
     }
     this.content = new Klass(data);
+    if (this.isReading) {
+      MediaActions.parse(this.content.html);
+    }
     this.isFetched = true;
   }
 


### PR DESCRIPTION
The Media store holds html content so it can be used in the media popups.  reading steps weren't being added to it, causing the popups not to show up

<img width="938" alt="image" src="https://user-images.githubusercontent.com/79566/86409351-54a19c00-bc7e-11ea-9b42-2506aba55304.png">
