### PR TITLE
Use longest lasting preview course that is not expired

### DIFF
--- a/configs/test/jest.config.json
+++ b/configs/test/jest.config.json
@@ -5,7 +5,7 @@
   "collectCoverageFrom": ["**/*.{jsx,js,coffee,cjsx}", "!**/node_modules/**"],
   "coverageDirectory": "../coverage/",
   "coverageReporters": ["json", "lcov", "text-summary"],
-  "testRegex": "specs\/((?!integration).)*\/.*\\.spec\\.(coffee|js|jsx|cjsx|json)$",
+  "testRegex": "specs\/((?!integration).)*\/.*\\.spec\\.(ts|tsx|js|jsx|json)$",
   "transform": {
     "^.+\\.jsx?$": "babel7-jest",
     "^.+\\.tsx?$": "ts-jest"

--- a/tutor/specs/store/courses.spec.ts
+++ b/tutor/specs/store/courses.spec.ts
@@ -1,0 +1,46 @@
+import { useLatestCoursePreview } from '../../src/store/courses'
+import { TimeMock } from '../helpers';
+import { map } from 'lodash'
+
+
+let mockedCourses:any = {}
+let mockedIds: number[] = []
+
+jest.mock('react-redux', () => ({
+    useSelector: jest.fn((cb) => cb({ courses: { ids: mockedIds, entities: mockedCourses } })),
+}));
+
+describe('CoursesStore', () => {
+    TimeMock.setTo('2020-01-15T12:00:00.000Z');
+
+
+    beforeEach( () => {
+    })
+
+    afterEach(() => {
+        mockedIds = []// .splice(0, mockedIds.length)
+        mockedCourses = {} // .(0, mockedCourses.length)
+    });
+
+    describe('useLatestCoursePreview', () => {
+        it('should return latest non-expired preview', () => {
+            mockedCourses = {
+                1: { id: 1, offering_id: 2, is_preview: true, ends_at: '2020-01-01T00:00:00.000Z' },
+                2: { id: 2, offering_id: 1, is_preview: true, ends_at: '2021-01-01T00:00:00.000Z' },
+                3: { id: 3, offering_id: 1, is_preview: true, ends_at: '2018-01-01T00:00:00.000Z' },
+                4: { id: 4, offering_id: 1, is_preview: false, ends_at: '2022-01-01T00:00:00.000Z' },
+            }
+            mockedIds.push(...map(mockedCourses, 'id'))
+            expect(useLatestCoursePreview(1)?.id).toEqual(2)
+        });
+
+        it('returns undefined if all previews are expired', () => {
+            mockedCourses = {
+                1: { id: 1, offering_id: 1, is_preview: true, ends_at: '2015-01-01T00:00:00.000Z' },
+                2: { id: 2, offering_id: 1, is_preview: true, ends_at: '2017-01-01T00:00:00.000Z' },
+            }
+            mockedIds.push(...map(mockedCourses, 'id'))
+            expect(useLatestCoursePreview(1)).toBeUndefined()
+        })
+    })
+});

--- a/tutor/src/store/courses.ts
+++ b/tutor/src/store/courses.ts
@@ -1,6 +1,7 @@
 import { createSlice, createEntityAdapter, PayloadAction } from '@reduxjs/toolkit'
+import moment from 'moment'
 import { useSelector } from 'react-redux'
-import { endsWith, get, first, sortBy, find, capitalize, sumBy, filter, union } from 'lodash'
+import { endsWith, get, first, last, sortBy, find, capitalize, sumBy, filter, union } from 'lodash'
 import { Course, Role } from './types'
 import { updateCourse, createPreviewCourse } from './api'
 import { bootstrap } from './bootstrap'
@@ -102,7 +103,14 @@ export const useCoursesByOfferingId = (offeringId: string | number, includePrevi
 
 export const useLatestCoursePreview = (offeringId: string | number) => useSelector<CourseSlice, Course | undefined>(state => {
     const courses = selectors.selectAll(state)
-    return find(courses, c => c.offering_id === offeringId && String(c.term) == 'preview')
+    const latest = last(sortBy(
+        filter(courses, c => c.offering_id === offeringId && c.is_preview),
+        'ends_at'
+    ))
+    if (moment().isAfter(latest?.ends_at)) {
+        return undefined;
+    }
+    return latest
 })
 
 export const useDisplayedCourseOfferingIds = () => {


### PR DESCRIPTION
Previously it was returning unusable preview courses