### PR TITLE
Move TZ info to tooltips on the student side

### DIFF
--- a/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
+++ b/tutor/specs/screens/student-dashboard/__snapshots__/dashboard.spec.jsx.snap
@@ -370,13 +370,23 @@ exports[`Student Dashboard displays as loading 1`] = `
                       <span
                         className="c3 date-range"
                       >
-                        <time>
+                        <time
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                        >
                           Oct 12, 2015
                         </time>
                         <span>
                            – 
                         </span>
-                        <time>
+                        <time
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                        >
                           Oct 18, 2015
                         </time>
                       </span>
@@ -571,8 +581,13 @@ exports[`Student Dashboard displays as loading 1`] = `
                     <div
                       className="sc-fznyAO c4"
                     >
-                      <time>
-                        Wed, Oct 21, 7:00am CDT
+                      <time
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        Wed, Oct 21, 7:00am
                       </time>
                     </div>
                     <div
@@ -641,8 +656,13 @@ exports[`Student Dashboard displays as loading 1`] = `
                     <div
                       className="sc-fznyAO c4"
                     >
-                      <time>
-                        Wed, Oct 21, 7:00am CDT
+                      <time
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        Wed, Oct 21, 7:00am
                       </time>
                     </div>
                     <div
@@ -711,8 +731,13 @@ exports[`Student Dashboard displays as loading 1`] = `
                     <div
                       className="sc-fznyAO c4"
                     >
-                      <time>
-                        Wed, Oct 21, 7:00am CDT
+                      <time
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        Wed, Oct 21, 7:00am
                       </time>
                     </div>
                     <div
@@ -781,8 +806,13 @@ exports[`Student Dashboard displays as loading 1`] = `
                     <div
                       className="sc-fznyAO c4"
                     >
-                      <time>
-                        Wed, Oct 21, 7:00am CDT
+                      <time
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        Wed, Oct 21, 7:00am
                       </time>
                     </div>
                     <div
@@ -1253,13 +1283,23 @@ exports[`Student Dashboard matches snapshot 1`] = `
                       <span
                         className="c3 date-range"
                       >
-                        <time>
+                        <time
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                        >
                           Oct 12, 2015
                         </time>
                         <span>
                            – 
                         </span>
