### PR TITLE
minor fixes in add details step

### DIFF
--- a/tutor/specs/screens/teacher-dashboard/sidebar.spec.js
+++ b/tutor/specs/screens/teacher-dashboard/sidebar.spec.js
@@ -20,10 +20,10 @@ describe('CourseCalendar AddAssignmentMenu', function() {
     const wrapper = mount(<C><Sidebar {...props} /></C>);
     const links = wrapper.find('.new-assignments li').map(el => el.render().text());
     expect(links).toEqual([
-      'Add Reading',
-      'Add Homework',
-      'Add External Assignment',
-      'Add Event',
+      'Add reading',
+      'Add homework',
+      'Add external assignment',
+      'Add event',
     ]);
   });
 

--- a/tutor/src/helpers/string.js
+++ b/tutor/src/helpers/string.js
@@ -103,4 +103,9 @@ export default {
     return isString(text) ? text.replace(/(<([^>]+)>)/ig, '') : text;
   },
 
+  assignmentHeaderText(type) {
+    if(type === 'external') return 'external assignment';
+    return type;
+  },
+
 };

--- a/tutor/src/screens/assignment-edit/builder.js
+++ b/tutor/src/screens/assignment-edit/builder.js
@@ -132,9 +132,11 @@ const AssignmentBuilder = observer(({ ux, children, title, middleControls }) => 
   return (
     <ScrollToTop>
       <Header className="heading" templateColors={colors.templates[ux.plan.type]}>
+        {Boolean(ux.steps && ux.steps.headerText) &&
         <HeaderStep>
           {ux.steps.headerText}
-        </HeaderStep>
+        </HeaderStep> 
+        }
         {title}
       </Header>
       <BodyWrapper>

--- a/tutor/src/screens/assignment-edit/controls.js
+++ b/tutor/src/screens/assignment-edit/controls.js
@@ -17,6 +17,12 @@ const Footer = styled.div`
   .btn, .btn.btn-plain {
     padding: 0.6rem 2rem;
   }
+
+  .btn.btn-plain {
+    background: #fff;
+    color: ${colors.neutral.dark};
+    border: 1px solid ${colors.neutral.pale};
+  }
 `;
 
 const FooterInner = styled.div`
@@ -33,12 +39,8 @@ const LeftButton = styled(Button).attrs({
   variant: 'plain',
 })`
   &.btn.btn-plain {
-    background: #fff;
-    color: ${colors.neutral.dark};
-    border: 1px solid ${colors.neutral.pale};
     min-width: 10rem;
-  }
-`;
+  }`;
 
 const RightButton = styled(Button)`
   min-width: 16rem;

--- a/tutor/src/screens/assignment-edit/delete-btn.js
+++ b/tutor/src/screens/assignment-edit/delete-btn.js
@@ -77,7 +77,7 @@ class DeleteButton extends React.Component {
         />
         <Button
           onClick={this.open}
-          variant="default"
+          variant="plain"
           className="control delete-assignment"
         >
           <Icon type="trash" />Delete

--- a/tutor/src/screens/assignment-edit/details-body.js
+++ b/tutor/src/screens/assignment-edit/details-body.js
@@ -222,7 +222,7 @@ const DetailsBody = observer(({ ux }) => {
     <Body>
       <SplitRow>
         <RowLabel htmlFor="title">
-          Assignment name
+          {ux.titleTextLabel}
           <HintText>(This will show on the student dashboard)</HintText>
         </RowLabel>
         <StyledTextInput

--- a/tutor/src/screens/assignment-edit/index.js
+++ b/tutor/src/screens/assignment-edit/index.js
@@ -9,6 +9,7 @@ import { withRouter } from 'react-router';
 import UX from './ux';
 import { BackgroundWrapper, ContentWrapper } from '../../helpers/background-wrapper';
 import CourseBreadcrumb from '../../components/course-breadcrumb';
+import S from '../../helpers/string';
 
 import './styles.scss';
 
@@ -71,7 +72,7 @@ class AssignmentBuilder extends React.Component {
             courseId={ux.course.id}
           >
             <ContentWrapper>
-              <CourseBreadcrumb course={this.ux.course} currentTitle={`Add ${ux.plan.type}`} />
+              <CourseBreadcrumb course={this.ux.course} currentTitle={`Add ${S.assignmentHeaderText(ux.plan.type)}`} />
               <Formik
                 initialValues={ux.formValues}
                 validateOnMount={true}

--- a/tutor/src/screens/assignment-edit/ux.js
+++ b/tutor/src/screens/assignment-edit/ux.js
@@ -477,4 +477,14 @@ export default class AssignmentUX {
   @computed get canEditSettings() {
     return this.plan.isNew || every(this.plan.tasking_plans, ['isPastOpen', false]);
   }
+
+  @computed get titleTextLabel() {
+    if(this.plan.isEvent) return 'Event name';
+    return 'Assignment name';
+  }
+
+  @computed get headerTextLabel() {
+    if(this.plan.isExternal) return 'external assignment';
+    return this.plan.type;
+  }
 }

--- a/tutor/src/screens/teacher-dashboard/add-menu.jsx
+++ b/tutor/src/screens/teacher-dashboard/add-menu.jsx
@@ -6,6 +6,7 @@ import { autobind } from 'core-decorators';
 import Router from '../../helpers/router';
 import CourseGroupingLabel from '../../components/course-grouping-label';
 import { colors } from 'theme';
+import S from '../../helpers/string';
 
 const StyledMenuContainer = styled.div`
   & hr {
@@ -36,25 +37,25 @@ export default class CourseAddMenu {
     if (hasPeriods) {
       links = [
         {
-          text: 'Add Reading',
+          text: `Add ${S.assignmentHeaderText('reading')}`,
           to: 'editAssignment',
           params: { type: 'reading', courseId: course.id, id: 'new' },
           type: 'reading',
           query: { due_at },
         }, {
-          text: 'Add Homework',
+          text: `Add ${S.assignmentHeaderText('homework')}`,
           to: 'editAssignment',
           params: { type: 'homework', courseId: course.id, id: 'new' },
           type: 'homework',
           query: { due_at },
         }, {
-          text: 'Add External Assignment',
+          text: `Add ${S.assignmentHeaderText('external')}`,
           to: 'editAssignment',
           params: { type: 'external', courseId: course.id, id: 'new' },
           type: 'external',
           query: { due_at },
         }, {
-          text: 'Add Event',
+          text: `Add ${S.assignmentHeaderText('event')}`,
           to: 'editAssignment',
           params: { type: 'event', courseId: course.id, id: 'new' },
           type: 'event',

--- a/tutor/src/screens/teacher-dashboard/styles/sidebar.scss
+++ b/tutor/src/screens/teacher-dashboard/styles/sidebar.scss
@@ -135,6 +135,7 @@
       a {
         padding: 3px 12px;
         color: $tutor-neutral-darker;
+        text-transform: capitalize;
         &:hover, &:focus { text-decoration: none; }
       }
     }


### PR DESCRIPTION
- In events and external assignment builder, the 'Add Details' label should be left-aligned with the text below.
- When adding an event, in the 'Add details' step, the label for the first text box should be Event name (and not Assignment name)
- When adding an External assignment, the page header in the builder should be Add external assignment
- When reviewing a draft assignment, the Delete button should be a white default button (like the 'Cancel' button next to it)