### PR TITLE
move preview card to end, fix clickable area and font size

### DIFF
--- a/tutor/resources/styles/components/my-courses.scss
+++ b/tutor/resources/styles/components/my-courses.scss
@@ -203,8 +203,8 @@ $my-courses-card-padding: 12px;
           > * { margin: 0; }
           p {
             margin-top: 0.5rem;
-            @include tutor-sans-font(1.2rem);
-            line-height: 1.8rem;
+            @include tutor-sans-font(1.4rem);
+            line-height: 2rem;
             font-weight: 400;
             color: $tutor-neutral-darker;
           }

--- a/tutor/src/screens/my-courses/dashboard/offering-block.tsx
+++ b/tutor/src/screens/my-courses/dashboard/offering-block.tsx
@@ -56,7 +56,6 @@ const ResourcesInfo: React.FC<ResourcesInfoProps> = ({ offering, os_book_id, isF
     )
     return (
         <>
-            {renderCoursePreview()}
             {generalResources}
             {os_book_id &&
                 <Resource
@@ -65,6 +64,7 @@ const ResourcesInfo: React.FC<ResourcesInfoProps> = ({ offering, os_book_id, isF
                     info="Free resources integrated with your book. "
                     link={`https://openstax.org/details/books/${os_book_id}?Instructor%20resources`} />
             }
+            {renderCoursePreview()}
         </>
     )
 }

--- a/tutor/src/screens/my-courses/dashboard/preview-course.tsx
+++ b/tutor/src/screens/my-courses/dashboard/preview-course.tsx
@@ -15,6 +15,8 @@ import { Icon } from 'shared'
 const StyledPreviewCourse = styled.div`
     &&& {
         .my-courses-item-title {
+            padding: 0;
+            display: block;
             .name {
                 padding-right: 3.2rem;
                 overflow-wrap: break-word;


### PR DESCRIPTION
- Move preview card to end of list if it's in Resouces tab
- Make the entire preview card clickable
- Use a larger font size for description text
![image](https://user-images.githubusercontent.com/34174/110871283-f4d6a880-8282-11eb-8b22-65390f6b4070.png)
