### PR TITLE
MPP: move tooltip to bottom

### DIFF
--- a/tutor/resources/styles/global/tooltip.scss
+++ b/tutor/resources/styles/global/tooltip.scss
@@ -16,8 +16,7 @@
     left: 1px;
   }
   .tooltip-inner {
-    padding: 5px 10px;
-    width: 75%;
+    padding: 10px;
     font-size: 1.2rem;
   }
 }

--- a/tutor/src/components/buttons/save-practice.js
+++ b/tutor/src/components/buttons/save-practice.js
@@ -124,7 +124,7 @@ const SavePracticeButton = observer(({
     if(isMpq() && isSaved()) {
         return(
             <OverlayTrigger
-                placement="right"
+                placement="bottom"
                 overlay={mpqTooltip}
                 delay={{ show: 50, hide: 150 }}
             >


### PR DESCRIPTION
In a MPQ, the tooltip info runs out of space on the right when the browser window is small.
Moving the tooltip to the bottom fix this.

![Screen Shot 2021-04-06 at 2 58 27 PM](https://user-images.githubusercontent.com/3774774/113771292-ccf32d00-96e8-11eb-9a42-cb77be205f85.png)
