### PR TITLE
remove timeout when expecting teacher screen selector

### DIFF
--- a/tutor/specs/e2e/my-courses.e2e.ts
+++ b/tutor/specs/e2e/my-courses.e2e.ts
@@ -9,10 +9,10 @@ describe('My Courses', () => {
 
     it('allows a new teacher select and suggest subjects', async () => {
         await visitPage(page, '/courses')
-        await expect(page).toHaveSelector('testEl=existing-teacher-screen', { timeout: 1000 })
+        await expect(page).toHaveSelector('testEl=existing-teacher-screen')
         await modifyBootstrapData(page, (data) => ({ ...data, courses: [] }))
         await visitPage(page, '/courses')
-        await expect(page).toHaveSelector('testEl=new-teacher-screen', { timeout: 1000 })
+        await expect(page).toHaveSelector('testEl=new-teacher-screen')
         await page.type('testEl=input-suggested-subject', 'test')
         await page.click('testEl=submit-suggested-subject')
         await page.waitForNavigation()
@@ -27,7 +27,7 @@ describe('My Courses', () => {
         await expect(page).not.toHaveSelector('testEl=show-detail', { timeout: 100 })
         await page.type('testEl=input-suggested-subject', 'test')
         await page.click('testEl=offering-0', { force: true })
-        await expect(page).toHaveSelector('testEl=show-detail', { timeout: 100 })
+        await expect(page).toHaveSelector('testEl=show-detail')
         await expect(page).not.toHaveSelector('testEl=submit-suggested-subject', { timeout: 100 })
         await page.type('testEl=input-suggested-subject', 'test')
         await expect(page).not.toHaveSelector('testEl=show-detail', { timeout: 100 })

--- a/tutor/specs/e2e/my-courses.e2e.ts
+++ b/tutor/specs/e2e/my-courses.e2e.ts
@@ -9,11 +9,10 @@ describe('My Courses', () => {
 
     it('allows a new teacher select and suggest subjects', async () => {
         await visitPage(page, '/courses')
-        // The 500ms timeouts may be too low when using DEBUG, temp set to 1000 if you see issues
-        await expect(page).toHaveSelector('testEl=existing-teacher-screen', { timeout: 500 })
+        await expect(page).toHaveSelector('testEl=existing-teacher-screen', { timeout: 1000 })
         await modifyBootstrapData(page, (data) => ({ ...data, courses: [] }))
         await visitPage(page, '/courses')
-        await expect(page).toHaveSelector('testEl=new-teacher-screen', { timeout: 500 })
+        await expect(page).toHaveSelector('testEl=new-teacher-screen', { timeout: 1000 })
         await page.type('testEl=input-suggested-subject', 'test')
         await page.click('testEl=submit-suggested-subject')
         await page.waitForNavigation()


### PR DESCRIPTION
Remove the timeout, the default behavior does what we want