### PR TITLE
Manage subjects bug

### DIFF
--- a/tutor/src/screens/my-courses/dashboard/index.tsx
+++ b/tutor/src/screens/my-courses/dashboard/index.tsx
@@ -37,6 +37,9 @@ const StyledMyCoursesDashboard = styled.div`
         padding-top: 2.4rem;
         padding: 2.4rem 3.2rem 6.4rem;
         min-height: 40rem;
+        h3 {
+            color: ${colors.neutral.std};
+        }
         .edit-mode-icons {
             float: right;
         }
@@ -74,6 +77,15 @@ const StyledMyCoursesDashboard = styled.div`
                 font-size: 1.8rem;
                 color: ${colors.neutral.darker};
                 margin: 7rem auto;
+            }
+        }
+        &.is-edit-mode {
+            h3 {
+                color: ${colors.neutral.darker};
+            }
+            .my-courses-item-wrapper , .my-courses-add-zone{
+                opacity: 0.6;
+                pointer-events: none;
             }
         }
     }

--- a/tutor/src/screens/my-courses/dashboard/offering-block.tsx
+++ b/tutor/src/screens/my-courses/dashboard/offering-block.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect, ReactElement, Dispatch, SetStateAction } from 'react'
 import { map, filter } from 'lodash'
+import cn from 'classnames'
 import moment from 'moment'
 import { Icon } from 'shared'
 import UiSettings from 'shared/model/ui-settings'
@@ -189,7 +190,7 @@ const OfferingBlock: React.FC<OfferingBlockProps> = ({ offering, courses, swapOf
     )
 
     return (
-        <div className="offering-container">
+        <div className={cn('offering-container', { 'is-edit-mode': isEditMode })}>
             {editModeIcons}
             <h3>{offering.title}</h3>
             <Tabs

--- a/tutor/src/screens/my-courses/dashboard/use-displayed-offerings.tsx
+++ b/tutor/src/screens/my-courses/dashboard/use-displayed-offerings.tsx
@@ -11,9 +11,7 @@ const useDisplayedOfferings = () : ReturnUseDisplayedOfferings => {
     // getting all the data: offerings and courses
     const courses = useAllCourses()
     const offerings = useAvailableOfferings(courses)
-    const [displayedOfferingIds, setDisplayedOfferingIds] = useState<ID[]>(
-        UiSettings.get('displayedOfferingIds') || useDisplayedCourseOfferingIds()
-    )
+    const [displayedOfferingIds, setDisplayedOfferingIds] = useState<ID[]>(useDisplayedCourseOfferingIds())
 
     // update the `displayedOfferingIds` if users adds/delete offerings
     useEffect(() => {

--- a/tutor/src/screens/my-courses/dashboard/use-displayed-offerings.tsx
+++ b/tutor/src/screens/my-courses/dashboard/use-displayed-offerings.tsx
@@ -12,7 +12,7 @@ const useDisplayedOfferings = () : ReturnUseDisplayedOfferings => {
     const courses = useAllCourses()
     const offerings = useAvailableOfferings(courses)
     const [displayedOfferingIds, setDisplayedOfferingIds] = useState<ID[]>(
-        useDisplayedCourseOfferingIds()
+        UiSettings.get('displayedOfferingIds') || useDisplayedCourseOfferingIds()
     )
 
     // update the `displayedOfferingIds` if users adds/delete offerings

--- a/tutor/src/store/courses.ts
+++ b/tutor/src/store/courses.ts
@@ -108,7 +108,7 @@ export const useLatestCoursePreview = (offeringId: string | number) => useSelect
 export const useDisplayedCourseOfferingIds = () => {
     const courseOfferingIds = useAllCourses().map(c => c.offering_id)
     const selectedIds = UiSettings.get('displayedOfferingIds') || []
-    return union(courseOfferingIds, selectedIds)
+    return union(selectedIds, courseOfferingIds)
 }
 
 export { createPreviewCourse, updateCourse, selectors }


### PR DESCRIPTION
Disabled course item cards when in edit mode.
Persist the order of the offerings after a refresh.

<img width="1822" alt="Screen Shot 2021-03-09 at 11 55 46 AM" src="https://user-images.githubusercontent.com/3774774/110515817-6e796580-80ce-11eb-99c9-98294904e2c7.png">
