### PR TITLE
Fix new flag before due

### DIFF
--- a/tutor/src/models/task-plans/teacher/plan.js
+++ b/tutor/src/models/task-plans/teacher/plan.js
@@ -287,6 +287,7 @@ class TeacherTaskPlan extends BaseModel {
   }
   @computed get isFailed() { return Boolean(this.failed_at || this.killed_at); }
   @computed get isPastDue() { return this.duration.end.isBefore(Time.now); }
+  @computed get isGradeable() { return this.dateRanges.due.start.isBefore(Time.now); }
   @computed get isVisibleToStudents() { return this.isPublished && this.isOpen; }
 
   @computed get isPollable() {

--- a/tutor/src/models/task-plans/teacher/plan.js
+++ b/tutor/src/models/task-plans/teacher/plan.js
@@ -203,7 +203,7 @@ class TeacherTaskPlan extends BaseModel {
     return moment.range(first(dates), last(dates));
   }
 
-  @computed get dateRanges() {
+  get dateRanges() {
     return {
       opens: this.rangeFor('opens_at'),
       due: this.rangeFor('due_at'),

--- a/tutor/src/screens/teacher-dashboard/plan-label.jsx
+++ b/tutor/src/screens/teacher-dashboard/plan-label.jsx
@@ -20,7 +20,7 @@ const Text = styled.span`
 `;
 
 const GradeBanner = observer(({ plan }) => {
-  if (!plan.isPastDue || !plan.ungraded_step_count) { return null; }
+  if (!plan.isGradeable || !plan.ungraded_step_count) { return null; }
   return (
     <Ribbon>
       <Text>{plan.ungraded_step_count} NEW</Text>

--- a/tutor/src/screens/teacher-dashboard/plan-label.jsx
+++ b/tutor/src/screens/teacher-dashboard/plan-label.jsx
@@ -20,7 +20,7 @@ const Text = styled.span`
 `;
 
 const GradeBanner = observer(({ plan }) => {
-  if (!plan.ungraded_step_count) { return null; }
+  if (!plan.isPastDue || !plan.ungraded_step_count) { return null; }
   return (
     <Ribbon>
       <Text>{plan.ungraded_step_count} NEW</Text>


### PR DESCRIPTION
- Fixes new flag (ex. "3 NEW") on the dashboard showing up before the plan is past due (checks for the earliest due date for the past due check.)
- Fixes an issue with `dateRanges` returning an incorrect due time of `11:59` regardless of the correct value (locally `3:50`). I suspect this is an issue with the date time initialization on that field, and for some reason computed doesn't see that the value has changed. Removing the computed here fixes the issue, I don't think there's any real side effect here besides a very minor performance hit.

Will need a backend change to start filtering `ungraded_step_count` to only include past due.