### PR TITLE
sort exercises first by chapter-section, then user

### DIFF
--- a/tutor/src/components/exercises/details.jsx
+++ b/tutor/src/components/exercises/details.jsx
@@ -53,20 +53,6 @@ class ExerciseDetails extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    if (!this.props.selectedSection) {
-      return;
-    }
-    if (!prevProps.selectedSection || !this.props.selectedSection.eq(prevProps.selectedSection)) {
-      const index = this.exercises.findIndex(
-        ex => ex.page.chapter_section.eq(this.props.selectedSection)
-      );
-      if (index != -1) {
-        this.currentIndex = index;
-      }
-    }
-  }
-
   @action.bound onPrev() { this.moveTo(this.currentIndex - 1); }
   @action.bound onNext() { this.moveTo(this.currentIndex + 1); }
 

--- a/tutor/src/models/exercises.js
+++ b/tutor/src/models/exercises.js
@@ -13,14 +13,15 @@ export { COMPLETE, PENDING };
 
 export const exerciseSort = (exercises, course, user) => {
   return sortBy(exercises, (ex) => {
+    const cs = ex.page.chapter_section.asString;
     if (ex.belongsToUser(user)) {
-      return 1;
+      return [cs, 1];
     } else if (course.teacher_profiles.find(tp => ex.belongsToUser(tp))) {
-      return 2;
+      return [cs, 2];
     } else if (!ex.belongsToOpenStax){
-      return 3;
+      return [cs, 3];
     }
-    return 4;
+    return [cs, 4];
   });
 };
 


### PR DESCRIPTION
Otherwise details view gets out of order when the section changes