### PR TITLE
wait for scores to be fetched before checking if tab is available

### DIFF
--- a/tutor/src/components/tabs.jsx
+++ b/tutor/src/components/tabs.jsx
@@ -56,7 +56,9 @@ const Tabs = ({
     ) {
       const ev = new FakeEvent;
       onSelect(activeIndex, ev);
-      selectTabIndex(activeIndex);
+      if (ev.isDefaultPrevented()) {
+        selectTabIndex(activeIndex);
+      }
     }
     prevSelectedIndexRef.current = selectedIndex;
   }, [selectedIndex]);

--- a/tutor/src/components/tabs.jsx
+++ b/tutor/src/components/tabs.jsx
@@ -56,9 +56,7 @@ const Tabs = ({
     ) {
       const ev = new FakeEvent;
       onSelect(activeIndex, ev);
-      if (ev.isDefaultPrevented()) {
-        selectTabIndex(activeIndex);
-      }
+      selectTabIndex(activeIndex);
     }
     prevSelectedIndexRef.current = selectedIndex;
   }, [selectedIndex]);

--- a/tutor/src/screens/assignment-review/index.js
+++ b/tutor/src/screens/assignment-review/index.js
@@ -99,7 +99,8 @@ class AssignmentReview extends React.Component {
     const {
       isScoresReady, course, scores, planScores, assignedPeriods, selectedPeriod, setSelectedPeriod,
     } = this.ux;
-    if (!isScoresReady) {
+    
+    if (!isScoresReady || !scores) {
       return <LoadingScreen message="Loading Assignment…" />;
     }
 


### PR DESCRIPTION
Review index component was not waiting for the scores to be fetched so it will always render the page with just one tab.