### PR TITLE
fix hour scroll not working in firefox

### DIFF
--- a/tutor/resources/styles/components/date-time-input.scss
+++ b/tutor/resources/styles/components/date-time-input.scss
@@ -885,6 +885,7 @@ tr > .oxdt-cell-in-view {
   &:first-child {
     display: flex;
     flex-direction: column-reverse;
+    justify-content: flex-start;
 
     // somehow the default order is 12, 1, 2, ... so keep the first item as order 1
     li:first-child {


### PR DESCRIPTION
Fixes the hour column not scrolling in Firefox.