### PR TITLE
add small heading changes in free trial activated and ended nag

### DIFF
--- a/tutor/resources/styles/components/modals/onboarding.scss
+++ b/tutor/resources/styles/components/modals/onboarding.scss
@@ -29,7 +29,8 @@
         padding: 16px;
     
         .heading {
-          padding: 0;
+          padding: 15px 0 0;
+          font-size: 16px;
         }
       }
     }
@@ -46,6 +47,7 @@
     background-color: $tutor-neutral-lighter;
 
     .heading {
+      line-height: 20px;
       font-weight: 700;
       font-size: 18px;
       padding: 50px 50px 0 50px;


### PR DESCRIPTION
Small css changes for the free trial ended nag.

![Screen Shot 2020-09-14 at 12 30 57 PM](https://user-images.githubusercontent.com/3774774/93118642-309f0580-f686-11ea-8a23-b8541a91c49a.png)
