### PR TITLE
Fix teacher removing themselves from course

### DIFF
--- a/tutor/scripts/test-server/backend.js
+++ b/tutor/scripts/test-server/backend.js
@@ -48,6 +48,7 @@ const MULTI_HANDLERS = [
   require('./backend/tasks'),
   require('./backend/terms'),
   require('./backend/exercises'),
+  require('./backend/course-roster'),
 ];
 
 // routes that have custom logic

--- a/tutor/scripts/test-server/backend/course-roster.js
+++ b/tutor/scripts/test-server/backend/course-roster.js
@@ -1,0 +1,21 @@
+const Factory = require('object-factory-bot');
+const { getCourse } = require('./bootstrap');
+const { fe_port, be_port } = require('../ports');
+require('../../../specs/factories/course-roster');
+
+module.exports = {
+
+  setRole() { },
+
+  route(server) {
+    server.get('/api/courses/:courseId/roster', (req, res) => {
+      const course = getCourse(req.params.courseId);
+      const roster = Factory.create('CourseRoster', { course });
+      roster.teachers[0].role_id = course.roles.find(r => r.type == 'teacher').id;
+      res.json(roster);
+    });
+
+    server.delete('/api/teachers/:teacherId', (req, res) => { res.json({}) });
+  },
+
+};

--- a/tutor/specs/e2e/course-roster.e2e.js
+++ b/tutor/specs/e2e/course-roster.e2e.js
@@ -1,0 +1,23 @@
+import { visitPage, setTimeouts } from './helpers'
+
+// the BE mock api server is primarily in backend/task-plans
+
+describe('Course Roster', () => {
+
+  beforeEach(async () => {
+    await setTimeouts()
+    await visitPage(page, '/course/1/roster')
+
+  })
+
+  it('can remove self from course', async () => {
+    await expect(page).toHaveSelector('.teachers-table')
+    const userId = await page.evaluate(() => window._MODELS.courses.get(1).primaryRole.id)
+    await expect(page).toHaveSelector(`tr[data-teacher-id="${userId}"]`)
+    await page.click(`tr[data-teacher-id="${userId}"] >> a.remove`)
+    await expect(page).toHaveText('.popover-body >> .warning', 'remove yourself')
+    await page.click('testEl=remove-confirm-btn')
+    await page.waitForNavigation({ url: /dashboard/ })
+  });
+
+})

--- a/tutor/specs/factories/course-roster.js
+++ b/tutor/specs/factories/course-roster.js
@@ -6,6 +6,7 @@ const moment = require('moment');
 
 Factory.define('CourseRosterStudent')
   .id(sequence)
+  .role_id(sequence)
   .is_active(true)
   .is_comped(false)
   .is_paid(false)

--- a/tutor/specs/factories/user.js
+++ b/tutor/specs/factories/user.js
@@ -2,9 +2,9 @@ const { Factory, uuid, sequence } = require('./helpers');
 
 Factory.define('User')
   .profile_id(sequence)
-  .name(({ is_teacher }) => is_teacher ? 'Charles Morris' : 'Atticus Finch')
   .first_name(({ is_teacher }) => is_teacher ? 'Charles' : 'Atticus')
   .last_name(({ is_teacher }) => is_teacher ? 'Morris' : 'Finch')
+  .name(({ object }) => `${object.first_name} ${object.last_name}`)
   .is_admin(false)
   .is_customer_service(false)
   .is_content_analyst(false)

--- a/tutor/src/screens/course-roster/index.jsx
+++ b/tutor/src/screens/course-roster/index.jsx
@@ -59,6 +59,9 @@ class CourseRoster extends React.Component {
   }
 
   renderEmpty() {
+    if (!this.course) {
+      return null;
+    }
     return (
       <NoPeriods
         courseId={this.course.id}
@@ -68,7 +71,13 @@ class CourseRoster extends React.Component {
   }
 
   render() {
-    const { course, course: { periods: { active: periods } } } = this;
+    const { course } = this;
+    let periods = [];
+    // course can be null when a teacher removes themselves and this
+    // re-renders before the redirect to dashboard occurs
+    if (course) {
+      periods = course.periods.active;
+    }
     if (0 === periods.length) { return this.renderEmpty(); }
     const activePeriod = periods[this.periodIndex] || periods[0];
 

--- a/tutor/src/screens/course-roster/remove-teacher.jsx
+++ b/tutor/src/screens/course-roster/remove-teacher.jsx
@@ -50,6 +50,7 @@ class RemoveTeacherLink extends React.Component {
 
           <AsyncButton
             variant="danger"
+            data-test-id="remove-confirm-btn"
             onClick={this.performDeletion}
             isWaiting={teacher.api.isPending}
             waitingText="Removing..."
@@ -71,8 +72,9 @@ class RemoveTeacherLink extends React.Component {
         rootClose={true}
         trigger="click"
         placement="left"
-        overlay={this.confirmPopOver()}>
-        <a>
+        overlay={this.confirmPopOver()}
+      >
+        <a className="remove">
           <Icon type="ban" />
           {' Remove'}
         </a>

--- a/tutor/src/screens/course-roster/teacher-roster.jsx
+++ b/tutor/src/screens/course-roster/teacher-roster.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Table } from 'react-bootstrap';
-import { map } from 'lodash';
 import { autobind } from 'core-decorators';
 import { observer } from 'mobx-react';
 import RemoveTeacherLink from './remove-teacher';
@@ -18,7 +17,7 @@ class TeacherRoster extends React.Component {
 
   @autobind renderRow(teacher) {
     return (
-      <tr key={teacher.id}>
+      <tr key={teacher.id} data-teacher-id={teacher.role_id}>
         <td>
           {teacher.first_name}
         </td>
@@ -71,4 +70,4 @@ class TeacherRoster extends React.Component {
       </div>
     );
   }
-};
+}


### PR DESCRIPTION
Previously they'd get an error when the course roster re-rendered and the current user was no longer an instructor