### PR TITLE
add the question type: teacher-preview for the exercise cards when cr…

### DIFF
--- a/tutor/src/screens/assignment-edit/homework/choose-exercises.jsx
+++ b/tutor/src/screens/assignment-edit/homework/choose-exercises.jsx
@@ -162,6 +162,7 @@ class ChooseExercises extends React.Component {
       getExerciseActions: this.getExerciseActions,
       getExerciseIsSelected: this.getExerciseIsSelected,
       pageIds: ux.selectedPageIds,
+      questionType: 'teacher-preview',
     };
 
     let body;


### PR DESCRIPTION
If no `questionType` is set for the Question cards, then it will show the default radio buttons to select an answer. Therefore, add `teacher-preview` as `questionType` for the exercise cards in the `choose-exercise.js` component.