### PR TITLE
add link to the bloom and dk popover info

### DIFF
--- a/tutor/src/components/add-edit-question/form/general.js
+++ b/tutor/src/components/add-edit-question/form/general.js
@@ -1,6 +1,6 @@
 import { React, PropTypes, styled, css, observer } from 'vendor';
 import { partial, map } from 'lodash';
-import { Dropdown } from 'react-bootstrap';
+import { Dropdown, Button } from 'react-bootstrap';
 import { AddEditQuestionFormBlock, AddEditFormTextInput } from './shared';
 import TutorDropdown from '../../dropdown';
 import AddEditQuestionUX from '../ux';
@@ -141,7 +141,7 @@ const GeneralForm = observer(({ ux }) => {
             label={
               <>
                 <span>Allow other instructors to copy and edit this question under the CC-BY license. </span>
-                {/* <a href="www.google.com" target="_blank">Learn more.</a> */}
+                <Button variant="link" onClick={() => ux.showTermsOfUse = true}>Learn more.</Button>
               </>
             }
             checked={ux.allowOthersCopyEdit}

--- a/tutor/src/components/add-edit-question/form/shared.js
+++ b/tutor/src/components/add-edit-question/form/shared.js
@@ -123,11 +123,13 @@ export const QuestionInfo = ({ popoverInfo, placement = 'top' }) => {
         type="question-circle"
         className="question-info-icon"
         onClick={handleClick}
-        onBlur={handleClick}/>
+      />
       <Overlay
+        rootClose
         show={show}
         target={target}
         placement={placement}
+        onHide={() => setShow(false)}
       >
         {popover}
       </Overlay>

--- a/tutor/src/components/add-edit-question/form/tags/index.js
+++ b/tutor/src/components/add-edit-question/form/tags/index.js
@@ -141,7 +141,7 @@ const TagForm = observer(({ ux }) => {
                     Bloom’s taxonomy is designed to make it easier for
                     teachers to classify learning outcomes and write better assessments.
                   </p>
-                  {/* <a href="www.google.com" target="_blank">Learn More</a> */}
+                  <a href="https://openstax.org/blog/use-blooms-taxonomy-and-depth-of-knowledge-to-write-better-questions-in-openstax-tutor" target="_blank">Learn More</a>
                 </>
               }/>
           </div>
@@ -162,7 +162,7 @@ const TagForm = observer(({ ux }) => {
                     Depth of Knowledge or DoK is used to identify the level of rigor for
                     an assessment and categorize activities according to the level of complexity in thinking.
                   </p>
-                  {/* <a href="www.google.com" target="_blank">Learn More</a> */}
+                  <a href="https://openstax.org/blog/use-blooms-taxonomy-and-depth-of-knowledge-to-write-better-questions-in-openstax-tutor" target="_blank">Learn More</a>
                 </>
               }/>
           </div>

--- a/tutor/src/components/add-edit-question/index.js
+++ b/tutor/src/components/add-edit-question/index.js
@@ -20,6 +20,10 @@ const AddEditQuestionModals = observer(({ ux }) => {
       <FeedbackTipModal ux={ux} />
       <ExitWarningModal ux={ux} />
       <QuestionPreviewModal ux={ux} />
+      <AddEditQuestionTermsOfUse
+        onClose={() => ux.showTermsOfUse = false}
+        show={ux.showTermsOfUse}
+        displayOnly />;
     </>
   );
 });

--- a/tutor/src/components/add-edit-question/ux.js
+++ b/tutor/src/components/add-edit-question/ux.js
@@ -28,6 +28,7 @@ export default class AddEditQuestionUX {
   }
   @observable showExitWarningModal = false;
   @observable showPreviewQuestionModal = false;
+  @observable showTermsOfUse = false;
 
   /** props */
   @observable book;


### PR DESCRIPTION
New 'Learn more' link added for both DOK and Blooms popover info in the add/edit question form.