### PR TITLE
Fix timezone tests

### DIFF
--- a/tutor/specs/helpers/time-mock.js
+++ b/tutor/specs/helpers/time-mock.js
@@ -17,11 +17,15 @@ const TimeMock = {
 
   mock(dateTime) {
     const now = new Date(dateTime);
+    const tz  = 'America/Chicago';
+
     MockDate.set(now, -360);
     FactoryBot.defaults.now = dateTime;
     const spy = jest.spyOn(Time, 'now', 'get');
     spy.mockImplementation(() => now);
-    moment.tz.setDefault('America/Chicago');
+
+    jest.spyOn(moment.tz, 'guess').mockImplementation(() => tz);
+    moment.tz.setDefault(tz);
     moment.locale('en');
   },
 

--- a/tutor/specs/helpers/time.spec.js
+++ b/tutor/specs/helpers/time.spec.js
@@ -3,7 +3,7 @@ import TimeHelper from '../../src/helpers/time';
 import Courses from '../../src/models/courses-map';
 
 const COURSE_ID = 'TEST_COURSE_ID';
-const TEST_TIMEZONE = 'US/Pacific';
+const TEST_TIMEZONE = 'US/Alaska';
 const TODAY_IN_CURRENT_ZONE = moment().startOf('day').format();
 
 describe('Time Helpers', function() {

--- a/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
+++ b/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
@@ -526,7 +526,7 @@ exports[`Student Dashboard displays as loading 1`] = `
                           className="tour-anchor"
                           data-tour-anchor-id="assignment-progress-status"
                         >
-
+                          
                         </span>
                       </div>
                     </div>
@@ -1350,7 +1350,7 @@ exports[`Student Dashboard matches snapshot 1`] = `
                           className="tour-anchor"
                           data-tour-anchor-id="assignment-progress-status"
                         >
-
+                          
                         </span>
                       </div>
                     </div>

--- a/tutor/specs/screens/student-dashboard/dashboard.spec.jsx
+++ b/tutor/specs/screens/student-dashboard/dashboard.spec.jsx
@@ -24,15 +24,13 @@ describe('Student Dashboard', () => {
     };
   });
 
-  // TODO: Fix issues with CI timezone mock not working
-  xit('matches snapshot', () => {
+  it('matches snapshot', () => {
     props.course.studentTaskPlans.all_tasks_are_ready = false;
     props.course.primaryRole.joined_at = new Date('2015-09-14T12:00:00.000Z');
     expect.snapshot(<C><Dashboard {...props} /></C>).toMatchSnapshot();
   });
 
-  // TODO: Fix issues with CI timezone mock not working
-  xit('displays as loading', () => {
+  it('displays as loading', () => {
     props.course.studentTaskPlans.all_tasks_are_ready = false;
     props.course.primaryRole.joined_at = new Date('2015-10-14T12:00:00.000Z');
     const dash = mount(<C><Dashboard {...props} /></C>);

--- a/tutor/specs/screens/student-dashboard/event-row.spec.jsx
+++ b/tutor/specs/screens/student-dashboard/event-row.spec.jsx
@@ -40,8 +40,7 @@ describe('Event Row', function() {
     deletedNotStartedRow.unmount();
   });
 
-  // TODO: Fix issues with CI timezone mock not working
-  xit('renders and matches snapshot', () => {
+  it('renders and matches snapshot', () => {
     expect.snapshot(
       <C>
         <EventRow

--- a/tutor/specs/screens/student-dashboard/homework-row.spec.jsx
+++ b/tutor/specs/screens/student-dashboard/homework-row.spec.jsx
@@ -15,15 +15,13 @@ describe('Homework Row', function() {
     };
   });
 
-  // TODO: Fix issues with CI timezone mock not working
-  xit('renders in progress', () => {
+  it('renders in progress', () => {
     props.event.completed_steps_count = 1;
     props.event.due_at = new Date('2017-10-15T12:00:00.000Z');
     expect.snapshot(<C><Row {...props} /></C>).toMatchSnapshot();
   });
 
-  // TODO: Fix issues with CI timezone mock not working
-  xit('renders with completed count', function() {
+  it('renders with completed count', function() {
     props.event.correct_exercise_count = null;
     expect.snapshot(<C><Row {...props} /></C>).toMatchSnapshot();
   });


### PR DESCRIPTION
- Fixes the new failures that came from `tz.guess()` being used, should now always return 'America/Chicago'
- Fix a couple tests that only I've experienced as the only Pacific dev 😛 so now the test syncs to Alaska tz instead of Pacific