### PR TITLE
only show feedback tip modal if form is MCQ

### DIFF
--- a/tutor/src/components/add-edit-question/ux.js
+++ b/tutor/src/components/add-edit-question/ux.js
@@ -389,7 +389,8 @@ export default class AddEditQuestionUX {
   }
 
   @action async publish(shouldExit) {
-    if(!this.hasAnyFeedback) {
+    // only show feedback tip modal if form is MCQ
+    if(!this.hasAnyFeedback && this.isMCQ) {
       this.feedbackTipModal = {
         show: true,
         shouldExitOnPublish: shouldExit,


### PR DESCRIPTION
When trying to create a WRQ, it shows the feedback tips modal because there is no feedback for a MCQ. It shouldn't show.