### PR TITLE
Put files inside the "assets" dir in the s3 bucket

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,4 @@ jobs:
           AWS_REGION: ${{ secrets.TUTOR_AWS_REGION }}
           AWS_S3_BUCKET: ${{ secrets.TUTOR_AWS_S3_BUCKET }}
           SOURCE_DIR: tutor/dist
+          DEST_DIR: assets


### PR DESCRIPTION
CloudFront passes the path to s3 so to load `/assets/some.file` it's way easier if `some.file` is inside the `assets` dir in the bucket.