### PR TITLE
fix hour scroll not working in firefox

### DIFF
--- a/tutor/resources/styles/components/date-time-input.scss
+++ b/tutor/resources/styles/components/date-time-input.scss
@@ -886,6 +886,10 @@ tr > .oxdt-cell-in-view {
     display: flex;
     flex-direction: column-reverse;
 
+    @supports (-moz-appearance:none) {
+      justify-content: flex-end;
+    }
+
     // somehow the default order is 12, 1, 2, ... so keep the first item as order 1
     li:first-child {
       order: 1;


### PR DESCRIPTION
There's a difference in overflow implementation with flexbox between Firefox and Chrome: https://bugzilla.mozilla.org/show_bug.cgi?id=1108514#c2

I can't fix this with the `min-height: 0` trick because we don't easily control the html render coming from the date time component.

I'm targeting Firefox with `supports` instead of using `data-browser` because it's set on the wrapper div not the body (this popup is attached to body.)