### PR TITLE
fix the size of verify email on mobile

### DIFF
--- a/shared/src/components/notifications/email.js
+++ b/shared/src/components/notifications/email.js
@@ -128,7 +128,7 @@ class EmailNotification extends React.Component {
       <span className="body">
         <Icon type="envelope" />
         {'\
-    Verifying your email address allows you to recover your password if you ever forget it.\
+    Verify your email\
          '}
         <a className="action" onClick={this.onVerify}>
           Verify now

--- a/tutor/resources/styles/global/notifications-bar.scss
+++ b/tutor/resources/styles/global/notifications-bar.scss
@@ -28,6 +28,10 @@
       .dismiss {
         margin-right: 0;
       }
+      .action {
+        font-size: 1.4rem;
+        padding: 4px 8px;
+      }
     }
 
     @media (max-width: $tablet-collapse-breakpoint) {


### PR DESCRIPTION
Wasn't able to test locally, but it should look like this on mobile:

![image](https://user-images.githubusercontent.com/34174/93511831-3ab84280-f8d8-11ea-9cdd-616d600132f6.png)