-                        <time>
+                        <time
+                          onBlur={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                        >
                           Oct 18, 2015
                         </time>
                       </span>
@@ -1454,8 +1494,13 @@ exports[`Student Dashboard matches snapshot 1`] = `
                     <div
                       className="sc-fznyAO c4"
                     >
-                      <time>
-                        Wed, Oct 21, 7:00am CDT
+                      <time
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        Wed, Oct 21, 7:00am
                       </time>
                     </div>
                     <div
@@ -1524,8 +1569,13 @@ exports[`Student Dashboard matches snapshot 1`] = `
                     <div
                       className="sc-fznyAO c4"
                     >
-                      <time>
-                        Wed, Oct 21, 7:00am CDT
+                      <time
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        Wed, Oct 21, 7:00am
                       </time>
                     </div>
                     <div
@@ -1594,8 +1644,13 @@ exports[`Student Dashboard matches snapshot 1`] = `
                     <div
                       className="sc-fznyAO c4"
                     >
-                      <time>
-                        Wed, Oct 21, 7:00am CDT
+                      <time
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        Wed, Oct 21, 7:00am
                       </time>
                     </div>
                     <div
@@ -1664,8 +1719,13 @@ exports[`Student Dashboard matches snapshot 1`] = `
                     <div
                       className="sc-fznyAO c4"
                     >
-                      <time>
-                        Wed, Oct 21, 7:00am CDT
+                      <time
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        Wed, Oct 21, 7:00am
                       </time>
                     </div>
                     <div

--- a/tutor/specs/screens/student-dashboard/__snapshots__/event-row.spec.jsx.snap
+++ b/tutor/specs/screens/student-dashboard/__snapshots__/event-row.spec.jsx.snap
@@ -210,8 +210,13 @@ exports[`Event Row renders and matches snapshot 1`] = `
         <div
           className="sc-AxiKw c3"
         >
-          <time>
-            Wed, Oct 30, 7:00am CDT
+          <time
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            Wed, Oct 30, 7:00am
           </time>
         </div>
         <div

--- a/tutor/specs/screens/student-dashboard/__snapshots__/homework-row.spec.jsx.snap
+++ b/tutor/specs/screens/student-dashboard/__snapshots__/homework-row.spec.jsx.snap
@@ -210,8 +210,13 @@ exports[`Homework Row renders in progress 1`] = `
         <div
           className="sc-fznyAO c3"
         >
-          <time>
-            Sun, Oct 15, 7:00am CDT
+          <time
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            Sun, Oct 15, 7:00am
           </time>
         </div>
         <div
@@ -491,8 +496,13 @@ exports[`Homework Row renders with completed count 1`] = `
         <div
           className="sc-fznyAO c3"
         >
-          <time>
-            Sat, Oct 14, 7:00am CDT
+          <time
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            Sat, Oct 14, 7:00am
           </time>
         </div>
         <div

--- a/tutor/src/components/time.js
+++ b/tutor/src/components/time.js
@@ -2,6 +2,8 @@ import TimeModel from '../models/time';
 import PropTypes from 'prop-types';
 import React from 'react';
 import TimeHelper from '../helpers/time';
+import { moment } from 'vendor';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 export default class Time extends React.Component {
   static defaultProps = {
@@ -18,20 +20,31 @@ export default class Time extends React.Component {
     format: PropTypes.string,
   };
 
+  dateFormat = (value) => { switch (value) {
+    case 'shortest': return 'M/D'; // 9/14
+    case 'short': return 'MMM DD, YYYY'; // Feb 14, 2010
+    case 'concise': return 'ddd, MMM DD[,] h:mma';
+    case 'medium': return 'dddd, MMMM Do YYYY, h:mma'; // Sunday, February 14th 2010, 3:25pm
+    case 'long': return 'dddd, MMMM Do YYYY, h:mm:ss a'; // Sunday, February 14th 2010, 3:25:50 pm
+    default: return value;
+  } };
+
   render() {
     let { format, date } = this.props;
-    format = (() => { switch (this.props.format) {
-      case 'shortest': return 'M/D'; // 9/14
-      case 'short': return 'MMM DD, YYYY'; // Feb 14, 2010
-      case 'concise': return 'ddd, MMM DD[,] h:mma z';
-      case 'long': return 'dddd, MMMM Do YYYY, h:mm:ss a'; // Sunday, February 14th 2010, 3:25:50 pm
-      default: return this.props.format;
-    } })();
 
     return (
-      <time>
-        {TimeHelper.momentInLocal(date).format(format)}
-      </time>
+      <OverlayTrigger
+        placement="right"
+        overlay={
+          <Tooltip>
+            {moment(date).format(this.dateFormat('medium'))} {TimeHelper.momentOffsetWithBrowserTzName(date)}
+          </Tooltip>
+        }
+      >
+        <time>
+          {moment(date).format(this.dateFormat(format))}
+        </time>
+      </OverlayTrigger>
     );
   }
 }

--- a/tutor/src/helpers/time.js
+++ b/tutor/src/helpers/time.js
@@ -139,6 +139,10 @@ const TimeHelper = {
     return moment.tz.guess();
   },
 
+  momentOffsetWithBrowserTzName(date) {
+    return `${moment(date).format('Z')} ${Intl.DateTimeFormat().resolvedOptions().timeZone}`;
+  },
+
   getMomentPreserveDate(value, ...args) {
     const preserve = TimeHelper.makeMoment(value, ...Array.from(args));
     return preserve.hour(12).locale(moment.locale());

--- a/tutor/src/screens/task/exercise-task-header.js
+++ b/tutor/src/screens/task/exercise-task-header.js
@@ -5,7 +5,7 @@ import Router from '../../helpers/router';
 import UX from './ux';
 import { colors } from 'theme';
 import { Icon } from 'shared';
-import TimeHelper from 'helpers/time';
+import Time from '../../components/time';
 
 const StyledHeadingTitle = styled.div`
   display: flex;
@@ -35,11 +35,11 @@ const StyledHeadingTitle = styled.div`
       color: ${colors.neutral.pale};
     }
   }
-  
+
   .overview-task-icon {
       display: none;
     }
-  
+
   /*
     Hide the date when screen is tablet size or smaller.
     Show overview icon.
@@ -71,13 +71,13 @@ const headerContent = (ux) => {
         <div className="title-info">
           <div className="title-name">{ux.task.title}</div>
           <div className="title-divider">|</div>
-          <div className="title-due-date">Due {TimeHelper.toShortHumanDateTimeTz(ux.task.dueAtMoment)}</div>
+          <div className="title-due-date">Due {<Time date={ux.task.dueAtMoment} format="concise" />}</div>
         </div>
         <div className="overview-task-icon">
           <Icon
             type="th"
             onClick={ux.toggleTaskProgressTable}
-            className={cn({ 'isShowingTable': !ux.hideTaskProgressTable })} 
+            className={cn({ 'isShowingTable': !ux.hideTaskProgressTable })}
           />
         </div>
       </StyledHeadingTitle>
@@ -126,7 +126,7 @@ class ExercisesTaskHeader extends React.Component {
 
     const { ux, unDocked } = this.props;
     return (
-      <Header 
+      <Header
         unDocked={unDocked}
         headerContent={headerContent(ux)}
         backTo={Router.makePathname('dashboard', { courseId: ux.course.id })}

--- a/tutor/src/screens/task/reading-navbar.js
+++ b/tutor/src/screens/task/reading-navbar.js
@@ -4,8 +4,8 @@ import UX from './ux';
 import MilestonesToggle from './reading-milestones-toggle';
 import NotesSummaryToggle from '../../components/notes/summary-toggle';
 import { Icon } from 'shared';
-import TimeHelper from '../../helpers/time';
 import TutorLink from '../../components/link';
+import Time from '../../components/time';
 import { colors, breakpoint } from 'theme';
 
 const StyledNavbar = styled.div`
@@ -143,7 +143,9 @@ class ReadingNavbar extends React.Component {
           <Left>
             <TaskTitle>{ux.task.title}</TaskTitle>
             <Divider className="hide-mobile">|</Divider>
-            <span className="hide-mobile">Due {TimeHelper.toShortHumanDateTime(ux.task.due_at)}</span>
+            <span className="hide-mobile">
+              Due <Time date={ux.task.due_at} format="llll" />
+            </span>
           </Left>
           <Right>
             <NotesSummaryToggle

--- a/tutor/src/screens/task/step/instructions.js
+++ b/tutor/src/screens/task/step/instructions.js
@@ -119,7 +119,7 @@ const ReadingWeights = observer(({ task }) => {
   );
 });
 
-const format = (date) => <Time date={date} format="ddd, MMM D, h:mma" />;
+const format = (date) => <Time date={date} format="concise" />;
 
 const LateWorkPolicy = observer(({ task }) => {
   if (!task.hasLateWorkPolicy) { return null; }

--- a/tutor/src/screens/task/step/instructions.js
+++ b/tutor/src/screens/task/step/instructions.js
@@ -5,7 +5,7 @@ import { OuterStepCard, InnerStepCard } from './card';
 import StepContinueBtn from './continue-btn';
 import S from '../../../helpers/string';
 import ScoresHelper from '../../../helpers/scores';
-import TimeHelper from '../../../helpers/time';
+import Time from '../../../components/time';
 
 const CardBody = styled(InnerStepCard)`
   padding-bottom: 5rem;
@@ -119,7 +119,7 @@ const ReadingWeights = observer(({ task }) => {
   );
 });
 
-const format = (date) => TimeHelper.momentInLocal(date).format(TimeHelper.HUMAN_DATE_TIME_TZ_FORMAT);
+const format = (date) => <Time date={date} format="ddd, MMM D, h:mma" />;
 
 const LateWorkPolicy = observer(({ task }) => {
   if (!task.hasLateWorkPolicy) { return null; }

--- a/tutor/src/screens/task/task-info.js
+++ b/tutor/src/screens/task/task-info.js
@@ -1,6 +1,6 @@
 import { React, PropTypes, observer, styled } from 'vendor';
 import Task from '../../models/student-tasks/task';
-import TimeHelper from '../../helpers/time';
+import Time from '../../components/time';
 
 const StyledTaskInfo = styled.div`
   display: flex;
@@ -30,7 +30,7 @@ class TaskInfo extends React.Component {
       <StyledTaskInfo>
         <Title>{task.title}</Title>
         {task.due_at &&
-          <DueDate>due {TimeHelper.toShortHumanDateTime(task.due_at)}</DueDate>}
+          <DueDate>Due {<Time date={task.due_at} format="concise" />}</DueDate>}
       </StyledTaskInfo>
     );
   }


### PR DESCRIPTION
Loading the entire TZ set just for abbreviations is very large, and the browser can give us comprehensive info, so we've decided to change how we display time zone data on the student side.

- Remove the abbreviated time zone in the format
- Display detailed time info on hover, getting the offset from moment formatting ("Z") and the timezone name from `Intl.DateTimeFormat().resolvedOptions().timeZone`

This should also resolve the issue with times displaying as UTC when viewed with a timezone setting we don't have loaded.

Examples:

<img width="499" alt="image" src="https://user-images.githubusercontent.com/34174/91607782-621c8f00-e96c-11ea-9128-22310aaeb5fe.png">

<img width="561" alt="image" src="https://user-images.githubusercontent.com/34174/91607813-6e085100-e96c-11ea-87d8-270676334cfd.png">
