### PR TITLE
only show the feedback tip modal once per question building

### DIFF
--- a/tutor/src/components/add-edit-question/ux.js
+++ b/tutor/src/components/add-edit-question/ux.js
@@ -253,6 +253,10 @@ export default class AddEditQuestionUX {
     return some(this.filledOptions, fo => !S.isEmpty(S.stripHTMLTags(fo.feedback)));
   }
 
+  @computed get shouldShowFeedbackTipModal() {
+    return !this.hasAnyFeedback && this.isMCQ && !this.feedbackTipModal.didShow;
+  }
+
   @computed get canExit() {
     // ignore check for chapter, section and author
     // after publish, we reset everything except this three fields
@@ -395,7 +399,7 @@ export default class AddEditQuestionUX {
 
   @action async publish(shouldExit) {
     // only show feedback tip modal if form is MCQ
-    if(!this.hasAnyFeedback && this.isMCQ && !this.feedbackTipModal.didShow) {
+    if(this.shouldShowFeedbackTipModal) {
       this.feedbackTipModal = {
         show: true,
         didShow: true,

--- a/tutor/src/components/add-edit-question/ux.js
+++ b/tutor/src/components/add-edit-question/ux.js
@@ -25,6 +25,7 @@ export default class AddEditQuestionUX {
   //modal
   @observable feedbackTipModal = {
     show: false,
+    didShow: false,
     shouldExitOnPublish: false,
   }
   @observable showExitWarningModal = false;
@@ -394,9 +395,10 @@ export default class AddEditQuestionUX {
 
   @action async publish(shouldExit) {
     // only show feedback tip modal if form is MCQ
-    if(!this.hasAnyFeedback && this.isMCQ) {
+    if(!this.hasAnyFeedback && this.isMCQ && !this.feedbackTipModal.didShow) {
       this.feedbackTipModal = {
         show: true,
+        didShow: true,
         shouldExitOnPublish: shouldExit,
       };
     }


### PR DESCRIPTION
CASE:
add/edit modal is opened -> question is filled without feedback -> try to publish -> show feedback tip -> feedback tip is closed -> tries to publish again -> do not show the feedback tip.

*If the user opens the add/edit modal again then the above logic is applied.