### PR TITLE
Responsive accessibility statement

### DIFF
--- a/tutor/resources/styles/components/info-page.scss
+++ b/tutor/resources/styles/components/info-page.scss
@@ -1,4 +1,3 @@
-.accessibility-statement,
 .student-preview {
   margin-top: 2rem;
   padding: 40px 30px 0 50px;

--- a/tutor/specs/components/__snapshots__/content-page.spec.js.snap
+++ b/tutor/specs/components/__snapshots__/content-page.spec.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Content Page renders and matches snapshot 1`] = `
+.c0 {
+  background: #fff;
+  line-height: 2rem;
+  margin: 0 auto;
+  max-width: 1200px;
+  padding: 40px 80px;
+}
+
+.c0 h3 {
+  font-size: 1.4rem;
+  font-weight: bold;
+}
+
+.c0 p,
+.c0 ul {
+  margin-bottom: 2rem;
+}
+
+@media (max-width:999px) {
+  .c0 {
+    padding: calc(8px * 2) 24px;
+  }
+}
+
+@media (max-width:600px) {
+  .c0 {
+    padding: 8px;
+  }
+}
+
+<div
+  className="c0"
+/>
+`;

--- a/tutor/specs/components/content-page.spec.js
+++ b/tutor/specs/components/content-page.spec.js
@@ -1,0 +1,8 @@
+import ContentPage from '../../src/components/content-page';
+
+describe('Content Page', () => {
+
+  it('renders and matches snapshot', () => {
+    expect.snapshot(<ContentPage />).toMatchSnapshot();
+  });
+});

--- a/tutor/specs/components/payments/__snapshots__/manage.spec.jsx.snap
+++ b/tutor/specs/components/payments/__snapshots__/manage.spec.jsx.snap
@@ -21,7 +21,7 @@ exports[`Student Payments Management renders and matches snapshot 1`] = `
   align-items: center;
   background-color: white;
   border-bottom: 1px solid #d5d5d5;
-  padding: 16px 24px 16px;
+  padding: 24px 32px;
   background-color: white;
 }
 
@@ -97,7 +97,7 @@ exports[`Student Payments Management renders and matches snapshot 1`] = `
 
 @media (max-width:999px) {
   .c0 {
-    padding: 16px 24px;
+    padding: 24px 24px;
   }
 }
 
@@ -575,7 +575,7 @@ exports[`Student Payments Management renders empty when no payments 1`] = `
   align-items: center;
   background-color: white;
   border-bottom: 1px solid #d5d5d5;
-  padding: 16px 24px 16px;
+  padding: 24px 32px;
   background-color: white;
 }
 
@@ -651,7 +651,7 @@ exports[`Student Payments Management renders empty when no payments 1`] = `
 
 @media (max-width:999px) {
   .c0 {
-    padding: 16px 24px;
+    padding: 24px 24px;
   }
 }
 

--- a/tutor/specs/components/payments/__snapshots__/manage.spec.jsx.snap
+++ b/tutor/specs/components/payments/__snapshots__/manage.spec.jsx.snap
@@ -19,29 +19,37 @@ exports[`Student Payments Management renders and matches snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  padding: 25px 0 10px;
+  background-color: white;
   border-bottom: 1px solid #d5d5d5;
