### PR TITLE
flatten user metrics

### DIFF
--- a/tutor/specs/models/user.spec.js
+++ b/tutor/specs/models/user.spec.js
@@ -22,6 +22,13 @@ describe('User Model', () => {
     expect(User.terms).toBeInstanceOf(UserTerms);
   });
 
+  it('calculates metrics tags', () => {
+    bootstrapCoursesList();
+    expect(User.metrics.is_new_user).toEqual(true)
+    expect(User.metrics.course_subjects).toEqual('testing');
+    expect(User.metrics.course_types).toEqual('real');
+  })
+  
   it('calculates audience tags', () => {
     bootstrapCoursesList();
     expect(User.tourAudienceTags).toEqual(['teacher', 'teacher-not-previewed']);


### PR DESCRIPTION
The new structure will look like:
```
course_enrollment_types: "links"
course_roles: "teacher"
course_subjects: "college_physics;biology_2e;intro_sociology;ap_physics"
course_types: "real"
has_per_cost_course: false
has_viewed_preview: false
is_new_user: false
is_test_user: true
max_course_enrollment: 6
role: "instructor"
```