### PR TITLE
update homework scores table with detailed states and icons [Needs BE]

### DIFF
--- a/shared/src/components/icon.js
+++ b/shared/src/components/icon.js
@@ -169,6 +169,10 @@ const Variants = {
     color: '#027EB5',
     type: 'exchange-alt',
   },
+  lateWork: {
+    color: '#D0021B',
+    type: 'clock',
+  },
 };
 
 

--- a/tutor/specs/helpers/scores.spec.js
+++ b/tutor/specs/helpers/scores.spec.js
@@ -11,6 +11,8 @@ describe('Scores helper', function() {
   });
 
   it('makes late penalty negative and rounds towards zero', function() {
+    expect(ScoresHelper.formatLatePenalty(null)).toEqual('0');
+    expect(ScoresHelper.formatLatePenalty(0.0)).toEqual('0');
     expect(ScoresHelper.formatLatePenalty(0.255)).toEqual('-0.25');
     expect(ScoresHelper.formatLatePenalty(0.126)).toEqual('-0.13');
     expect(ScoresHelper.formatLatePenalty(0.40)).toEqual('-0.4');

--- a/tutor/src/components/dropped-question.js
+++ b/tutor/src/components/dropped-question.js
@@ -22,15 +22,6 @@ CornerTriangle.propTypes = {
   tooltip: PropTypes.string.isRequired,
 };
 
-const StyledTriangle = styled.div`
-  height: 0;
-  width: 0;
-  position: absolute;
-  top: 0;
-  right: 0;
-  ${TriangleCSS}
-`;
-
 const TriangleCSS = css`
   border-style: solid;
   border-width: 0 1rem 1rem 0;
@@ -41,6 +32,15 @@ const TriangleCSS = css`
   ${props => props.color === 'blue' && css`
     border-color: transparent ${colors.assignments.scores.dropped} transparent transparent;
   `}
+`;
+
+const StyledTriangle = styled.div`
+  height: 0;
+  width: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+  ${TriangleCSS}
 `;
 
 export { CornerTriangle, TriangleCSS };

--- a/tutor/src/components/dropped-question.js
+++ b/tutor/src/components/dropped-question.js
@@ -3,7 +3,7 @@ import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 import { colors } from 'theme';
 
-export const CornerTriangle = ({ color, tooltip }) => {
+const CornerTriangle = ({ color, tooltip }) => {
   return (
     <OverlayTrigger
       placement="right"
@@ -21,20 +21,26 @@ CornerTriangle.propTypes = {
   color: PropTypes.string.isRequired,
   tooltip: PropTypes.string.isRequired,
 };
-  
+
 const StyledTriangle = styled.div`
-    height: 0;
-    width: 0;
-    position: absolute;
-    top: 0;
-    right: 0;
-    border-style: solid;
-    border-width: 0 1rem 1rem 0;
-    border-color: transparent #000 transparent transparent;
-    ${props => props.color === 'green' && css`
-      border-color: transparent ${colors.assignments.scores.extension} transparent transparent;
-    `}
-    ${props => props.color === 'blue' && css`
-      border-color: transparent ${colors.assignments.scores.dropped} transparent transparent;
-    `}
-  `;
+  height: 0;
+  width: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+  ${TriangleCSS}
+`;
+
+const TriangleCSS = css`
+  border-style: solid;
+  border-width: 0 1rem 1rem 0;
+  border-color: transparent #000 transparent transparent;
+  ${props => props.color === 'green' && css`
+    border-color: transparent ${colors.assignments.scores.extension} transparent transparent;
+  `}
+  ${props => props.color === 'blue' && css`
+    border-color: transparent ${colors.assignments.scores.dropped} transparent transparent;
+  `}
+`;
+
+export { CornerTriangle, TriangleCSS };

--- a/tutor/src/components/icons/extension.js
+++ b/tutor/src/components/icons/extension.js
@@ -1,5 +1,6 @@
 import { React, PropTypes, styled, moment, cn, css } from 'vendor';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { colors } from 'theme';
 
 const GreenCircle = styled.div`
   width: 1.4rem;
@@ -33,6 +34,16 @@ EIcon.propTypes = {
   inline: PropTypes.bool,
 };
 
+const StyledTooltip = styled(Tooltip)`
+  pointer-events: none;
+  max-width: 214px;
+  color: ${colors.neutral.thin};
+  // Fix absolute positioning confusing where to place tooltip
+  &.bs-tooltip-right {
+    margin-left: 2.5rem;
+  }
+`;
+
 const ExtensionIcon = ({ className, extension, timezone, inline = false }) => {
   let msg = 'Student was granted an extension.';
   const format = (dte) => moment.tz(dte, timezone).format('h:mm a z on MMM D');
@@ -43,13 +54,16 @@ const ExtensionIcon = ({ className, extension, timezone, inline = false }) => {
   return (
     <OverlayTrigger
       placement="auto"
-
-      overlay={<Tooltip id="extension-icon">{msg}</Tooltip>}
+      overlay={<StyledTooltip id="extension-icon">{msg}</StyledTooltip>}
+      popperConfig={{
+        modifiers: {
+          preventOverflow: { enabled: false },
+        },
+      }}
     >
       <ExtensionIconWrapper inline={inline}>
         <EIcon className={className} />
       </ExtensionIconWrapper>
-
     </OverlayTrigger>
   );
 };

--- a/tutor/src/helpers/scores.js
+++ b/tutor/src/helpers/scores.js
@@ -1,15 +1,19 @@
+import { isNumber } from 'lodash';
+
 const UNWORKED = '---';
+const UNGRADED = 'UG';
 const FORMATTER = new Intl.NumberFormat('en-US', {
   style: 'decimal',
   minimumFractionDigits: 1,
   maximumFractionDigits: 2,
 });
 
-export { UNWORKED };
+export { UNWORKED, UNGRADED };
 
 export default {
   // Converts to negative number so the rounding will occur towards zero
   formatLatePenalty(num) {
+    if (!isNumber(num) || num === 0) { return '0'; }
     return this.formatDecimal(Math.round(-parseFloat(num) * 100) / 100);
   },
 

--- a/tutor/src/screens/assignment-review/reading-scores.js
+++ b/tutor/src/screens/assignment-review/reading-scores.js
@@ -18,7 +18,8 @@ import {
   Heading, HeadingTop, HeadingMiddle, HeadingBottom,
   ColumnHeading as BasicColumnHeading,
   SplitCell, ColumnFooter, Total,
-  LateWork, ControlsWrapper, ControlGroup,
+  LateWork, TableBottom,
+  ControlsWrapper, ControlGroup,
   OrderIcon, NameWrapper,
 } from './table-elements';
 
@@ -105,7 +106,6 @@ const Legend = styled.div`
     padding: 8px 15px;
   }
 `;
-
 
 const popover = (gradingTemplate) => (
   <Popover className="scores-popover">
@@ -330,7 +330,7 @@ const ReadingScores = observer(({ ux }) => {
               ux={ux}
               student={student}
               striped={0 === sIndex % 2}
-              didNextStudentComplete={ux.didStudentComplete(ux.sortedStudents[sIndex + 1])} 
+              didNextStudentComplete={ux.didStudentComplete(ux.sortedStudents[sIndex + 1])}
               isNextStudentAboveFiftyPercentage={ux.isStudentAboveFiftyPercentage(ux.sortedStudents[sIndex + 1])}
               isLastRow={sIndex === ux.sortedStudents.length - 1}
             />
@@ -352,7 +352,7 @@ const ReadingScores = observer(({ ux }) => {
         <div className="extension-legend">
           <ExtIcon></ExtIcon><span>Extension granted</span>
         </div>
-        
+
       </Legend>
     </>
   );

--- a/tutor/src/screens/assignment-review/reading-scores.js
+++ b/tutor/src/screens/assignment-review/reading-scores.js
@@ -18,8 +18,7 @@ import {
   Heading, HeadingTop, HeadingMiddle, HeadingBottom,
   ColumnHeading as BasicColumnHeading,
   SplitCell, ColumnFooter, Total,
-  LateWork, TableBottom,
-  ControlsWrapper, ControlGroup,
+  LateWork, ControlsWrapper, ControlGroup,
   OrderIcon, NameWrapper,
 } from './table-elements';
 

--- a/tutor/src/screens/assignment-review/reading-scores.js
+++ b/tutor/src/screens/assignment-review/reading-scores.js
@@ -48,27 +48,17 @@ const ColumnHeading = styled(BasicColumnHeading)`
 
 const StyledCompleteInfoCell = styled(Cell)`
   ${props => !props.isComplete && css`
-  &&&& {
+    &&&& {
       background-color: ${colors.neutral.pale};
       border-top: 1px solid ${colors.neutral.std};
-
-      /* check if next student did complete assignment. Otherwise we would ended up with a 2px border */
-      ${props => (props.didNextStudentComplete || props.isLastRow) && css`
-          border-bottom: 1px solid ${colors.neutral.std};
-      `}
-  }`
-}
+    }
+  `}
 `;
 
 const StyledTotal = styled(Total)`
    ${props => !props.isAboveFiftyPercentage && css`
     background-color: ${colors.states.trouble};
     border-top: 1px solid ${colors.danger};
-
-      /* check if next student has above 50%. Otherwise we would ended up with a 2px border */
-      ${props => (props.isNextStudentAboveFiftyPercentage || props.isLastRow) && css`
-          border-bottom: 1px solid ${colors.danger};
-      `}
   `}
 `;
 
@@ -202,7 +192,7 @@ const StudentColumnHeader = observer(({ ux }) => (
   </Cell>
 ));
 
-const StudentCell = observer(({ ux, student, striped, didNextStudentComplete, isNextStudentAboveFiftyPercentage, isLastRow }) => {
+const StudentCell = observer(({ ux, student, striped }) => {
   const countData = ux.getReadingCountData(student);
   return (
     <>
@@ -223,8 +213,6 @@ const StudentCell = observer(({ ux, student, striped, didNextStudentComplete, is
 
           <StyledTotal
             isAboveFiftyPercentage={ux.isStudentAboveFiftyPercentage(student)}
-            isNextStudentAboveFiftyPercentage={isNextStudentAboveFiftyPercentage}
-            isLastRow={isLastRow}
           >
             {ux.displayTotalInPercent ?
               `${ScoresHelper.asPercent(student.total_fraction || 0)}%` :
@@ -239,8 +227,6 @@ const StudentCell = observer(({ ux, student, striped, didNextStudentComplete, is
       <StyledCompleteInfoCell
         striped={striped}
         isComplete={ux.didStudentComplete(student)}
-        didNextStudentComplete={didNextStudentComplete}
-        isLastRow={isLastRow}
       >
         <CellContents>
           {countData.complete} of {countData.total}
@@ -330,9 +316,6 @@ const ReadingScores = observer(({ ux }) => {
               ux={ux}
               student={student}
               striped={0 === sIndex % 2}
-              didNextStudentComplete={ux.didStudentComplete(ux.sortedStudents[sIndex + 1])}
-              isNextStudentAboveFiftyPercentage={ux.isStudentAboveFiftyPercentage(ux.sortedStudents[sIndex + 1])}
-              isLastRow={sIndex === ux.sortedStudents.length - 1}
             />
           </Row>))}
         <Row>

--- a/tutor/src/screens/assignment-review/result-tooltip.js
+++ b/tutor/src/screens/assignment-review/result-tooltip.js
@@ -1,0 +1,82 @@
+import { React, PropTypes, observer, styled } from 'vendor';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
+import { colors } from 'theme';
+
+const StyledPopover = styled(Popover)`
+  pointer-events: none;
+
+  &.bs-popover-bottom {
+    margin-top: -0.75rem;
+  }
+`;
+
+const PopoverContent = styled(Popover.Content)`
+  && {
+    font-size: 1.4rem;
+    width: 15rem;
+    color: ${colors.neutral.thin};
+  }
+
+  > div {
+    display: flex;
+    justify-content: space-between;
+
+    &:first-child {
+      font-weight: bold;
+    }
+  }
+
+  div + div {
+    text-align: right;
+  }
+`;
+
+const BodyContent = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 3.9rem;
+  width: 100%;
+`;
+
+const ResultsTooltip = observer(({ result, children }) => (
+  <OverlayTrigger
+    trigger="hover"
+    placement="bottom"
+    popperConfig={{
+      modifiers: {
+        preventOverflow: { enabled: false },
+      },
+    }}
+    overlay={
+      <StyledPopover>
+        <PopoverContent>
+          <div>
+            <div>Points earned:</div>
+            <div>{result.displayValue}</div>
+          </div>
+          <div>
+            <div>Late penalty:</div>
+            <div>{result.latePenalty}</div>
+          </div>
+          <div>
+            <div>Final points:</div>
+            <div>{result.finalPoints}</div>
+          </div>
+        </PopoverContent>
+      </StyledPopover>
+    }
+  >
+    <BodyContent>{children}</BodyContent>
+  </OverlayTrigger>
+));
+
+ResultsTooltip.propTypes = {
+  result: PropTypes.shape({
+    displayValue: PropTypes.string,
+    latePenalty: PropTypes.string,
+    finalPoints: PropTypes.string,
+  }),
+};
+
+export default ResultsTooltip;

--- a/tutor/src/screens/assignment-review/table-elements.js
+++ b/tutor/src/screens/assignment-review/table-elements.js
@@ -6,16 +6,33 @@ import { colors } from 'theme';
 const StyledStickyTable = styled(StickyTable)`
   margin: 2.2rem 0 1.4rem;
 
-  .sticky-table-row:last-child .sticky-table-cell {
-    border-bottom: 1px solid ${colors.neutral.pale};
-  }
+  && {
+    border-collapse: collapse;
 
-  .sticky-table-cell {
-    vertical-align: middle;
+    .sticky-table-row {
+      .sticky-table-cell {
+        vertical-align: middle;
+        font-size: 1.6rem;
+        border-bottom: 0;
+        /* Fix a Firefox bug that prevents borders from rendering when
+           using sticky position with border-collapse. */
+        background-clip: padding-box;
+      }
+
+      &:first-child .sticky-table-cell {
+        border-bottom: 2px solid ${colors.neutral.pale};
+      }
+
+      &:last-child .sticky-table-cell {
+        border-bottom: 1px solid ${colors.neutral.pale};
+        border-top: 2px solid ${colors.neutral.pale};
+      }
+    }
   }
 `;
 
 const Cell = styled(TableCell)`
+  position: relative;
   padding: 0;
   border-width: 1px;
   border-color: transparent;
@@ -27,8 +44,20 @@ const Cell = styled(TableCell)`
   ${props => props.striped && css`
     background: ${colors.neutral.lighter};
   `}
-  && {
+  /* Order and specificity here is important */
+  &&&.sticky-table-cell {
+    ${props => props.isUnattemptedAutoZero && isUnattemptedAutoZeroCSS}
     ${props => props.isTrouble && isTroubleCSS}
+    ${props => props.border === false && 'border-bottom: 0;'}
+  }
+
+  .ox-icon-clock {
+    position: absolute;
+    top: 3px;
+    right: 3px;
+    margin: 0;
+    width: 0.8rem;
+    height: 0.8rem;
   }
   && {
     ${props => props.borderTop && css`
@@ -90,11 +119,13 @@ const HeadingBottom = styled.div`
   color: ${colors.neutral.thin};
   background: #fff;
   position: relative;
+  min-height: 3.8rem;
 `;
 
 const ColumnHeading = styled.div`
   border-top: 0.4rem solid ${props => props.variant === 'q' ? colors.templates.homework.border : colors.neutral.std};
   cursor: ${props => props.onClick || props.clickable ? 'pointer' : 'inherit'};
+  font-size: 1.4rem;
   &:not(:last-child) {
     border-right: 1px solid ${colors.neutral.pale};
   }
@@ -111,8 +142,6 @@ const ColumnFooter = styled.div`
     border-right: 1px solid ${colors.neutral.pale};
   }
   > * {
-    /* TODO change to 1.6rem across the board */
-    font-size: 1.4rem;
     ${props => !props.first && css`
       ${centeredCSS}
     `}
@@ -149,37 +178,81 @@ const Total = styled.div`
 
 const isTroubleCSS = css`
   background-color: ${colors.states.trouble};
-  border-top: 1px solid ${colors.danger};
+  border-top: 1px solid ${colors.danger} !important;
   border-bottom: 1px solid ${colors.danger} !important;
 `;
 
-const DefinitionsWrapper = styled.dl`
-  margin: 1.4rem 0;
+const isUnattemptedAutoZeroCSS = css`
+  background-color: ${colors.neutral.light};
+  border-top: 1px solid ${colors.neutral.std};
+  border-bottom: 1px solid ${colors.neutral.std};
+`;
+
+const TableBottom = styled.div`
+  margin: 2.4rem 0;
+  max-width: 788px;
+  color: ${colors.neutral.thin};
+  line-height: 2rem;
+`;
+
+const Definitions = styled.dl`
   display: flex;
   align-items: center;
-  dd + dt {
-    margin-left: 4.8rem;
+  flex-wrap: wrap;
+
+  > * {
+    display: flex;
+    align-items: center;
+    margin-right: 2.4rem;
+    margin-bottom: 0.8rem;
+
+    > :first-child {
+      width: 3rem;
+    }
   }
 `;
 
+const Entry = styled.div`
+  ${props => props.wide && 'width: 344px'}
+`;
+
 const Term = styled.dt`
-  border-color: ${colors.neutral.light};
-  border-style: solid;
-  ${props => props.variant === 'trouble' && isTroubleCSS}
-  ${props => props.variant === 'trouble' && `border-color: ${colors.danger}`};
-  border-width: 1px;
-  display: flex;
-  justify-content: center;
-  width: 5.6rem;
-  height: 2.8rem;
-  margin-right: 1.1rem;
+  ${props => props.variant !== 'icon' && css`
+    border-color: ${colors.neutral.light};
+    border-style: solid;
+  `}
+  ${props => props.variant === 'trouble' && css`
+    ${isTroubleCSS}
+    border-color: ${colors.danger};
+  `}
+  ${props => props.variant === 'unattempted' && css`
+    ${isUnattemptedAutoZeroCSS}
+    border-color: ${colors.neutral.std};
+  `}
+  ${props => props.variant !== 'icon' && css`
+    border-width: 1px;
+    display: flex;
+    justify-content: center;
+  `}
+  width: 3rem;
+  height: 1.8rem;
   font-size: 1.4rem;
-  line-height: 2.4rem;
+  line-height: 1.4rem;
+  ${props => props.variant === 'icon' && css`
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    > * {
+      max-width: 1.8rem;
+    }
+    .ox-icon {
+      margin: 0;
+    }
+  `}
 `;
 
 const Definition = styled.dd`
-  margin: 0;
-  color: ${colors.neutral.thin};
+  margin: 0 0 0 0.8rem;
 `;
 
 const ControlsWrapper = styled.div`
@@ -235,7 +308,7 @@ export {
   Heading, HeadingTop, HeadingMiddle, HeadingBottom,
   ColumnHeading, ColumnFooter,
   SplitCell, LateWork, Total, isTroubleCSS,
-  DefinitionsWrapper, Term, Definition,
+  TableBottom, Definitions, Entry, Term, Definition,
   ControlsWrapper, ControlGroup,
   OrderIcon, NameWrapper,
 };

--- a/tutor/src/screens/assignment-review/ux.js
+++ b/tutor/src/screens/assignment-review/ux.js
@@ -67,7 +67,7 @@ export default class AssignmentReviewUX {
 
   @computed get isExercisesReady() { return this.exercisesHaveBeenFetched; }
   @computed get planId() { return this.planScores.id; }
-  
+
   @computed get isScoresReady() {
     return Boolean(this.selectedPeriod);
   }
@@ -429,7 +429,7 @@ export default class AssignmentReviewUX {
       return false;
     }
     const data = this.getReadingCountData(student);
-    return data.complete === data.total; 
+    return data.complete === data.total;
   }
 
   isStudentAboveFiftyPercentage(student) {


### PR DESCRIPTION
- Adds datetime information to the extension tooltip
- Adds "UG" to mean Ungraded, "---" now only refers to not yet unattempted
- Adds red clock icon for responses that were submitted late
- Adds gray cell background for unattempted questions that were auto-assigned 0
- Updates table legend to include the above changes
- Show available points when there are different numbers of Tutor-assigned questions
- Improves table visuals by using border-collapse and cleaning up inconsistencies

![image](https://user-images.githubusercontent.com/34174/88858818-7161be80-d1ad-11ea-8d70-e73bd44c9672.png)

