### PR TITLE
Fixed preview courses with should_reuse_preview: false

### DIFF
--- a/tutor/specs/models/courses/offerings/previews.spec.js
+++ b/tutor/specs/models/courses/offerings/previews.spec.js
@@ -33,6 +33,7 @@ describe('Offering Previews Model', () => {
       beforeAll(() => CoursesMap.reset());
 
       it('returns a preview offering with no existing courses', () => {
+        expect(Previews.all[0].isCreated).toBe(false);
         expect(Previews.all[0].previewCourse).toBeUndefined();
       });
     });
@@ -49,6 +50,7 @@ describe('Offering Previews Model', () => {
       beforeAll(() => CoursesMap.onLoaded({ data: [ COURSEDATA ] }));
 
       it('returns a preview offering with no existing courses', () => {
+        expect(Previews.all[0].isCreated).toBe(false);
         expect(Previews.all[0].previewCourse).toBeUndefined();
       });
     });
@@ -65,22 +67,7 @@ describe('Offering Previews Model', () => {
       beforeAll(() => CoursesMap.onLoaded({ data: [ COURSEDATA ] }));
 
       it('returns a preview offering with no existing courses', () => {
-        expect(Previews.all[0].previewCourse).toBeUndefined();
-      });
-    });
-
-    describe('when the course is not reusable', () => {
-      const COURSEDATA = {
-        id: 21,
-        offering_id: OFFERINGDATA.id,
-        is_active: true,
-        is_preview: true,
-        should_reuse_preview: false,
-        roles: [ { type: 'teacher' } ],
-      }
-      beforeAll(() => CoursesMap.onLoaded({ data: [ COURSEDATA ] }));
-
-      it('returns a preview offering with no existing courses', () => {
+        expect(Previews.all[0].isCreated).toBe(false);
         expect(Previews.all[0].previewCourse).toBeUndefined();
       });
     });
@@ -97,6 +84,7 @@ describe('Offering Previews Model', () => {
       beforeAll(() => CoursesMap.onLoaded({ data: [ COURSEDATA ] }));
 
       it('returns a preview offering with no existing courses', () => {
+        expect(Previews.all[0].isCreated).toBe(false);
         expect(Previews.all[0].previewCourse).toBeUndefined();
       });
     });
@@ -113,7 +101,25 @@ describe('Offering Previews Model', () => {
       beforeAll(() => CoursesMap.onLoaded({ data: [ COURSEDATA ] }));
 
       it('returns a preview offering with no existing courses', () => {
+        expect(Previews.all[0].isCreated).toBe(false);
         expect(Previews.all[0].previewCourse).toBeUndefined();
+      });
+    });
+
+    describe('when the course is not reusable', () => {
+      const COURSEDATA = {
+        id: 21,
+        offering_id: OFFERINGDATA.id,
+        is_active: true,
+        is_preview: true,
+        should_reuse_preview: false,
+        roles: [ { type: 'teacher' } ],
+      }
+      beforeAll(() => CoursesMap.onLoaded({ data: [ COURSEDATA ] }));
+
+      it('isCreated is false but returns the existing preview course', () => {
+        expect(Previews.all[0].isCreated).toBe(false);
+        expect(Previews.all[0].previewCourse.id).toBe(COURSEDATA.id);
       });
     });
 
@@ -130,7 +136,8 @@ describe('Offering Previews Model', () => {
         }
         beforeAll(() => CoursesMap.onLoaded({ data: [ COURSEDATA ] }));
 
-        it('returns the existing preview course', () => {
+        it('isCreated is true and returns the existing preview course', () => {
+          expect(Previews.all[0].isCreated).toBe(true);
           expect(Previews.all[0].previewCourse.id).toBe(COURSEDATA.id);
         });
       }

--- a/tutor/src/models/course/offerings/previews.js
+++ b/tutor/src/models/course/offerings/previews.js
@@ -1,4 +1,4 @@
-import { sortBy, find } from 'lodash';
+import { orderBy, sortBy, find } from 'lodash';
 import { action, observable, computed, decorate } from 'mobx';
 import { identifiedBy } from 'shared/model';
 import Course from '../../course';
@@ -26,13 +26,17 @@ class PreviewCourseOffering extends Course {
     this.offering = offering;
   }
 
+  // This property is called to determine if the preview course already exists
+  // We return false if shouldReusePreview is false so we get an updated course
   @computed get isCreated() {
-    return !!this.previewCourse;
+    return !!(this.previewCourse && this.previewCourse.should_reuse_preview);
   }
 
+  // To avoid errors, this method needs to accept any course returned by build()
   @computed get previewCourse() {
     return find(
-      Courses.preview.active.teaching.shouldReusePreview.array, { offering_id: this.offering_id }
+      orderBy(Courses.preview.active.teaching.array, 'should_reuse_preview', 'desc'),
+      { offering_id: this.offering_id }
     );
   }
 

--- a/tutor/src/models/courses-map.js
+++ b/tutor/src/models/courses-map.js
@@ -70,10 +70,6 @@ export class CoursesMap extends Map {
     return this.where(c => c.dashboardViewCount > 0);
   }
 
-  @computed get shouldReusePreview() {
-    return this.where(c => c.should_reuse_preview);
-  }
-
   @action addNew(courseData) {
     const course = new Course(courseData, this);
     course.just_created = true;


### PR DESCRIPTION
previewCourse() now returns courses with should_reuse_preview: false (but prefers courses with should_reuse_preview: true) so we can still redirect to outdated courses if the API returns them.

isCreated() now returns true only for courses with should_reuse_preview: true so the FE will request a new course if should_reuse_preview is false.