### PR TITLE
fix-feedback-tip-publish

### DIFF
--- a/tutor/src/components/add-edit-question/ux.js
+++ b/tutor/src/components/add-edit-question/ux.js
@@ -452,6 +452,7 @@ export default class AddEditQuestionUX {
       this.feedbackTipModal = {
         show: false,
         shouldExitOnPublish: false,
+        didShow: this.feedbackTipModal.didShow,
       };
     }
   }


### PR DESCRIPTION
keep track of the feedback tip after the instructor clicks on the publish question button and stay in the modal.