### PR TITLE
fix ordering of min/max rows to match the heading

### DIFF
--- a/tutor/src/screens/teacher-gradebook/table.js
+++ b/tutor/src/screens/teacher-gradebook/table.js
@@ -437,7 +437,7 @@ const AggregateData = observer(({ ux }) => {
             </Average>
           </CellContents>
         </Cell>
-        {ux.headings.map((h, i) => (<MinMaxResult key={i} key={i} data={h} ux={ux} type={MinMaxType.MAX} drawBorderBottom/>))}
+        {ux.headings.map((h, i) => (<MinMaxResult key={i} key={i} data={h} ux={ux} type={MinMaxType.MIN} drawBorderBottom/>))}
       </Row>
       <Row>
         <Cell striped>
@@ -458,7 +458,7 @@ const AggregateData = observer(({ ux }) => {
             </Average>
           </CellContents>
         </Cell>
-        {ux.headings.map((h, i) => (<MinMaxResult key={i} data={h} ux={ux} type={MinMaxType.MIN} />))}
+        {ux.headings.map((h, i) => (<MinMaxResult key={i} data={h} ux={ux} type={MinMaxType.MAX} />))}
       </Row>
     </StyledAggregateData>
   );


### PR DESCRIPTION
I think I missed this when fixing the headings. Should make the result cells match the heading order (min first, max below.)

Before:

![image](https://user-images.githubusercontent.com/34174/88132975-c3935600-cb95-11ea-96fa-cd03e017adae.png)

After:

<img width="864" alt="image" src="https://user-images.githubusercontent.com/34174/88133034-f2a9c780-cb95-11ea-981c-d10bca05c637.png">
