### PR TITLE
let payment modal scroll, add padding to bottom

### DIFF
--- a/tutor/resources/styles/components/payments.scss
+++ b/tutor/resources/styles/components/payments.scss
@@ -1,8 +1,14 @@
-.make-payment.modal .modal-dialog {
-  width: 570px;
-  .error-message {
-    margin: 50px;
-    button { margin-top: 2rem; }
+.make-payment.modal
+  overflow: scroll;
+  .modal-dialog {
+    width: 570px;
+    .payments-wrapper {
+      padding-bottom: 50px;
+    }
+    .error-message {
+      margin: 50px;
+      button { margin-top: 2rem; }
+    }
   }
 }
 


### PR DESCRIPTION
- Let the payments modal scroll, so when viewed on mobile, the fields are able to be viewed
- Add some padding to the bottom to match the iframe content padding

![Screenshot_2020-09-15 OpenStax Tutor](https://user-images.githubusercontent.com/34174/93240577-238f1e80-f739-11ea-8627-5b86c0a8be80.png)
