### PR TITLE
change mobile payment bar z-index to be lower than the top navbar

### DIFF
--- a/tutor/src/components/navbar/student-payment-bar.js
+++ b/tutor/src/components/navbar/student-payment-bar.js
@@ -7,6 +7,8 @@ import Course from '../../models/course';
 
 const PaymentBar = styled(Nav)`
   top: ${Theme.navbars.top.height};
+  /* less than the nav so it is not on top of the dropdown navbar */
+  z-index: ${Theme.zIndex.navbar - 10};
   .student-pay-now {
     align-items: center;
     font-size: 1.4rem;


### PR DESCRIPTION
![Annotation 2020-09-09 121824](https://user-images.githubusercontent.com/3774774/92631210-ab3ae000-f296-11ea-96de-c6b01b3a8fa8.png)
![Annotation 2020-09-09 121839](https://user-images.githubusercontent.com/3774774/92631212-abd37680-f296-11ea-87c6-4be7cd461e5a.png)
