### PR TITLE
Added Cache-Control to S3 files and exercises-js build task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Upload built Tutor JS assets to S3
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --follow-symlinks
+          args: --follow-symlinks --cache-control public,max-age=31536000
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.TUTOR_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TUTOR_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Install npm
         uses: bahmutov/npm-install@v1
 
-      - name: Build Tutor JS assets
+      - name: Build tutor-js assets
         run: yarn run build tutor
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
 
-      - name: Upload built Tutor JS assets to S3
+      - name: Upload built tutor-js assets to S3
         uses: jakejarvis/s3-sync-action@master
         with:
           args: >-
@@ -31,4 +31,31 @@ jobs:
           AWS_REGION: ${{ secrets.TUTOR_AWS_REGION }}
           AWS_S3_BUCKET: ${{ secrets.TUTOR_AWS_S3_BUCKET }}
           SOURCE_DIR: tutor/dist
+          DEST_DIR: assets
+
+  exercises:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v2
+
+      - name: Install npm
+        uses: bahmutov/npm-install@v1
+
+      - name: Build exercises-js assets
+        run: yarn run build exercises
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+
+      - name: Upload built exercises-js assets to S3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: >-
+            --follow-symlinks --cache-control public,max-age=31536000 --metadata-directive REPLACE
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.EXERCISES_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.EXERCISES_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.EXERCISES_AWS_REGION }}
+          AWS_S3_BUCKET: ${{ secrets.EXERCISES_AWS_S3_BUCKET }}
+          SOURCE_DIR: exercises/dist
           DEST_DIR: assets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Upload built Tutor JS assets to S3
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --follow-symlinks --cache-control public,max-age=31536000
+          args: >-
+            --follow-symlinks --cache-control public,max-age=31536000 --metadata-directive REPLACE
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.TUTOR_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TUTOR_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
CloudFront will cache the files without the header, but if we want the browser to cache them too then the metadata must be set in S3