### PR TITLE
ignore node_modules to fix high idle cpu

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,6 +96,7 @@ const config = {
     maxAssetSize: 2.1 * 1000000,
   },
   watchOptions: {
+    ignored: /node_modules/,
     aggregateTimeout: 500,
     poll: 1000,
   },


### PR DESCRIPTION
Watching node_modules causes consistent 20-40% CPU use while idling. It's possible this is only an issue that started with macOS Big Sur. From https://webpack.js.org/configuration/watch/#watchoptionsignored:

> For some systems, watching many files can result in a lot of CPU or memory usage.