### PR TITLE
update perry-white to fix editor link modal focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "object-hash": "1.3.1",
     "path-to-regexp": "3.0.0",
     "pattern-library": "github:openstax/pattern-library#v1.1.0",
-    "perry-white": "0.2.5",
+    "perry-white": "0.2.6",
     "pluralize": "8.0.0",
     "popper.js": "1.15.0",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9563,10 +9563,10 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-perry-white@0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/perry-white/-/perry-white-0.2.5.tgz#a0c6f8e616f3738b766152830a169b4916d4eb67"
-  integrity sha512-z5Ttdf2Py/rT4eewhDP4F68XHa/Iv49NM5Sp4NJ+PdFMb+dc8dn/tEJeHTRM8shtNIANUo2UysAykLsnfKTNdw==
+perry-white@0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/perry-white/-/perry-white-0.2.6.tgz#a02df55d67c2922ec6e424be2b1c78bda9696ce7"
+  integrity sha512-hJzwwDJ4A78nQRTZUBLwNW0ldMzT+PR24Bd68EkpSbSMVPGqxI+aSxobd6BABvH24BMiDQa2TPash69rKGFBdg==
   dependencies:
     browserkeymap "2.0.2"
     color "3.1.2"


### PR DESCRIPTION
This commit fixed the issue: https://github.com/openstax/perry-white/commit/8c62ecc778aeb867cf4cdb92bde9468a9b78edd7

Tutor renders the editor inside a bootstrap modal which has a handler that grabs the focus back whenever it's lost.  That's an issue for PerryWhite modals that render inside `body` by default.  I'd fixed the math to render inside the editor div, and had to do the same for link