### PR TITLE
remove missing student id from notifications

### DIFF
--- a/shared/specs/model/notifications.spec.js
+++ b/shared/specs/model/notifications.spec.js
@@ -49,19 +49,6 @@ describe('Notifications', function() {
     expect(Notifications.getActive()).toEqual([]);
   });
 
-  it('adds missing student id when course role is set', function() {
-    const changeListener = jest.fn();
-    Notifications.once('change', changeListener);
-    const course = { id: '1', ends_at: moment().add(1, 'day'), students: [{ role_id: '111' }] };
-    const role = { id: '111', type: 'student', joined_at: '2016-01-30T01:15:43.807Z', latest_enrollment_at: '2016-01-30T01:15:43.807Z' };
-    Notifications.setCourseRole(course, role);
-    expect(changeListener).toHaveBeenCalled();
-    const active = Notifications.getActive()[0];
-    expect(active.type).toEqual('missing_student_id');
-    expect(active.course).toEqual(course);
-    expect(active.role).toEqual(role);
-  });
-
   it('clears old notices when course role is set', function() {
     Notifications.setCourseRole(
       { id: '1', students: [{ role_id: '111' }], ends_at: '2011-11-11T01:15:43.807Z' },

--- a/shared/src/model/notifications.js
+++ b/shared/src/model/notifications.js
@@ -27,7 +27,6 @@ const CLIENT_ID = 'client-specified';
 
 const Notifications = {
   POLLING_TYPES: {
-    MISSING_STUDENT_ID: 'missing_student_id',
     COURSE_HAS_ENDED: 'course_has_ended',
   },
 
@@ -112,18 +111,10 @@ const Notifications = {
   },
 
   // Called when the current course and/or role has changed
-  // The notification logic may display a notice
-  // based on the relationship or if student identifier is missing
+  // The notification logic may display a notice based on the relationship
   setCourseRole(course, role) {
     let id;
     if (isEmpty(role) || (role.type === 'teacher')) { return; }
-    const studentId = __guard__(find(course.students, { role_id: role.id }), x => x.student_identifier);
-    if (isEmpty(studentId) && (moment().diff(role.joined_at, 'days') > 7)) {
-      id = this.POLLING_TYPES.MISSING_STUDENT_ID;
-      this.display({ id, type: id, course, role });
-    } else {
-      this.removeType(this.POLLING_TYPES.MISSING_STUDENT_ID);
-    }
     if (moment(course.ends_at).isBefore(moment(), 'day')) {
       id = this.POLLING_TYPES.COURSE_HAS_ENDED;
       this.display({ id, type: id, course, role });


### PR DESCRIPTION
`buildCallbackHandlers` in helpers/notifications has this:

```
    missing_student_id: {
        onAdd({ course }) {
          return history.push(
            Router.makePathname('changeStudentId', { courseId: course.id })
          );
        },
```

which may also not be needed?