### PR TITLE
Increase displayed precision of points and scores

### DIFF
--- a/tutor/specs/helpers/scores.spec.js
+++ b/tutor/specs/helpers/scores.spec.js
@@ -1,0 +1,24 @@
+import ScoresHelper from '../../src/helpers/scores';
+
+describe('Scores helper', function() {
+
+  it('formats points', function() {
+    expect(ScoresHelper.formatPoints(0.0)).toEqual('0');
+    expect(ScoresHelper.formatPoints(1)).toEqual('1.0');
+    expect(ScoresHelper.formatPoints(2.50)).toEqual('2.5');
+    expect(ScoresHelper.formatPoints(2.554)).toEqual('2.55');
+    expect(ScoresHelper.formatPoints(2.559)).toEqual('2.56');
+  });
+
+  it('makes late penalty negative and rounds towards zero', function() {
+    expect(ScoresHelper.formatLatePenalty(0.255)).toEqual('-0.25');
+    expect(ScoresHelper.formatLatePenalty(0.126)).toEqual('-0.13');
+    expect(ScoresHelper.formatLatePenalty(0.40)).toEqual('-0.4');
+  });
+
+  it('rounds high precision numbers to percents', function() {
+    const fraction = 0.55499999999999999;
+    expect(ScoresHelper.asPercent(fraction)).toEqual(56);
+  });
+
+});

--- a/tutor/specs/helpers/scores.spec.js
+++ b/tutor/specs/helpers/scores.spec.js
@@ -14,6 +14,7 @@ describe('Scores helper', function() {
     expect(ScoresHelper.formatLatePenalty(0.255)).toEqual('-0.25');
     expect(ScoresHelper.formatLatePenalty(0.126)).toEqual('-0.13');
     expect(ScoresHelper.formatLatePenalty(0.40)).toEqual('-0.4');
+    expect(ScoresHelper.formatLatePenalty(1.0)).toEqual('-1.0');
   });
 
   it('rounds high precision numbers to percents', function() {

--- a/tutor/specs/helpers/string.spec.js
+++ b/tutor/specs/helpers/string.spec.js
@@ -132,4 +132,5 @@ describe('String helpers', function() {
     expect(S.isEmpty(' ')).toBe(true);
     expect(S.isEmpty('not empty')).toBe(false);
   });
+
 });

