### PR TITLE
support either - or . as LO separator

### DIFF
--- a/exercises/src/components/tags/aplo.js
+++ b/exercises/src/components/tags/aplo.js
@@ -15,12 +15,12 @@ import BookSelection from './book-selection';
 
 const BOOKS = {
   'stax-apbio': {
-    r: /^[A-Z]{3}(-|.)\d(-|\.)[A-Z]$/,
+    r: /^[A-Z]{3}[-.]\d[-.][A-Z]$/,
     pattern: '[A-Z]{3}-#.[A-Z]',
     disallowed: /[^0-9A-Z.-]/g,
   },
   'stax-apphys': {
-    r: /^\d(-|\.)[A-Z](-|\.)\d(-|\.)\d$/,
+    r: /^\d[-.][A-Z][-.]\d[-.]\d$/,
     pattern: '#.[A-Z].#.#',
     disallowed: /[^0-9A-Z.-]/g,
   },

--- a/exercises/src/components/tags/aplo.js
+++ b/exercises/src/components/tags/aplo.js
@@ -15,14 +15,14 @@ import BookSelection from './book-selection';
 
 const BOOKS = {
   'stax-apbio': {
-    r: /^[A-Z]{3}-\d.[A-Z]$/,
+    r: /^[A-Z]{3}(-|.)\d(-|\.)[A-Z]$/,
     pattern: '[A-Z]{3}-#.[A-Z]',
     disallowed: /[^0-9A-Z.-]/g,
   },
   'stax-apphys': {
-    r: /^\d\.[A-Z]\.\d\.\d$/,
+    r: /^\d(-|\.)[A-Z](-|\.)\d(-|\.)\d$/,
     pattern: '#.[A-Z].#.#',
-    disallowed: /[^0-9A-Z.]/g,
+    disallowed: /[^0-9A-Z.-]/g,
   },
 };
 

--- a/exercises/src/components/tags/lo.jsx
+++ b/exercises/src/components/tags/lo.jsx
@@ -31,7 +31,7 @@ class Input extends React.Component {
   }
 
   @action.bound onTextChange(ev) {
-    this.value = ev.target.value.replace(/[^0-9\-]/g, '');
+    this.value = ev.target.value.replace(/[^0-9.-]/g, '');
     this.errorMsg = null;
   }
 
@@ -40,7 +40,7 @@ class Input extends React.Component {
     const { tag } = this.props;
     const { lo, book } = defaults(attrs, { book: this.book, lo: this.lo });
 
-    if (!book || (lo != null && !lo.match( /^\d{1,2}-\d{1,2}-\d{1,2}$/ ))) {
+    if (!book || (lo != null && !lo.match( /^\d{1,2}(-|\.)\d{1,2}(-|\.)\d{1,2}$/ ))) {
       this.errorMsg = 'Must have book and match LO pattern of dd-dd-dd';
     } else {
       tag.value = lo;


### PR DESCRIPTION
Fixes https://github.com/openstax/tutor-js/pull/3176 which got rebased out somehow

![](https://user-images.githubusercontent.com/79566/87895299-ae3df080-ca0a-11ea-9449-7638dd30845c.png)
