### PR TITLE
fix mobile menu scroll and fix it being hidden behind ios navbar

### DIFF
--- a/tutor/resources/styles/components/top-nav-bar.scss
+++ b/tutor/resources/styles/components/top-nav-bar.scss
@@ -143,13 +143,13 @@
     }
 
     .dropdown-menu {
-      margin: 60px 0 0 0 !important;
+      margin: #{$tutor-navbar-height} 0 0 !important;
       transform: inherit !important;
       left: 0;
       right: 0;
       top: 0;
       overflow-y: auto;
-      max-height: calc(100vh - $tutor-navbar-height);
+      max-height: calc(100vh - #{$tutor-navbar-height} * 3);
     }
     .dropdown-item {
       padding-left: 16px;


### PR DESCRIPTION
- Fix scroll behavior
- Fix menu height causing the menu to go behind iOS footer navbar