### PR TITLE
add grading template learn more link

### DIFF
--- a/tutor/src/screens/grading-templates/index.js
+++ b/tutor/src/screens/grading-templates/index.js
@@ -157,7 +157,7 @@ class GradingTemplatesScreen extends React.Component {
                 <Instructions>
                   Manage pre-set submission and grading policy templates here. These
                   templates can be applied to multiple assignments. Template applied
-                  to open assignments cannot be edited or deleted. <a href="">Learn more</a>
+                  to open assignments cannot be edited or deleted. <a href="https://openstax.secure.force.com/help/articles/FAQ/What-are-Grading-templates" target="__blank">Learn more</a>
                 </Instructions>
               </Col>
             </Row>


### PR DESCRIPTION
Add 'https://openstax.secure.force.com/help/articles/FAQ/What-are-Grading-templates' as a "Learn More" link for the grading templates.