### PR TITLE
make navbar responsive

### DIFF
--- a/shared/src/components/icon.js
+++ b/shared/src/components/icon.js
@@ -64,6 +64,7 @@ const Icons = {
   'eye':                  require('@fortawesome/free-solid-svg-icons/faEye'),
   'eye-slash':            require('@fortawesome/free-solid-svg-icons/faEyeSlash'),
   'ghost':                require('@fortawesome/free-solid-svg-icons/faGhost'),
+  'home':                 require('@fortawesome/free-solid-svg-icons/faHome'),
   'hand-paper':           require('@fortawesome/free-solid-svg-icons/faHandPaper'),
   'info-circle':          require('@fortawesome/free-solid-svg-icons/faInfoCircle'),
   'lock':                 require('@fortawesome/free-solid-svg-icons/faLock'),

--- a/tutor/resources/styles/components/top-nav-bar.scss
+++ b/tutor/resources/styles/components/top-nav-bar.scss
@@ -4,15 +4,6 @@
 
   @mixin top-nav-action() {
     font-size: 1.6rem;
-
-    @include media-breakpoint-down('sm') {
-      .control-label { display: none; }
-      .ox-icon:not(.toggle) { display: inline-block; }
-    }
-    @include media-breakpoint-up('md') {
-      .control-label { display: inline-block; }
-      .ox-icon:not(.toggle) { display: none; }
-    }
   }
 
   @media print {
@@ -100,6 +91,70 @@
     min-width: 250px;
     white-space: nowrap;
     .btn { margin-left: 10px; }
+  }
+
+  .actions-menu, .mobile-menu {
+    .ox-icon {
+      margin-left: 0;
+    }
+
+    [data-item="dashboard"] {
+      .tour-anchor {
+        display: flex;
+        & > :first-child {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 2.5rem;
+        }
+      }
+    }
+
+    [data-item="browseBook"],
+    [data-item="viewGradebook"],
+    [data-item="viewPerformanceGuide"],
+    [data-item="changeStudentId"],
+    [data-item="viewQuestionsLibrary"],
+    [data-item="courseSettings"],
+    [data-item="courseRoster"],
+    [data-item="cloneCourse"] {
+      .tour-anchor {
+        padding-left: 2.5rem;
+      }
+    }
+  }
+
+  .mobile-menu {
+    position: inherit;
+    z-index: 1502; // 1 above tour z-index
+
+    .close-icon {
+      display: none;
+    }
+
+    &.show {
+      .open-icon {
+        display: none;
+      }
+      .close-icon {
+        display: block;
+        width: 14px;
+      }
+    }
+
+    .dropdown-menu {
+      margin: 60px 0 0 0 !important;
+      transform: inherit !important;
+      left: 0;
+      right: 0;
+      top: 0;
+      overflow-y: auto;
+      max-height: calc(100vh - 60px);
+    }
+    .dropdown-item {
+      padding-left: 8px;
+      padding-right: 8px;
+    }
   }
 
   @import './top-nav-bar/center-controls';

--- a/tutor/resources/styles/components/top-nav-bar.scss
+++ b/tutor/resources/styles/components/top-nav-bar.scss
@@ -149,11 +149,11 @@
       right: 0;
       top: 0;
       overflow-y: auto;
-      max-height: calc(100vh - 60px);
+      max-height: calc(100vh - $tutor-navbar-height);
     }
     .dropdown-item {
-      padding-left: 8px;
-      padding-right: 8px;
+      padding-left: 16px;
+      padding-right: 16px;
     }
   }
 

