### PR TITLE
use lower precision for Pre-WRM scores

### DIFF
--- a/tutor/src/models/scores/task-result.js
+++ b/tutor/src/models/scores/task-result.js
@@ -7,6 +7,7 @@ import Big from 'big.js';
 import moment from 'moment';
 import Time from '../time';
 import ScoresHelper, { UNWORKED } from '../../helpers/scores';
+import S from '../../helpers/string';
 
 export default
 @identifiedBy('scores/task-result')
@@ -200,8 +201,9 @@ class TaskResult extends BaseModel {
     return `${this.completedPercent}%`;
   }
 
-  @computed get humanScoreNumber() {
-    return `${isNil(this.published_points) ? '0' : ScoresHelper.formatPoints(this.published_points)} of ${ScoresHelper.formatPoints(this.available_points)}`;
+  @computed get preWrmHumanScoreNumber() {
+    // Pre-WRM scores don't get higher precision
+    return `${isNil(this.published_points) ? '0' : S.numberWithOneDecimalPlace(this.published_points)} of ${S.numberWithOneDecimalPlace(this.available_points)}`;
   }
 
   @computed get isDue() {

--- a/tutor/src/screens/pre-wrm-scores-report/correctness-value.jsx
+++ b/tutor/src/screens/pre-wrm-scores-report/correctness-value.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { isNil } from 'lodash';
 import { observer } from 'mobx-react';
-import ScoresHelper from '../../helpers/scores';
+import S from '../../helpers/string';
 import TaskResult from '../../models/scores/task-result';
 import TutorLink from '../../components/link';
 import UX from './ux';
@@ -29,12 +29,13 @@ ReviewLink.propTypes = {
 };
 
 const Progress = observer(({ task }) => {
-  const progress = isNil(task.correct_exercise_count) ? '---' : task.humanScoreNumber;
+  const progress = isNil(task.correct_exercise_count) ? '---' : task.preWrmHumanScoreNumber;
   return <div className="correct-progress">{progress}</div>;
 });
 
 const Percent = observer(({ task: { published_score } }) => {
-  const display = isNil(published_score) ? '---' : `${ScoresHelper.asPercent(published_score)}%`;
+  // Pre-WRM scores don't get higher precision
+  const display = isNil(published_score) ? '---' : `${S.asPercent(published_score)}%`;
   return <div className="correct-score">{display}</div>;
 });
 


### PR DESCRIPTION
Reverting this change (for Pre-WRM scores only) keeps old course scores the same.