### PR TITLE
Don't lock instructor to student course

### DIFF
--- a/tutor/specs/components/my-courses.spec.jsx
+++ b/tutor/specs/components/my-courses.spec.jsx
@@ -109,7 +109,10 @@ describe('My Courses Component', function() {
     const c = Courses.get(STUDENT_COURSE_ONE_MODEL.id);
     c.ends_at = moment().add(1, 'week');
     c.starts_at = moment().subtract(1, 'week');
+    User.can_create_courses = true;
     const wrapper = mount(<C><CourseListing /></C>);
+    expect(wrapper).not.toHaveRendered('Redirect');
+    User.can_create_courses = false;
     expect(wrapper).toHaveRendered('Redirect[to="/course/1"]');
   });
 

--- a/tutor/src/components/my-courses/index.jsx
+++ b/tutor/src/components/my-courses/index.jsx
@@ -28,7 +28,7 @@ class MyCourses extends React.Component {
       return false;
     }
     return (
-      this.firstCourse.currentRole.isStudent && this.firstCourse.isActive
+      !User.canCreateCourses && this.firstCourse.currentRole.isStudent && this.firstCourse.isActive
     );
   }
 

--- a/tutor/src/models/user/menu.js
+++ b/tutor/src/models/user/menu.js
@@ -77,11 +77,7 @@ const ROUTES = {
   },
   createNewCourse: {
     label: 'Create a Course',
-    isAllowed(course) {
-      return Boolean(
-        User.canCreateCourses && (!course || !course.currentRole.isTeacherStudent)
-      );
-    },
+    isAllowed() { return User.canCreateCourses; },
     options({ course }) {
       return course ? { separator: 'before' } : { separator: 'both' };
     },


### PR DESCRIPTION
If a verified instructor is ONLY a student in a single course,
they were automatically redirected to it and skip the "my courses" listing.

Then in the course the "create a course" menu option was hidden
because they're a student in that course.