### PR TITLE
fix extensions disordering gradebook [Needs BE #2151]

### DIFF
--- a/tutor/src/models/scores/task-result.js
+++ b/tutor/src/models/scores/task-result.js
@@ -34,6 +34,7 @@ class TaskResult extends BaseModel {
   @field correct_on_time_step_count;
   @field correct_accepted_late_step_count;
   @field({ type: 'date' }) due_at;
+  @field({ type: 'date' }) due_at_without_extension;
   @field is_past_due;
   @field is_extended;
   @field exercise_count;
@@ -77,7 +78,7 @@ class TaskResult extends BaseModel {
   @computed get isStarted() {
     return Boolean(this.completed_step_count || this.completed_exercise_count);
   }
-  
+
   @computed get canBeReviewed() {
     return Boolean(this.isStarted && !this.isExternal);
   }

--- a/tutor/src/screens/teacher-gradebook/student-data-sorter.js
+++ b/tutor/src/screens/teacher-gradebook/student-data-sorter.js
@@ -59,7 +59,7 @@ const StudentDataSorter = {
       ]; },
     },
     date: {
-      tasks(task) { return task.due_at; },
+      tasks(task) { return task.due_at_without_extension; },
       headings(heading) { return heading.due_at; },
     },
   },


### PR DESCRIPTION
`due_at` on student data won't match heading data if it received an extension, so we need to use `due_at_without_extension` to make sure the heading data matches.