### PR TITLE
fix extension icon in a reading assignment not showing dates

### DIFF
--- a/tutor/src/screens/assignment-review/reading-scores.js
+++ b/tutor/src/screens/assignment-review/reading-scores.js
@@ -231,12 +231,12 @@ const StudentCell = observer(({ ux, student, striped }) => {
               ?`${ScoresHelper.asPercent(student.total_fraction || 0)}%`
               : isUndefined(student.total_points)
                 ? UNWORKED
-                : ScoresHelper.formatPoints(student.total_points) 
+                : ScoresHelper.formatPoints(student.total_points)
             }
           </StyledTotal>
           <LateWork>
             {student.late_work_point_penalty ? ScoresHelper.formatLatePenalty(student.late_work_point_penalty) : '0'}
-            {ux.wasGrantedExtension(student.role_id) && <ExtensionIcon />}
+            {ux.wasGrantedExtension(student.role_id) && <ExtensionIcon extension={student.extension} timezone={ux.course.timezone} />}
           </LateWork>
         </CellContents>
       </Cell>


### PR DESCRIPTION
The extension icon wasn't getting passed the extension object, so the icon would render, but not the dates granted. This seems to have only affected the reading assignment table not homework.

Before:
![image](https://user-images.githubusercontent.com/34174/102127100-eb16e380-3e00-11eb-99c2-7c4f825285b2.png)

After:
![image](https://user-images.githubusercontent.com/34174/102127208-11d51a00-3e01-11eb-951f-40b04dc99b85.png)