+  padding: 16px 24px 16px;
   background-color: white;
 }
 
 .c0 > div {
-  margin-bottom: 12px;
-}
-
-.c0 .sticky-table {
-  margin-left: 15px;
-  margin-right: 15px;
+  margin-bottom: 8px;
 }
 
 .c1 {
   width: 100%;
+}
+
+.c1 a {
   color: #027EB5;
-  padding-left: 10px;
+}
+
+.c1 .ox-icon {
+  margin-left: 0;
 }
 
 .c3 {
-  font-size: 3.5rem;
-  padding-left: 12px;
+  font-weight: bold;
+  font-size: 3.6rem;
+  line-height: 4rem;
+  -webkit-letter-spacing: -0.144rem;
+  -moz-letter-spacing: -0.144rem;
+  -ms-letter-spacing: -0.144rem;
+  letter-spacing: -0.144rem;
+  margin: 0;
 }
 
 .c4 {
@@ -87,17 +95,26 @@ exports[`Student Payments Management renders and matches snapshot 1`] = `
   margin-top: 10px;
 }
 
-@media (max-width:600px) {
+@media (max-width:999px) {
   .c0 {
-    padding-bottom: 0;
+    padding: 16px 24px;
   }
 }
 
 @media (max-width:600px) {
-  .c0 .sticky-table {
-    margin-left: 0;
-    margin-right: 0;
-    margin-bottom: 0;
+  .c0 {
+    padding: 16px 8px;
+  }
+}
+
+@media (max-width:600px) {
+  .c3 {
+    font-size: 1.8rem;
+    line-height: 3rem;
+    -webkit-letter-spacing: -0.072rem;
+    -moz-letter-spacing: -0.072rem;
+    -ms-letter-spacing: -0.072rem;
+    letter-spacing: -0.072rem;
   }
 }
 
@@ -121,7 +138,7 @@ exports[`Student Payments Management renders and matches snapshot 1`] = `
   >
     <div>
       <div
-        className="c0 task-homework breadcrumbs-wrapper"
+        className="c0"
         role="dialog"
         tabIndex="-1"
       >
@@ -134,7 +151,7 @@ exports[`Student Payments Management renders and matches snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              className="svg-inline--fa fa-angle-left fa-w-8 fa-lg c2 ox-icon ox-icon-angle-left -move-exercise-up circle"
+              className="svg-inline--fa fa-angle-left fa-w-8 fa-lg c2 ox-icon ox-icon-angle-left"
               data-icon="angle-left"
               data-prefix="fas"
               focusable="false"
@@ -556,29 +573,37 @@ exports[`Student Payments Management renders empty when no payments 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  padding: 25px 0 10px;
+  background-color: white;
   border-bottom: 1px solid #d5d5d5;
+  padding: 16px 24px 16px;
   background-color: white;
 }
 
 .c0 > div {
-  margin-bottom: 12px;
-}
-
-.c0 .sticky-table {
-  margin-left: 15px;
-  margin-right: 15px;
+  margin-bottom: 8px;
 }
 
 .c1 {
   width: 100%;
+}
+
+.c1 a {
   color: #027EB5;
-  padding-left: 10px;
+}
+
+.c1 .ox-icon {
+  margin-left: 0;
 }
 
 .c3 {
-  font-size: 3.5rem;
-  padding-left: 12px;
+  font-weight: bold;
+  font-size: 3.6rem;
+  line-height: 4rem;
+  -webkit-letter-spacing: -0.144rem;
+  -moz-letter-spacing: -0.144rem;
+  -ms-letter-spacing: -0.144rem;
+  letter-spacing: -0.144rem;
+  margin: 0;
 }
 
 .c4 {
@@ -624,17 +649,26 @@ exports[`Student Payments Management renders empty when no payments 1`] = `
   margin-top: 10px;
 }
 
-@media (max-width:600px) {
+@media (max-width:999px) {
   .c0 {
-    padding-bottom: 0;
+    padding: 16px 24px;
   }
 }
 
 @media (max-width:600px) {
-  .c0 .sticky-table {
-    margin-left: 0;
-    margin-right: 0;
-    margin-bottom: 0;
+  .c0 {
+    padding: 16px 8px;
+  }
+}
+
+@media (max-width:600px) {
+  .c3 {
+    font-size: 1.8rem;
+    line-height: 3rem;
+    -webkit-letter-spacing: -0.072rem;
+    -moz-letter-spacing: -0.072rem;
+    -ms-letter-spacing: -0.072rem;
+    letter-spacing: -0.072rem;
   }
 }
 
@@ -658,7 +692,7 @@ exports[`Student Payments Management renders empty when no payments 1`] = `
   >
     <div>
       <div
-        className="c0 task-homework breadcrumbs-wrapper"
+        className="c0"
         role="dialog"
         tabIndex="-1"
       >
@@ -671,7 +705,7 @@ exports[`Student Payments Management renders empty when no payments 1`] = `
           >
             <svg
               aria-hidden="true"
-              className="svg-inline--fa fa-angle-left fa-w-8 fa-lg c2 ox-icon ox-icon-angle-left -move-exercise-up circle"
+              className="svg-inline--fa fa-angle-left fa-w-8 fa-lg c2 ox-icon ox-icon-angle-left"
               data-icon="angle-left"
               data-prefix="fas"
               focusable="false"

--- a/tutor/src/components/accessibility-statement.jsx
+++ b/tutor/src/components/accessibility-statement.jsx
@@ -1,134 +1,155 @@
-import React from 'react';
+import { React, styled } from 'vendor';
 import Router from '../helpers/router';
-import CourseBranding from './branding/course';
-import BackButton from './buttons/back-button';
-import { Container, Table } from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
+import { breakpoint } from 'theme';
+import Header from './header';
+
+const Page = styled.div`
+  background: #fff;
+  line-height: 2rem;
+  margin: 0 auto;
+  max-width: 1200px;
+  padding: 40px 80px;
+  ${breakpoint.tablet`
+    padding: calc(${breakpoint.margins.mobile} * 2) ${breakpoint.margins.tablet};
+  `}
+  ${breakpoint.mobile`
+    padding: ${breakpoint.margins.mobile};
+  `}
+  h3 {
+    font-size: 1.4rem;
+    font-weight: bold;
+  }
+  p, ul {
+    margin-bottom: 2rem;
+  }
+`;
 
 export default function AccessibilityStatement() {
   const params = Router.currentParams();
   const { courseId } = params;
-  const backLink = courseId ? { to: 'dashboard', text: 'Back to Dashboard', params: { courseId } } :
-    { to: 'myCourses', text: 'Back to My Courses' };
+  const backTo = courseId ? { to: 'dashboard', params: { courseId } } : { to: 'myCourses' };
 
   return (
-    <Container className="accessibility-statement">
-      <header>
-        <h1>
-          <CourseBranding /> accessibility
-        </h1>
-        <BackButton fallbackLink={backLink} />
-      </header>
+    <>
+      <Header
+        backTo={backTo.to}
+        backToParams={backTo.params}
+        title="Accessibility Statement"
+        unDocked
+      />
+      <Page>
+        <h3>Accessibility</h3>
+        <p>
+          At OpenStax, we're committed to ensuring that OpenStax Tutor is as accessible as possible to the widest possible audience, including students with disabilities.
+        </p>
 
-      <h3>Accessibility</h3>
-      <p>
-        At OpenStax, we're committed to ensuring that OpenStax Tutor is as accessible as possible to the widest possible audience, including students with disabilities.
-      </p>
+        <h3>Web accessibility</h3>
+        <p>
+          Our goal is to ensure that OpenStax Tutor Beta follows accessible web design best practices so that it meets the W3C-WAI Web Content Accessibility Guidelines (WCAG) 2.0 at Level AA and Section 508 of the Rehabilitation Act. The WCAG 2.0 guidelines explain ways to make web content more accessible for people with disabilities and more user-friendly for everyone.
+        </p>
 
-      <h3>Web accessibility</h3>
-      <p>
-        Our goal is to ensure that OpenStax Tutor Beta follows accessible web design best practices so that it meets the W3C-WAI Web Content Accessibility Guidelines (WCAG) 2.0 at Level AA and Section 508 of the Rehabilitation Act. The WCAG 2.0 guidelines explain ways to make web content more accessible for people with disabilities and more user-friendly for everyone.
-      </p>
+        <h3>Our progress</h3>
+        <p>
+          The text in OpenStax Tutor Beta, including the headers, features, and exercises, is designed to be as reader-friendly as possible on-screen. Math content is rendered in MathML, which is an accessible format that can be read with screen readers and styled with CSS. Though we render some complex mathematical graphics as images, all images are developed with detailed explanatory text.
+        </p>
+        <p>
+          We're working hard to achieve our goal of Level AA accessibility, but we realize there are some areas that still need improving. Our developers are actively working to resolve issues that may hinder accessibility according to the above guidelines.
+        </p>
 
-      <h3>Our progress</h3>
-      <p>
-        The text in OpenStax Tutor Beta, including the headers, features, and exercises, is designed to be as reader-friendly as possible on-screen. Math content is rendered in MathML, which is an accessible format that can be read with screen readers and styled with CSS. Though we render some complex mathematical graphics as images, all images are developed with detailed explanatory text.
-      </p>
-      <p>
-        We're working hard to achieve our goal of Level AA accessibility, but we realize there are some areas that still need improving. Our developers are actively working to resolve issues that may hinder accessibility according to the above guidelines.
-      </p>
+        <h3>Feedback</h3>
+        <p>
+          You can help us to meet our accessibility goals by letting us know about your experience using OpenStax Tutor Beta by emailing us at support@openstaxtutor.org.
+          If you've encountered an accessibility problem with OpenStax Tutor Beta, please provide the following information:
+        </p>
+        <ul>
+          <li>Full name as listed in your OpenStax Account.</li>
+          <li>A description of what happened.  What were you unable to accomplish?</li>
+          <li>URL  and/or name of the OpenStax Tutor feature where the issue occurs.</li>
+          <li>The name of your browser (e.g. Firefox 37, Safari 7, Chrome 42, etc.). If possible, please also provide the version number.</li>
+          <li>The name of your operating system (e.g. Windows 7, iOS 6, Android 4.4, etc.). If possible, please also provide the version number.</li>
+          <li>Any assistive technology that you are using (e.g. JAWS, VoiceOver, Dragon, etc.).</li>
+        </ul>
 
-      <h3>Feedback</h3>
-      <p>
-        You can help us to meet our accessibility goals by letting us know about your experience using OpenStax Tutor Beta by emailing us at support@openstaxtutor.org.
-        If you've encountered an accessibility problem with OpenStax Tutor Beta, please provide the following information:
-      </p>
-      <ul>
-        <li>Full name as listed in your OpenStax Account.</li>
-        <li>A description of what happened.  What were you unable to accomplish?</li>
-        <li>URL  and/or name of the OpenStax Tutor feature where the issue occurs.</li>
-        <li>The name of your browser (e.g. Firefox 37, Safari 7, Chrome 42, etc.). If possible, please also provide the version number.</li>
-        <li>The name of your operating system (e.g. Windows 7, iOS 6, Android 4.4, etc.). If possible, please also provide the version number.</li>
-        <li>Any assistive technology that you are using (e.g. JAWS, VoiceOver, Dragon, etc.).</li>
-      </ul>
+        <h3>Interactive simulations and videos</h3>
+        <p>
+          Some learning materials include links to interactive simulations (e.g. PhET physics simulations developed by the University of Colorado) and videos. While simulations are more difficult to make accessible than more conventional static textbook content, an effort to improve the accessibility of many PhET simulations is underway. We strive to make sure that all of our videos have captions. We encourage students to submit support tickets for content that is not captioned appropriately and we will address the matter promptly. As with any OpenStax feature, your feedback about the accessibility of the videos and PhET simulations welcome at <a href="mailto:support@openstaxtutor.org">support@openstaxtutor.org</a>.
+        </p>
 
-      <h3>Interactive simulations and videos</h3>
-      <p>
-        Some learning materials include links to interactive simulations (e.g. PhET physics simulations developed by the University of Colorado) and videos. While simulations are more difficult to make accessible than more conventional static textbook content, an effort to improve the accessibility of many PhET simulations is underway. We strive to make sure that all of our videos have captions. We encourage students to submit support tickets for content that is not captioned appropriately and we will address the matter promptly. As with any OpenStax feature, your feedback about the accessibility of the videos and PhET simulations welcome at <a href="mailto:support@openstaxtutor.org">support@openstaxtutor.org</a>.
-      </p>
-
-      <h3>Keyboard navigation</h3>
-      <p>
-        To navigate OpenStax Tutor Beta by keyboard in Internet Explorer, Chrome, Firefox, Netscape, Opera, or Safari, use the following key equivalents:
-      </p>
-      <Table>
-        <thead>
-          <tr className="highlight">
-            <th rowSpan="2">If you want to -</th>
-            <th colSpan="2">Select -</th>
-          </tr>
-          <tr>
-            <th>For Windows...</th>
-            <th>For Macintosh</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Increase font size</td>
-            <td>Ctrl +</td>
-            <td>⌘ +</td>
-          </tr>
-          <tr>
-            <td>Decrease font size</td>
-            <td>Ctrl -</td>
-            <td>⌘ -</td>
-          </tr>
-          <tr>
-            <td>Move forward from link to link</td>
-            <td>Tab</td>
-            <td>Tab</td>
-          </tr>
-          <tr>
-            <td>Move backward from link to link</td>
-            <td>Shift + tab</td>
-            <td>Shift + tab</td>
-          </tr>
-          <tr>
-            <td>Move from one assignment to the next</td>
-            <td>Tab</td>
-            <td>Tab</td>
-          </tr>
-          <tr>
-            <td>Go to the next page in a reading</td>
-            <td>Right Arrow</td>
-            <td>Right Arrow</td>
-          </tr>
-          <tr>
-            <td>Go to the previous page in a reading</td>
-            <td>Left Arrow</td>
-            <td>Left Arrow</td>
-          </tr>
-          <tr>
-            <td>Selecting answer “a” from a multiple choice question</td>
-            <td>a</td>
-            <td>a</td>
-          </tr>
-          <tr>
-            <td>Selecting answer “b” from a multiple choice question</td>
-            <td>b</td>
-            <td>b</td>
-          </tr>
-          <tr>
-            <td>Selecting answer “c” from a multiple choice question</td>
-            <td>c</td>
-            <td>c</td>
-          </tr>
-          <tr>
-            <td>Selecting answer “d” from a multiple choice question</td>
-            <td>d</td>
-            <td>d</td>
-          </tr>
-        </tbody>
-      </Table>
-    </Container>
+        <h3>Keyboard navigation</h3>
+        <p>
+          To navigate OpenStax Tutor Beta by keyboard in Internet Explorer, Chrome, Firefox, Netscape, Opera, or Safari, use the following key equivalents:
+        </p>
+        <Table>
+          <thead>
+            <tr className="highlight">
+              <th rowSpan="2">If you want to -</th>
+              <th colSpan="2">Select -</th>
+            </tr>
+            <tr>
+              <th>For Windows...</th>
+              <th>For Macintosh</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Increase font size</td>
+              <td>Ctrl +</td>
+              <td>⌘ +</td>
+            </tr>
+            <tr>
+              <td>Decrease font size</td>
+              <td>Ctrl -</td>
+              <td>⌘ -</td>
+            </tr>
+            <tr>
+              <td>Move forward from link to link</td>
+              <td>Tab</td>
+              <td>Tab</td>
+            </tr>
+            <tr>
+              <td>Move backward from link to link</td>
+              <td>Shift + tab</td>
+              <td>Shift + tab</td>
+            </tr>
+            <tr>
+              <td>Move from one assignment to the next</td>
+              <td>Tab</td>
+              <td>Tab</td>
+            </tr>
+            <tr>
+              <td>Go to the next page in a reading</td>
+              <td>Right Arrow</td>
+              <td>Right Arrow</td>
+            </tr>
+            <tr>
+              <td>Go to the previous page in a reading</td>
+              <td>Left Arrow</td>
+              <td>Left Arrow</td>
+            </tr>
+            <tr>
+              <td>Selecting answer “a” from a multiple choice question</td>
+              <td>a</td>
+              <td>a</td>
+            </tr>
+            <tr>
+              <td>Selecting answer “b” from a multiple choice question</td>
+              <td>b</td>
+              <td>b</td>
+            </tr>
+            <tr>
+              <td>Selecting answer “c” from a multiple choice question</td>
+              <td>c</td>
+              <td>c</td>
+            </tr>
+            <tr>
+              <td>Selecting answer “d” from a multiple choice question</td>
+              <td>d</td>
+              <td>d</td>
+            </tr>
+          </tbody>
+        </Table>
+      </Page>
+    </>
   );
 }

--- a/tutor/src/components/accessibility-statement.jsx
+++ b/tutor/src/components/accessibility-statement.jsx
@@ -1,29 +1,8 @@
 import { React, styled } from 'vendor';
 import Router from '../helpers/router';
 import { Table } from 'react-bootstrap';
-import { breakpoint } from 'theme';
+import ContentPage from './content-page';
 import Header from './header';
-
-const Page = styled.div`
-  background: #fff;
-  line-height: 2rem;
-  margin: 0 auto;
-  max-width: 1200px;
-  padding: 40px 80px;
-  ${breakpoint.tablet`
-    padding: calc(${breakpoint.margins.mobile} * 2) ${breakpoint.margins.tablet};
-  `}
-  ${breakpoint.mobile`
-    padding: ${breakpoint.margins.mobile};
-  `}
-  h3 {
-    font-size: 1.4rem;
-    font-weight: bold;
-  }
-  p, ul {
-    margin-bottom: 2rem;
-  }
-`;
 
 export default function AccessibilityStatement() {
   const params = Router.currentParams();
@@ -38,7 +17,7 @@ export default function AccessibilityStatement() {
         title="Accessibility Statement"
         unDocked
       />
-      <Page>
+      <ContentPage>
         <h3>Accessibility</h3>
         <p>
           At OpenStax, we're committed to ensuring that OpenStax Tutor is as accessible as possible to the widest possible audience, including students with disabilities.
@@ -149,7 +128,7 @@ export default function AccessibilityStatement() {
             </tr>
           </tbody>
         </Table>
-      </Page>
+      </ContentPage>
     </>
   );
 }

--- a/tutor/src/components/content-page.js
+++ b/tutor/src/components/content-page.js
@@ -1,4 +1,4 @@
-import { React, styled } from 'vendor';
+import { styled } from 'vendor';
 import { breakpoint } from 'theme';
 
 const ContentPage = styled.div`

--- a/tutor/src/components/content-page.js
+++ b/tutor/src/components/content-page.js
@@ -1,0 +1,25 @@
+import { React, styled } from 'vendor';
+import { breakpoint } from 'theme';
+
+const ContentPage = styled.div`
+  background: #fff;
+  line-height: 2rem;
+  margin: 0 auto;
+  max-width: 1200px;
+  padding: 40px 80px;
+  ${breakpoint.tablet`
+    padding: calc(${breakpoint.margins.mobile} * 2) ${breakpoint.margins.tablet};
+  `}
+  ${breakpoint.mobile`
+    padding: ${breakpoint.margins.mobile};
+  `}
+  h3 {
+    font-size: 1.4rem;
+    font-weight: bold;
+  }
+  p, ul {
+    margin-bottom: 2rem;
+  }
+`;
+
+export default ContentPage;

--- a/tutor/src/components/header.js
+++ b/tutor/src/components/header.js
@@ -60,12 +60,13 @@ class Header extends React.Component {
     headerContent: PropTypes.node,
   }
   render() {
-    const { unDocked, title, headerContent, backTo, backToText, backToParams } = this.props;
+    const { unDocked, title, headerContent, backTo, backToText, backToParams, className } = this.props;
     return (
       <HeaderWrapper
         role="dialog"
         tabIndex="-1"
         unDocked={unDocked}
+        className={className}
       >
         <StyledBackLink>
           <TutorLink to={backTo} params={backToParams}>

--- a/tutor/src/components/header.js
+++ b/tutor/src/components/header.js
@@ -55,6 +55,7 @@ class Header extends React.Component {
     unDocked: PropTypes.bool.isRequired,
     backTo: PropTypes.string.isRequired,
     backToText: PropTypes.string,
+    backToParams: PropTypes.object,
     title: PropTypes.string,
     headerContent: PropTypes.node,
   }

--- a/tutor/src/components/header.js
+++ b/tutor/src/components/header.js
@@ -11,9 +11,9 @@ const HeaderWrapper = styled.div`
   align-items: center;
   background-color: ${colors.white};
   border-bottom: 1px solid ${colors.neutral.pale};
-  padding: 16px 24px 16px;
+  padding: 24px 32px;
   ${breakpoint.tablet`
-    padding: 16px ${breakpoint.margins.tablet};
+    padding: 24px ${breakpoint.margins.tablet};
   `}
   ${breakpoint.mobile`
     padding: 16px ${breakpoint.margins.mobile};

--- a/tutor/src/components/header.js
+++ b/tutor/src/components/header.js
@@ -58,6 +58,7 @@ class Header extends React.Component {
     backToParams: PropTypes.object,
     title: PropTypes.string,
     headerContent: PropTypes.node,
+    className: PropTypes.string,
   }
   render() {
     const { unDocked, title, headerContent, backTo, backToText, backToParams, className } = this.props;

--- a/tutor/src/components/header.js
+++ b/tutor/src/components/header.js
@@ -2,46 +2,51 @@ import { React, PropTypes, observer, styled, css } from 'vendor';
 import TutorLink from './link';
 import { colors } from 'theme';
 import { Icon } from 'shared';
+import { breakpoint } from 'theme';
 
-const ExercisesTaskHeaderWrapper = styled.div`
+const HeaderWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   min-height: 55px;
   align-items: center;
-  padding: 25px 0 10px;
-  ${({ theme }) => theme.breakpoint.only.mobile`
-    padding-bottom: 0;
-  `}
+  background-color: ${colors.white};
   border-bottom: 1px solid ${colors.neutral.pale};
+  padding: 16px 24px 16px;
+  ${breakpoint.tablet`
+    padding: 16px ${breakpoint.margins.tablet};
+  `}
+  ${breakpoint.mobile`
+    padding: 16px ${breakpoint.margins.mobile};
+  `}
+
   > div {
-      margin-bottom: 12px;
-    }
+    margin-bottom: 8px;
+  }
 
   ${props => props.unDocked && css`
     background-color: ${colors.white};
   `}
-
-  .sticky-table {
-    margin-left: 15px;
-    margin-right: 15px;
-
-    ${({ theme }) => theme.breakpoint.only.mobile`
-      margin-left: 0;
-      margin-right: 0;
-      margin-bottom: 0;
-    `};
-  }
 `;
 
 const StyledBackLink = styled.div`
   width: 100%;
-  color: ${colors.link};
-  padding-left: 10px;
+  a {
+    color: ${colors.link};
+  }
+  .ox-icon { margin-left: 0; }
 `;
 
 const StyledTitle = styled.h1`
-  font-size: 3.5rem;
-  padding-left: 12px;
+  font-weight: bold;
+  font-size: 3.6rem;
+  line-height: 4rem;
+  letter-spacing: -0.144rem;
+  margin: 0;
+  ${breakpoint.mobile`
+    font-size: 1.8rem;
+    line-height: 3rem;
+    letter-spacing: -0.072rem;
+  `}
 `;
 
 @observer
@@ -54,20 +59,18 @@ class Header extends React.Component {
     headerContent: PropTypes.node,
   }
   render() {
-    const { unDocked, title, headerContent, backTo, backToText } = this.props;
+    const { unDocked, title, headerContent, backTo, backToText, backToParams } = this.props;
     return (
-      <ExercisesTaskHeaderWrapper
-        className="task-homework breadcrumbs-wrapper"
+      <HeaderWrapper
         role="dialog"
         tabIndex="-1"
         unDocked={unDocked}
       >
         <StyledBackLink>
-          <TutorLink to={backTo}>
+          <TutorLink to={backTo} params={backToParams}>
             <Icon
               size="lg"
               type="angle-left"
-              className="-move-exercise-up circle"
             />
             {backToText || 'Back'}
           </TutorLink>
@@ -76,7 +79,7 @@ class Header extends React.Component {
           <StyledTitle>{title}</StyledTitle>
         }
         {Boolean(headerContent) && headerContent}
-      </ExercisesTaskHeaderWrapper>
+      </HeaderWrapper>
     );
   }
 

--- a/tutor/src/screens/student-gradebook/index.js
+++ b/tutor/src/screens/student-gradebook/index.js
@@ -2,44 +2,11 @@ import { React, PropTypes, observer, styled } from 'vendor';
 import Table from './table';
 import TourRegion from '../../components/tours/region';
 import TutorLink from '../../components/link';
+import Header from '../../components/header';
 import LoadingScreen from 'shared/components/loading-animation';
 import { Icon } from 'shared';
 import { colors, breakpoint } from 'theme';
 import UX from './ux';
-
-const StudentGradebookHeader = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  min-height: 55px;
-  align-items: center;
-  background-color: ${colors.white};
-  border-bottom: 1px solid ${colors.neutral.pale};
-  padding: 25px 32px 16px;
-  ${breakpoint.tablet`
-    padding: 16px ${breakpoint.margins.tablet};
-  `}
-  ${breakpoint.mobile`
-    padding: 16px ${breakpoint.margins.mobile};
-  `}
-
-  a {
-    width: 100%;
-    color: ${colors.link};
-    .ox-icon { margin-left: 0; }
-  }
-  .title {
-    font-weight: bold;
-    font-size: 3.6rem;
-    line-height: 4rem;
-    letter-spacing: -0.144rem;
-    margin: 10px 0 0 0;
-    ${breakpoint.mobile`
-      font-size: 1.8rem;
-      line-height: 3rem;
-      letter-spacing: -0.072rem;
-    `}
-  }
-`;
 
 const StyledTourRegion = styled(TourRegion)`
   ${breakpoint.desktop`
@@ -78,22 +45,12 @@ class StudentGradebook extends React.Component {
 
     return (
       <>
-        <StudentGradebookHeader
-          role="dialog"
-          tabIndex="-1"
-        >
-          <TutorLink to="dashboard" params={{ courseId: ux.course.id }}>
-            <Icon
-              size="lg"
-              type="angle-left"
-              className="-move-exercise-up circle"
-            />
-              Dashboard
-          </TutorLink>
-          {/** 5/27/20: Display title as Scores */}
-          <h1 className="title">Scores</h1>
-        </StudentGradebookHeader>
-
+        <Header
+         backTo="dashboard"
+         backToParams={{ courseId: ux.course.id }}
+         backToText="Dashboard"
+         title="Scores"
+        />
         <StyledTourRegion
           id="gradebook"
           className="gradebook-table"

--- a/tutor/src/screens/student-gradebook/index.js
+++ b/tutor/src/screens/student-gradebook/index.js
@@ -1,11 +1,9 @@
 import { React, PropTypes, observer, styled } from 'vendor';
 import Table from './table';
 import TourRegion from '../../components/tours/region';
-import TutorLink from '../../components/link';
 import Header from '../../components/header';
 import LoadingScreen from 'shared/components/loading-animation';
-import { Icon } from 'shared';
-import { colors, breakpoint } from 'theme';
+import { breakpoint } from 'theme';
 import UX from './ux';
 
 const StyledTourRegion = styled(TourRegion)`
@@ -46,10 +44,10 @@ class StudentGradebook extends React.Component {
     return (
       <>
         <Header
-         backTo="dashboard"
-         backToParams={{ courseId: ux.course.id }}
-         backToText="Dashboard"
-         title="Scores"
+          backTo="dashboard"
+          backToParams={{ courseId: ux.course.id }}
+          backToText="Dashboard"
+          title="Scores"
         />
         <StyledTourRegion
           id="gradebook"

--- a/tutor/src/screens/task/exercise-task-header.js
+++ b/tutor/src/screens/task/exercise-task-header.js
@@ -4,15 +4,24 @@ import TaskProgress from '../../components/task-progress';
 import Header from '../../components/header';
 import Router from '../../helpers/router';
 import UX from './ux';
-import { colors } from 'theme';
+import { colors, breakpoint } from 'theme';
 import { Icon } from 'shared';
 import Time from '../../components/time';
+
+const StyledWrapper = styled.div`
+  .sticky-table {
+    ${breakpoint.only.mobile`
+      margin-left: -${breakpoint.margins.mobile};
+      margin-right: -${breakpoint.margins.mobile};
+      margin-bottom: -24px;
+    `};
+  }
+`;
 
 const StyledHeadingTitle = styled.div`
   display: flex;
   font-size: 1.7rem;
   line-height: none;
-  padding-left: 10px;
   width: 100%;
   .title-info {
     padding: 6px;
@@ -26,7 +35,7 @@ const StyledHeadingTitle = styled.div`
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
-    };
+    }
     .title-divider {
       padding: 0 0.8rem;
       color: ${colors.neutral.pale};
@@ -41,7 +50,7 @@ const StyledHeadingTitle = styled.div`
   */
   ${({ theme }) => theme.breakpoint.tablet`
     justify-content: space-between;
-    padding: 0 10px;
+    padding: 0 10px 0 0;
     .title-info {
       .title-divider, .title-due-date {
         display: none;
@@ -120,12 +129,15 @@ class ExercisesTaskHeader extends React.Component {
 
     const { ux, unDocked } = this.props;
     return (
-      <Header
-        unDocked={unDocked}
-        headerContent={headerContent(ux)}
-        backTo={Router.makePathname('dashboard', { courseId: ux.course.id })}
-        backToText='Dashboard'
-      />
+      <StyledWrapper>
+        <Header
+          unDocked={unDocked}
+          headerContent={headerContent(ux)}
+          backTo={Router.makePathname('dashboard', { courseId: ux.course.id })}
+          backToText='Dashboard'
+          className="task-homework breadcrumbs-wrapper"
+        />
+      </StyledWrapper>
     );
   }
 }

--- a/tutor/src/screens/task/exercise-task-header.js
+++ b/tutor/src/screens/task/exercise-task-header.js
@@ -8,12 +8,14 @@ import { colors, breakpoint } from 'theme';
 import { Icon } from 'shared';
 import Time from '../../components/time';
 
-const StyledWrapper = styled.div`
+const StyledHeader = styled(Header)`
+  padding-bottom: 8px;
+
   .sticky-table {
     ${breakpoint.only.mobile`
       margin-left: -${breakpoint.margins.mobile};
       margin-right: -${breakpoint.margins.mobile};
-      margin-bottom: -24px;
+      margin-bottom: -${breakpoint.margins.mobile};
     `};
   }
 `;
@@ -25,6 +27,7 @@ const StyledHeadingTitle = styled.div`
   width: 100%;
   .title-info {
     padding: 6px;
+    padding-left: 0;
     display: flex;
     div + div {
       margin-left: 10px;
@@ -129,15 +132,12 @@ class ExercisesTaskHeader extends React.Component {
 
     const { ux, unDocked } = this.props;
     return (
-      <StyledWrapper>
-        <Header
-          unDocked={unDocked}
-          headerContent={headerContent(ux)}
-          backTo={Router.makePathname('dashboard', { courseId: ux.course.id })}
-          backToText='Dashboard'
-          className="task-homework breadcrumbs-wrapper"
-        />
-      </StyledWrapper>
+      <StyledHeader
+        unDocked={unDocked}
+        headerContent={headerContent(ux)}
+        backTo={Router.makePathname('dashboard', { courseId: ux.course.id })}
+        backToText='Dashboard'
+      />
     );
   }
 }


### PR DESCRIPTION
- Refactor `Header` component to be more generic and reusable, move HW task header styles into `ExercisesTaskHeader`
- Make Accessibility Statement page responsive


Desktop | Tablet | Mobile
------------ | ------------- | -------------
![image](https://user-images.githubusercontent.com/34174/91920775-cf873300-ec7e-11ea-911c-dabd0ef57b48.png) | ![image](https://user-images.githubusercontent.com/34174/91920793-d8780480-ec7e-11ea-9a59-19b78700f891.png) | ![image](https://user-images.githubusercontent.com/34174/91920806-e168d600-ec7e-11ea-924e-6b1a120629db.png)

Changing the Header to be reusable creates some changes for a few screen headers:

Old | New
------------ | -------------
![image](https://user-images.githubusercontent.com/34174/91921116-91d6da00-ec7f-11ea-87b9-99e966d07d11.png) | ![image](https://user-images.githubusercontent.com/34174/91921133-9d2a0580-ec7f-11ea-887d-7b651524ca23.png)
![image](https://user-images.githubusercontent.com/34174/91921249-e2e6ce00-ec7f-11ea-85c3-c48e48ffb185.png) |![image](https://user-images.githubusercontent.com/34174/91921261-ea0ddc00-ec7f-11ea-97ff-e2518cc1d1c9.png)