### PR TITLE
Fix mobile menu

### DIFF
--- a/tutor/resources/styles/components/top-nav-bar.scss
+++ b/tutor/resources/styles/components/top-nav-bar.scss
@@ -31,6 +31,24 @@
     }
   }
 
+  .dropdown-menu {
+    padding: 0;
+
+    .dropdown-item {
+      border-bottom: 1px solid #f5f5f5;
+      padding-left: 16px;
+      padding-right: 16px;
+    }
+
+    .dropdown-divider {
+      margin: 0;
+    }
+    .dropdown-divider + .dropdown-divider {
+      display: none;
+    }
+  }
+
+
   > * {
     display: flex;
     align-items: center;
@@ -153,10 +171,6 @@
       top: 0;
       overflow-y: auto;
       max-height: calc(100vh - #{$tutor-navbar-height} * 3);
-    }
-    .dropdown-item {
-      padding-left: 16px;
-      padding-right: 16px;
     }
   }
 

--- a/tutor/resources/styles/components/top-nav-bar.scss
+++ b/tutor/resources/styles/components/top-nav-bar.scss
@@ -132,13 +132,16 @@
       display: none;
     }
 
+    .ox-icon {
+      width: 16px;
+    }
+
     &.show {
       .open-icon {
         display: none;
       }
       .close-icon {
         display: block;
-        width: 14px;
       }
     }
 

--- a/tutor/resources/styles/tutor.scss
+++ b/tutor/resources/styles/tutor.scss
@@ -51,3 +51,7 @@ body[data-js-error]::before {
   font-size: 100px;
   color: red;
 }
+
+body.freeze-scroll {
+  overflow: hidden;
+}

--- a/tutor/resources/styles/tutor.scss
+++ b/tutor/resources/styles/tutor.scss
@@ -52,6 +52,6 @@ body[data-js-error]::before {
   color: red;
 }
 
-body.freeze-scroll {
+.hide-overflow {
   overflow: hidden;
 }

--- a/tutor/src/components/navbar/menus.js
+++ b/tutor/src/components/navbar/menus.js
@@ -20,7 +20,13 @@ const DesktopMenus = observer(({ course }) => (
 ));
 
 const MobileMenus = observer(({ course }) => (
-  <Dropdown className="mobile-menu">
+  <Dropdown
+    className="mobile-menu"
+    onToggle={(v) => {
+      const el = window.document.querySelector('body');
+      v ? el.classList.add('freeze-scroll') : el.classList.remove('freeze-scroll');
+    }}
+  >
     <Dropdown.Toggle
       id="mobile-menu"
       aria-label="Menu and settings"

--- a/tutor/src/components/navbar/menus.js
+++ b/tutor/src/components/navbar/menus.js
@@ -36,8 +36,8 @@ const MobileMenus = observer(({ course }) => (
       <Icon type="close" className="close-icon" />
     </Dropdown.Toggle>
     <Dropdown.Menu>
-      <SupportMenu course={course} />
       <ActionsMenu course={course} />
+      <SupportMenu course={course} />
       <UserMenu />
     </Dropdown.Menu>
   </Dropdown>

--- a/tutor/src/components/navbar/menus.js
+++ b/tutor/src/components/navbar/menus.js
@@ -30,8 +30,8 @@ const MobileMenus = observer(({ course }) => (
       aria-label="Menu and settings"
       variant="ox"
     >
-      <Icon type="bars" className="open-icon" />
-      <Icon type="close" className="close-icon" />
+      <Icon type="bars" className="open-icon" size="lg" />
+      <Icon type="close" className="close-icon" size="lg" />
     </Dropdown.Toggle>
     <Dropdown.Menu>
       <ActionsMenu course={course} />

--- a/tutor/src/components/navbar/menus.js
+++ b/tutor/src/components/navbar/menus.js
@@ -8,6 +8,7 @@ import StudentPayNowBtn    from './student-pay-now-btn';
 import ActionsMenu         from './actions-menu';
 import PreviewAddCourseBtn from './preview-add-course-btn';
 import UserMenu            from './user-menu';
+import dom                 from '../../helpers/dom';
 
 const DesktopMenus = observer(({ course }) => (
   <>
@@ -22,10 +23,7 @@ const DesktopMenus = observer(({ course }) => (
 const MobileMenus = observer(({ course }) => (
   <Dropdown
     className="mobile-menu"
-    onToggle={(v) => {
-      const el = window.document.querySelector('body');
-      v ? el.classList.add('freeze-scroll') : el.classList.remove('freeze-scroll');
-    }}
+    onToggle={v => dom(document.body).hideOverflow(v) }
   >
     <Dropdown.Toggle
       id="mobile-menu"

--- a/tutor/src/helpers/dom.js
+++ b/tutor/src/helpers/dom.js
@@ -285,6 +285,9 @@ export default function dom(el) {
       };
     },
 
+    hideOverflow(on = true) {
+      on ? this.addClass('hide-overflow') : this.removeClass('hide-overflow');
+    },
 
   };
 


### PR DESCRIPTION
- Add border between menu items (on desktop + tablet as well.)
- Fix icon sizes 
- Add helper to hide body overflow, fixes an issue with the mobile menu scrolling content underneath.
- Put the support menu at the bottom on mobile
- Prevent dropdown-dividers from stacking for some edge render cases.