### PR TITLE
use padding instead of margin for section selector on HW edit

### DIFF
--- a/tutor/specs/components/__snapshots__/radio-input.spec.jsx.snap
+++ b/tutor/specs/components/__snapshots__/radio-input.spec.jsx.snap
@@ -10,7 +10,7 @@ exports[`RadioInput matches snapshot 1`] = `
 }
 
 .c1 + label {
-  margin-left: 1.4rem;
+  padding-left: 1.4rem;
 }
 
 .c1 + label::before {

--- a/tutor/src/components/radio-input.jsx
+++ b/tutor/src/components/radio-input.jsx
@@ -13,7 +13,7 @@ const StyledRadioInput = styled.input.attrs( () => ({
   opacity: 0;
 
   & + label {
-    ${props => !isEmpty(props.label) && 'margin-left: 1.4rem;'}
+    ${props => !isEmpty(props.label) && 'padding-left: 1.4rem;'}
     ${props => props.labelSize === 'lg' && 'font-size: 1.6rem;'}
   }
 


### PR DESCRIPTION
Before:

<img width="799" alt="image" src="https://user-images.githubusercontent.com/79566/94313855-19dd9600-ff45-11ea-8f8b-97f6ea0825a1.png">


After:
<img width="788" alt="image" src="https://user-images.githubusercontent.com/79566/94313819-07fbf300-ff45-11ea-933f-12690d1a2f39.png">
