### PR TITLE
add new header to the course-roster

### DIFF
--- a/tutor/src/screens/course-roster/index.jsx
+++ b/tutor/src/screens/course-roster/index.jsx
@@ -4,6 +4,7 @@ import { computed, observable, action } from 'mobx';
 import { observer } from 'mobx-react';
 import { map } from 'lodash';
 import Tabs from '../../components/tabs';
+import CourseBreadcrumb from '../../components/course-breadcrumb';
 import Courses from '../../models/courses-map';
 import TeacherRoster from './teacher-roster';
 import StudentRoster from './student-roster';
@@ -70,6 +71,10 @@ class CourseRoster extends React.Component {
       );
   }
 
+  renderTitleBreadcrumbs() {
+      return <CourseBreadcrumb course={this.course} currentTitle="Course Roster" noBottomMargin />;
+  }
+
   render() {
       const { course } = this;
       let periods = [];
@@ -84,15 +89,11 @@ class CourseRoster extends React.Component {
       return (
           <CoursePage
               className="roster"
-              title="Course roster"
               course={course}
+              titleBreadcrumbs={this.renderTitleBreadcrumbs()}
+              titleAppearance="light"
+              controlBackgroundColor='white'
           >
-              <div className="course-settings-title">
-                  {course.name}
-              </div>
-              <h4 className="course-settings-term">
-                  {course.termFull}
-              </h4>
               <div className="settings-section teachers">
                   <TeacherRoster course={course} />
               </div>

--- a/tutor/src/screens/course-roster/styles.scss
+++ b/tutor/src/screens/course-roster/styles.scss
@@ -47,7 +47,6 @@
   .body {
     font-size: 16px;
     line-height: 24px;
-    padding-top: 40px;
   }
 
   .course-settings-detail {


### PR DESCRIPTION
Just a small UI change in the course roster screen.

<img width="1427" alt="Screen Shot 2021-03-09 at 3 39 54 PM" src="https://user-images.githubusercontent.com/3774774/110541710-ba87d280-80ed-11eb-9c54-a56727e37d9e.png">
