### PR TITLE
dispay `splash-video` as full width

### DIFF
--- a/tutor/resources/styles/book-content/splash-image.scss
+++ b/tutor/resources/styles/book-content/splash-image.scss
@@ -7,7 +7,8 @@
   }
 
   // splash elements are full width without margin or surrounding padding
-  .splash {
+  .splash,
+  .splash-video {
     @include book-content-full-width();
     margin-bottom: 2rem;
     padding-bottom: 2rem;


### PR DESCRIPTION
fixes:
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/79566/98403610-db9cc180-202e-11eb-859e-25fe99570e27.png">



after:
<img width="1293" alt="image" src="https://user-images.githubusercontent.com/79566/98403574-ce7fd280-202e-11eb-811d-2f440c96a0d2.png">
