### PR TITLE
change padding of course listing on tablet and mobile

### DIFF
--- a/tutor/specs/components/__snapshots__/app.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/app.spec.jsx.snap
@@ -119,6 +119,11 @@ exports[`main Tutor App renders and matches snapshot 1`] = `
     padding-left: 8px;
     padding-right: 8px;
   }
+
+  .my-courses .c0.c0.c0 .tutor-navbar {
+    padding-left: calc(8px * 2);
+    padding-right: calc(8px * 2);
+  }
 }
 
 <div

--- a/tutor/specs/components/__snapshots__/my-courses.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/my-courses.spec.jsx.snap
@@ -1,6 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`My Courses Component matches snapshot 1`] = `
+@media (max-width:1199px) {
+  .c0 {
+    max-width: 100%;
+    padding: 0 24px;
+  }
+}
+
+@media (max-width:600px) {
+  .c0 {
+    max-width: 100%;
+    padding: 0 calc(8px * 2);
+  }
+}
+
 <div
   className="openstax-debug-content"
 >
@@ -17,7 +31,7 @@ exports[`My Courses Component matches snapshot 1`] = `
           data-test-id="current-courses"
         >
           <div
-            className="container"
+            className="c0 container"
           >
             <div
               className="my-courses-title row"

--- a/tutor/specs/components/__snapshots__/my-courses.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/my-courses.spec.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`My Courses Component matches snapshot 1`] = `
-@media (max-width:1199px) {
+@media (max-width:999px) {
   .c0 {
     max-width: 100%;
     padding: 0 24px;

--- a/tutor/specs/components/__snapshots__/tutor-layout.spec.js.snap
+++ b/tutor/specs/components/__snapshots__/tutor-layout.spec.js.snap
@@ -15,7 +15,7 @@ exports[`Tutor Layout renders and matches snapshot 1`] = `
                       <TutorLayout>
                         <MobXProvider topNavbar={{...}} courseContext={{...}} bottomNavbar={{...}} setSecondaryTopControls={[Function: res]}>
                           <styled.div hasNavbar={true}>
-                            <div className=\\"sc-fznKkj kejZeK\\">
+                            <div className=\\"sc-fznKkj feiMkx\\">
                               <Navbar area=\\"header\\" context={{...}} isDocked={false}>
                                 <styled.nav area=\\"header\\" shouldHideNavbar={[undefined]} isDocked={false} className=\\"tutor-navbar\\">
                                   <nav className=\\"sc-AxjAm fhzKny tutor-navbar\\">
@@ -61,7 +61,35 @@ exports[`Tutor Layout renders and matches snapshot 1`] = `
                                             <Responsive desktop={{...}} mobile={{...}}>
                                               <Memo(wrappedComponent) course={[undefined]}>
                                                 <StudentPayNowBtn course={[undefined]} />
-                                                <ActionsMenu course={[undefined]} />
+                                                <ActionsMenu course={[undefined]}>
+                                                  <Responsive desktop={{...}} mobile={{...}}>
+                                                    <Dropdown className=\\"actions-menu\\" navbar={false}>
+                                                      <ReactOverlaysDropdown drop={[undefined]} show={[undefined]} alignEnd={[undefined]} onToggle={[Function]} focusFirstItemOnShow={[undefined]} itemSelector=\\".dropdown-item:not(.disabled):not(:disabled)\\">
+                                                        <div onKeyDown={[Function: handleKeyDown]} className=\\"actions-menu dropdown\\">
+                                                          <DropdownToggle id=\\"actions-menu\\" aria-label=\\"Menu and settings\\" variant=\\"ox\\">
+                                                            <Button onClick={[Function]} className=\\"dropdown-toggle\\" aria-haspopup={true} aria-expanded={false} id=\\"actions-menu\\" aria-label=\\"Menu and settings\\" variant=\\"ox\\" active={false} disabled={false} type=\\"button\\">
+                                                              <button onClick={[Function]} aria-haspopup={true} aria-expanded={false} id=\\"actions-menu\\" aria-label=\\"Menu and settings\\" disabled={false} type=\\"button\\" className=\\"dropdown-toggle btn btn-ox\\">
+                                                                <Icon type=\\"bars\\" buttonProps={{...}} tooltipProps={{...}}>
+                                                                  <IconWrapper data-variant={[undefined]} className=\\"ox-icon ox-icon-bars\\" icon={{...}}>
+                                                                    <FontAwesomeIcon data-variant={[undefined]} className=\\"IconWrapper-ra27cp-0 gKKqUB ox-icon ox-icon-bars\\" icon={{...}} border={false} mask={{...}} fixedWidth={false} inverse={false} flip={{...}} listItem={false} pull={{...}} pulse={false} rotation={{...}} size={{...}} spin={false} symbol={false} title=\\"\\" transform={{...}}>
+                                                                      <svg aria-hidden=\\"true\\" focusable=\\"false\\" data-prefix=\\"fas\\" data-icon=\\"bars\\" className=\\"svg-inline--fa fa-bars fa-w-14 IconWrapper-ra27cp-0 gKKqUB ox-icon ox-icon-bars\\" role=\\"img\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 448 512\\" style={{...}} data-variant={[undefined]}>
+                                                                        <path fill=\\"currentColor\\" d=\\"M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z\\" style={{...}} />
+                                                                      </svg>
+                                                                    </FontAwesomeIcon>
+                                                                  </IconWrapper>
+                                                                </Icon>
+                                                                <span className=\\"control-label\\" title=\\"Menu and settings\\">
+                                                                  Menu
+                                                                </span>
+                                                              </button>
+                                                            </Button>
+                                                          </DropdownToggle>
+                                                          <DropdownMenu alignRight={true} flip={true} />
+                                                        </div>
+                                                      </ReactOverlaysDropdown>
+                                                    </Dropdown>
+                                                  </Responsive>
+                                                </ActionsMenu>
                                                 <withRouter(inject(SupportMenu)) course={[undefined]}>
                                                   <inject(SupportMenu) course={[undefined]} history={{...}} location={{...}} match={{...}} staticContext={[undefined]}>
                                                     <Observer>

--- a/tutor/specs/components/__snapshots__/tutor-layout.spec.js.snap
+++ b/tutor/specs/components/__snapshots__/tutor-layout.spec.js.snap
@@ -15,7 +15,7 @@ exports[`Tutor Layout renders and matches snapshot 1`] = `
                       <TutorLayout>
                         <MobXProvider topNavbar={{...}} courseContext={{...}} bottomNavbar={{...}} setSecondaryTopControls={[Function: res]}>
                           <styled.div hasNavbar={true}>
-                            <div className=\\"sc-fznKkj fZlCeP\\">
+                            <div className=\\"sc-fznKkj kejZeK\\">
                               <Navbar area=\\"header\\" context={{...}} isDocked={false}>
                                 <styled.nav area=\\"header\\" shouldHideNavbar={[undefined]} isDocked={false} className=\\"tutor-navbar\\">
                                   <nav className=\\"sc-AxjAm fhzKny tutor-navbar\\">
@@ -61,35 +61,7 @@ exports[`Tutor Layout renders and matches snapshot 1`] = `
                                             <Responsive desktop={{...}} mobile={{...}}>
                                               <Memo(wrappedComponent) course={[undefined]}>
                                                 <StudentPayNowBtn course={[undefined]} />
-                                                <ActionsMenu course={[undefined]}>
-                                                  <Responsive desktop={{...}} mobile={{...}}>
-                                                    <Dropdown className=\\"actions-menu\\" navbar={false}>
-                                                      <ReactOverlaysDropdown drop={[undefined]} show={[undefined]} alignEnd={[undefined]} onToggle={[Function]} focusFirstItemOnShow={[undefined]} itemSelector=\\".dropdown-item:not(.disabled):not(:disabled)\\">
-                                                        <div onKeyDown={[Function: handleKeyDown]} className=\\"actions-menu dropdown\\">
-                                                          <DropdownToggle id=\\"actions-menu\\" aria-label=\\"Menu and settings\\" variant=\\"ox\\">
-                                                            <Button onClick={[Function]} className=\\"dropdown-toggle\\" aria-haspopup={true} aria-expanded={false} id=\\"actions-menu\\" aria-label=\\"Menu and settings\\" variant=\\"ox\\" active={false} disabled={false} type=\\"button\\">
-                                                              <button onClick={[Function]} aria-haspopup={true} aria-expanded={false} id=\\"actions-menu\\" aria-label=\\"Menu and settings\\" disabled={false} type=\\"button\\" className=\\"dropdown-toggle btn btn-ox\\">
-                                                                <Icon type=\\"bars\\" buttonProps={{...}} tooltipProps={{...}}>
-                                                                  <IconWrapper data-variant={[undefined]} className=\\"ox-icon ox-icon-bars\\" icon={{...}}>
-                                                                    <FontAwesomeIcon data-variant={[undefined]} className=\\"IconWrapper-ra27cp-0 gKKqUB ox-icon ox-icon-bars\\" icon={{...}} border={false} mask={{...}} fixedWidth={false} inverse={false} flip={{...}} listItem={false} pull={{...}} pulse={false} rotation={{...}} size={{...}} spin={false} symbol={false} title=\\"\\" transform={{...}}>
-                                                                      <svg aria-hidden=\\"true\\" focusable=\\"false\\" data-prefix=\\"fas\\" data-icon=\\"bars\\" className=\\"svg-inline--fa fa-bars fa-w-14 IconWrapper-ra27cp-0 gKKqUB ox-icon ox-icon-bars\\" role=\\"img\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 448 512\\" style={{...}} data-variant={[undefined]}>
-                                                                        <path fill=\\"currentColor\\" d=\\"M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z\\" style={{...}} />
-                                                                      </svg>
-                                                                    </FontAwesomeIcon>
-                                                                  </IconWrapper>
-                                                                </Icon>
-                                                                <span className=\\"control-label\\" title=\\"Menu and settings\\">
-                                                                  Menu
-                                                                </span>
-                                                              </button>
-                                                            </Button>
-                                                          </DropdownToggle>
-                                                          <DropdownMenu alignRight={true} flip={true} />
-                                                        </div>
-                                                      </ReactOverlaysDropdown>
-                                                    </Dropdown>
-                                                  </Responsive>
-                                                </ActionsMenu>
+                                                <ActionsMenu course={[undefined]} />
                                                 <withRouter(inject(SupportMenu)) course={[undefined]}>
                                                   <inject(SupportMenu) course={[undefined]} history={{...}} location={{...}} match={{...}} staticContext={[undefined]}>
                                                     <Observer>

--- a/tutor/src/components/my-courses/listings.jsx
+++ b/tutor/src/components/my-courses/listings.jsx
@@ -1,7 +1,6 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import { observer } from 'mobx-react';
-import { computed, observable } from 'mobx';
+import {
+  React, PropTypes, computed, observer, observable, styled,
+} from 'vendor';
 import { isEmpty, merge, map, take, last } from 'lodash';
 import { Col, Row, Container } from 'react-bootstrap';
 import classnames from 'classnames';
@@ -12,6 +11,18 @@ import CourseModel from '../../models/course';
 import CreateACourse from './create-a-course';
 import { CoursePreview, Course, CourseTeacher } from './course';
 import TourAnchor from '../tours/anchor';
+import { breakpoint } from 'theme';
+
+const StyledContainer = styled(Container)`
+  ${breakpoint.tablet`
+    max-width: 100%;
+    padding: 0 ${breakpoint.margins.tablet};
+  `}
+  ${breakpoint.mobile`
+    max-width: 100%;
+    padding: 0 calc(${breakpoint.margins.mobile} * 2);
+  `}
+`;
 
 function wrapCourseItem(Item, course = {}) {
   return (
@@ -111,14 +122,14 @@ class MyCoursesCurrent extends React.Component {
     const courses = Courses.tutor.nonPreview.currentAndFuture.array;
     return (
       <div data-test-id="current-courses" className={baseName}>
-        <Container>
+        <StyledContainer>
           <MyCoursesTitle title="Current Courses" main={true} />
           {isEmpty(courses) ? <MyCoursesNone /> : undefined}
           <MyCoursesBase
             className={`${baseName}-section`}
             courses={courses}
             after={User.canCreateCourses ? <MyCoursesCreate /> : undefined} />
-        </Container>
+        </StyledContainer>
       </div>
     );
   }
@@ -141,7 +152,7 @@ class MyCoursesBasic extends React.Component {
     return (
       (
         <div className={baseName}>
-          <Container>
+          <StyledContainer>
             <MyCoursesTitle title={title} />
             <MyCoursesBase
               className={`${baseName}-section`}
@@ -149,7 +160,7 @@ class MyCoursesBasic extends React.Component {
               before={before}
               after={after}
             />
-          </Container>
+          </StyledContainer>
         </div>
       )
     );

--- a/tutor/src/components/tutor-layout.js
+++ b/tutor/src/components/tutor-layout.js
@@ -54,6 +54,10 @@ const StyledLayout = styled.div`
       padding-left: ${breakpoint.margins.mobile};
       padding-right: ${breakpoint.margins.mobile};
     }
+    .my-courses &&& .tutor-navbar {
+      padding-left: calc(${breakpoint.margins.mobile} * 2);
+      padding-right: calc(${breakpoint.margins.mobile} * 2);
+    }
   `}
 
   ${props => !props.hasNavbar && breakpoint.only.mobile`


### PR DESCRIPTION
Just some tiny tweaks here to the padding. Only unusual thing here is to special-case the mobile padding for the container and navbar to 16px to match the design doc.

Tablet:

![image](https://user-images.githubusercontent.com/34174/91367178-a9fbb480-e7ba-11ea-8566-a1cdb8fc52a1.png)

Mobile:

![image](https://user-images.githubusercontent.com/34174/91367192-b3851c80-e7ba-11ea-9e6e-d22a5193fe26.png)
