### PR TITLE
Remove title attribute from PF sections

### DIFF
--- a/tutor/src/screens/performance-forecast/section.js
+++ b/tutor/src/screens/performance-forecast/section.js
@@ -15,7 +15,7 @@ const PerformanceForecastSection = (props) => {
                 <span className="number">
                     {cs.asString}
                 </span>
-                <span className="title" title={section.title}>
+                <span className="title">
                     <BookPartTitle part={section} />
                 </span>
             </h4>


### PR DESCRIPTION
Fixes HTML showing up on hover over the title. `section.title` is the HTML here.