### PR TITLE
fix a regression by updating the class name of the preview course

### DIFF
--- a/tutor/resources/styles/components/my-courses.scss
+++ b/tutor/resources/styles/components/my-courses.scss
@@ -282,7 +282,7 @@ $my-courses-card-padding: 12px;
     }
   }
 
-  .my-courses-item-actions {
+  .my-courses-item-actions, .my-preview-courses-item-actions {
     @each $book in map-keys($openstax-books) {
       $fg: openstax-book-color($book, primary);
       &[data-appearance=#{$book}] {

--- a/tutor/src/screens/my-courses/dashboard/preview-course.tsx
+++ b/tutor/src/screens/my-courses/dashboard/preview-course.tsx
@@ -40,7 +40,7 @@ const StyledPreviewCourse = styled.div`
             }
           }
         }
-        .my-courses-item-actions {
+        .my-preview-courses-item-actions {
             position: absolute;
             right: 10px;
             top: 40px;


### PR DESCRIPTION
Just fixing css issue. I changed the name of a css class and it modified a little bit the course actions of the cards.

Current:
![Screen Shot 2021-03-26 at 11 40 30 AM](https://user-images.githubusercontent.com/3774774/112664571-19f11c80-8e28-11eb-818c-458b8fd277df.png)

Fix:
![Screen Shot 2021-03-26 at 11 40 10 AM](https://user-images.githubusercontent.com/3774774/112664592-1f4e6700-8e28-11eb-9caa-6423f5ff0c5a.png)
