### PR TITLE
do not display "pending verification" to students

### DIFF
--- a/tutor/specs/components/my-courses.spec.jsx
+++ b/tutor/specs/components/my-courses.spec.jsx
@@ -129,8 +129,19 @@ describe('My Courses Component', function() {
     wrapper.unmount();
   });
 
-  describe('non-allowed instructors', () => {
-    it('locks them out and displays message when they hve no courses', () => {
+  describe('non-allowed users', () => {
+    it('shows empty courses for self reported students', () => {
+      Courses.clear();
+      User.can_create_courses = false;
+      User.self_reported_role = 'student';
+      const wrapper = mount(<C><CourseListing /></C>);
+      User.created_at = new Date('2021-01-15T12:00:00.000Z') // now
+      expect(wrapper).not.toHaveRendered('PendingVerification');
+      expect(wrapper).toHaveRendered('EmptyCourses');
+      wrapper.unmount();
+    });
+
+    it('locks instructors out and displays message when they hve no courses', () => {
       User.faculty_status = 'confirmed_faculty';
       User.can_create_courses = false;
       Courses.clear();
@@ -143,7 +154,7 @@ describe('My Courses Component', function() {
       wrapper.unmount();
     });
 
-    it('hides previews if they cannot create course', () => {
+    it('hides previews for self reported instructors who cannot create course', () => {
       User.can_create_courses = true;
       const wrapper = mount(<C><CourseListing /></C>);
       expect(wrapper).toHaveRendered('MyCoursesPreview MyCoursesBasic');

--- a/tutor/src/components/my-courses/index.jsx
+++ b/tutor/src/components/my-courses/index.jsx
@@ -11,8 +11,8 @@ import PendingVerification from './pending-verification';
 import NonAllowedTeacher from './non-allowed-teacher';
 import { MyCoursesPast, MyCoursesCurrent, MyCoursesPreview } from './listings';
 
-export default
 @observer
+export default
 class MyCourses extends React.Component {
 
   componentDidMount() {
@@ -34,6 +34,9 @@ class MyCourses extends React.Component {
 
   render() {
     if (Courses.isEmpty) {
+      if (!User.isProbablyTeacher) {
+        return <EmptyCourses />;
+      }
       if (User.wasNewlyCreated && !User.canCreateCourses) {
         return <PendingVerification />;
       } else if (User.isConfirmedFaculty) {


### PR DESCRIPTION
While rare, a student can signup directly and not have any courses.  We only want to show the pending verification message to instructors