### PR TITLE
Fix verify email

### DIFF
--- a/shared/resources/styles/components/notifications-bar.scss
+++ b/shared/resources/styles/components/notifications-bar.scss
@@ -28,8 +28,14 @@
         text-align: right;
       }
     }
-    .body {
+    .body, .content {
       flex: 1;
+    }
+
+    .content {
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
 
     .mobile-text {

--- a/shared/src/components/notifications/email.js
+++ b/shared/src/components/notifications/email.js
@@ -179,8 +179,10 @@ class EmailNotification extends React.Component {
     );
     return (
       <div className={classNames}>
-        {error}
-        {body}
+        <div className="content">
+          {error}
+          {body}
+        </div>
         <a className="dismiss" onClick={this.props.onDismiss}>
           <Icon type="close" />
         </a>

--- a/tutor/resources/styles/global/notifications-bar.scss
+++ b/tutor/resources/styles/global/notifications-bar.scss
@@ -58,7 +58,6 @@
 
     @media (max-width: $tablet-collapse-breakpoint) {
       padding: 8px 24px;
-
     }
 
     @media (max-width: $mobile-collapse-breakpoint) {

--- a/tutor/resources/styles/global/notifications-bar.scss
+++ b/tutor/resources/styles/global/notifications-bar.scss
@@ -20,11 +20,6 @@
       min-height: 40px;
       height: auto;
 
-      &.email {
-        .body {
-        }
-      }
-
       .ox-icon {
         height: 2rem;
         margin-right: 0.25rem;

--- a/tutor/resources/styles/global/notifications-bar.scss
+++ b/tutor/resources/styles/global/notifications-bar.scss
@@ -17,7 +17,13 @@
     @media (max-width: $tablet-collapse-breakpoint), (max-width: $mobile-collapse-breakpoint) {
       font-size: 1.4rem;
       font-weight: 500;
-      height: 40px;
+      min-height: 40px;
+      height: auto;
+
+      &.email {
+        .body {
+        }
+      }
 
       .ox-icon {
         height: 2rem;
@@ -31,6 +37,8 @@
       .action {
         font-size: 1.4rem;
         padding: 4px 8px;
+        height: 32px;
+        white-space: nowrap;
       }
 
       .desktop-text {
@@ -49,6 +57,19 @@
       padding: 0 16px;
       .dismiss {
         margin-right: -1px;
+      }
+      .body {
+        &.verify {
+          margin: 5px 0;
+        }
+        .message {
+          text-align: left;
+          margin-left: 0.75rem;
+        }
+      }
+      &.email input[type="text"] {
+        width: 7rem;
+        padding-left: 0.45rem;
       }
     }
   }

--- a/tutor/resources/styles/global/notifications-bar.scss
+++ b/tutor/resources/styles/global/notifications-bar.scss
@@ -19,6 +19,11 @@
       font-weight: 500;
       min-height: 40px;
       height: auto;
+      justify-content: space-between;
+
+      .content {
+        flex-direction: column;
+      }
 
       .ox-icon {
         height: 2rem;
@@ -42,27 +47,46 @@
       .mobile-text {
         display: inline;
       }
+      .error {
+        margin: 8px 0;
+        flex: 1;
+        .body {
+          flex: initial;
+        }
+      }
     }
 
     @media (max-width: $tablet-collapse-breakpoint) {
-      padding: 0 24px;
+      padding: 8px 24px;
+
     }
 
     @media (max-width: $mobile-collapse-breakpoint) {
-      padding: 0 16px;
+      padding: 8px 16px;
       .dismiss {
         margin-right: -1px;
       }
+      .error {
+        .body {
+          justify-content: flex-start;
+          margin-left: 0.75rem;
+        }
+      }
+
+      .content {
+        justify-content: center;
+      }
+
       .body {
         &.verify {
-          margin: 5px 0;
+          margin: 5px 10px 5px 0;
         }
         .message {
           text-align: left;
           margin-left: 0.75rem;
         }
       }
-      &.email input[type="text"] {
+      &.email input {
         width: 7rem;
         padding-left: 0.45rem;
       }


### PR DESCRIPTION
Fixes some mobile layout issues when displaying the verify pin text, and some small button and sizing changes to better work on mobile. The bar is now 8px taller than the invision spec, but this helps to visually contain the text when an error message + pin verify are both rendered as a stack. Adding `.content` is needed to adjust flexbox styles without affecting the dismiss button.

![Screenshot_2020-09-23 OpenStax Tutor(2)](https://user-images.githubusercontent.com/34174/94082524-f89a6f80-fdb5-11ea-9ff5-60cdf414e72d.png)
![Screenshot_2020-09-23 OpenStax Tutor(1)](https://user-images.githubusercontent.com/34174/94082529-fa643300-fdb5-11ea-921a-328e9fe4b6e6.png)
![Screenshot_2020-09-23 OpenStax Tutor](https://user-images.githubusercontent.com/34174/94082532-fb956000-fdb5-11ea-81c2-7f732cdd22bb.png)
