### PR TITLE
add metrics to pulse insight data

### DIFF
--- a/tutor/src/models/app.js
+++ b/tutor/src/models/app.js
@@ -47,7 +47,7 @@ export default class TutorApp {
     await documentReady();
 
     const app = new TutorApp();
-    [Raven, PulseInsights, Api].forEach(lib => lib.boot());
+    [Raven, Api].forEach(lib => lib.boot({ app }));
 
     app.data = readBootstrapData();
     if (isEmpty(app.data)) {
@@ -66,6 +66,7 @@ export default class TutorApp {
 
   @action.bound initializeApp() {
     window._MODELS.bootstrapData = this.data;
+    window._MODELS.app = this;
     forIn(BOOTSTRAPED_MODELS, (model, storeId) => {
       const data = this.data[storeId];
       if (data) { model.bootstrap(data); }
@@ -82,6 +83,9 @@ export default class TutorApp {
     startMathJax();
     TransitionAssistant.startMonitoring();
     Raven.setUser(User);
+    this.user = User;
+    this.courses = Courses;
+    PulseInsights.boot({ app: this });
     return Promise.resolve(this);
   }
 

--- a/tutor/src/models/app/pulse-insights.js
+++ b/tutor/src/models/app/pulse-insights.js
@@ -3,7 +3,7 @@ import Raven from './raven';
 import Flags from '../feature_flags';
 
 export default {
-  boot() {
+  boot({ app }) {
     if (!Flags.pulse_insights) {
       return Promise.resolve({});
     }
@@ -14,7 +14,7 @@ export default {
     };
     w.pi('identify', 'PI-16384954');
     w.pi('get', 'surveys');
-
+    w.pi('set_custom_data', app.user.metrics);
     return loadjs('//js.pulseinsights.com/surveys.js', {
       async: true,
       returnPromise: true,

--- a/tutor/src/models/user.js
+++ b/tutor/src/models/user.js
@@ -33,7 +33,7 @@ class User extends BaseModel {
 
   @field can_create_courses;
   @field profile_url;
-
+  @field is_test;
   @field is_admin;
   @field is_content_analyst;
   @field is_customer_service;
@@ -176,6 +176,23 @@ class User extends BaseModel {
     return { category, code, data };
   }
 
+  @computed get metrics() {
+    return {
+      role: this.isProbablyTeacher ? 'instructor' : 'student',
+      is_new_user: Courses.completed.nonPreview.isEmpty,
+      is_test_user: this.is_test,
+      has_viewed_preview: Courses.preview.any,
+      courses: Courses.nonPreview.array.map(c => ({
+        subject: c.appearance_code,
+        type: c.is_preview ? 'preview' : 'real',
+        role: c.currentRole.type,
+        active: c.isActive,
+        enrollment: c.currentRole.isTeacher ? c.num_enrolled_students : -1,
+        enrollment_type: c.is_lms_enabled ? 'lms' : 'links',
+        cost: c.does_cost,
+      })),
+    };
+  }
 }
 
 export { User };


### PR DESCRIPTION
reports data:
```
{
  "role": "instructor",   // uses "isProbablyTeacher" which combines can_create_courses and self reported role.  It's what tours use
  "is_new_user": true, // true if no past courses
  "is_test_user": true, // from admin settings
  "has_viewed_preview": false, // true if they have preview courses associated 
  "courses": [
    {
      "subject": "biology_2e",  // this is the appearance code
      "type": "real",  // or preview
      "role": "teacher", // or student
      "active": true,  // or preview
      "enrollment": 17, // how many students are a member. if user is a student it will be -1 since we don't know
      "enrollment_type": "links", // or las
      "cost": false. // or true 
    },
    {
      "subject": "college_physics",
      "type": "real",
      "role": "student",
      "active": true,
      "enrollment": -1,
      "enrollment_type": "links",
      "cost": false
    }
  ]
}
```