### PR TITLE
do not render editor pane as flexbox

### DIFF
--- a/tutor/src/components/add-edit-question/form/shared.js
+++ b/tutor/src/components/add-edit-question/form/shared.js
@@ -35,8 +35,6 @@ const StyledRowContent = styled.div`
       }
     }
     .editor {
-      display: flex;
-      flex-flow: column wrap;
       .error-info {
         color: ${colors.strong_red};
       }

--- a/tutor/src/components/editor/index.js
+++ b/tutor/src/components/editor/index.js
@@ -27,7 +27,7 @@ const Wrapper = styled.div({
   minHeight: '150px',
   display: 'flex',
   '.openstax-has-html': {
-    flex: 1,
+    width: '100%',
   },
 });
 
@@ -67,7 +67,7 @@ export const EditableHTML = ({
   if (isEditing) {
     body = <Editing html={currentHTML} runtime={limitedEditing ? runtimes.limited : runtimes.full} />;
   } else {
-    body = <HTML autoFocus html={currentHTML || placeholder} onClick={() => setEditing(true)}/>;
+    body = <HTML block className="preview" autoFocus html={currentHTML || placeholder} onClick={() => setEditing(true)}/>;
   }
 
 


### PR DESCRIPTION
It breaks responsive embed sizes
Before:
<img width="1325" alt="image" src="https://user-images.githubusercontent.com/79566/101707628-391e9680-3a51-11eb-8346-0c59c72186ce.png">



after:
<img width="1315" alt="image" src="https://user-images.githubusercontent.com/79566/101707586-273cf380-3a51-11eb-8a30-d65cabb2f760.png">
