### PR TITLE
add min width to progress bar based on char display length

### DIFF
--- a/tutor/src/screens/assignment-review/grading-block.js
+++ b/tutor/src/screens/assignment-review/grading-block.js
@@ -102,6 +102,9 @@ const ChartItem = styled.div`
   &:last-child { border-width: 1px 1px 1px 0; }
   &:only-child { border-width: 1px; }
   width: ${props => props.width}%;
+  min-width ${props => css`
+    calc(0.5rem + 1rem * ${props.value.toString().length});
+  `};
   height: 4.5rem;
   display: flex;
   align-items: center;
@@ -152,6 +155,7 @@ const StackedBarChart = observer(({ stats, isReading = false }) => {
         {stats.filter(s => s.value > 0).map((stat, i) =>
           <ChartItem
             width={stat.percent * 100}
+            value={stat.value}
             variant={stat.label}
             aria-label={`${stat.label}: ${stat.value}`}
             key={`chart-item-${i}`}

--- a/tutor/src/screens/assignment-review/grading-block.js
+++ b/tutor/src/screens/assignment-review/grading-block.js
@@ -103,7 +103,7 @@ const ChartItem = styled.div`
   &:only-child { border-width: 1px; }
   width: ${props => props.width}%;
   min-width ${props => css`
-    calc(0.5rem + 1rem * ${props.value.toString().length});
+    calc(1rem + 1rem * ${props.value.toString().length});
   `};
   height: 4.5rem;
   display: flex;


### PR DESCRIPTION
Set a minimum width + increase it based on how many digits are being displayed. Fixes a bug where a large class size to task completion ratio would cause the completion bar to not be wide enough.

![image](https://user-images.githubusercontent.com/34174/94447754-00179b00-015f-11eb-86de-ee58b33ab203.png)
![image](https://user-images.githubusercontent.com/34174/94447833-17ef1f00-015f-11eb-9d9c-6316c14a4e67.png)
![image](https://user-images.githubusercontent.com/34174/94447937-38b77480-015f-11eb-9ceb-8e4d872312b7.png)
