### PR TITLE
Assignment dates

### DIFF
--- a/tutor/specs/components/__snapshots__/date-time-input.spec.js.snap
+++ b/tutor/specs/components/__snapshots__/date-time-input.spec.js.snap
@@ -45,6 +45,10 @@ exports[`DateTimeInput matches snapshot 1`] = `
   box-shadow: 0 0 4px 0 rgba(13,192,220,0.5);
 }
 
+.c3.c3.error {
+  border-color: red;
+}
+
 .c4 {
   width: 3.3rem;
   z-index: 1;

--- a/tutor/specs/factories/teacher-task-plan.js
+++ b/tutor/specs/factories/teacher-task-plan.js
@@ -13,7 +13,7 @@ Factory.define('TeacherTaskPlanTasking')
   .target_type('period')
   .opens_at(({ now, days_ago }) => moment(now).subtract(days_ago, 'days').toISOString())
   .due_at(({ now, days_ago }) => moment(now).subtract(days_ago, 'days').add(3, 'days').toISOString())
-  .closes_at(({ now, days_ago }) => moment(now).subtract(days_ago, 'days').add(1, 'days').toISOString());
+  .closes_at(({ now, days_ago }) => moment(now).subtract(days_ago, 'days').add(5, 'days').toISOString());
 
 
 Factory.define('TeacherTaskPlan')

--- a/tutor/specs/integration/assignment-edit.spec.js
+++ b/tutor/specs/integration/assignment-edit.spec.js
@@ -247,4 +247,28 @@ context('Assignment Edit', () => {
       expect(d[0].defaultValue).eq(currentClosesDate)
     })
   });
+
+  it('shows error if due date is before open date', () => {
+    const typedOpenDate = 'Jul 23 | 05:00 PM'
+    const typedDueDate = 'Jul 10 | 05:00 PM'
+    cy.visit('/course/2/assignment/edit/homework/new')
+    cy.disableTours()
+    cy.get('input[name="tasking_plans[0].opens_at"]').clear({ force: true }).type(typedOpenDate, { force: true });
+    cy.get('.oxdt-ok').click();
+    cy.get('input[name="tasking_plans[0].due_at"]').clear({ force: true }).type(typedDueDate, { force: true });
+    cy.get('.oxdt-ok').last().click();
+    cy.getTestElement('date-error-message').should('contain.text', 'Due time cannot be before the open time');
+  });
+
+  it('shows error if closes date is before due date', () => {
+    const typedClosesDate = 'Jul 10 | 05:00 PM'
+    const typedDueDate = 'Jul 23 | 05:00 PM'
+    cy.visit('/course/2/assignment/edit/homework/new')
+    cy.disableTours()
+    cy.get('input[name="tasking_plans[0].closes_at"]').clear({ force: true }).type(typedClosesDate, { force: true });
+    cy.get('.oxdt-ok').click();
+    cy.get('input[name="tasking_plans[0].due_at"]').clear({ force: true }).type(typedDueDate, { force: true });
+    cy.get('.oxdt-ok').last().click();
+    cy.getTestElement('date-error-message').should('contain.text', 'Close time cannot be before the due time');
+  });
 });

--- a/tutor/specs/models/task-plans/teacher/tasking.spec.js
+++ b/tutor/specs/models/task-plans/teacher/tasking.spec.js
@@ -21,7 +21,7 @@ describe('Teacher tasking plan tasking', () => {
       target_id: course.periods[0].id,
       due_at: '2015-10-14 07:00',  // 12am - 5 hours
       opens_at: '2015-10-14 07:00',
-      closes_at: '2015-10-15 07:00',
+      closes_at: '2015-10-19 07:00',
     });
   });
 

--- a/tutor/specs/models/task-plans/teacher/tasking.spec.js
+++ b/tutor/specs/models/task-plans/teacher/tasking.spec.js
@@ -40,28 +40,12 @@ describe('Teacher tasking plan tasking', () => {
     expect(tasking.canEditOpensAt).toBe(false);
   });
 
-  it('sets open/due but not past the opposing open/due', () => {
-    tasking.setOpensDate(moment(now).year(2016));
+  it('sets the closes_at the same as due_at if the plan type is an event', () => {
+    const due_at = '2015-10-15 07:00';
+    plan.type = 'event';
+    tasking.setDueDate(moment(due_at));
 
-    tasking.due_at = '2016-10-14T12:00:00.000Z';
-    tasking.setOpensDate('2016-10-20T12:00:00.000Z');
-    expect(tasking.opens_at).toEqual('2016-10-14T11:59:00.000Z');
-
-    // tasking.setOpensTime('1:42');
-    // expect(tasking.opens_at).toEqual('2016-10-14T06:42:00.000Z');
-
-    // tasking.setOpensTime('15:00'); // past due date, clips to that
-    // expect(tasking.opens_at).toEqual('2016-10-14T11:59:00.000Z');
-
-    tasking.setOpensDate('2016-10-11T21:18:00.000Z');
-    // should have been accepted without changes
-    expect(tasking.opens_at).toEqual('2016-10-11T21:18:00.000Z');
-
-    expect(tasking.closes_at).toEqual('2015-10-15T12:00:00.000Z')
-
-    // test setting due date to after closes_at: it clips to same as closes_at
-    tasking.setDueDate('2016-01-20T12:00:00.000Z');
-    expect(tasking.due_at).toEqual('2015-10-15T12:00:00.000Z');
+    expect(tasking.due_at).toEqual(tasking.closes_at);
   });
 
   it('#initializeWithDueAt', () => {
@@ -88,5 +72,49 @@ describe('Teacher tasking plan tasking', () => {
     tasking.initializeWithDueAt({ dueAt: '2015-10-01T12:00:00.000Z', ...defaults });
     expect(tasking.due_at).toEqual(moment(now).add(30, 'minutes').toISOString());
     expect(tasking.opens_at).toEqual(moment(now).add(29, 'minutes').toISOString());
+  });
+
+  it('should return invalid if dates are not in order', () => {
+    // opens_at is after due_at
+    let opens_at = '2015-10-17T12:00:00.000Z';
+    let due_at = '2015-10-15T12:00:00.000Z';
+    let closes_at = '2015-10-16T12:00:00.000Z';
+    
+    tasking.setOpensDate(moment(opens_at));
+    tasking.setDueDate(moment(due_at));
+    tasking.setClosesDate(moment(closes_at));
+    expect(tasking.isValid).toEqual(false);
+
+    // closes_at is after due_at
+    opens_at = '2015-10-15T12:00:00.000Z';
+    due_at = '2015-10-18T12:00:00.000Z';
+    closes_at = '2015-10-16T12:00:00.000Z';
+    
+    tasking.setOpensDate(moment(opens_at));
+    tasking.setDueDate(moment(due_at));
+    tasking.setClosesDate(moment(closes_at));
+    expect(tasking.isValid).toEqual(false);
+
+    // due_at is before current time
+    opens_at = '2015-10-11T12:00:00.000Z';
+    due_at = '2015-10-13T12:00:00.000Z';
+    closes_at = '2015-10-14T12:00:00.000Z';
+    
+    tasking.setOpensDate(moment(opens_at));
+    tasking.setDueDate(moment(due_at));
+    tasking.setClosesDate(moment(closes_at));
+    expect(tasking.isValid).toEqual(false);
+
+  });
+
+  it('should return valid if dates are in order', () => {
+    let opens_at = '2015-10-18T12:00:00.000Z';
+    let due_at = '2015-10-20T12:00:00.000Z';
+    let closes_at = '2015-10-31T12:00:00.000Z';
+    
+    tasking.setOpensDate(moment(opens_at));
+    tasking.setDueDate(moment(due_at));
+    tasking.setClosesDate(moment(closes_at));
+    expect(tasking.isValid).toEqual(true);
   });
 });

--- a/tutor/src/components/date-time-input.js
+++ b/tutor/src/components/date-time-input.js
@@ -39,6 +39,10 @@ const StyledPicker = styled(Picker)`
       border-color: ${colors.forms.borders.focus};
       box-shadow: 0 0 4px 0 ${colors.forms.borders.focusShadow};
     }
