### PR TITLE
Reading fixes

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -167,7 +167,7 @@
   .os-table {
     margin-top: 2rem;
     @media screen and ( max-width: $book-content-collapse-breakpoint ) {
-      overflow-x: scroll;
+      overflow-x: auto;
       max-width: calc(100vw - #{$book-content-narrow-horizontal-padding});
     }
     .os-table-title {

--- a/tutor/specs/screens/task/steps/__snapshots__/end.spec.js.snap
+++ b/tutor/specs/screens/task/steps/__snapshots__/end.spec.js.snap
@@ -68,6 +68,13 @@ exports[`Tasks Ending Screen completed state 1`] = `
   }
 }
 
+@media (min-width:1200px) {
+  .video-step .c2 .openstax-exercise-badges,
+  .interactive-step .c2 .openstax-exercise-badges {
+    margin-right: 3.8rem;
+  }
+}
+
 <div
   className="openstax-debug-content"
 >
@@ -190,6 +197,13 @@ exports[`Tasks Ending Screen completed state 2`] = `
 @media (max-width:600px) {
   .c2 {
     padding: 10px 25px 20px;
+  }
+}
+
+@media (min-width:1200px) {
+  .video-step .c2 .openstax-exercise-badges,
+  .interactive-step .c2 .openstax-exercise-badges {
+    margin-right: 3.8rem;
   }
 }
 
@@ -318,6 +332,13 @@ exports[`Tasks Ending Screen not started state 1`] = `
   }
 }
 
+@media (min-width:1200px) {
+  .video-step .c2 .openstax-exercise-badges,
+  .interactive-step .c2 .openstax-exercise-badges {
+    margin-right: 3.8rem;
+  }
+}
+
 <div
   className="openstax-debug-content"
 >
@@ -443,6 +464,13 @@ exports[`Tasks Ending Screen partial state 1`] = `
 @media (max-width:600px) {
   .c2 {
     padding: 10px 25px 20px;
+  }
+}
+
+@media (min-width:1200px) {
+  .video-step .c2 .openstax-exercise-badges,
+  .interactive-step .c2 .openstax-exercise-badges {
+    margin-right: 3.8rem;
   }
 }
 

--- a/tutor/specs/screens/task/steps/__snapshots__/html-content.spec.js.snap
+++ b/tutor/specs/screens/task/steps/__snapshots__/html-content.spec.js.snap
@@ -69,6 +69,13 @@ exports[`Html Content Tasks Screen matches snapshot 1`] = `
   }
 }
 
+@media (min-width:1200px) {
+  .video-step .c3 .openstax-exercise-badges,
+  .interactive-step .c3 .openstax-exercise-badges {
+    margin-right: 3.8rem;
+  }
+}
+
 <div
   className="openstax-debug-content"
 >

--- a/tutor/specs/screens/task/steps/__snapshots__/reading.spec.js.snap
+++ b/tutor/specs/screens/task/steps/__snapshots__/reading.spec.js.snap
@@ -65,6 +65,13 @@ exports[`Reading Tasks Screen matches snapshot 1`] = `
   }
 }
 
+@media (min-width:1200px) {
+  .video-step .c2 .openstax-exercise-badges,
+  .interactive-step .c2 .openstax-exercise-badges {
+    margin-right: 3.8rem;
+  }
+}
+
 <div
   className="openstax-debug-content"
 >

--- a/tutor/src/components/icons/pagination.js
+++ b/tutor/src/components/icons/pagination.js
@@ -5,7 +5,7 @@ import { Icon } from 'shared';
 const StyledIcon = styled(Icon).attrs({
   className: 'icon',
 })`
-  &&&.icon {
+  .arrow-wrapper &&&.icon {
     top: calc(55vh - 80px);
     margin: 0 auto;
     path {

--- a/tutor/src/screens/task/step/card.js
+++ b/tutor/src/screens/task/step/card.js
@@ -104,6 +104,14 @@ const StepCardQuestion = styled.div`
     padding: 0;
   }
 
+  ${breakpoint.desktop`
+    .video-step &, .interactive-step & {
+      .openstax-exercise-badges {
+        margin-right: 3.8rem;
+      }
+    }
+  `}
+
   &&& {
     .openstax-has-html .frame-wrapper {
 


### PR DESCRIPTION
- Don't render the table scrollbar unless overflow occurs
- Fix an issue with the desktop video and interactive badge not having a right margin

Before | After
------------ | -------------
![Screenshot_2020-08-19 PhET Explorations Equation Grapher(1)](https://user-images.githubusercontent.com/34174/90695780-f3368c00-e22f-11ea-99ca-c83d5583c604.png) | ![Screenshot_2020-08-19 PhET Explorations Equation Grapher](https://user-images.githubusercontent.com/34174/90695784-f5004f80-e22f-11ea-93b2-1bba0502c89d.png)
