### PR TITLE
add the question type in exercise details

### DIFF
--- a/tutor/src/components/exercises/details.jsx
+++ b/tutor/src/components/exercises/details.jsx
@@ -24,6 +24,7 @@ class ExerciseDetails extends React.Component {
     onShowCardViewClick:   PropTypes.func.isRequired,
     getExerciseActions:    PropTypes.func.isRequired,
     getExerciseIsSelected: PropTypes.func.isRequired,
+    questionType:          PropTypes.string,
     selectedSection:       PropTypes.instanceOf(ChapterSection),
     displayFeedback:       PropTypes.bool,
     onSectionChange:       PropTypes.func,
@@ -138,6 +139,7 @@ class ExerciseDetails extends React.Component {
               displayFeedback={this.props.displayFeedback}
               extractedInfo={exercise}
               exercise={exercise.content}
+              questionType={this.props.questionType}
               actionsOnSide={true}
               leftFooterRenderer={leftFooter}
               rightFooterRenderer={rightFooter}


### PR DESCRIPTION
Missed another `questionType` prop to show the correct answer in the exercise details