+
+    &.error {
+      border-color: red
+    }
   }
 `;
 
@@ -118,12 +122,14 @@ const DateTimeInput = (assignedProps) => useObserver(() => {
           prefixCls="oxdt"
           id={id}
           autoFocus={props.autoFocus}
+          className={cn({ error: props.errorMessage })}
         />
         <IconWrapper>
           <Icon type="calendar" />
         </IconWrapper>
       </PickerWrapper>
       {meta.error && meta.touched && <Error>{meta.error}</Error>}
+      {props.errorMessage && <Error>{props.errorMessage}</Error>}
     </StyledWrapper>
   );
 });

--- a/tutor/src/components/date-time-input.js
+++ b/tutor/src/components/date-time-input.js
@@ -129,7 +129,7 @@ const DateTimeInput = (assignedProps) => useObserver(() => {
         </IconWrapper>
       </PickerWrapper>
       {meta.error && meta.touched && <Error>{meta.error}</Error>}
-      {props.errorMessage && <Error>{props.errorMessage}</Error>}
+      {props.errorMessage && <Error data-test-id="date-error-message">{props.errorMessage}</Error>}
     </StyledWrapper>
   );
 });

--- a/tutor/src/models/course.js
+++ b/tutor/src/models/course.js
@@ -208,11 +208,8 @@ class Course extends BaseModel {
 
   // bind to this so it can be used in disabledDate check
   isInvalidAssignmentDate = (date) => {
-    return !this.momentInZone(date).isBetween(
-      this.allowedAssignmentDateRange.start,
-      this.allowedAssignmentDateRange.end,
-      'day', '[]'
-    );
+    return date < moment(this.starts_at).endOf('day') ||
+    date > moment(this.ends_at).endOf('day');
   }
 
   @computed get hasStarted() {

--- a/tutor/src/models/task-plans/teacher/tasking.js
+++ b/tutor/src/models/task-plans/teacher/tasking.js
@@ -103,14 +103,26 @@ class TaskingPlan extends BaseModel {
     return moment(this.due_at).isAfter(Time.now);
   }
 
+  @computed get isDueAfterOpen() {
+    return moment(this.due_at).isAfter(moment(this.opens_at));
+  }
+
+  @computed get isCloseAfterDue() {
+    return moment(this.closes_at).isAfter(moment(this.due_at));
+  }
+
   @computed get isValid() {
-    return Boolean(
-      this.target_id &&
-        this.target_type &&
-        this.opens_at &&
-        this.due_at &&
-        ((this.isNew || this.dueAtChanged) ? this.isBeforeDue : true)
-    );
+    let isValid = this.target_id && this.target_type && this.opens_at && this.due_at && this.isDueAfterOpen;
+
+    if(this.isNew || this.dueAtChanged) {
+      isValid = isValid && this.isBeforeDue;
+    }
+    //event does not have a close date (visually)
+    if(!this.plan.isEvent) {
+      isValid = isValid && this.isCloseAfterDue;
+    }
+
+    return isValid;
   }
 
   @computed get dueAtChanged() {
@@ -184,30 +196,18 @@ class TaskingPlan extends BaseModel {
   }
 
   @action setOpensDate(date) {
-    this.opens_at = findEarliest(
-      moment(this.due_at).subtract(1, 'minute'),
-      date,
-    ).toISOString();
+    this.opens_at = date.toISOString();
   }
 
   @action setDueDate(date) {
-    this.due_at = findEarliest(
-      findLatest(
-        moment(this.opens_at).add(1, 'minute'),
-        date,
-      ),
-      this.plan.isEvent ? date : this.closes_at,
-    ).toISOString();
+    this.due_at = date.toISOString();
     if (this.plan.isEvent) { // closes_at === due_at for events
       this.closes_at = this.due_at;
     }
   }
 
   @action setClosesDate(date) {
-    this.closes_at = findLatest(
-      moment(this.due_at).add(1, 'minute'),
-      date,
-    ).toISOString();
+    this.closes_at = date.toISOString();
   }
 
   // note: these are not @computed so that a new moment is

--- a/tutor/src/models/task-plans/teacher/tasking.js
+++ b/tutor/src/models/task-plans/teacher/tasking.js
@@ -4,9 +4,6 @@ import {
 import { pick, get, extend, find } from 'lodash';
 import moment from 'moment';
 import Time from '../../time';
-import {
-  findEarliest, findLatest,
-} from '../../../helpers/dates';
 import Toasts from '../../toasts';
 
 export default

--- a/tutor/src/models/task-plans/teacher/tasking.js
+++ b/tutor/src/models/task-plans/teacher/tasking.js
@@ -101,11 +101,11 @@ class TaskingPlan extends BaseModel {
   }
 
   @computed get isDueAfterOpen() {
-    return moment(this.due_at).isAfter(moment(this.opens_at));
+    return moment(this.due_at).isAfter(this.opens_at);
   }
 
   @computed get isCloseAfterDue() {
-    return moment(this.closes_at).isAfter(moment(this.due_at));
+    return moment(this.closes_at).isAfter(this.due_at);
   }
 
   @computed get isValid() {

--- a/tutor/src/screens/assignment-edit/tasking.js
+++ b/tutor/src/screens/assignment-edit/tasking.js
@@ -120,26 +120,6 @@ class Tasking extends React.Component {
     });
   }
 
-  renderDueAtError() {
-    const tasking = this.taskings[0];
-    if (tasking.isValid || !tasking.due_at) { return null; }
-
-    let msg = null;
-    const due = moment(tasking.due_at);
-
-    if (due.isBefore(Time.now)) {
-      msg = 'Due time has already passed';
-    } else if (due.isBefore(tasking.opens_at)) {
-      msg = 'Due time cannot come before task opens';
-    }
-    if (!msg) { return null; }
-    return (
-      <StyledAlert variant="danger">
-        {msg}
-      </StyledAlert>
-    );
-  }
-
   renderSelectionCheckbox() {
     const { ux, period, ux: { plan } } = this.props;
     if (!period) { return null; }
@@ -185,7 +165,7 @@ class Tasking extends React.Component {
 
   displayCloseDateError(tasking) {    
     if(!tasking.isCloseAfterDue) {
-      return 'Due time cannot be before the open time';
+      return 'Close time cannot be before the due time';
     }
 
     return null;

--- a/tutor/src/screens/assignment-edit/tasking.js
+++ b/tutor/src/screens/assignment-edit/tasking.js
@@ -152,7 +152,9 @@ class Tasking extends React.Component {
       return 'Due time cannot be before the open time';
     }
 
-    if(tasking.isPastDue) {
+    // In Edit mode: Do not show this error when the instructor goes to edit mode and due date has past already.
+    // show this error after the instructor made a change.
+    if((tasking.isNew || tasking.dueAtChanged) && tasking.isPastDue) {
       return 'Due time has already passed';
     }
 

--- a/tutor/src/screens/assignment-edit/tasking.js
+++ b/tutor/src/screens/assignment-edit/tasking.js
@@ -5,7 +5,6 @@ import moment from 'moment';
 import { Icon } from 'shared';
 import { Row, Col, Alert, OverlayTrigger } from 'react-bootstrap';
 import { compact } from 'lodash';
-import Time from '../../models/time';
 import DateTime from '../../components/date-time-input';
 import NewTooltip from './new-tooltip';
 import CheckboxInput from '../../components/checkbox-input';
@@ -32,9 +31,6 @@ const StyledInner = styled.div`
     margin-top: 0.5rem;
     padding-left: 2.2rem;
   }