--- a/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
+++ b/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
@@ -606,7 +606,7 @@ exports[`Student Dashboard displays as loading 1`] = `
                       <div
                         className="c12"
                       >
-                        0.0
+                        0
                         <svg
                           aria-hidden="true"
                           background="#5e5e5e"

--- a/tutor/src/components/task-progress.js
+++ b/tutor/src/components/task-progress.js
@@ -3,7 +3,7 @@ import { StickyTable, Row, Cell } from 'react-sticky-table';
 import { map, sumBy, isNil } from 'lodash';
 import { colors } from 'theme';
 import { CornerTriangle } from './dropped-question';
-import S, { UNWORKED } from '../../src/helpers/string';
+import ScoresHelper, { UNWORKED } from '../../src/helpers/scores';
 
 const PointsScoredStatus = {
   NOT_ANSWERED_NOT_GRADED: 'not-answered-not-graded',
@@ -123,7 +123,7 @@ class TaskProgress extends React.Component {
   render() {
     const { steps, currentStep, currentStep: { task }, goToStep } = this.props;
     let progressIndex = 0;
-  
+
     return (
       <StyledStickyTable rightStickyColumnCount={1} borderWidth={'1px'} >
         <Row>
@@ -176,14 +176,14 @@ class TaskProgress extends React.Component {
             steps.map((step, stepIndex) => {
               if(!step.isInfo) {
                 progressIndex += 1;
-                return <Cell key={stepIndex}>{S.numberWithOneDecimalPlace(step.available_points)}</Cell>;
+                return <Cell key={stepIndex}>{ScoresHelper.formatPoints(step.available_points)}</Cell>;
               }
               return <Cell key={stepIndex}></Cell>;
             })
           }
           {task.hasLateWorkPolicy &&
             <LateWorkCell>-{task.humanLateWorkPenalty} per {task.late_work_penalty_applied == 'daily' ? 'day' : 'assignment'}</LateWorkCell>}
-          <Cell>{S.numberWithOneDecimalPlace(sumBy(steps, s => s.available_points))}</Cell>
+          <Cell>{ScoresHelper.formatPoints(sumBy(steps, s => s.available_points))}</Cell>
         </Row>
         {
           steps.some(s => s.correct_answer_id || !isNil(s.published_points)) &&
@@ -194,7 +194,7 @@ class TaskProgress extends React.Component {
                   if(!step.isInfo) {
                     return (
                       <Cell key={stepIndex} className={pointsScoredStatus(step)}>
-                        {step.pointsScored !== null ? S.numberWithOneDecimalPlace(step.pointsScored) : UNWORKED }
+                        {step.pointsScored !== null ? ScoresHelper.formatPoints(step.pointsScored) : UNWORKED }
                       </Cell>
                     );
                   }
@@ -203,11 +203,11 @@ class TaskProgress extends React.Component {
               }
               {task.hasLateWorkPolicy &&
                 <Cell>
-                  {task.publishedLateWorkPenalty ? `-${S.numberWithOneDecimalPlace(task.publishedLateWorkPenalty)}` : '0.0'}
+                  {task.publishedLateWorkPenalty ? `${ScoresHelper.formatLatePenalty(task.publishedLateWorkPenalty)}` : '0.0'}
                 </Cell>}
               <Cell>
                 {isNil(task.publishedPoints) ?
-                  UNWORKED : S.numberWithOneDecimalPlace(task.publishedPoints)}
+                  UNWORKED : ScoresHelper.formatPoints(task.publishedPoints)}
               </Cell>
             </Row>
         }

--- a/tutor/src/helpers/scores.js
+++ b/tutor/src/helpers/scores.js
@@ -1,0 +1,30 @@
+const UNWORKED = '---';
+const FORMATTER = new Intl.NumberFormat('en-US', {
+  style: 'decimal',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 2,
+});
+
+export { UNWORKED };
+
+export default {
+  // Converts to negative number so the rounding will occur towards zero
+  formatLatePenalty(num) {
+    return this.formatDecimal(Math.round(-parseFloat(num) * 100) / 100);
+  },
+
+  formatDecimal(dec) {
+    return FORMATTER.format(dec);
+  },
+
+  formatPoints(points) {
+    if (points === 0.0) { return '0'; }
+    return this.formatDecimal(points);
+  },
+
+  asPercent(num) {
+    // Let the formatter round before passing, otherwise
+    // significant values will be lost.
+    return Math.round(this.formatDecimal(num * 100));
+  },
+};

--- a/tutor/src/helpers/string.js
+++ b/tutor/src/helpers/string.js
@@ -2,9 +2,6 @@ import { isNaN, isString, isEmpty } from 'lodash';
 
 const SMALL_WORDS = /^(a|an|and|as|at|but|by|en|for|if|in|nor|of|on|or|per|the|to|vs?\.?|via)$/i;
 const UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
-const UNWORKED = '---';
-
-export { UNWORKED };
 
 export default {
   asPercent(num) {

--- a/tutor/src/models/scores/task-result.js
+++ b/tutor/src/models/scores/task-result.js
@@ -6,7 +6,7 @@ import {
 import Big from 'big.js';
 import moment from 'moment';
 import Time from '../time';
-import S, { UNWORKED } from '../../helpers/string';
+import ScoresHelper, { UNWORKED } from '../../helpers/scores';
 
 export default
 @identifiedBy('scores/task-result')
@@ -77,7 +77,7 @@ class TaskResult extends BaseModel {
   @computed get isStarted() {
     return Boolean(this.completed_step_count || this.completed_exercise_count);
   }
-  
+
   @computed get canBeReviewed() {
     return Boolean(this.isStarted && !this.isExternal);
   }
@@ -201,7 +201,7 @@ class TaskResult extends BaseModel {
   }
 
   @computed get humanScoreNumber() {
-    return `${isNil(this.published_points) ? '0' : S.numberWithOneDecimalPlace(this.published_points)} of ${S.numberWithOneDecimalPlace(this.available_points)}`;
+    return `${isNil(this.published_points) ? '0' : ScoresHelper.formatPoints(this.published_points)} of ${ScoresHelper.formatPoints(this.available_points)}`;
   }
 
   @computed get isDue() {
@@ -210,11 +210,11 @@ class TaskResult extends BaseModel {
 
   @computed get humanScore() {
     const score = this.course.currentRole.isTeacher ? this.score : this.published_score;
-    return isNil(score) ? UNWORKED : S.asPercent(score) + '%';
+    return isNil(score) ? UNWORKED : `${ScoresHelper.asPercent(score)}%`;
   }
 
   @computed get humanPoints() {
     const points = this.course.currentRole.isTeacher ? this.points : this.published_points;
-    return isNil(points) ? UNWORKED : `${S.numberWithOneDecimalPlace(points)} of ${S.numberWithOneDecimalPlace(this.available_points)}`;
+    return isNil(points) ? UNWORKED : `${ScoresHelper.formatPoints(points)} of ${ScoresHelper.formatPoints(this.available_points)}`;
   }
 }

--- a/tutor/src/models/task-plans/student/task.js
+++ b/tutor/src/models/task-plans/student/task.js
@@ -1,7 +1,7 @@
 import { observable } from 'mobx';
 import { computed } from 'mobx';
 import { get, isNil } from 'lodash';
-import S from '../../../helpers/string';
+import ScoresHelper, { UNWORKED } from '../../../helpers/scores';
 import moment from 'moment';
 import Time from '../../time';
 import {
@@ -123,7 +123,7 @@ class StudentTask extends BaseModel {
   }
 
   @computed get humanScore() {
-    return isNil(this.published_points) ? '---' : S.numberWithOneDecimalPlace(this.published_points);
+    return isNil(this.published_points) ? UNWORKED : ScoresHelper.formatPoints(this.published_points);
   }
 
   // called from API

--- a/tutor/src/models/task-plans/teacher/scores.js
+++ b/tutor/src/models/task-plans/teacher/scores.js
@@ -7,7 +7,7 @@ import {
   get, some, reduce, every, uniq, isNumber,
 } from 'lodash';
 import DroppedQuestion from './dropped_question';
-import S, { UNWORKED } from '../../../helpers/string';
+import ScoresHelper, { UNWORKED } from '../../../helpers/scores';
 
 @identifiedBy('task-plan/scores/student-question')
 class TaskPlanScoreStudentQuestion extends BaseModel {
@@ -77,12 +77,14 @@ class TaskPlanScoreStudentQuestion extends BaseModel {
     if (this.needs_grading) { return UNWORKED; }
 
     if (dropped && this.is_completed) {
-      return S.numberWithOneDecimalPlace(
+      return ScoresHelper.formatPoints(
         dropped.drop_method == 'full_credit' ? this.availablePoints : 0
       );
     }
 
-    if (!isNil(this.gradedPoints)) { return S.numberWithOneDecimalPlace(this.gradedPoints); }
+    if (!isNil(this.gradedPoints)) {
+      return ScoresHelper.formatPoints(this.gradedPoints);
+    }
 
     return UNWORKED;
   }
@@ -123,11 +125,11 @@ class TaskPlanScoreStudent extends BaseModel {
   }
 
   @computed get humanTotalFraction() {
-    return isNumber(this.total_fraction) ? `${S.asPercent(this.total_fraction)}%` : UNWORKED;
+    return isNumber(this.total_fraction) ? `${ScoresHelper.asPercent(this.total_fraction)}%` : UNWORKED;
   }
 
   @computed get humanTotalPoints() {
-    return isNumber(this.total_points) ? S.numberWithOneDecimalPlace(this.total_points) : UNWORKED;
+    return isNumber(this.total_points) ? ScoresHelper.formatPoints(this.total_points) : UNWORKED;
   }
 }
 
@@ -326,7 +328,7 @@ class TaskPlanScoresTasking extends BaseModel {
   }
 
   @computed get totalAverageScoreInPercent() {
-    return isNil(this.total_fraction) ? UNWORKED : `${S.asPercent(this.total_fraction)}%`;
+    return isNil(this.total_fraction) ? UNWORKED : `${ScoresHelper.asPercent(this.total_fraction)}%`;
   }
 
   @computed get allStudentQuestionStatus() {

--- a/tutor/src/screens/assignment-grade/answer.js
+++ b/tutor/src/screens/assignment-grade/answer.js
@@ -3,7 +3,7 @@ import { Button } from 'react-bootstrap';
 import { colors } from 'theme';
 import { useState } from 'react';
 import { isNumber } from 'lodash';
-import S from '../../helpers/string';
+import ScoresHelper from '../../helpers/scores';
 
 const Name=styled.div`
   font-weight: bold;
