### PR TITLE
Only display lines and extra spacing for tasks

### DIFF
--- a/shared/resources/styles/components/question.scss
+++ b/shared/resources/styles/components/question.scss
@@ -51,12 +51,6 @@
     }
   }
 
-  .openstax-answer {
-    border-top: 1px solid #d5d5d5;
-    margin: 10px 0;
-    padding: 10px 0;
-  }
-
   .multiple-choice-prompt {
     font-weight: 600;
   }

--- a/tutor/src/screens/task/step/exercise-question.js
+++ b/tutor/src/screens/task/step/exercise-question.js
@@ -28,6 +28,11 @@ const StyledExerciseQuestion = styled.div`
   ${breakpoint.mobile`
     margin: ${breakpoint.margins.mobile};
   `}
+  .openstax-answer {
+    border-top: 1px solid #d5d5d5;
+    margin: 10px 0;
+    padding: 10px 0;
+  }
 `;
 
 export default


### PR DESCRIPTION
Other screens can be more compact and don't need lines to separate answers

Task screen:
<img width="1209" alt="image" src="https://user-images.githubusercontent.com/79566/94313162-dafb1080-ff43-11ea-8c7b-68f3dcf0d244.png">


Teacher review screen goes from:
<img width="1185" alt="image" src="https://user-images.githubusercontent.com/79566/94313231-f6feb200-ff43-11ea-8a0f-a3b60a2f53f6.png">


To:
<img width="1196" alt="image" src="https://user-images.githubusercontent.com/79566/94313190-eb12f000-ff43-11ea-922d-a984eec81265.png">


