### PR TITLE
update close and due date when open date is changed and assignment cr…

### DIFF
--- a/tutor/src/screens/assignment-edit/tasking.js
+++ b/tutor/src/screens/assignment-edit/tasking.js
@@ -66,13 +66,17 @@ class Tasking extends React.Component {
       this.form.setFieldValue(name, t.opens_at);
 
       if(!didUserChangeDatesManually) {
-        if(dueAt) {
+        // *!dueAt* means that assignment creation was started from the sidebar
+        // if open date is changed and assignment creation started from the sidebar,
+        // then change dates according to grading template intervals
+        if(!dueAt) {
           if (gradingTemplate) {
             t.onGradingTemplateUpdate(gradingTemplate);
           }
           this.form.setFieldValue(`tasking_plans[${index}].due_at`, t.due_at);
           this.form.setFieldValue(`tasking_plans[${index}].closes_at`, t.closes_at);
         }
+        // otherwise do not enforce grading template dates interval anymore
         else {
           this.props.ux.setDidUserChangeDatesManually(true);
         }
@@ -91,15 +95,18 @@ class Tasking extends React.Component {
       }
 
       if(!didUserChangeDatesManually) {
+        // *dueAt* means that assignment creation was started from the calendar
+        // if due date is changed and assignment creation started from the calendar,
+        // then change dates according to grading template intervals
         if(dueAt) {
           if (gradingTemplate) {
             // this will also reset the due_at to template time
             t.onGradingTemplateUpdate(gradingTemplate, t.due_at, { dateWasManuallySet: true });
           }
-
           this.form.setFieldValue(`tasking_plans[${index}].opens_at`, t.opens_at);
           this.form.setFieldValue(`tasking_plans[${index}].closes_at`, t.closes_at);
         }
+        // otherwise do not enforce grading template dates interval anymore
         else
           this.props.ux.setDidUserChangeDatesManually(true);
       }


### PR DESCRIPTION
From the docs:

Changing dates (DK, May 7, 2020)
**When clicking from the sidebar**

1. We calculate dates around the OPEN (pivot) date
2. If a user changes the OPEN date, the Due date and Close date will automatically change based on the template, UNLESS the user has changed the INTERVAL between open/due/close dates. If the user has changed the interval, we assume they are overriding the template and we honor the dates they select.
3. Even if a user has changed the INTERVAL between dates, if they change templates, the Due date and Close date are re-calculated using new template intervals, with OPEN date staying the same as the most recent user selection.

**When clicking from the calendar**

1.We calculate dates around the DUE (pivot) date
2. If a user changes the DUE date, the Open date and Close date will automatically change based on the template UNLESS the user has changed the INTERVAL between open/due/close dates. If the user has changed the interval, we assume they are overriding the template and we honor the dates they select.
3. Even if a user has changed the INTERVAL between dates, if they change templates, the Open date and Close date are re-calculated using new template intervals, with DUE date staying the same as the most recent user selection.
4. In the point above, according to the new template intervals IF the open date has already passed THEN open the assignment immediately.