### PR TITLE
Responsive student scores

### DIFF
--- a/tutor/specs/components/responsive.spec.js
+++ b/tutor/specs/components/responsive.spec.js
@@ -3,15 +3,15 @@ import Responsive from '../../src/components/responsive'
 
 jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 
-const Mobile = () => <p>MOBILE</p> 
-const Tablet = () => <p>TABLET</p> 
+const Mobile = () => <p>MOBILE</p>
+const Tablet = () => <p>TABLET</p>
 const Desktop = () => <p>DESKTOP</p>
 
 
 describe('Responsive Rendering', () => {
   let props;
   jest.useFakeTimers();
-  
+
   beforeEach(() => {
     props = {
       windowImpl: new FakeWindow(),
@@ -23,7 +23,7 @@ describe('Responsive Rendering', () => {
 
   it('switches view depending on window width', () => {
     const { windowImpl } = props;
-    windowImpl.resizeTo({ width: 1024 })
+    windowImpl.resizeTo({ width: 1200 })
     const c = mount(<Responsive {...props} />)
     expect(c).toHaveRendered(Desktop)
     windowImpl.resizeTo({ width: 780 })
@@ -31,7 +31,7 @@ describe('Responsive Rendering', () => {
 
     expect(c).toHaveRendered(Tablet)
 
-    windowImpl.resizeTo({ width: 650 })
+    windowImpl.resizeTo({ width: 550 })
     expect(c).toHaveRendered(Mobile)
   })
 
@@ -49,7 +49,7 @@ describe('Responsive Rendering', () => {
     }
     const c = mount(<Responsive {...props} />)
     expect(c).toHaveRendered(Tablet)
-    props.windowImpl.resizeTo({ width: 1000 })
+    props.windowImpl.resizeTo({ width: 1200 })
     expect(c).toHaveRendered(Desktop)
   })
 

--- a/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
+++ b/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
@@ -212,19 +212,19 @@ exports[`Student Dashboard displays as loading 1`] = `
   margin-top: 25px;
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c2 {
     min-width: 100%;
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c3 {
     padding-left: 1.2rem;
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c4 {
     -webkit-flex: 1;
     -ms-flex: 1;
@@ -232,7 +232,7 @@ exports[`Student Dashboard displays as loading 1`] = `
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c5 {
     -webkit-flex: 1;
     -ms-flex: 1;
@@ -240,7 +240,7 @@ exports[`Student Dashboard displays as loading 1`] = `
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c11.c11.c11 {
     height: -webkit-fit-content;
     height: -moz-fit-content;
@@ -258,7 +258,7 @@ exports[`Student Dashboard displays as loading 1`] = `
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c7 span:last-child {
     margin-left: 0;
     margin-top: 5px;
@@ -1076,19 +1076,19 @@ exports[`Student Dashboard matches snapshot 1`] = `
   margin-top: 25px;
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c2 {
     min-width: 100%;
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c3 {
     padding-left: 1.2rem;
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c4 {
     -webkit-flex: 1;
     -ms-flex: 1;
@@ -1096,7 +1096,7 @@ exports[`Student Dashboard matches snapshot 1`] = `
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c5 {
     -webkit-flex: 1;
     -ms-flex: 1;
@@ -1104,7 +1104,7 @@ exports[`Student Dashboard matches snapshot 1`] = `
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c11.c11.c11 {
     height: -webkit-fit-content;
     height: -moz-fit-content;
@@ -1122,7 +1122,7 @@ exports[`Student Dashboard matches snapshot 1`] = `
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c7 span:last-child {
     margin-left: 0;
     margin-top: 5px;

--- a/tutor/specs/screens/student-dashboard/__snapshots__/event-row.spec.jsx.snap
+++ b/tutor/specs/screens/student-dashboard/__snapshots__/event-row.spec.jsx.snap
@@ -132,19 +132,19 @@ exports[`Event Row renders and matches snapshot 1`] = `
   background: #929292;
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c1 {
     min-width: 100%;
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c3 {
     padding-left: 1.2rem;
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c4 {
     -webkit-flex: 1;
     -ms-flex: 1;
@@ -152,7 +152,7 @@ exports[`Event Row renders and matches snapshot 1`] = `
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c6 {
     -webkit-flex: 1;
     -ms-flex: 1;
@@ -160,7 +160,7 @@ exports[`Event Row renders and matches snapshot 1`] = `
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c0.c0.c0 {
     height: -webkit-fit-content;
     height: -moz-fit-content;

--- a/tutor/specs/screens/student-dashboard/__snapshots__/homework-row.spec.jsx.snap
+++ b/tutor/specs/screens/student-dashboard/__snapshots__/homework-row.spec.jsx.snap
@@ -132,19 +132,19 @@ exports[`Homework Row renders in progress 1`] = `
   background: #929292;
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c1 {
     min-width: 100%;
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c3 {
     padding-left: 1.2rem;
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c4 {
     -webkit-flex: 1;
     -ms-flex: 1;
@@ -152,7 +152,7 @@ exports[`Homework Row renders in progress 1`] = `
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c6 {
     -webkit-flex: 1;
     -ms-flex: 1;
@@ -160,7 +160,7 @@ exports[`Homework Row renders in progress 1`] = `
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c0.c0.c0 {
     height: -webkit-fit-content;
     height: -moz-fit-content;
@@ -410,19 +410,19 @@ exports[`Homework Row renders with completed count 1`] = `
   background: #929292;
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c1 {
     min-width: 100%;
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c3 {
     padding-left: 1.2rem;
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c4 {
     -webkit-flex: 1;
     -ms-flex: 1;
@@ -430,7 +430,7 @@ exports[`Homework Row renders with completed count 1`] = `
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c6 {
     -webkit-flex: 1;
     -ms-flex: 1;
@@ -438,7 +438,7 @@ exports[`Homework Row renders with completed count 1`] = `
   }
 }
 
-@media (max-width:749px) {
+@media (max-width:600px) {
   .c0.c0.c0 {
     height: -webkit-fit-content;
     height: -moz-fit-content;

--- a/tutor/src/components/responsive.js
+++ b/tutor/src/components/responsive.js
@@ -3,8 +3,8 @@ import { defaults } from 'lodash';
 import WindowSize from '../models/window-size';
 
 const DEFAULT_BREAKPOINTS = {
-  tablet: 768,
-  desktop: 992,
+  tablet: 600,
+  desktop: 1199,
 };
 
 
@@ -36,7 +36,7 @@ class Responsive extends React.Component {
     }
     return mobile;
   }
-  
+
 }
 
 export default Responsive;

--- a/tutor/src/screens/student-gradebook/index.js
+++ b/tutor/src/screens/student-gradebook/index.js
@@ -4,7 +4,7 @@ import TourRegion from '../../components/tours/region';
 import TutorLink from '../../components/link';
 import LoadingScreen from 'shared/components/loading-animation';
 import { Icon } from 'shared';
-import { colors } from 'theme';
+import { colors, breakpoint } from 'theme';
 import UX from './ux';
 
 const StudentGradebookHeader = styled.div`
@@ -29,7 +29,15 @@ const StudentGradebookHeader = styled.div`
 `;
 
 const StyledTourRegion = styled(TourRegion)`
-  margin: 40px 10rem;
+  ${breakpoint.desktop`
+    margin: 40px 10rem;
+  `}
+  ${breakpoint.tablet`
+    margin: ${breakpoint.margins.tablet};
+  `}
+  ${breakpoint.mobile`
+    margin: ${breakpoint.margins.mobile};
+  `}
 `;
 
 @observer

--- a/tutor/src/screens/student-gradebook/index.js
+++ b/tutor/src/screens/student-gradebook/index.js
@@ -15,16 +15,29 @@ const StudentGradebookHeader = styled.div`
   background-color: ${colors.white};
   border-bottom: 1px solid ${colors.neutral.pale};
   padding: 25px 32px 16px;
+  ${breakpoint.tablet`
+    padding: 16px ${breakpoint.margins.tablet};
+  `}
+  ${breakpoint.mobile`
+    padding: 16px ${breakpoint.margins.mobile};
+  `}
 
   a {
     width: 100%;
     color: ${colors.link};
+    .ox-icon { margin-left: 0; }
   }
   .title {
     font-weight: bold;
     font-size: 3.6rem;
-    line-height: 4.5rem;
+    line-height: 4rem;
+    letter-spacing: -0.144rem;
     margin: 10px 0 0 0;
+    ${breakpoint.mobile`
+      font-size: 1.8rem;
+      line-height: 3rem;
+      letter-spacing: -0.072rem;
+    `}
   }
 `;
 

--- a/tutor/src/screens/student-gradebook/table.js
+++ b/tutor/src/screens/student-gradebook/table.js
@@ -123,6 +123,9 @@ const StyledTable = styled(Table)`
     th, td {
       vertical-align: middle;
       word-break: break-all;
+      ${breakpoint.desktop`
+        word-break: normal;
+      `}
     }
     td:first-child {
       padding-left: 10px;

--- a/tutor/src/screens/student-gradebook/table.js
+++ b/tutor/src/screens/student-gradebook/table.js
@@ -40,6 +40,10 @@ const Header = styled.div`
     margin-top: 8px;
   }
 
+  h3 {
+    letter-spacing: -0.096rem;
+  }
+
   ${breakpoint.desktop`
     padding: 0;
 
@@ -189,6 +193,27 @@ const hasExtension = (studentTaskPlans, studentTaskPlanId) => {
   return studentTaskPlan ? studentTaskPlan.is_extended : false;
 };
 
+const DueInfo = ({ sd, course }) => (
+  <div className="icon-wrapper">
+    {moment(sd.due_at).format('MMM D')}
+    {hasExtension(course.studentTaskPlans, sd.id) && <EIcon inline />}
+  </div>
+);
+
+const PointsInfo = ({ sd }) => (
+  <div className="icon-wrapper">
+    {sd.humanPoints}
+    {sd.isLate && <Icon color={colors.danger} type="clock" />}
+  </div>
+);
+
+const PercentageInfo = ({ sd  }) => (
+  <div className="icon-wrapper">
+    <strong>{sd.humanScore}</strong>
+    {sd.is_provisional_score && <Icon variant="circledStar" />}
+  </div>
+);
+
 const MobileStudentDataRow = ({ sd, history, ux: { course, goToAssignment } }) => (
   <tr>
     <td
@@ -199,24 +224,15 @@ const MobileStudentDataRow = ({ sd, history, ux: { course, goToAssignment } }) =
       </div>
       <InfoItem>
         <div>Due date</div>
-        <div className="icon-wrapper">
-          {moment(sd.due_at).format('MMM D')}
-          {hasExtension(course.studentTaskPlans, sd.id) && <EIcon inline />}
-        </div>
+        <DueInfo sd={sd} course={course} />
       </InfoItem>
       <InfoItem>
         <div>Points scored</div>
-        <div className="icon-wrapper">
-          {sd.humanPoints}
-          {sd.isLate && <Icon color={colors.danger} type="clock" />}
-        </div>
+        <PointsInfo sd={sd} />
       </InfoItem>
       <InfoItem>
         <div>Percentage</div>
-        <div className="icon-wrapper">
-          <strong>{sd.humanScore}</strong>
-          {sd.is_provisional_score && <Icon variant="circledStar" />}
-        </div>
+        <PercentageInfo sd={sd} />
       </InfoItem>
     </td>
   </tr>
@@ -235,22 +251,13 @@ const DesktopStudentDataRow = ({ sd, history, ux: { course, goToAssignment } }) 
       {sd.reportHeading.title}
     </td>
     <td>
-      <div className="icon-wrapper">
-        {moment(sd.due_at).format('MMM D')}
-        {hasExtension(course.studentTaskPlans, sd.id) && <EIcon inline />}
-      </div>
+      <DueInfo sd={sd} course={course} />
     </td>
     <td>
-      <div className="icon-wrapper">
-        {sd.humanPoints}
-        {sd.isLate && <Icon color={colors.danger} type="clock" />}
-      </div>
+      <PointsInfo sd={sd} />
     </td>
     <td>
-      <div className="icon-wrapper">
-        {sd.humanScore}
-        {sd.is_provisional_score && <Icon variant="circledStar" />}
-      </div>
+      <PercentageInfo sd={sd} />
     </td>
   </tr>
 );

--- a/tutor/src/screens/student-gradebook/table.js
+++ b/tutor/src/screens/student-gradebook/table.js
@@ -221,6 +221,11 @@ const MobileStudentDataRow = ({ sd, history, ux: { course, goToAssignment } }) =
     </td>
   </tr>
 );
+MobileStudentDataRow.propTypes = {
+  sd: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
+  ux: PropTypes.object.isRequired,
+};
 
 const DesktopStudentDataRow = ({ sd, history, ux: { course, goToAssignment } }) => (
   <tr>
@@ -249,6 +254,11 @@ const DesktopStudentDataRow = ({ sd, history, ux: { course, goToAssignment } }) 
     </td>
   </tr>
 );
+DesktopStudentDataRow.propTypes = {
+  sd: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
+  ux: PropTypes.object.isRequired,
+};
 
 const GradebookTable = observer((
   {

--- a/tutor/src/screens/student-gradebook/table.js
+++ b/tutor/src/screens/student-gradebook/table.js
@@ -16,11 +16,8 @@ const TableWrapper = styled.div`
     padding: 40px 10rem;
   `}
 
-  :first-child {
-    .info-circle-icon-button {
+  .info-circle-icon-button {
     color: ${colors.link};
-    margin-bottom: -2px;
-    width: 1.5rem;
     margin-left: 10px;
   }
 
@@ -42,6 +39,8 @@ const Header = styled.div`
 
   h3 {
     letter-spacing: -0.096rem;
+    display: flex;
+    align-items: center;
   }
 
   ${breakpoint.desktop`
@@ -187,6 +186,10 @@ const InfoItem = styled.div`
   }
 `;
 
+const StyledPopover = styled(Popover)`
+  pointer-events: none;
+`;
+
 const percentOrDash = (score) => isNil(score) ? UNWORKED : `${ScoresHelper.asPercent(score)}%`;
 const hasExtension = (studentTaskPlans, studentTaskPlanId) => {
   const studentTaskPlan = studentTaskPlans.array.find(s => parseInt(s.id, 10) === studentTaskPlanId);
@@ -276,17 +279,21 @@ const GradebookTable = observer((
     <TableWrapper>
       <Header>
         <h3>
-          <strong>Course Average:</strong> {percentOrDash(student.course_average)}
+          <span>
+            <strong>Course Average:</strong> {percentOrDash(student.course_average)}
+          </span>
           <OverlayTrigger
             placement="right"
+            trigger={['hover', 'click']}
+            rootClose
             delay={{ show: 150, hide: 300 }}
             overlay={
-              <Popover className="scores-popover">
+              <StyledPopover className="scores-popover">
                 <p>
                   <strong>Course Average = </strong><br/>
                   {ScoresHelper.asPercent(course.homework_weight)}% Homework average + {ScoresHelper.asPercent(course.reading_weight)}% Reading average
                 </p>
-              </Popover>
+              </StyledPopover>
             }
           >
             <Icon

--- a/tutor/src/screens/student-gradebook/table.js
+++ b/tutor/src/screens/student-gradebook/table.js
@@ -205,6 +205,10 @@ const DueInfo = ({ sd, course }) => (
     {hasExtension(course.studentTaskPlans, sd.id) && <EIcon inline />}
   </div>
 );
+DueInfo.propTypes = {
+  sd: PropTypes.object.isRequired,
+  course: PropTypes.object.isRequired,
+};
 
 const PointsInfo = ({ sd }) => (
   <div className="icon-wrapper">
@@ -212,13 +216,19 @@ const PointsInfo = ({ sd }) => (
     {sd.isLate && <Icon color={colors.danger} type="clock" />}
   </div>
 );
+PointsInfo.propTypes = {
+  sd: PropTypes.object.isRequired,
+};
 
-const PercentageInfo = ({ sd  }) => (
+const PercentageInfo = ({ sd }) => (
   <div className="icon-wrapper">
     <strong>{sd.humanScore}</strong>
     {sd.is_provisional_score && <Icon variant="circledStar" />}
   </div>
 );
+PercentageInfo.propTypes = {
+  sd: PropTypes.object.isRequired,
+};
 
 const MobileStudentDataRow = ({ sd, history, ux: { course, goToAssignment } }) => (
   <tr>

--- a/tutor/src/theme.js
+++ b/tutor/src/theme.js
@@ -168,7 +168,7 @@ export const navbars = {
   },
 };
 
-const breakpoint = {
+export const breakpoint = {
   mobile(...args) {
     return css`@media(max-width: 749px) { ${css(...args)} }`;
   },
@@ -176,7 +176,7 @@ const breakpoint = {
     return css`@media(max-width: 1199px) { ${css(...args)} }`;
   },
   desktop(...args) {
-    return css`@media(max-width: 1599px) { ${css(...args)} }`;
+    return css`@media(min-width: 1200px) { ${css(...args)} }`;
   },
   large(...args) {
     return css`@media(min-width: 1600px) { ${css(...args)} }`;
@@ -194,6 +194,10 @@ const breakpoint = {
     large(...args) {
       return css`@media(min-width: 1600px) { ${css(...args)} }`;
     },
+  },
+  margins: {
+    mobile: '8px',
+    tablet: '24px',
   },
 };
 

--- a/tutor/src/theme.js
+++ b/tutor/src/theme.js
@@ -170,7 +170,7 @@ export const navbars = {
 
 export const breakpoint = {
   mobile(...args) {
-    return css`@media(max-width: 749px) { ${css(...args)} }`;
+    return css`@media(max-width: 600px) { ${css(...args)} }`;
   },
   tablet(...args) {
     return css`@media(max-width: 1199px) { ${css(...args)} }`;


### PR DESCRIPTION
- Updated the breakpoints to match the doc
- Changed the query for `desktop` to check `min-width` so styles applied to desktop will also apply to anything larger.
- Make the student scores responsive. Tried to keep duplication to a minimum, but did need to break out the responsive component for the different cell presentation, and it was a cinch to use, well done @nathanstitt!

Mobile | Tablet | Desktop
------- | ------- | -------
![image](https://user-images.githubusercontent.com/34174/89236413-57f1b580-d5a5-11ea-93a6-63f9a6b9248b.png) | ![image](https://user-images.githubusercontent.com/34174/89236430-65a73b00-d5a5-11ea-920f-3bc3442f6887.png) | ![image](https://user-images.githubusercontent.com/34174/89236450-6fc93980-d5a5-11ea-8cda-7f532b4fae7d.png)


