### PR TITLE
add margins to label and chapter-section

### DIFF
--- a/tutor/src/components/book-part-title.js
+++ b/tutor/src/components/book-part-title.js
@@ -19,7 +19,10 @@ const StyledBookPartTitle = styled.div`
   }
   .chapter-section {
     font-weight: ${({ boldChapterSection }) => boldChapterSection ? 'bold' : 'normal'};
-    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+  }
+  .label {
+    margin-right: 0.5rem;
   }
 `;
 


### PR DESCRIPTION
Prevents the elements can run together when constructing the label

before:
<img width="567" alt="image" src="https://user-images.githubusercontent.com/79566/88073796-3839a680-cb3c-11ea-830c-2a59423b6b18.png">



after:
<img width="483" alt="image" src="https://user-images.githubusercontent.com/79566/88073864-4b4c7680-cb3c-11ea-8155-1e8cf551c9a0.png">

