### PR TITLE
add margin between index items title and link

### DIFF
--- a/tutor/resources/styles/book-content/base.scss
+++ b/tutor/resources/styles/book-content/base.scss
@@ -31,6 +31,12 @@
     font-weight: bold;
   }
 
+  // book index
+  .os-index-item {
+    .os-term + .os-term-section-link {
+      margin-left: 0.5rem;
+    }
+  }
 
   @include tutor-tables($tutor-neutral-light, $tutor-neutral-light);
   table + .os-caption-container{


### PR DESCRIPTION
Thanks to @lwtchu for listening while I floundered on this for a bit 🤣 

changes:
<img width="665" alt="image" src="https://user-images.githubusercontent.com/79566/104245418-78118480-5421-11eb-9acb-2dc365696d46.png">

to be:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/79566/104245406-70ea7680-5421-11eb-9259-775197c981fa.png">
