### PR TITLE
Display pending verification msg to locked out teachers for 1 day

### DIFF
--- a/tutor/specs/components/my-courses.spec.jsx
+++ b/tutor/specs/components/my-courses.spec.jsx
@@ -1,4 +1,4 @@
-import { C } from '../helpers';
+import { C, TimeMock } from '../helpers';
 import CourseListing from '../../src/components/my-courses';
 import { flatten } from 'lodash';
 import Courses from '../../src/models/courses-map';
@@ -16,12 +16,15 @@ const loadTeacherUser = () => {
 
 describe('My Courses Component', function() {
 
+  const now = TimeMock.setTo('2021-01-15T12:00:00.000Z');
+
   beforeEach(bootstrapCoursesList);
 
   afterEach(() => {
     Courses.clear();
     User.fetch = jest.fn();
     User.faculty_status = '';
+    User.created_at = now;
     User.school_type = 'college';
     User.self_reported_role = '';
   });
@@ -132,7 +135,11 @@ describe('My Courses Component', function() {
       User.can_create_courses = false;
       Courses.clear();
       const wrapper = mount(<C><CourseListing /></C>);
+      User.created_at = new Date('2021-01-11T12:00:00.000Z')
       expect(wrapper).toHaveRendered('NonAllowedTeachers');
+      User.created_at = new Date('2021-01-15T12:00:00.000Z')
+      expect(wrapper).not.toHaveRendered('NonAllowedTeachers');
+      expect(wrapper).toHaveRendered('PendingVerification');
       wrapper.unmount();
     });
 

--- a/tutor/specs/models/user.spec.js
+++ b/tutor/specs/models/user.spec.js
@@ -1,5 +1,5 @@
 import { autorun } from 'mobx';
-
+import { TimeMock } from '../helpers';
 import User from '../../src/models/user';
 import { UserTerms } from '../../src/models/user/terms';
 import Courses from '../../src/models/courses-map';
@@ -12,6 +12,8 @@ describe('User Model', () => {
   afterEach(() => {
     User.viewed_tour_stats.clear();
   });
+
+  TimeMock.setTo('2021-01-15T12:00:00.000Z');
 
   it('can be bootstrapped', () => {
     const spy = jest.fn();
@@ -107,4 +109,12 @@ describe('User Model', () => {
     expect(User.initials).toEqual('B S');
   });
 
+  it('calculates new users', () => {
+    // one hour ago
+    User.created_at = new Date('2021-01-15T11:00:00.000Z')
+    expect(User.wasNewlyCreated).toBe(true)
+    // a day + hour ago
+    User.created_at = new Date('202-0-0T14:11:00.000Z')
+    expect(User.wasNewlyCreated).toBe(false)
+  })
 });

--- a/tutor/src/components/my-courses/index.jsx
+++ b/tutor/src/components/my-courses/index.jsx
@@ -34,12 +34,16 @@ class MyCourses extends React.Component {
 
   render() {
     if (Courses.isEmpty) {
-      if (User.isConfirmedFaculty) {
+      if (User.wasNewlyCreated && !User.canCreateCourses) {
+        return <PendingVerification />;
+      } else if (User.isConfirmedFaculty) {
         if (!User.canCreateCourses) {
           return <NonAllowedTeacher />;
         }
+      } else if (User.isUnverifiedInstructor) {
+        return <PendingVerification />;
       } else {
-        return User.isUnverifiedInstructor? <PendingVerification /> : <EmptyCourses />;
+        return <EmptyCourses />;
       }
     }
 

--- a/tutor/src/models/user.js
+++ b/tutor/src/models/user.js
@@ -1,6 +1,7 @@
 import {
-  BaseModel, identifiedBy, field, hasMany,
+  BaseModel, identifiedBy, field, hasMany, session,
 } from 'shared/model';
+import moment from 'moment';
 import { find, startsWith, map, uniq, max } from 'lodash';
 import { action, computed, observable } from 'mobx';
 import UiSettings from 'shared/model/ui-settings';
@@ -9,6 +10,7 @@ import { UserTerms, Term } from './user/terms';
 import ViewedTourStat from './user/viewed-tour-stat';
 import { read_csrf } from '../helpers/dom';
 import Flags from './feature_flags';
+import Time from './time';
 
 @identifiedBy('user')
 class User extends BaseModel {
@@ -41,6 +43,7 @@ class User extends BaseModel {
   @hasMany({ model: Term  }) available_terms = [];
 
   @hasMany({ model: ViewedTourStat }) viewed_tour_stats;
+  @session({ type: 'date' }) created_at;
 
   @computed get firstName() {
     return this.first_name || (this.name ? this.name.replace(/ .*/, '') : '');
@@ -87,6 +90,10 @@ class User extends BaseModel {
   
   @computed get canCreateCourses() {
     return Boolean(this.can_create_courses);
+  }
+
+  @computed get wasNewlyCreated() {
+    return moment(Time.now).subtract(1, 'day').isBefore(this.created_at);
   }
 
   @computed get isProbablyTeacher() {


### PR DESCRIPTION
The school type can be delayed, causing teachers to incorrectly see the "must be 4 year institution" message.

To work around that, if a teacher can't create courses for any reason and their account is newer than 1 day, we always show the "Pending Verification" message