@@ -68,7 +68,7 @@ const Points = React.forwardRef(({ response, onChange }, ref) => {
         }}
         defaultValue={response.grader_points}
         disabled={Boolean(!onChange)}
-      /> out of {S.numberWithOneDecimalPlace(response.availablePoints)}
+      /> out of {ScoresHelper.formatPoints(response.availablePoints)}
     </ScoreWrapper>
   );
 });
@@ -123,14 +123,14 @@ const GradingStudent = observer(({ response, ux, index }) => {
     pointRef.current.select();
     pointRef.current.focus();
   }, []);
-  
+
   const { student } = response;
   const saveLabel = ux.isResponseGraded(response)
     ? 'Regrade'
     : ux.isLastStudent
       ? 'Save & open next question'
       : 'Save';
-  
+
   return (
     <GradingStudentWrapper data-student-id={student.id} data-test-id="student-answer" showShadow={!ux.isResponseGraded(response)}>
       <Panel>
@@ -152,7 +152,7 @@ const GradingStudent = observer(({ response, ux, index }) => {
             {saveLabel}
           </SaveButton>
         }
-        {ux.isLastStudent && !ux.isResponseGraded(response) && 
+        {ux.isLastStudent && !ux.isResponseGraded(response) &&
           <SaveButton
             variant="plain"
             className={cn('btn btn-standard', { 'btn-primary': ux.isLastQuestion })}
@@ -190,7 +190,7 @@ const Student = observer(({ index, response, ux, ...props }) => {
   }
   else if (ux.isResponseGraded(response))
     Component = GradingStudent;
-  else 
+  else
     Component = ux.selectedStudentIndex === index ? GradingStudent : CollapsedStudent;
   return (
     <Component

--- a/tutor/src/screens/assignment-grade/question.js
+++ b/tutor/src/screens/assignment-grade/question.js
@@ -3,7 +3,7 @@ import { Button } from 'react-bootstrap';
 import { ExerciseNumber, Question } from '../../components/homework-questions';
 import Answer from './answer';
 import { colors } from 'theme';
-import S from '../../helpers/string';
+import ScoresHelper from '../../helpers/scores';
 
 const AnswerKey = observer(({ ux }) => (
   <label>
@@ -93,7 +93,9 @@ const ExpandGraded = observer(({ ux }) => {
       >
         {ux.expandGradedAnswers ? 'Hide' : 'Expand'} graded answers {gradeProgress}
       </Button>
-      <label>Average Score: {S.numberWithOneDecimalPlace(ux.selectedHeading.averageGradedPoints)} out of {S.numberWithOneDecimalPlace(ux.selectedHeading.responseStats.availablePoints)}</label>
+      <label>
+        Average Score: {ScoresHelper.formatPoints(ux.selectedHeading.averageGradedPoints)} out of {ScoresHelper.formatPoints(ux.selectedHeading.responseStats.availablePoints)}
+      </label>
     </ExpandGradedWrapper>
   );
 });
@@ -118,10 +120,10 @@ const Overiew = observer(({ ux }) => {
                   onClick={() => ux.goToQuestionHeading(i, true)}
                   variant="link"
                 >
-                        Expand graded answers {ux.showOnlyAttempted ? h.gradedProgress : h.gradedProgressWithUnAttemptedResponses}
+                  Expand graded answers {ux.showOnlyAttempted ? h.gradedProgress : h.gradedProgressWithUnAttemptedResponses}
                 </Button>
                 <label>
-                        Average Score: {S.numberWithOneDecimalPlace(h.averageGradedPoints)} out of {S.numberWithOneDecimalPlace(h.responseStats.availablePoints)}
+                  Average Score: {ScoresHelper.formatPoints(h.averageGradedPoints)} out of {ScoresHelper.formatPoints(h.responseStats.availablePoints)}
                 </label>
               </ExpandGradedWrapper>
             </QuestionBody>
@@ -132,7 +134,7 @@ const Overiew = observer(({ ux }) => {
   );
 });
 
-const IndividualQuestion = observer(({ ux }) => 
+const IndividualQuestion = observer(({ ux }) =>
   (
     <StyledQuestion>
       <QuestionHeader questionIndex={ux.selectedHeading.index} ux={ux} showAnswerKey={true} />
@@ -146,7 +148,7 @@ const IndividualQuestion = observer(({ ux }) =>
         />
         <ExpandGraded ux={ux} />
         {
-          Boolean(ux.expandGradedAnswers) && ux.gradedResponses.map((response, index) => 
+          Boolean(ux.expandGradedAnswers) && ux.gradedResponses.map((response, index) =>
             <Answer
               response={response}
               key={index}

--- a/tutor/src/screens/assignment-review/details.js
+++ b/tutor/src/screens/assignment-review/details.js
@@ -3,7 +3,7 @@ import { Icon } from 'shared';
 import { colors } from 'theme';
 import Loading from 'shared/components/loading-animation';
 import HomeworkQuestions, { ExerciseNumber } from '../../components/homework-questions';
-import S from '../../helpers/string';
+import ScoresHelper from '../../helpers/scores';
 import { isEmpty } from 'lodash';
 import PreviewTooltip from '../assignment-edit/preview-tooltip';
 import DeleteModal from './delete-modal';
@@ -159,7 +159,7 @@ const QuestionHeader = observer(({ styleVariant, label, info }) => {
       <StyledExerciseNumber variant={styleVariant}>
         {label}
       </StyledExerciseNumber>
-      <strong>{S.numberWithOneDecimalPlace(info.availablePoints)} Points</strong>
+      <strong>{ScoresHelper.formatPoints(info.availablePoints)} Points</strong>
     </>
   );
 });

--- a/tutor/src/screens/assignment-review/external-scores.js
+++ b/tutor/src/screens/assignment-review/external-scores.js
@@ -6,6 +6,7 @@ import { colors } from 'theme';
 import SortIcon from '../../components/icons/sort';
 import SearchInput from '../../components/search-input';
 import TutorLink from '../../components/link';
+import { UNWORKED } from '../../helpers/scores';
 
 const StyledStickyTable = styled(StickyTable)`
   margin: 2.2rem 0 1.4rem;
@@ -182,7 +183,7 @@ const TaskResult = observer(({ result, striped }) => {
   return (
     <Cell striped={striped}>
       <Result>
-        {result && result.is_completed ? 'clicked' : '---'}
+        {result && result.is_completed ? 'clicked' : UNWORKED}
       </Result>
     </Cell>
   );

--- a/tutor/src/screens/assignment-review/homework-scores.js
+++ b/tutor/src/screens/assignment-review/homework-scores.js
@@ -3,7 +3,7 @@ import { Row } from 'react-sticky-table';
 
 import LoadingScreen from 'shared/components/loading-animation';
 import { colors } from 'theme';
-import S from '../../helpers/string';
+import ScoresHelper, { UNWORKED } from '../../helpers/scores';
 import ExtensionIcon from '../../components/icons/extension';
 import InfoIcon from '../../components/icons/info';
 import SortIcon from '../../components/icons/sort';
@@ -91,7 +91,7 @@ const StudentColumnHeader = observer(({ ux }) => (
           </SplitCell>
         </HeadingMiddle>
         <HeadingBottom>
-          {S.numberWithOneDecimalPlace(ux.scores.availablePoints)}
+          {ScoresHelper.formatPoints(ux.scores.availablePoints)}
           {!ux.scores.hasEqualTutorQuestions && (
             <InfoIcon
               color="#f36a31"
@@ -135,7 +135,8 @@ const StudentCell = observer(({ ux, student, striped }) => (
         {ux.displayTotalInPercent ? student.humanTotalFraction : student.humanTotalPoints}
       </Total>
       <LateWork>
-        {student.late_work_point_penalty ? `-${S.numberWithOneDecimalPlace(student.late_work_point_penalty)}` : '0'}
+        {student.late_work_point_penalty ?
+          `${ScoresHelper.formatLatePenalty(student.late_work_point_penalty)}` : '0'}
         {ux.wasGrantedExtension(student.role_id) && <ExtensionIcon />}
       </LateWork>
     </CellContents>
@@ -159,7 +160,7 @@ const AssignmentHeading = observer(({ ux, heading }) => (
             tooltip={heading.dropped.drop_method == 'zeroed' ?
               'Points changed to 0' : 'Full credit given to all students'}
           />}
-        {S.numberWithOneDecimalPlace(heading.displayPoints)}
+        {ScoresHelper.formatPoints(heading.displayPoints)}
       </HeadingBottom>
     </ColumnHeading>
   </Cell>
@@ -248,8 +249,8 @@ const Scores = observer(({ ux }) => {
           {scores.question_headings.map((h, i) => (
             <Cell key={i}>
               <Result>
-                {isNaN(h.responseStats.averageGradedPoints) && '---' ||
-                  S.numberWithOneDecimalPlace(h.responseStats.averageGradedPoints)}
+                {isNaN(h.responseStats.averageGradedPoints) && UNWORKED ||
+                  ScoresHelper.formatPoints(h.responseStats.averageGradedPoints)}
               </Result>
             </Cell>
           ))}
@@ -258,7 +259,7 @@ const Scores = observer(({ ux }) => {
       <DefinitionsWrapper>
         <Term variant="trouble" aria-label="Less than 50%"></Term>
         <Definition>Scores less than 50% of question's point value</Definition>
-        <Term aria-label="Unattempted">---</Term>
+        <Term aria-label="Unattempted">{UNWORKED}</Term>
         <Definition>Unattempted question or ungraded responses</Definition>
       </DefinitionsWrapper>
     </>

--- a/tutor/src/screens/assignment-review/overview.js
+++ b/tutor/src/screens/assignment-review/overview.js
@@ -2,7 +2,7 @@ import { React, PropTypes, styled, css, observer, cn } from 'vendor';
 import { StickyTable, Row, Cell } from 'react-sticky-table';
 import TutorLink from '../../components/link';
 import { Button } from 'react-bootstrap';
-import S from '../../helpers/string';
+import ScoresHelper from '../../helpers/scores';
 import { Icon, ArbitraryHtmlAndMath } from 'shared';
 import HomeworkQuestions, { ExerciseNumber } from '../../components/homework-questions';
 import InfoIcon from '../../components/icons/info';
@@ -44,7 +44,7 @@ const QuestionHeader = observer(({ ux, styleVariant, label, info }) => (
       {ux.planScores.isReading ? 'Question' :
         (info.isCore ? label : 'OpenStax Tutor Selection')}
     </ExerciseNumber>
-    <div>{S.numberWithOneDecimalPlace(info.availablePoints)} Points</div>
+    <div>{ScoresHelper.formatPoints(info.availablePoints)} Points</div>
   </>
 ));
 QuestionHeader.propTypes = {
@@ -59,7 +59,7 @@ const QuestionFooter = observer(({ ux, info }) => {
 
   return (<Footer>
     <strong>
-      Average score: {info.averagePoints ? S.numberWithOneDecimalPlace(info.averagePoints) : 'n/a'}
+      Average score: {info.averagePoints ? ScoresHelper.formatPoints(info.averagePoints) : 'n/a'}
     </strong>
     {ux.canDisplayGradingButton &&
       <GradeButton
@@ -240,7 +240,7 @@ const WRQFreeResponse = observer(({ info }) => {
             {response.needs_grading && 'Not graded'}
             {!isNaN(response.grader_points) &&
               <div>
-                <h3>{response.grader_points}</h3>
+                <h3>{ScoresHelper.formatPoints(response.grader_points)}</h3>
                 {response.grader_comments}
               </div>}
           </div>
@@ -365,7 +365,7 @@ const AvailablePoints = ({ value }) => {
     );
   }
   return (
-    <strong>({S.numberWithOneDecimalPlace(value)})</strong>
+    <strong>({ScoresHelper.formatPoints(value)})</strong>
   );
 };
 AvailablePoints.propTypes = {
@@ -435,7 +435,7 @@ const Overview = observer(({ ux, ux: { scores } }) => (
             <Header>
           Available Points <AvailablePoints value={(scores.hasEqualTutorQuestions && scores.availablePoints) || false} />
             </Header>
-            {scores.question_headings.map((h, i) => <Cell key={i}>{S.numberWithOneDecimalPlace(h.points)}</Cell>)}
+            {scores.question_headings.map((h, i) => <Cell key={i}>{ScoresHelper.formatPoints(h.points)}</Cell>)}
           </Row>
           <Row>
             <Header>Correct Responses</Header>
@@ -453,7 +453,6 @@ const Overview = observer(({ ux, ux: { scores } }) => (
         </Legend>
       </>
       )}
-
     {ux.isExercisesReady
       ? <QuestionList ux={ux} scores={scores} />
       : <Loading message="Loading Questions…"/>}

--- a/tutor/src/screens/assignment-review/reading-scores.js
+++ b/tutor/src/screens/assignment-review/reading-scores.js
@@ -3,7 +3,7 @@ import { StickyTable, Row } from 'react-sticky-table';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 import LoadingScreen from 'shared/components/loading-animation';
 import { colors } from 'theme';
-import S from '../../helpers/string';
+import ScoresHelper from '../../helpers/scores';
 import ExtensionIcon from '../../components/icons/extension';
 import InfoIcon from '../../components/icons/info';
 import SortIcon from '../../components/icons/sort';
@@ -59,7 +59,7 @@ const popover = (gradingTemplate) => (
         <Cell>{gradingTemplate.humanCompletionWeight} of question's point value</Cell>
       </Row>
       <Row>
-        <Cell>Total</Cell> 
+        <Cell>Total</Cell>
         <Cell>{gradingTemplate.humanTotalWeight}</Cell>
       </Row>
     </StickyTable>
@@ -118,7 +118,7 @@ const StudentColumnHeader = observer(({ ux }) => (
             %
           </SplitCell>
         </HeadingMiddle>
-        <HeadingBottom> 
+        <HeadingBottom>
           <OverlayTrigger placement="right" overlay={popover(ux.planScores.grading_template)} trigger="hover">
             <InfoIcon
               color={colors.bright_blue}
@@ -163,11 +163,11 @@ const StudentCell = observer(({ ux, student, striped }) => {
 
           <Total>
             {ux.displayTotalInPercent ?
-              `${S.asPercent(student.total_fraction || 0)}%` :
-              S.numberWithOneDecimalPlace(student.total_points || 0)}
+              `${ScoresHelper.asPercent(student.total_fraction || 0)}%` :
+              ScoresHelper.formatPoints(student.total_points)}
           </Total>
           <LateWork>
-            {student.late_work_point_penalty ? `-${S.numberWithOneDecimalPlace(student.late_work_point_penalty)}` : '0'}
+            {student.late_work_point_penalty ? ScoresHelper.formatLatePenalty(student.late_work_point_penalty) : '0'}
             {ux.wasGrantedExtension(student.role_id) && <ExtensionIcon />}
           </LateWork>
         </CellContents>

--- a/tutor/src/screens/pre-wrm-scores-report/correctness-value.jsx
+++ b/tutor/src/screens/pre-wrm-scores-report/correctness-value.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { isNil } from 'lodash';
 import { observer } from 'mobx-react';
-import S from '../../helpers/string';
+import ScoresHelper from '../../helpers/scores';
 import TaskResult from '../../models/scores/task-result';
 import TutorLink from '../../components/link';
 import UX from './ux';
@@ -34,7 +34,7 @@ const Progress = observer(({ task }) => {
 });
 
 const Percent = observer(({ task: { published_score } }) => {
-  const display = isNil(published_score) ? '---' : `${S.asPercent(published_score)}%`;
+  const display = isNil(published_score) ? '---' : `${ScoresHelper.asPercent(published_score)}%`;
   return <div className="correct-score">{display}</div>;
 });
 

--- a/tutor/src/screens/student-gradebook/table.js
+++ b/tutor/src/screens/student-gradebook/table.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { isNil } from 'lodash';
 import { colors } from 'theme';
 import { Icon } from 'shared';
-import S, { UNWORKED } from '../../helpers/string';
+import ScoresHelper, { UNWORKED } from '../../helpers/scores';
 import SortIcon from '../../components/icons/sort';
 import { EIcon } from '../../components/icons/extension';
 
@@ -23,7 +23,7 @@ const TableWrapper = styled.div`
   .average-score {
     margin-top: 10px;
     width: 50%;
-    
+
     span:first-child {
       margin-right: 20px;
     }
@@ -60,7 +60,7 @@ const StyledTable = styled(Table)`
 
   thead {
     background: ${colors.neutral.lighter};
-    border-bottom: 1px solid ${colors.neutral.pale}; 
+    border-bottom: 1px solid ${colors.neutral.pale};
 
     tr {
       th {
@@ -96,7 +96,7 @@ const StyledTable = styled(Table)`
     .border-event {
       border-left: 10px solid ${colors.templates.event.border};
     }
-    
+
   }
 
   /** Striped colors */
@@ -105,7 +105,7 @@ const StyledTable = styled(Table)`
   }
 `;
 
-const percentOrDash = (score) => isNil(score) ? UNWORKED : S.asPercent(score) + '%';
+const percentOrDash = (score) => isNil(score) ? UNWORKED : `${ScoresHelper.asPercent(score)}%`;
 const hasExtension = (studentTaskPlans, studentTaskPlanId) => {
   const studentTaskPlan = studentTaskPlans.array.find(s => parseInt(s.id, 10) === studentTaskPlanId);
   return studentTaskPlan ? studentTaskPlan.is_extended : false;
@@ -114,7 +114,7 @@ const hasExtension = (studentTaskPlans, studentTaskPlanId) => {
 const GradebookTable = observer((
   {
     history,
-    ux: { student, studentData, course, goToAssignment, sort, displaySort, sortFieldConstants }, 
+    ux: { student, studentData, course, goToAssignment, sort, displaySort, sortFieldConstants },
   }) => {
   return (
     <TableWrapper>
@@ -127,7 +127,7 @@ const GradebookTable = observer((
             <Popover className="scores-popover">
               <p>
                 <strong>Course Average = </strong><br/>
-                {S.asPercent(course.homework_weight)}% Homework average + {S.asPercent(course.reading_weight)}% Reading average
+                {ScoresHelper.asPercent(course.homework_weight)}% Homework average + {ScoresHelper.asPercent(course.reading_weight)}% Reading average
               </p>
             </Popover>
           }

--- a/tutor/src/screens/task/step/instructions.js
+++ b/tutor/src/screens/task/step/instructions.js
@@ -4,6 +4,7 @@ import { colors } from '../../../theme';
 import { OuterStepCard, InnerStepCard } from './card';
 import StepContinueBtn from './continue-btn';
 import S from '../../../helpers/string';
+import ScoresHelper from '../../../helpers/scores';
 import TimeHelper from '../../../helpers/time';
 
 const CardBody = styled(InnerStepCard)`
@@ -33,7 +34,7 @@ const Points = ({ task }) => {
   }
   return (
     <StyledPoints>
-      {S.numberWithOneDecimalPlace(task.availablePoints)} points
+      {ScoresHelper.formatPoints(task.availablePoints)} points
     </StyledPoints>
   );
 };

--- a/tutor/src/screens/task/step/wrq-status.js
+++ b/tutor/src/screens/task/step/wrq-status.js
@@ -4,7 +4,7 @@ import {
 import { Icon } from 'shared';
 import { colors } from 'theme';
 import { isNil } from 'lodash';
-import S from '../../../helpers/string';
+import ScoresHelper from '../../../helpers/scores';
 import TaskStep from '../../../models/student-tasks/step';
 
 const StyledMessage = styled.div`
@@ -87,7 +87,7 @@ const PointsAndFeedback = observer(({ step }) => {
       <div>
         <Label>Points:</Label>
         <Value>
-          {S.numberWithOneDecimalPlace(step.published_points)} / {S.numberWithOneDecimalPlace(step.available_points)}
+          {ScoresHelper.formatPoints(step.published_points)} / {ScoresHelper.formatPoints(step.available_points)}
         </Value>
       </div>
       {step.published_comments && (

--- a/tutor/src/screens/teacher-gradebook/aggregate-result-cell.js
+++ b/tutor/src/screens/teacher-gradebook/aggregate-result-cell.js
@@ -2,21 +2,22 @@ import { React, PropTypes } from 'vendor';
 import { observer } from 'mobx-react';
 import { sumBy, countBy, filter, isNil, isNaN } from 'lodash';
 import { getCell } from './styles';
-import S, { UNWORKED } from '../../helpers/string';
-
+import S from '../../helpers/string';
+import ScoresHelper, { UNWORKED } from '../../helpers/scores';
 
 const Cell = getCell('0 10px');
+window.ScoresHelper = ScoresHelper;
 
 const getPoints = (tasks) => {
   const aggregatePoints = sumBy(tasks, (t) => t.published_points);
-  return isNil(aggregatePoints) ? UNWORKED : S.numberWithOneDecimalPlace(aggregatePoints/tasks.length);
+  return isNil(aggregatePoints) ? UNWORKED : ScoresHelper.formatPoints(aggregatePoints/tasks.length);
 };
 
 const getPercentage = (tasks) => {
-  const aggregateScore = sumBy(tasks, (t) => parseFloat(t.published_score , 10));
-  return isNil(aggregateScore) || isNaN(aggregateScore) ? UNWORKED : `${S.asPercent(aggregateScore/tasks.length)}%`;
+  const aggregateScore = sumBy(tasks, (t) => parseFloat(t.published_score));
+  if (isNil(aggregateScore) || isNaN(aggregateScore)) { return UNWORKED; }
+  return `${ScoresHelper.asPercent(aggregateScore/tasks.length)}%`;
 };
-
 
 const AggregateResult = observer(({ data, ux, drawBorderBottom }) => {
   if(data.type === 'external') {

--- a/tutor/src/screens/teacher-gradebook/min-max-result-cell.js
+++ b/tutor/src/screens/teacher-gradebook/min-max-result-cell.js
@@ -2,7 +2,7 @@ import { React, PropTypes } from 'vendor';
 import { observer } from 'mobx-react';
 import { minBy, maxBy, filter } from 'lodash';
 import { getCell } from './styles';
-import S, { UNWORKED } from '../../helpers/string';
+import ScoresHelper, { UNWORKED } from '../../helpers/scores';
 
 const Cell = getCell('0 10px');
 
@@ -45,11 +45,11 @@ const MinMaxResult = observer(({ data, ux, type, drawBorderBottom }) => {
   let taskResult;
   let averageOrPoints;
   if(ux.displayScoresAsPoints) {
-    taskResult =  getMinOrMaxResultPoints(tasksWithoutDroppedStudents, type);
-    averageOrPoints = taskResult ? `${S.numberWithOneDecimalPlace(taskResult.published_points)}` : UNWORKED;
+    taskResult = getMinOrMaxResultPoints(tasksWithoutDroppedStudents, type);
+    averageOrPoints = taskResult ? ScoresHelper.formatPoints(taskResult.published_points) : UNWORKED;
   } else {
-    taskResult =  getMinOrMaxResultAverage(tasksWithoutDroppedStudents, type);
-    averageOrPoints = taskResult ? `${S.asPercent(taskResult.published_score)}%` : UNWORKED;
+    taskResult = getMinOrMaxResultAverage(tasksWithoutDroppedStudents, type);
+    averageOrPoints = taskResult ? `${ScoresHelper.asPercent(taskResult.published_score)}%` : UNWORKED;
   }
   return (
     <Cell striped drawBorderBottom={drawBorderBottom}>

--- a/tutor/src/screens/teacher-gradebook/table.js
+++ b/tutor/src/screens/teacher-gradebook/table.js
@@ -4,7 +4,7 @@ import { isNil } from 'lodash';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 import { Icon } from 'shared';
 import { colors } from 'theme';
-import S, { UNWORKED } from '../../helpers/string';
+import ScoresHelper, { UNWORKED } from '../../helpers/scores';
 import SortIcon from '../../components/icons/sort';
 import TutorLink from '../../components/link';
 import TaskResultCell from './task-result-cell';
@@ -354,7 +354,7 @@ const AssignmentHeading = observer(({ ux, heading }) => {
   );
 });
 
-const percentOrDash = (score) => isNil(score) ? UNWORKED : S.asPercent(score) + '%';
+const percentOrDash = (score) => isNil(score) ? UNWORKED : ScoresHelper.asPercent(score) + '%';
 
 const StudentCell = observer(({ ux, student, striped, isLast }) => {
   return (

--- a/tutor/src/screens/teacher-gradebook/task-result-cell.js
+++ b/tutor/src/screens/teacher-gradebook/task-result-cell.js
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react';
 import { isNil } from 'lodash';
 import { colors } from 'theme';
 import TutorLink from '../../components/link';
-import S, { UNWORKED } from '../../helpers/string';
+import ScoresHelper, { UNWORKED } from '../../helpers/scores';
 import { getCell } from './styles';
 
 const Cell = getCell('0, 10px');
@@ -35,12 +35,12 @@ const ReviewLink = ({ task, children }) => useObserver(() => {
 });
 
 const Points = observer(({ task }) => {
-  const points = isNil(task.published_points) ? UNWORKED : S.numberWithOneDecimalPlace(task.published_points);
+  const points = isNil(task.published_points) ? UNWORKED : ScoresHelper.formatPoints(task.published_points);
   return <div className="correct-points">{points}</div>;
 });
 
 const Percent = observer(({ task }) => {
-  const display = isNil(task.published_score) ? UNWORKED : `${S.asPercent(task.published_score)}%`;
+  const display = isNil(task.published_score) ? UNWORKED : `${ScoresHelper.asPercent(task.published_score)}%`;
   return <div className="correct-score">{display}</div>;
 });
 
@@ -51,7 +51,7 @@ const External = observer(({ task: { completed_step_count } }) => {
 const TaskResult = observer(({ ux, task, striped, isLast }) => {
   let contents = null;
   if (task.isStarted || task.isDue) {
-    
+
     let Component;
 
     if (task.isExternal){

--- a/tutor/src/screens/teacher-gradebook/ux.js
+++ b/tutor/src/screens/teacher-gradebook/ux.js
@@ -9,7 +9,8 @@ import {
   groupBy, flow, map, partial, uniq, keys, isEmpty, isNil,
   filter, sortBy, maxBy, minBy, orderBy, some,
 } from 'lodash';
-import S, { UNWORKED } from '../../helpers/string';
+import S from '../../helpers/string';
+import ScoresHelper, { UNWORKED } from '../../helpers/scores';
 
 const scoreKeyToType = (key) => (key.match(/(course_average|homework|reading)/)[0]);
 
@@ -238,12 +239,12 @@ export default class GradeBookUX {
   maxScore(type) {
     const score = maxBy(this.students, type);
     if(!score) return UNWORKED;
-    return `${S.asPercent(score[type])}%`;
+    return `${ScoresHelper.asPercent(score[type])}%`;
   }
 
   minScore(type) {
     const score = minBy(this.students, type);
     if(!score) return UNWORKED;
-    return `${S.asPercent(score[type])}%`;
+    return `${ScoresHelper.asPercent(score[type])}%`;
   }
 }


### PR DESCRIPTION
## General

- Moved all calculations for scores/points displays into a dedicated helper to help testability and isolate from any unrelated refactorings.
- Moved UNWORKED into the ScoresHelper.

## Points

`ScoresHelper.formatPoints(points)`

Formats points to have increased precision to 2 decimal places using the following rule: A minimum of 1, a maximum of 2, unless '0.0' (special case it as '0'.) Drop insignificant trailing 0s like in '.50'.

I used`Intl.NumberFormat` as it seemed to give us all that in a simple way (besides the 0 case.)

Value | Display
---- | ----
0.0 | 0
1 | 1.0
0.50 | 0.5
0.559 | 0.56

OLD:
![image](https://user-images.githubusercontent.com/34174/88412238-19325300-cd8e-11ea-8db5-4314079bc4bb.png)

NEW:
![image](https://user-images.githubusercontent.com/34174/88412127-eab47800-cd8d-11ea-82eb-61da5604eb14.png)

OLD:
![Screen Shot 2020-07-24 at 09 23 41](https://user-images.githubusercontent.com/34174/88413197-9d390a80-cd8f-11ea-9858-8152b06555aa.png)

NEW:
![Screen Shot 2020-07-24 at 09 24 12](https://user-images.githubusercontent.com/34174/88413210-a1fdbe80-cd8f-11ea-8412-d568ae5df5d0.png)

OLD:
![Screen Shot 2020-07-24 at 09 36 49](https://user-images.githubusercontent.com/34174/88414175-47fdf880-cd91-11ea-9dc5-c75fa7e67858.png)

NEW:
![Screen Shot 2020-07-24 at 09 36 58](https://user-images.githubusercontent.com/34174/88414182-4b917f80-cd91-11ea-9469-0e162758cc36.png)

OLD:
![Screen Shot 2020-07-24 at 09 38 06](https://user-images.githubusercontent.com/34174/88414270-6d8b0200-cd91-11ea-8b9b-3e47dec1bf54.png)

NEW:
![Screen Shot 2020-07-24 at 09 38 11](https://user-images.githubusercontent.com/34174/88414275-71b71f80-cd91-11ea-91ec-6dea0f823155.png)

OLD | NEW
--- | ---
![Screen Shot 2020-07-24 at 10 28 34](https://user-images.githubusercontent.com/34174/88418525-8814a980-cd98-11ea-9334-9087c4e7f741.png) | ![Screen Shot 2020-07-24 at 10 28 39](https://user-images.githubusercontent.com/34174/88418532-8ba83080-cd98-11ea-906d-2f5c24707f6f.png)

OLD | NEW
--- | ---
![image](https://user-images.githubusercontent.com/34174/88415586-97452880-cd93-11ea-8cdd-fb3a9e9b2b10.png) | ![image](https://user-images.githubusercontent.com/34174/88415619-a6c47180-cd93-11ea-8f31-d511b46e8b36.png)

## Percents

Our normal `asPercent` function doesn't work for the higher precision numbers we're sending down like `0.5549999999999999`. To match Excel and intuition, the decimals should be rounded `0.5549999999999999 -> 55.5 -> 56`

Old calculation:

```
S.asPercent(0.5549999999999999)
=> 55
```

New calculation:

```
ScoresHelper.asPercent(0.5549999999999999)
=> 56
```
OLD | NEW
---- | ----
![image](https://user-images.githubusercontent.com/34174/88414705-20f3f680-cd92-11ea-9223-2ea430bff958.png) | ![image](https://user-images.githubusercontent.com/34174/88413320-d40f2080-cd8f-11ea-9040-3fcdc7afc3af.png)
![image](https://user-images.githubusercontent.com/34174/88415335-2b62c000-cd93-11ea-9568-078fc0159add.png) | ![image](https://user-images.githubusercontent.com/34174/88415358-36b5eb80-cd93-11ea-9a03-d36f17c6e243.png)


## Late Penalty

The late penalty needs to be rounded towards zero. Thankfully `Math.round` already does this correctly for negative numbers, so I added a convenience method to handle the conversion and rounding.

```
ScoresHelper.formatLatePenalty(0.255)
=> -0.25
```