### PR TITLE
strip html from errata link

### DIFF
--- a/shared/src/components/exercise-identifier-link.js
+++ b/shared/src/components/exercise-identifier-link.js
@@ -28,8 +28,13 @@ class ExerciseIdentifierLink extends React.Component {
   getLocationInfo() {
     const info = this.props.related_content ?
       first(this.props.related_content) : this.props;
-
-    return pick(info, 'chapter_section', 'title');
+    // book titles may have HTML in them, remove any tags
+    const lo = pick(info, 'chapter_section', 'title');
+    lo.title = (lo.title || '').replace(/(<([^>]+)>)/gi, '');
+    if (lo.title.includes(lo.chapter_section.toString())) {
+      lo.chapter_section = '';
+    }
+    return lo;
   }
 
   render() {


### PR DESCRIPTION
before:
<img width="673" alt="image" src="https://user-images.githubusercontent.com/79566/98406176-1c96d500-2033-11eb-8205-06bf2f3feea4.png">


after
<img width="719" alt="image" src="https://user-images.githubusercontent.com/79566/98406127-09840500-2033-11eb-8def-40c4ae76f8ca.png">
