### PR TITLE
use default heading and result ordering from the BE

### DIFF
--- a/tutor/src/screens/teacher-gradebook/student-data-sorter.js
+++ b/tutor/src/screens/teacher-gradebook/student-data-sorter.js
@@ -58,9 +58,9 @@ const StudentDataSorter = {
         StudentDataSorter.columns.type.headings(heading), StudentDataSorter.columns.points.headings(heading),
       ]; },
     },
-    date: {
-      tasks(task) { return task.due_at; },
-      headings(heading) { return heading.due_at; },
+    default: {
+      tasks() { return null; },
+      headings() { return null; },
     },
   },
 };

--- a/tutor/src/screens/teacher-gradebook/ux.js
+++ b/tutor/src/screens/teacher-gradebook/ux.js
@@ -103,7 +103,7 @@ export default class GradeBookUX {
     if (this.arrangeColumnsByType) {
       return sorter.type;
     }
-    return sorter.date;
+    return sorter.default;
   }
 
   @computed get headings() {


### PR DESCRIPTION
This resolves an issue with the gradebook columns becoming disordered when a student was granted an extension, as that causes the task `due_at` to be the extension date, not the original date. The BE already puts these into the correct order by default, so using that is a quick short term fix until we do a larger refactoring to use tasking plan ids to build the table.