-`;
-
-const StyledAlert = styled(Alert)`
 `;
 
 @observer

--- a/tutor/src/screens/assignment-edit/tasking.js
+++ b/tutor/src/screens/assignment-edit/tasking.js
@@ -169,7 +169,26 @@ class Tasking extends React.Component {
         onChange={ux.togglePeriodTasking}
       />
     );
+  }
 
+  displayDueDateError(tasking) {
+    if(!tasking.isDueAfterOpen) {
+      return 'Due time cannot be before the open time';
+    }
+
+    if(tasking.isPastDue) {
+      return 'Due time has already passed';
+    }
+
+    return null;
+  }
+
+  displayCloseDateError(tasking) {    
+    if(!tasking.isCloseAfterDue) {
+      return 'Due time cannot be before the open time';
+    }
+
+    return null;
   }
 
   render() {
@@ -193,6 +212,7 @@ class Tasking extends React.Component {
   renderDateTimeInputs(tasking) {
     const { ux } = this.props;
     const index = this.props.ux.plan.tasking_plans.indexOf(tasking);
+    // disable dates before the course start date, and after the course end date
     const disabledDate = (current) => current < moment(this.course.starts_at).endOf('day') || current > moment(this.course.ends_at).endOf('day');
     return (
       <Row className="tasking-date-time">
@@ -212,8 +232,8 @@ class Tasking extends React.Component {
             disabledDate={disabledDate}
             onChange={(target) => this.onDueChange(target, index)}
             timezone={this.course.timezone}
+            errorMessage={this.displayDueDateError(tasking)}
           />
-          {this.renderDueAtError()}
         </Col>
         {!this.plan.isEvent &&
           <Col xs={12} md={4} className="closes-at">
@@ -224,6 +244,7 @@ class Tasking extends React.Component {
               onChange={this.onClosesChange}
               disabledDate={disabledDate}
               timezone={this.course.timezone}
+              errorMessage={this.displayCloseDateError(tasking)}
             />
           </Col>
         }

--- a/tutor/src/screens/assignment-edit/tasking.js
+++ b/tutor/src/screens/assignment-edit/tasking.js
@@ -193,7 +193,7 @@ class Tasking extends React.Component {
   renderDateTimeInputs(tasking) {
     const { ux } = this.props;
     const index = this.props.ux.plan.tasking_plans.indexOf(tasking);
-
+    const disabledDate = (current) => current < moment(this.course.starts_at).endOf('day') || current > moment(this.course.ends_at).endOf('day');
     return (
       <Row className="tasking-date-time">
         <Col xs={12} md={!this.plan.isEvent ? 4 : 6} className="opens-at">
@@ -201,7 +201,7 @@ class Tasking extends React.Component {
             index={index}
             tasking={tasking}
             onChange={this.onOpensChange}
-            disabled={this.course.isInvalidAssignmentDate}
+            disabledDate={disabledDate}
             timezone={this.course.timezone}
           />
         </Col>
@@ -209,7 +209,7 @@ class Tasking extends React.Component {
           <DateTime
             label="Due date & time"
             name={`tasking_plans[${index}].due_at`}
-            disabledDate={this.course.isInvalidAssignmentDate}
+            disabledDate={disabledDate}
             onChange={(target) => this.onDueChange(target, index)}
             timezone={this.course.timezone}
           />
@@ -222,7 +222,7 @@ class Tasking extends React.Component {
               labelWrapper={ux.isShowingPeriodTaskings ? null : NewTooltip}
               name={`tasking_plans[${index}].closes_at`}
               onChange={this.onClosesChange}
-              disabledDate={this.course.isInvalidAssignmentDate}
+              disabledDate={disabledDate}
               timezone={this.course.timezone}
             />
           </Col>
@@ -232,14 +232,14 @@ class Tasking extends React.Component {
   }
 }
 
-const OpensDateTime = observer(({ index, disabled, tasking, onChange, timezone }) => {
+const OpensDateTime = observer(({ index, disabledDate, tasking, onChange, timezone }) => {
   const input = (
     <DateTime
       label="Open date & Time"
       disabled={!tasking.canEditOpensAt}
       name={`tasking_plans[${index}].opens_at`}
       onChange={(ev) => onChange(ev, index)}
-      disabledDate={disabled}
+      disabledDate={disabledDate}
       timezone={timezone}
     />
   );

--- a/tutor/src/screens/assignment-edit/tasking.js
+++ b/tutor/src/screens/assignment-edit/tasking.js
@@ -3,7 +3,7 @@ import {
 } from 'vendor';
 import moment from 'moment';
 import { Icon } from 'shared';
-import { Row, Col, Alert, OverlayTrigger } from 'react-bootstrap';
+import { Row, Col, OverlayTrigger } from 'react-bootstrap';
 import { compact } from 'lodash';
 import DateTime from '../../components/date-time-input';
 import NewTooltip from './new-tooltip';

--- a/tutor/src/screens/assignment-edit/tasking.js
+++ b/tutor/src/screens/assignment-edit/tasking.js
@@ -1,7 +1,6 @@
 import {
   React, PropTypes, styled, computed, action, observer,
 } from 'vendor';
-import moment from 'moment';
 import { Icon } from 'shared';
 import { Row, Col, OverlayTrigger } from 'react-bootstrap';
 import { compact } from 'lodash';
@@ -190,8 +189,6 @@ class Tasking extends React.Component {
   renderDateTimeInputs(tasking) {
     const { ux } = this.props;
     const index = this.props.ux.plan.tasking_plans.indexOf(tasking);
-    // disable dates before the course start date, and after the course end date
-    const disabledDate = (current) => current < moment(this.course.starts_at).endOf('day') || current > moment(this.course.ends_at).endOf('day');
     return (
       <Row className="tasking-date-time">
         <Col xs={12} md={!this.plan.isEvent ? 4 : 6} className="opens-at">
@@ -199,7 +196,7 @@ class Tasking extends React.Component {
             index={index}
             tasking={tasking}
             onChange={this.onOpensChange}
-            disabledDate={disabledDate}
+            disabledDate={this.course.isInvalidAssignmentDate}
             timezone={this.course.timezone}
           />
         </Col>
@@ -207,7 +204,7 @@ class Tasking extends React.Component {
           <DateTime
             label="Due date & time"
             name={`tasking_plans[${index}].due_at`}
-            disabledDate={disabledDate}
+            disabledDate={this.course.isInvalidAssignmentDate}
             onChange={(target) => this.onDueChange(target, index)}
             timezone={this.course.timezone}
             errorMessage={this.displayDueDateError(tasking)}
@@ -220,7 +217,7 @@ class Tasking extends React.Component {
               labelWrapper={ux.isShowingPeriodTaskings ? null : NewTooltip}
               name={`tasking_plans[${index}].closes_at`}
               onChange={this.onClosesChange}
-              disabledDate={disabledDate}
+              disabledDate={this.course.isInvalidAssignmentDate}
               timezone={this.course.timezone}
               errorMessage={this.displayCloseDateError(tasking)}
             />


### PR DESCRIPTION
 - In the calendar, disable the dates before the course start date
 - In the calendar, disable the dates after the course end date
 - Allow users to select any enabled date from the calendar
 - If the date/time combination is not valid then show an error (See expected behavior above) Invision Screens for error messages: https://invis.io/V6XZPQ74ZBM
 - If any of the day and time is not valid then disable the Save button
 - When you edit assignment details for an assignment that is past due (or past close), the error state does not show up on the due date (or close date) unless the user makes a date edit