### PR TITLE
fix add edit options inline error

### DIFF
--- a/tutor/src/components/add-edit-question/ux.js
+++ b/tutor/src/components/add-edit-question/ux.js
@@ -311,7 +311,12 @@ export default class AddEditQuestionUX {
 
   @action changeOptions(answer, index) {
     this.options[index].text = answer;
-    if(index <= 1) {
+    // if two or more options are filled, then take out the errors
+    if(this.filledOptions.length >= 2 && some(this.isEmpty.options, o => o)) {
+      this.isEmpty.options[0] = false;
+      this.isEmpty.options[1] = false;
+    }
+    else if (index <= 1 && this.isEmpty.options[index]) {
       this.isEmpty.options[index] = false;
     }
   }
@@ -532,9 +537,18 @@ export default class AddEditQuestionUX {
       if(key === 'correctOption') {
         this.isEmpty[key] = every(this.options, o => !o.isCorrect);
       }
-      else if (key === 'options') {
-        this.isEmpty[key][0] = S.isEmpty(S.stripHTMLTags(this[key][0].text));
-        this.isEmpty[key][1] = S.isEmpty(S.stripHTMLTags(this[key][1].text));
+      else if (key === 'options' && this.filledOptions.length <= 1) {
+        // if there ar no filled options, show the inline error in the first two option editors
+        if(this.filledOptions.length === 0) {
+          this.isEmpty[key][0] = true;
+          this.isEmpty[key][1] = true;
+        }
+        else if (this.filledOptions.length === 1) {
+          // show error in the first option editor
+          this.isEmpty[key][0] = S.isEmpty(S.stripHTMLTags(this[key][0].text));
+          // show error in the second option editor if the first is filled
+          this.isEmpty[key][1] = S.isEmpty(S.stripHTMLTags(this[key][1].text)) && !this.isEmpty[key][0];
+        }
       }
       else {
         this.isEmpty[key] = typeof this[key] === 'string' ? S.isEmpty(S.stripHTMLTags(this[key])) : !this[key];


### PR DESCRIPTION
Update some of the inline error logic for options.

1. If the user enters two options, take out the inline error.
2. Check also if the user enters an option in option 3 or higher. It should show an inline error in option 1 if there is only 1 option.
3. Show only inline error in option 2 if option 1 is the only filled.