### PR TITLE
fetch terms when modal is showing

### DIFF
--- a/tutor/specs/components/app.spec.jsx
+++ b/tutor/specs/components/app.spec.jsx
@@ -9,6 +9,8 @@ jest.mock('../../src/models/user', () => ({
   },
   can_create_courses: true,
   terms: {
+    areSignaturesNeeded: false,
+    fetchIfNeeded() {},
     api: {
       isPending: false,
     },

--- a/tutor/src/components/terms-modal.jsx
+++ b/tutor/src/components/terms-modal.jsx
@@ -33,6 +33,7 @@ class TermsModal extends React.Component {
 
   componentDidMount() {
     this.props.modalManager.queue(this, 1);
+    User.terms.fetchIfNeeded();
   }
 
   // for terms to be displayed the user must be in a course and need them signed

--- a/tutor/src/models/user/terms.js
+++ b/tutor/src/models/user/terms.js
@@ -50,7 +50,7 @@ class UserTerms extends BaseModel {
   }
 
   @action.bound fetchIfNeeded() {
-    if (this.user.terms_signatures_needed) { this.fetch(); }
+    if (this.areSignaturesNeeded) { this.fetch(); }
   }
 
   get(name) {


### PR DESCRIPTION
They weren't being fetched completely before which caused the terms modal to display with empty terms