### PR TITLE
clear subject when typing a suggestion

### DIFF
--- a/tutor/specs/e2e/my-courses.e2e.ts
+++ b/tutor/specs/e2e/my-courses.e2e.ts
@@ -9,7 +9,8 @@ describe('My Courses', () => {
 
     it('allows a new teacher select and suggest subjects', async () => {
         await visitPage(page, '/courses')
-        await expect(page).toHaveSelector('testEl=existing-teacher-screen', { timeout: 1000 })
+        // The 500ms timeouts may be too low when using DEBUG, temp set to 1000 if you see issues
+        await expect(page).toHaveSelector('testEl=existing-teacher-screen', { timeout: 500 })
         await modifyBootstrapData(page, (data) => ({ ...data, courses: [] }))
         await visitPage(page, '/courses')
         await expect(page).toHaveSelector('testEl=new-teacher-screen', { timeout: 500 })

--- a/tutor/specs/e2e/my-courses.e2e.ts
+++ b/tutor/specs/e2e/my-courses.e2e.ts
@@ -25,8 +25,13 @@ describe('My Courses', () => {
             await page.evaluate(() => document.location.search)
         ).toContain('onboarding=0')
         await expect(page).not.toHaveSelector('testEl=show-detail', { timeout: 100 })
+        await page.type('testEl=input-suggested-subject', 'test')
         await page.click('testEl=offering-0', { force: true })
         await expect(page).toHaveSelector('testEl=show-detail', { timeout: 100 })
+        await expect(page).not.toHaveSelector('testEl=submit-suggested-subject', { timeout: 100 })
+        await page.type('testEl=input-suggested-subject', 'test')
+        await expect(page).not.toHaveSelector('testEl=show-detail', { timeout: 100 })
+        await page.click('testEl=offering-0', { force: true })
         await page.click('testEl=show-detail')
     })
 

--- a/tutor/src/screens/my-courses/index.tsx
+++ b/tutor/src/screens/my-courses/index.tsx
@@ -19,7 +19,7 @@ const MyCourses: React.FC<MyCoursesProps> = ({ history }) => {
 
     // a verified instructor from approved institution
     if (User.canCreateCourses) {
-        return <NewTeacher history={history} data-test-id="new-teacher-screen" />
+        return <NewTeacher history={history} />
     }
 
     // even though this case should be handled by router;

--- a/tutor/src/screens/my-courses/new-teacher.tsx
+++ b/tutor/src/screens/my-courses/new-teacher.tsx
@@ -477,7 +477,7 @@ const SubjectSelect: React.FC<SubjectSelectProps> = ({
     }
 
     return (
-        <StyledPage data-test-id="new-teacher-screen" >
+        <StyledPage>
             <Header>
                 <h2>Welcome to OpenStax Tutor</h2>
                 <h1 id="instructions">

--- a/tutor/src/screens/my-courses/new-teacher.tsx
+++ b/tutor/src/screens/my-courses/new-teacher.tsx
@@ -468,7 +468,7 @@ const SubjectSelect: React.FC<SubjectSelectProps> = ({
     }
 
     const onChangeSuggestion = (value) => {
-        if (value.length > 0) {
+        if (value) {
             setSelectedSubject(null)
         }
 

--- a/tutor/src/screens/my-courses/new-teacher.tsx
+++ b/tutor/src/screens/my-courses/new-teacher.tsx
@@ -43,7 +43,7 @@ const Header = styled.div`
         font-size: 1.8rem;
         font-weight: bold;
         line-height: 3rem;
-        letter-spacing: 0.05rem;
+        letter-spacing: -0.05rem;
         margin: 0 0 1rem;
     }
 
@@ -468,6 +468,10 @@ const SubjectSelect: React.FC<SubjectSelectProps> = ({
     }
 
     const onChangeSuggestion = (value) => {
+        if (value.length > 0) {
+            setSelectedSubject(null)
+        }
+
         setSuggestedSubject(value)
         setShowSuggestSubmitButton(value.length > 0)
     }
@@ -500,7 +504,10 @@ const SubjectSelect: React.FC<SubjectSelectProps> = ({
                                                 type="radio"
                                                 name="offering"
                                                 checked={selectedSubject === book.id}
-                                                onChange={() => setSelectedSubject(book.id)}
+                                                onChange={() => {
+                                                    setSelectedSubject(book.id)
+                                                    onChangeSuggestion('')
+                                                }}
                                                 data-test-id={`offering-${i}`}
                                             />
                                             <div className="control">
@@ -521,6 +528,7 @@ const SubjectSelect: React.FC<SubjectSelectProps> = ({
                                 <input
                                     type="text"
                                     maxLength={50}
+                                    value={suggestedSubject}
                                     placeholder="Suggest a subject"
                                     onChange={(e) => onChangeSuggestion(e.target.value)}
                                     data-test-id="input-suggested-subject"


### PR DESCRIPTION
We decided to clear the selected subject when typing a suggestion, and clear the suggestion when selecting a subject, so that only 1 primary button will be visible on screen at any time.