### PR TITLE
fill screen with payments modal on mobile

### DIFF
--- a/tutor/resources/styles/components/modals/onboarding.scss
+++ b/tutor/resources/styles/components/modals/onboarding.scss
@@ -38,8 +38,13 @@
   &.pay-now-or-later,
   &.free-trial-ended,
   &.make-payment {
+    margin: 0;
+    width: 100%;
     .modal-dialog {
       transform: translateY(80px);
+      @media screen and ( max-width: $mobile-collapse-breakpoint ){
+        margin: 0;
+      }
     }
   }
 


### PR DESCRIPTION
This way it has enough room to display buttons.

Goes along with https://github.com/openstax/ospayments/pull/221

<img width="369" alt="image" src="https://user-images.githubusercontent.com/79566/95215225-5d8e9600-07b6-11eb-85da-2adb6822846e.png">