--- a/tutor/resources/styles/components/top-nav-bar/drop-down-menu.scss
+++ b/tutor/resources/styles/components/top-nav-bar/drop-down-menu.scss
@@ -37,7 +37,7 @@
   .dropdown-menu {
     border-width: 0;
     border-top: 4px solid $green;
-    box-shadow: 0 5px 5px 0 rgba(0, 0, 0, 0.1);
+    box-shadow: 0 3px 7px 0 rgba(0, 0, 0, 0.2);
     margin-top: -4px;
     min-width: calc(100% + 15px);
     margin-left: -15px;
@@ -67,6 +67,7 @@
 
     input[type=submit] {
       @include tutor-sans-font(1.4rem, 1.4rem);
+      color: $tutor-neutral-darker;
       border: 0;
       background-color: transparent;
       width: 100%;
@@ -103,6 +104,7 @@
       align-items: center;
       border-radius: $diameter/2;
       font-size: $diameter * 0.4;
+      font-weight: 500;
       color: white;
       background-color: #2e7194;
       letter-spacing: -2px;

--- a/tutor/specs/components/__snapshots__/app.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/app.spec.jsx.snap
@@ -74,6 +74,53 @@ exports[`main Tutor App renders and matches snapshot 1`] = `
   padding-bottom: 0;
 }
 
+@media (min-width:1200px) {
+  .c0.c0.c0 .tutor-navbar {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+@media (max-width:1199px) {
+  .c0.c0.c0 .tutor-navbar {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+
+  .c0.c0.c0 .tutor-navbar .control-label {
+    display: none;
+  }
+
+  .c0.c0.c0 .tutor-navbar .dropdown-toggle .ox-icon {
+    margin-left: 1rem;
+  }
+
+  .c0.c0.c0 .tutor-navbar .user-menu .initials {
+    height: 22px;
+    width: 22px;
+    font-size: 0.9rem;
+    -webkit-letter-spacing: -1px;
+    -moz-letter-spacing: -1px;
+    -ms-letter-spacing: -1px;
+    letter-spacing: -1px;
+  }
+
+  .c0.c0.c0 .tutor-navbar .right-side-controls > * {
+    margin-left: 0;
+  }
+
+  .c0.c0.c0 .tutor-navbar .right-side-controls > *:last-child {
+    margin-left: 1rem;
+  }
+}
+
+@media (max-width:600px) {
+  .c0.c0.c0 .tutor-navbar {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+}
+
 <div
   className="openstax-debug-content"
 >
@@ -207,23 +254,6 @@ exports[`main Tutor App renders and matches snapshot 1`] = `
                         >
                           Help
                         </span>
-                        <svg
-                          aria-hidden="true"
-                          className="svg-inline--fa fa-chevron-down fa-w-14 c3 ox-icon ox-icon-chevron-down toggle"
-                          data-icon="chevron-down"
-                          data-prefix="fas"
-                          focusable="false"
-                          role="img"
-                          style={Object {}}
-                          viewBox="0 0 448 512"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-                            fill="currentColor"
-                            style={Object {}}
-                          />
-                        </svg>
                       </div>
                     </button>
                     <div

--- a/tutor/specs/components/__snapshots__/tutor-layout.spec.js.snap
+++ b/tutor/specs/components/__snapshots__/tutor-layout.spec.js.snap
@@ -15,7 +15,7 @@ exports[`Tutor Layout renders and matches snapshot 1`] = `
                       <TutorLayout>
                         <MobXProvider topNavbar={{...}} courseContext={{...}} bottomNavbar={{...}} setSecondaryTopControls={[Function: res]}>
                           <styled.div hasNavbar={true}>
-                            <div className=\\"sc-fznKkj dwPkzX\\">
+                            <div className=\\"sc-fznKkj fWJWms\\">
                               <Navbar area=\\"header\\" context={{...}} isDocked={false}>
                                 <styled.nav area=\\"header\\" shouldHideNavbar={[undefined]} isDocked={false} className=\\"tutor-navbar\\">
                                   <nav className=\\"sc-AxjAm fhzKny tutor-navbar\\">
@@ -58,121 +58,120 @@ exports[`Tutor Layout renders and matches snapshot 1`] = `
                                       <Component>
                                         <Menus>
                                           <Memo(wrappedComponent) courseContext={{...}}>
-                                            <StudentPayNowBtn course={[undefined]} />
-                                            <withRouter(inject(SupportMenu)) course={[undefined]}>
-                                              <inject(SupportMenu) course={[undefined]} history={{...}} location={{...}} match={{...}} staticContext={[undefined]}>
-                                                <Observer>
-                                                  <SupportMenu course={[undefined]} history={{...}} location={{...}} match={{...}} staticContext={[undefined]} tourContext={{...}}>
-                                                    <Dropdown show={true} onToggle={[Function: res]} navbar={false}>
-                                                      <ReactOverlaysDropdown drop={[undefined]} show={true} alignEnd={[undefined]} onToggle={[Function]} focusFirstItemOnShow={[undefined]} itemSelector=\\".dropdown-item:not(.disabled):not(:disabled)\\">
-                                                        <div onKeyDown={[Function: handleKeyDown]} className=\\"show dropdown\\">
-                                                          <DropdownToggle id=\\"support-menu\\" aria-label=\\"Page tips and support\\" variant=\\"ox\\">
-                                                            <Button onClick={[Function]} className=\\"dropdown-toggle\\" aria-haspopup={true} aria-expanded={true} id=\\"support-menu\\" aria-label=\\"Page tips and support\\" variant=\\"ox\\" active={false} disabled={false} type=\\"button\\">
-                                                              <button onClick={[Function]} aria-haspopup={true} aria-expanded={true} id=\\"support-menu\\" aria-label=\\"Page tips and support\\" disabled={false} type=\\"button\\" className=\\"dropdown-toggle btn btn-ox\\">
-                                                                <inject(TourAnchor) id=\\"support-menu-button\\" aria-labelledby=\\"support-menu\\" onSelect={[Function: res]}>
-                                                                  <Observer>
-                                                                    <TourAnchor id=\\"support-menu-button\\" aria-labelledby=\\"support-menu\\" onSelect={[Function: res]} tourContext={{...}} tag=\\"div\\" className=\\"\\">
-                                                                      <div className=\\"tour-anchor\\" data-tour-anchor-id=\\"support-menu-button\\" aria-labelledby=\\"support-menu\\" onSelect={[Function: res]}>
-                                                                        <Icon type=\\"question-circle\\" buttonProps={{...}} tooltipProps={{...}}>
-                                                                          <IconWrapper data-variant={[undefined]} className=\\"ox-icon ox-icon-question-circle\\" icon={{...}}>
-                                                                            <FontAwesomeIcon data-variant={[undefined]} className=\\"IconWrapper-ra27cp-0 gKKqUB ox-icon ox-icon-question-circle\\" icon={{...}} border={false} mask={{...}} fixedWidth={false} inverse={false} flip={{...}} listItem={false} pull={{...}} pulse={false} rotation={{...}} size={{...}} spin={false} symbol={false} title=\\"\\" transform={{...}}>
-                                                                              <svg aria-hidden=\\"true\\" focusable=\\"false\\" data-prefix=\\"fas\\" data-icon=\\"question-circle\\" className=\\"svg-inline--fa fa-question-circle fa-w-16 IconWrapper-ra27cp-0 gKKqUB ox-icon ox-icon-question-circle\\" role=\\"img\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 512 512\\" style={{...}} data-variant={[undefined]}>
-                                                                                <path fill=\\"currentColor\\" d=\\"M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z\\" style={{...}} />
-                                                                              </svg>
-                                                                            </FontAwesomeIcon>
-                                                                          </IconWrapper>
-                                                                        </Icon>
-                                                                        <span title=\\"Page tips and support\\" className=\\"control-label\\">
-                                                                          Help
-                                                                        </span>
-                                                                        <Icon type=\\"chevron-down\\" className=\\"toggle\\" buttonProps={{...}} tooltipProps={{...}}>
-                                                                          <IconWrapper data-variant={[undefined]} className=\\"ox-icon ox-icon-chevron-down toggle\\" icon={{...}}>
-                                                                            <FontAwesomeIcon data-variant={[undefined]} className=\\"IconWrapper-ra27cp-0 gKKqUB ox-icon ox-icon-chevron-down toggle\\" icon={{...}} border={false} mask={{...}} fixedWidth={false} inverse={false} flip={{...}} listItem={false} pull={{...}} pulse={false} rotation={{...}} size={{...}} spin={false} symbol={false} title=\\"\\" transform={{...}}>
-                                                                              <svg aria-hidden=\\"true\\" focusable=\\"false\\" data-prefix=\\"fas\\" data-icon=\\"chevron-down\\" className=\\"svg-inline--fa fa-chevron-down fa-w-14 IconWrapper-ra27cp-0 gKKqUB ox-icon ox-icon-chevron-down toggle\\" role=\\"img\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 448 512\\" style={{...}} data-variant={[undefined]}>
-                                                                                <path fill=\\"currentColor\\" d=\\"M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z\\" style={{...}} />
-                                                                              </svg>
-                                                                            </FontAwesomeIcon>
-                                                                          </IconWrapper>
-                                                                        </Icon>
-                                                                      </div>
-                                                                    </TourAnchor>
-                                                                  </Observer>
-                                                                </inject(TourAnchor)>
-                                                              </button>
-                                                            </Button>
-                                                          </DropdownToggle>
-                                                          <DropdownMenu className=\\" hide\\" alignRight={false} flip={true}>
-                                                            <div x-placement=\\"bottom-start\\" aria-labelledby=\\"support-menu\\" style={{...}} className=\\" hide dropdown-menu show\\">
-                                                              <Memo(wrappedComponent) onPlayClick={[Function: res]} course={[undefined]} history={{...}} location={{...}} match={{...}} staticContext={[undefined]} tourContext={{...}} />
-                                                              <DropdownItem className=\\"-help-link\\" target=\\"_blank\\" onSelect={[Function: res]} href=\\"https://openstax.secure.force.com/help?search=tutor\\" as={{...}} disabled={false}>
-                                                                <SafeAnchor target=\\"_blank\\" href=\\"https://openstax.secure.force.com/help?search=tutor\\" disabled={false} className=\\"-help-link dropdown-item\\" onClick={[Function]}>
-                                                                  <a target=\\"_blank\\" href=\\"https://openstax.secure.force.com/help?search=tutor\\" className=\\"-help-link dropdown-item\\" onClick={[Function: handleClick]} onKeyDown={[Function: handleKeyDown]}>
-                                                                    <span>
-                                                                      Help Articles
-                                                                    </span>
-                                                                  </a>
-                                                                </SafeAnchor>
-                                                              </DropdownItem>
-                                                              <SupportDocumentLink course={[undefined]}>
-                                                                <DropdownItem className=\\"support-document-link\\" target=\\"_blank\\" href=\\"https://d3bxy9euw4e147.cloudfront.net/oscms-prodcms/media/documents/openstax_tutor_getting_started_guide_student.pdf\\" as={{...}} disabled={false}>
-                                                                  <SafeAnchor target=\\"_blank\\" href=\\"https://d3bxy9euw4e147.cloudfront.net/oscms-prodcms/media/documents/openstax_tutor_getting_started_guide_student.pdf\\" disabled={false} className=\\"support-document-link dropdown-item\\" onClick={[Function]}>
-                                                                    <a target=\\"_blank\\" href=\\"https://d3bxy9euw4e147.cloudfront.net/oscms-prodcms/media/documents/openstax_tutor_getting_started_guide_student.pdf\\" className=\\"support-document-link dropdown-item\\" onClick={[Function: handleClick]} onKeyDown={[Function: handleKeyDown]}>
-                                                                      <inject(TourAnchor) id=\\"menu-support-document\\">
+                                            <Responsive desktop={{...}} mobile={{...}}>
+                                              <Memo(wrappedComponent) course={[undefined]}>
+                                                <StudentPayNowBtn course={[undefined]} />
+                                                <ActionsMenu course={[undefined]} />
+                                                <withRouter(inject(SupportMenu)) course={[undefined]}>
+                                                  <inject(SupportMenu) course={[undefined]} history={{...}} location={{...}} match={{...}} staticContext={[undefined]}>
+                                                    <Observer>
+                                                      <SupportMenu course={[undefined]} history={{...}} location={{...}} match={{...}} staticContext={[undefined]} tourContext={{...}}>
+                                                        <Responsive desktop={{...}} mobile={{...}}>
+                                                          <Dropdown show={true} onToggle={[Function: res]} navbar={false}>
+                                                            <ReactOverlaysDropdown drop={[undefined]} show={true} alignEnd={[undefined]} onToggle={[Function]} focusFirstItemOnShow={[undefined]} itemSelector=\\".dropdown-item:not(.disabled):not(:disabled)\\">
+                                                              <div onKeyDown={[Function: handleKeyDown]} className=\\"show dropdown\\">
+                                                                <DropdownToggle id=\\"support-menu\\" aria-label=\\"Page tips and support\\" variant=\\"ox\\">
+                                                                  <Button onClick={[Function]} className=\\"dropdown-toggle\\" aria-haspopup={true} aria-expanded={true} id=\\"support-menu\\" aria-label=\\"Page tips and support\\" variant=\\"ox\\" active={false} disabled={false} type=\\"button\\">
+                                                                    <button onClick={[Function]} aria-haspopup={true} aria-expanded={true} id=\\"support-menu\\" aria-label=\\"Page tips and support\\" disabled={false} type=\\"button\\" className=\\"dropdown-toggle btn btn-ox\\">
+                                                                      <inject(TourAnchor) id=\\"support-menu-button\\" aria-labelledby=\\"support-menu\\" onSelect={[Function: res]}>
                                                                         <Observer>
-                                                                          <TourAnchor id=\\"menu-support-document\\" tourContext={{...}} tag=\\"div\\" className=\\"\\">
-                                                                            <div className=\\"tour-anchor\\" data-tour-anchor-id=\\"menu-support-document\\">
-                                                                              Getting Started Guide
+                                                                          <TourAnchor id=\\"support-menu-button\\" aria-labelledby=\\"support-menu\\" onSelect={[Function: res]} tourContext={{...}} tag=\\"div\\" className=\\"\\">
+                                                                            <div className=\\"tour-anchor\\" data-tour-anchor-id=\\"support-menu-button\\" aria-labelledby=\\"support-menu\\" onSelect={[Function: res]}>
+                                                                              <Icon type=\\"question-circle\\" buttonProps={{...}} tooltipProps={{...}}>
+                                                                                <IconWrapper data-variant={[undefined]} className=\\"ox-icon ox-icon-question-circle\\" icon={{...}}>
+                                                                                  <FontAwesomeIcon data-variant={[undefined]} className=\\"IconWrapper-ra27cp-0 gKKqUB ox-icon ox-icon-question-circle\\" icon={{...}} border={false} mask={{...}} fixedWidth={false} inverse={false} flip={{...}} listItem={false} pull={{...}} pulse={false} rotation={{...}} size={{...}} spin={false} symbol={false} title=\\"\\" transform={{...}}>
+                                                                                    <svg aria-hidden=\\"true\\" focusable=\\"false\\" data-prefix=\\"fas\\" data-icon=\\"question-circle\\" className=\\"svg-inline--fa fa-question-circle fa-w-16 IconWrapper-ra27cp-0 gKKqUB ox-icon ox-icon-question-circle\\" role=\\"img\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 512 512\\" style={{...}} data-variant={[undefined]}>
+                                                                                      <path fill=\\"currentColor\\" d=\\"M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z\\" style={{...}} />
+                                                                                    </svg>
+                                                                                  </FontAwesomeIcon>
+                                                                                </IconWrapper>
+                                                                              </Icon>
+                                                                              <span title=\\"Page tips and support\\" className=\\"control-label\\">
+                                                                                Help
+                                                                              </span>
                                                                             </div>
                                                                           </TourAnchor>
                                                                         </Observer>
                                                                       </inject(TourAnchor)>
-                                                                    </a>
-                                                                  </SafeAnchor>
-                                                                </DropdownItem>
-                                                              </SupportDocumentLink>
-                                                              <BestPracticesGuide course={[undefined]} />
-                                                              <DropdownItem className=\\"-help-link\\" onSelect={[Function: res]} href=\\"/accessibility-statement/\\" onClick={[Function: res]} as={{...}} disabled={false}>
-                                                                <SafeAnchor href=\\"/accessibility-statement/\\" disabled={false} className=\\"-help-link dropdown-item\\" onClick={[Function]}>
-                                                                  <a href=\\"/accessibility-statement/\\" className=\\"-help-link dropdown-item\\" onClick={[Function: handleClick]} onKeyDown={[Function: handleKeyDown]}>
-                                                                    <span>
-                                                                      Accessibility Statement
-                                                                    </span>
-                                                                  </a>
-                                                                </SafeAnchor>
-                                                              </DropdownItem>
-                                                            </div>
-                                                          </DropdownMenu>
+                                                                    </button>
+                                                                  </Button>
+                                                                </DropdownToggle>
+                                                                <DropdownMenu className=\\" hide\\" alignRight={false} flip={true}>
+                                                                  <div x-placement=\\"bottom-start\\" aria-labelledby=\\"support-menu\\" style={{...}} className=\\" hide dropdown-menu show\\">
+                                                                    <Memo(wrappedComponent) onPlayClick={[Function: res]} course={[undefined]} history={{...}} location={{...}} match={{...}} staticContext={[undefined]} tourContext={{...}} />
+                                                                    <DropdownItem className=\\"-help-link\\" target=\\"_blank\\" onSelect={[Function: res]} href=\\"https://openstax.secure.force.com/help?search=tutor\\" as={{...}} disabled={false}>
+                                                                      <SafeAnchor target=\\"_blank\\" href=\\"https://openstax.secure.force.com/help?search=tutor\\" disabled={false} className=\\"-help-link dropdown-item\\" onClick={[Function]}>
+                                                                        <a target=\\"_blank\\" href=\\"https://openstax.secure.force.com/help?search=tutor\\" className=\\"-help-link dropdown-item\\" onClick={[Function: handleClick]} onKeyDown={[Function: handleKeyDown]}>
+                                                                          <span>
+                                                                            Help Articles
+                                                                          </span>
+                                                                        </a>
+                                                                      </SafeAnchor>
+                                                                    </DropdownItem>
+                                                                    <SupportDocumentLink course={[undefined]}>
+                                                                      <DropdownItem className=\\"support-document-link\\" target=\\"_blank\\" href=\\"https://d3bxy9euw4e147.cloudfront.net/oscms-prodcms/media/documents/openstax_tutor_getting_started_guide_student.pdf\\" as={{...}} disabled={false}>
+                                                                        <SafeAnchor target=\\"_blank\\" href=\\"https://d3bxy9euw4e147.cloudfront.net/oscms-prodcms/media/documents/openstax_tutor_getting_started_guide_student.pdf\\" disabled={false} className=\\"support-document-link dropdown-item\\" onClick={[Function]}>
+                                                                          <a target=\\"_blank\\" href=\\"https://d3bxy9euw4e147.cloudfront.net/oscms-prodcms/media/documents/openstax_tutor_getting_started_guide_student.pdf\\" className=\\"support-document-link dropdown-item\\" onClick={[Function: handleClick]} onKeyDown={[Function: handleKeyDown]}>
+                                                                            <inject(TourAnchor) id=\\"menu-support-document\\">
+                                                                              <Observer>
+                                                                                <TourAnchor id=\\"menu-support-document\\" tourContext={{...}} tag=\\"div\\" className=\\"\\">
+                                                                                  <div className=\\"tour-anchor\\" data-tour-anchor-id=\\"menu-support-document\\">
+                                                                                    Getting Started Guide
+                                                                                  </div>
+                                                                                </TourAnchor>
+                                                                              </Observer>
+                                                                            </inject(TourAnchor)>
+                                                                          </a>
+                                                                        </SafeAnchor>
+                                                                      </DropdownItem>
+                                                                    </SupportDocumentLink>
+                                                                    <BestPracticesGuide course={[undefined]} />
+                                                                    <DropdownItem className=\\"-help-link\\" onSelect={[Function: res]} href=\\"/accessibility-statement/\\" onClick={[Function: res]} as={{...}} disabled={false}>
+                                                                      <SafeAnchor href=\\"/accessibility-statement/\\" disabled={false} className=\\"-help-link dropdown-item\\" onClick={[Function]}>
+                                                                        <a href=\\"/accessibility-statement/\\" className=\\"-help-link dropdown-item\\" onClick={[Function: handleClick]} onKeyDown={[Function: handleKeyDown]}>
+                                                                          <span>
+                                                                            Accessibility Statement
+                                                                          </span>
+                                                                        </a>
+                                                                      </SafeAnchor>
+                                                                    </DropdownItem>
+                                                                  </div>
+                                                                </DropdownMenu>
+                                                              </div>
+                                                            </ReactOverlaysDropdown>
+                                                          </Dropdown>
+                                                        </Responsive>
+                                                      </SupportMenu>
+                                                    </Observer>
+                                                  </inject(SupportMenu)>
+                                                </withRouter(inject(SupportMenu))>
+                                                <withRouter(inject(PreviewAddCourseBtn)) course={[undefined]}>
+                                                  <inject(PreviewAddCourseBtn) course={[undefined]} history={{...}} location={{...}} match={{...}} staticContext={[undefined]}>
+                                                    <Observer>
+                                                      <PreviewAddCourseBtn course={[undefined]} history={{...}} location={{...}} match={{...}} staticContext={[undefined]} tourContext={{...}} />
+                                                    </Observer>
+                                                  </inject(PreviewAddCourseBtn)>
+                                                </withRouter(inject(PreviewAddCourseBtn))>
+                                                <UserMenu>
+                                                  <Responsive desktop={{...}} mobile={{...}}>
+                                                    <Dropdown className=\\"user-menu\\" navbar={false}>
+                                                      <ReactOverlaysDropdown drop={[undefined]} show={[undefined]} alignEnd={[undefined]} onToggle={[Function]} focusFirstItemOnShow={[undefined]} itemSelector=\\".dropdown-item:not(.disabled):not(:disabled)\\">
+                                                        <div onKeyDown={[Function: handleKeyDown]} className=\\"user-menu dropdown\\">
+                                                          <DropdownToggle id=\\"user-menu\\" variant=\\"link\\" aria-label=\\"Account settings\\">
+                                                            <Button onClick={[Function]} className=\\"dropdown-toggle\\" aria-haspopup={true} aria-expanded={false} id=\\"user-menu\\" variant=\\"link\\" aria-label=\\"Account settings\\" active={false} disabled={false} type=\\"button\\">
+                                                              <button onClick={[Function]} aria-haspopup={true} aria-expanded={false} id=\\"user-menu\\" aria-label=\\"Account settings\\" disabled={false} type=\\"button\\" className=\\"dropdown-toggle btn btn-link\\">
+                                                                <span className=\\"initials\\" />
+                                                              </button>
+                                                            </Button>
+                                                          </DropdownToggle>
+                                                          <DropdownMenu alignRight={true} flip={true} />
                                                         </div>
                                                       </ReactOverlaysDropdown>
                                                     </Dropdown>
-                                                  </SupportMenu>
-                                                </Observer>
-                                              </inject(SupportMenu)>
-                                            </withRouter(inject(SupportMenu))>
-                                            <ActionsMenu course={[undefined]} />
-                                            <withRouter(inject(PreviewAddCourseBtn)) course={[undefined]}>
-                                              <inject(PreviewAddCourseBtn) course={[undefined]} history={{...}} location={{...}} match={{...}} staticContext={[undefined]}>
-                                                <Observer>
-                                                  <PreviewAddCourseBtn course={[undefined]} history={{...}} location={{...}} match={{...}} staticContext={[undefined]} tourContext={{...}} />
-                                                </Observer>
-                                              </inject(PreviewAddCourseBtn)>
-                                            </withRouter(inject(PreviewAddCourseBtn))>
-                                            <UserMenu>
-                                              <Dropdown className=\\"user-menu\\" navbar={false}>
-                                                <ReactOverlaysDropdown drop={[undefined]} show={[undefined]} alignEnd={[undefined]} onToggle={[Function]} focusFirstItemOnShow={[undefined]} itemSelector=\\".dropdown-item:not(.disabled):not(:disabled)\\">
-                                                  <div onKeyDown={[Function: handleKeyDown]} className=\\"user-menu dropdown\\">
-                                                    <DropdownToggle id=\\"user-menu\\" variant=\\"link\\" aria-label=\\"Account settings\\">
-                                                      <Button onClick={[Function]} className=\\"dropdown-toggle\\" aria-haspopup={true} aria-expanded={false} id=\\"user-menu\\" variant=\\"link\\" aria-label=\\"Account settings\\" active={false} disabled={false} type=\\"button\\">
-                                                        <button onClick={[Function]} aria-haspopup={true} aria-expanded={false} id=\\"user-menu\\" aria-label=\\"Account settings\\" disabled={false} type=\\"button\\" className=\\"dropdown-toggle btn btn-link\\">
-                                                          <span className=\\"initials\\" />
-                                                        </button>
-                                                      </Button>
-                                                    </DropdownToggle>
-                                                    <DropdownMenu alignRight={true} flip={true} />
-                                                  </div>
-                                                </ReactOverlaysDropdown>
-                                              </Dropdown>
-                                            </UserMenu>
+                                                  </Responsive>
+                                                </UserMenu>
+                                              </Memo(wrappedComponent)>
+                                            </Responsive>
                                           </Memo(wrappedComponent)>
                                         </Menus>
                                       </Component>

--- a/tutor/specs/components/navbar/__snapshots__/actions-menu.spec.jsx.snap
+++ b/tutor/specs/components/navbar/__snapshots__/actions-menu.spec.jsx.snap
@@ -43,23 +43,6 @@ exports[`Student Navbar Component has actions menu that matches snapshot 1`] = `
     >
       Menu
     </span>
-    <svg
-      aria-hidden="true"
-      className="svg-inline--fa fa-chevron-down fa-w-14 c0 ox-icon ox-icon-chevron-down toggle"
-      data-icon="chevron-down"
-      data-prefix="fas"
-      focusable="false"
-      role="img"
-      style={Object {}}
-      viewBox="0 0 448 512"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-        fill="currentColor"
-        style={Object {}}
-      />
-    </svg>
   </button>
 </div>
 `;
@@ -107,23 +90,6 @@ exports[`Teacher Navbar Component has actions menu that matches snapshot 1`] = `
     >
       Menu
     </span>
-    <svg
-      aria-hidden="true"
-      className="svg-inline--fa fa-chevron-down fa-w-14 c0 ox-icon ox-icon-chevron-down toggle"
-      data-icon="chevron-down"
-      data-prefix="fas"
-      focusable="false"
-      role="img"
-      style={Object {}}
-      viewBox="0 0 448 512"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-        fill="currentColor"
-        style={Object {}}
-      />
-    </svg>
   </button>
 </div>
 `;

--- a/tutor/specs/models/user/__snapshots__/menu.spec.js.snap
+++ b/tutor/specs/models/user/__snapshots__/menu.spec.js.snap
@@ -10,6 +10,7 @@ Array [
     },
   },
   Object {
+    "icon": "home",
     "label": "Dashboard",
     "name": "dashboard",
     "options": Object {},
@@ -44,7 +45,9 @@ Array [
   Object {
     "label": "Change Student ID",
     "name": "changeStudentId",
-    "options": Object {},
+    "options": Object {
+      "separator": "after",
+    },
     "params": Object {
       "courseId": 2,
     },
@@ -62,6 +65,7 @@ Array [
     },
   },
   Object {
+    "icon": "home",
     "label": "Dashboard",
     "name": "dashboard",
     "options": Object {},
@@ -118,6 +122,16 @@ Array [
     },
   },
   Object {
+    "label": "Copy this Course",
+    "name": "createNewCourse",
+    "options": Object {
+      "key": "cloneCourse",
+    },
+    "params": Object {
+      "sourceId": 1,
+    },
+  },
+  Object {
     "label": "Create a Course",
     "name": "createNewCourse",
     "options": Object {
@@ -125,17 +139,6 @@ Array [
     },
     "params": Object {
       "courseId": 1,
-    },
-  },
-  Object {
-    "label": "Copy this Course",
-    "name": "createNewCourse",
-    "options": Object {
-      "key": "cloneCourse",
-      "separator": "after",
-    },
-    "params": Object {
-      "sourceId": 1,
     },
   },
 ]

--- a/tutor/src/components/navbar/actions-menu.jsx
+++ b/tutor/src/components/navbar/actions-menu.jsx
@@ -7,10 +7,12 @@ import TourAnchor from '../tours/anchor';
 import Router from '../../helpers/router';
 import UserMenu from '../../models/user/menu';
 import Course from '../../models/course';
+import { breakpoint } from 'theme';
+import Responsive from '../../components/responsive';
 
 const RoutedDropdownItem = (props) => {
   // eslint-disable-next-line react/prop-types
-  let { label } = props;
+  let { label, icon } = props;
   const {
     // eslint-disable-next-line react/prop-types
     name, tourId, className, route, locked, href, options = {},
@@ -38,14 +40,19 @@ const RoutedDropdownItem = (props) => {
     );
   }
 
+  if (icon) {
+    icon = <span className="icon"><Icon type={icon} /></span>;
+  }
+
   return (
     <Dropdown.Item
       onClick={onClick}
       data-item={options.key || name}
       disabled={locked}
-      className={cn(className, { locked, active })}
+      className={cn(className, { locked, active, icon })}
     >
       <TourAnchor id={tourId}>
+        {icon}
         {label}
       </TourAnchor>
     </Dropdown.Item>
@@ -60,10 +67,11 @@ RoutedDropdownItem.propTypes = {
 
 
 // eslint-disable-next-line
-function BrowseBookDropdownItem({ course, className, active, label, ...props }) {
+function BrowseBookDropdownItem({ course, className, active, label, name, ...props }) {
   return (
     <Dropdown.Item
-      {...props}
+      className={className}
+      data-item={name}
       href={`/book/${course.id}`}
       target="_blank"
     >
@@ -132,12 +140,7 @@ class ActionsMenu extends React.Component {
     return item;
   }
 
-  render() {
-    const menuRoutes = UserMenu.getRoutes(this.props.course);
-    if (isEmpty(menuRoutes)) {
-      return null;
-    }
-
+  renderDesktop(menuRoutes) {
     return (
       <Dropdown className="actions-menu">
         <Dropdown.Toggle
@@ -147,12 +150,33 @@ class ActionsMenu extends React.Component {
         >
           <Icon type="bars" />
           <span className="control-label" title="Menu and settings">Menu</span>
-          <Icon type="chevron-down" className="toggle" />
         </Dropdown.Toggle>
-        <Dropdown.Menu>
-          {flatMap(menuRoutes, this.renderDropdownItem)}
+        <Dropdown.Menu alignRight={true}>
+          {this.renderItems(menuRoutes)}
         </Dropdown.Menu>
       </Dropdown>
+    );
+  }
+
+  renderItems(menuRoutes) {
+    return (
+      <>
+        {flatMap(menuRoutes, this.renderDropdownItem)}
+      </>
+    );
+  }
+
+  render() {
+    const menuRoutes = UserMenu.getRoutes(this.props.course);
+    if (isEmpty(menuRoutes)) {
+      return null;
+    }
+
+    return (
+      <Responsive
+        desktop={this.renderDesktop(menuRoutes)}
+        mobile={this.renderItems(menuRoutes)}
+      />
     );
   }
 

--- a/tutor/src/components/navbar/menus.js
+++ b/tutor/src/components/navbar/menus.js
@@ -1,4 +1,7 @@
 import { React, PropTypes, inject, observer } from 'vendor';
+import { Dropdown }        from 'react-bootstrap';
+import { Icon }            from 'shared';
+import Responsive          from '../responsive';
 import Course              from '../../models/course';
 import SupportMenu         from './support-menu';
 import StudentPayNowBtn    from './student-pay-now-btn';
@@ -6,16 +9,41 @@ import ActionsMenu         from './actions-menu';
 import PreviewAddCourseBtn from './preview-add-course-btn';
 import UserMenu            from './user-menu';
 
+const DesktopMenus = observer(({ course }) => (
+  <>
+    <StudentPayNowBtn    course={course} />
+    <ActionsMenu         course={course} />
+    <SupportMenu         course={course} />
+    <PreviewAddCourseBtn course={course} />
+    <UserMenu />
+  </>
+));
+
+const MobileMenus = observer(({ course }) => (
+  <Dropdown className="mobile-menu">
+    <Dropdown.Toggle
+      id="mobile-menu"
+      aria-label="Menu and settings"
+      variant="ox"
+    >
+      <Icon type="bars" className="open-icon" />
+      <Icon type="close" className="close-icon" />
+    </Dropdown.Toggle>
+    <Dropdown.Menu>
+      <ActionsMenu course={course} />
+      <SupportMenu course={course} />
+      <UserMenu />
+    </Dropdown.Menu>
+  </Dropdown>
+));
+
 const Menus = inject('courseContext')(
   observer(
     ({ courseContext: { course } }) => (
-      <React.Fragment>
-        <StudentPayNowBtn    course={course} />
-        <SupportMenu         course={course} />
-        <ActionsMenu         course={course} />
-        <PreviewAddCourseBtn course={course} />
-        <UserMenu />
-      </React.Fragment>
+      <Responsive
+        desktop={<DesktopMenus course={course} />}
+        mobile={<MobileMenus course={course} />}
+      />
     )
   )
 );

--- a/tutor/src/components/navbar/support-menu.jsx
+++ b/tutor/src/components/navbar/support-menu.jsx
@@ -65,7 +65,7 @@ class SupportMenu extends React.Component {
         onSelect={this.onSelect}
         onClick={Chat.start}
       >
-        <Icon type='comments-solid' color={Theme.colors.controls.active} /><span>Chat Support (9 - 5)</span>
+        <Icon type='comments-solid' color={Theme.colors.controls.active} /><span>Chat Support (9 - 5 CT)</span>
       </Dropdown.Item>,
       <Dropdown.Item
         style={{ display: 'none' }}

--- a/tutor/src/components/navbar/support-menu.jsx
+++ b/tutor/src/components/navbar/support-menu.jsx
@@ -15,6 +15,7 @@ import BestPracticesGuide from './best-practices-guide';
 import TourContext from '../../models/tour/context';
 import Course from '../../models/course';
 import Theme from '../../theme';
+import Responsive from '../../components/responsive';
 
 // eslint-disable-next-line no-unused-vars
 const PageTips = observer(({ onPlayClick, tourContext, staticContext, ...props }) => {
@@ -64,7 +65,7 @@ class SupportMenu extends React.Component {
         onSelect={this.onSelect}
         onClick={Chat.start}
       >
-        <Icon type='comments-solid' color={Theme.colors.controls.active} /><span>Chat with Support</span>
+        <Icon type='comments-solid' color={Theme.colors.controls.active} /><span>Chat Support (9 - 5)</span>
       </Dropdown.Item>,
       <Dropdown.Item
         style={{ display: 'none' }}
@@ -123,7 +124,7 @@ class SupportMenu extends React.Component {
     );
   }
 
-  render() {
+  renderDesktop() {
     const { course } = this.props;
     return (
       <Dropdown show={this.show} onToggle={this.onToggle}>
@@ -140,34 +141,51 @@ class SupportMenu extends React.Component {
           >
             <Icon type="question-circle" />
             <span title="Page tips and support" className="control-label">Help</span>
-            <Icon type="chevron-down" className="toggle" />
           </TourAnchor>
         </Dropdown.Toggle>
         <Dropdown.Menu className={this.hide ? ' hide' : null}>
-          <PageTips onPlayClick={this.onPlayTourClick} {...this.props} />
-          <Dropdown.Item
-            key="nav-help-link"
-            className="-help-link"
-            target="_blank"
-            onSelect={this.onSelect}
-            href={UserMenu.helpLinkForCourse(course)}
-          >
-            <span>Help Articles</span>
-          </Dropdown.Item>
-          <SupportDocument course={course} />
-          <BestPracticesGuide course={course} />
-          <Dropdown.Item
-            key="nav-keyboard-shortcuts"
-            className="-help-link"
-            onSelect={this.onSelect}
-            href={this.accessibilityLink}
-            onClick={this.goToAccessibility}
-          >
-            <span>Accessibility Statement</span>
-          </Dropdown.Item>
-          {this.renderChat()}
+          {this.renderItems()}
         </Dropdown.Menu>
       </Dropdown>
+    );
+  }
+
+  renderItems() {
+    const { course } = this.props;
+    return (
+      <>
+        <PageTips onPlayClick={this.onPlayTourClick} {...this.props} />
+        <Dropdown.Item
+          key="nav-help-link"
+          className="-help-link"
+          target="_blank"
+          onSelect={this.onSelect}
+          href={UserMenu.helpLinkForCourse(course)}
+        >
+          <span>Help Articles</span>
+        </Dropdown.Item>
+        <SupportDocument course={course} />
+        <BestPracticesGuide course={course} />
+        <Dropdown.Item
+          key="nav-keyboard-shortcuts"
+          className="-help-link"
+          onSelect={this.onSelect}
+          href={this.accessibilityLink}
+          onClick={this.goToAccessibility}
+        >
+          <span>Accessibility Statement</span>
+        </Dropdown.Item>
+        {this.renderChat()}
+      </>
+    );
+  }
+
+  render() {
+    return (
+      <Responsive
+        desktop={this.renderDesktop()}
+        mobile={this.renderItems()}
+      />
     );
   }
 

--- a/tutor/src/components/navbar/user-menu.jsx
+++ b/tutor/src/components/navbar/user-menu.jsx
@@ -5,12 +5,24 @@ import { observer } from 'mobx-react';
 import User from '../../models/user';
 import AccountLink from './account-link';
 import LogOut from './logout';
+import Responsive from '../../components/responsive';
 
 export default
 @observer
 class UserMenu extends React.Component {
 
-  render() {
+  renderItems() {
+    return (
+      <>
+        <Dropdown.Divider />
+        <AccountLink />
+        <Dropdown.Divider />
+        <LogOut />
+      </>
+    );
+  }
+
+  renderDesktop() {
     return (
       <Dropdown
         className="user-menu"
@@ -23,10 +35,18 @@ class UserMenu extends React.Component {
           <span className="initials">{User.initials}</span>
         </Dropdown.Toggle>
         <Dropdown.Menu alignRight>
-          <AccountLink />
-          <LogOut />
+          {this.renderItems()}
         </Dropdown.Menu>
       </Dropdown>
+    );
+  }
+
+  render() {
+    return (
+      <Responsive
+        desktop={this.renderDesktop()}
+        mobile={this.renderItems()}
+      />
     );
   }
 

--- a/tutor/src/components/tutor-layout.js
+++ b/tutor/src/components/tutor-layout.js
@@ -16,11 +16,47 @@ import { NavbarContext }    from './navbar/context';
 import { SecondaryToolbar } from './navbar/secondary-toolbar';
 import Router from '../helpers/router';
 import { get } from 'lodash';
+import { breakpoint } from 'theme';
 
 const StyledLayout = styled.div`
   min-height: 100vh;
 
-  ${props => !props.hasNavbar && Theme.breakpoint.only.mobile`
+  ${breakpoint.desktop`
+   &&& .tutor-navbar {
+      padding-left: ${breakpoint.margins.tablet};
+      padding-right: ${breakpoint.margins.tablet};
+    }
+  `}
+
+  ${breakpoint.tablet`
+    &&& .tutor-navbar {
+      padding-left: ${breakpoint.margins.tablet};
+      padding-right: ${breakpoint.margins.tablet};
+      .control-label { display: none; }
+      .dropdown-toggle .ox-icon { margin-left: 1rem; }
+      .user-menu .initials {
+        height: 22px;
+        width: 22px;
+        font-size: 0.9rem;
+        letter-spacing: -1px;
+      }
+      .right-side-controls > * {
+        margin-left: 0;
+        &:last-child {
+          margin-left: 1rem;
+        }
+      }
+    }
+  `}
+
+  ${breakpoint.mobile`
+    &&& .tutor-navbar {
+      padding-left: ${breakpoint.margins.mobile};
+      padding-right: ${breakpoint.margins.mobile};
+    }
+  `}
+
+  ${props => !props.hasNavbar && breakpoint.only.mobile`
     .tutor-navbar {
       display: none;
     }

--- a/tutor/src/models/user/menu.js
+++ b/tutor/src/models/user/menu.js
@@ -17,6 +17,7 @@ const ROUTES = {
   },
   dashboard: {
     label: 'Dashboard',
+    icon: 'home',
     isAllowed(course) { return !!course; },
   },
   browseBook: {
@@ -74,12 +75,8 @@ const ROUTES = {
     roles: {
       student: 'changeStudentId',
     },
-  },
-  createNewCourse: {
-    label: 'Create a Course',
-    isAllowed() { return User.canCreateCourses; },
-    options({ course }) {
-      return course ? { separator: 'before' } : { separator: 'both' };
+    options: {
+      separator: 'after',
     },
   },
   cloneCourse: {
@@ -90,11 +87,19 @@ const ROUTES = {
     roles: {
       teacher: 'createNewCourse',
     },
-    options: {
-      key: 'cloneCourse', separator: 'after',
-    },
     isAllowed(course) {
-      return !!(course && !course.is_preview && User.canCreateCourses); },
+      return !!(course && !course.is_preview && User.canCreateCourses);
+    },
+    options: {
+      key: 'cloneCourse',
+    },
+  },
+  createNewCourse: {
+    label: 'Create a Course',
+    isAllowed() { return User.canCreateCourses; },
+    options({ course }) {
+      return course ? { separator: 'before' } : { separator: 'both' };
+    },
   },
   customer_service: {
     label: 'Customer Service',
@@ -196,6 +201,7 @@ const UserMenu = observable({
       addRouteProperty(route, 'options', routeRules, options, {});
       addRouteProperty(route, 'params', routeRules, options, course ? { courseId } : null);
       addRouteProperty(route, 'label', routeRules, options);
+      addRouteProperty(route, 'icon', routeRules, options);
       routes.push(route);
     });
     return routes;


### PR DESCRIPTION
- Collapse separate menus into a single one at mobile size
- Change the displayed icons and ordering.

For example:
Old: 
<img width="174" alt="image" src="https://user-images.githubusercontent.com/34174/91106567-daf7b000-e627-11ea-8ba7-6426d518191f.png">
New:
<img width="183" alt="image" src="https://user-images.githubusercontent.com/34174/91106604-ec40bc80-e627-11ea-8710-15d8540f64c0.png">


Mobile | Tablet | Desktop
------------ | ------------- | -------------
![image](https://user-images.githubusercontent.com/34174/91106310-34131400-e627-11ea-9d68-677dca3308bf.png)| ![image](https://user-images.githubusercontent.com/34174/91106303-2d849c80-e627-11ea-81f1-1749ab8f03f6.png)| ![image](https://user-images.githubusercontent.com/34174/91106292-2493cb00-e627-11ea-8881-3fb173163757.png)


Teacher side isn't specifically targeted for mobile improvements, but since they use a shared menu, here's how that looks:

Mobile | Desktop
------------ | -------------
![image](https://user-images.githubusercontent.com/34174/91106375-560c9680-e627-11ea-8194-5b8da7e849c8.png)|![image](https://user-images.githubusercontent.com/34174/91106362-4ee58880-e627-11ea-8ef9-11ea94d3d7b8.png)

