### PR TITLE
Rename not accepted to late work penalty

### DIFF
--- a/tutor/src/components/late-points-info.js
+++ b/tutor/src/components/late-points-info.js
@@ -10,7 +10,6 @@ const StyledTable = styled.table`
 const LatePointsInfo = ({ step }) => {
   const originalPoints = step.published_points_without_lateness;
   const lateWorkPenalty = step.published_late_work_point_penalty;
-  const isLateWorkNotAccepted = step.task.late_work_penalty_applied === 'not_accepted';
   return (
     <StyledTable data-test-id="late-info-points-table">
       <tbody>
@@ -21,7 +20,7 @@ const LatePointsInfo = ({ step }) => {
           </td>
         </tr>
         <tr>
-          <td>{isLateWorkNotAccepted ? 'Not accepted' : 'Late penalty'}:</td>
+          <td>Late penalty:</td>
           <td>
             {ScoresHelper.formatLatePenalty(lateWorkPenalty)}
           </td>

--- a/tutor/src/components/task-progress.js
+++ b/tutor/src/components/task-progress.js
@@ -124,28 +124,30 @@ const StyledStickyTable = styled(StickyTable)`
 
 const StyledPopover = styled(Popover)`
   /** https://styled-components.com/docs/faqs#how-can-i-override-inline-styles */
-    &[style] {
-      border: 1px #d5d5d5 solid !important;
-      top: ${props => props.graded ? '62px' : '32px'} !important;
+  &[style] {
+    border: 1px #d5d5d5 solid !important;
+    top: ${props => props.graded ? '62px' : '32px'} !important;
+  }
+
+  pointer-events: none;
+  padding: 10px 7px;
+  text-align: center;
+
+  p {
+    margin-bottom: 0.2rem;
+  }
+
+  table {
+    font-size: 1.3rem;
+
+    td {
+      line-height: 1.2;
     }
-    padding: 10px 7px;
-    text-align: center;
 
-    p {
-      margin-bottom: 0.2rem;
+    tr td:last-child {
+      padding-left: 2px;
     }
-
-    table {
-        font-size: 1.3rem;
-
-        td {
-            line-height: 1.2;
-        }
-
-        tr td:last-child {
-            padding-left: 2px;
-        }
-    }
+  }
 `;
 
 const pointsScoredStatus = (step) => {


### PR DESCRIPTION
We decided that it's clearer to the student to always see "Late penalty" even when the grading template has late work set to "Not accepted".

Also fixes an issue with the popover flashing on and off in Firefox by turning off pointer events on the popover.

![Screen Shot 2020-09-29 at 13 36 12](https://user-images.githubusercontent.com/34174/94613002-c7f48300-0258-11eb-8e44-fe4303ae8ee5.png)

