### PR TITLE
Add an autosave to the question library editor

### DIFF
--- a/tutor/specs/e2e/add-edit-question.e2e.js
+++ b/tutor/specs/e2e/add-edit-question.e2e.js
@@ -67,7 +67,7 @@ describe('Add/Edit Questions', () => {
         await page.focus(editorSel)
         await page.type(editorSel, 'Hello World!')
         await page.click('testEl=add-edit-question >> .detailed-solution')
-        await page.waitForTimeout(500) // Give the debounce time
+        await page.waitForTimeout(10) // Give the autosave time
         await page.reload()
         await page.waitForSelector('testEl=create-question')
         await page.evaluate(() => {

--- a/tutor/specs/screens/question-library/dashboard.spec.jsx
+++ b/tutor/specs/screens/question-library/dashboard.spec.jsx
@@ -6,6 +6,7 @@ import ExerciseHelpers from '../../../src/helpers/exercise';
 import ScrollTo from '../../../src/helpers/scroll-to';
 import User from '../../../src/models/user';
 import { Term, UserTerms } from '../../../src/models/user/terms';
+import { TestRouter } from '../../helpers';
 
 jest.mock('../../../../shared/src/components/html', () => ({ html }) =>
     html ? <div dangerouslySetInnerHTML={{ __html: html }} /> : null
@@ -53,6 +54,7 @@ describe('Questions Dashboard Component', function() {
         props = {
             course,
             exercises,
+            history: new TestRouter().history,
         };
     });
 

--- a/tutor/specs/screens/question-library/index.spec.jsx
+++ b/tutor/specs/screens/question-library/index.spec.jsx
@@ -10,7 +10,7 @@ jest.mock('../../../src/models/courses-map', () => ({
 describe('Questions Library Screen', function() {
 
     it('clears exercises', () => {
-        const qa = shallow(<QA />)
+        const qa = shallow(<QA history={{ push: jest.fn() }} />)
         expect(Exercises.clear).toHaveBeenCalled()
         qa.unmount();
     })

--- a/tutor/src/components/add-edit-question/form/index.js
+++ b/tutor/src/components/add-edit-question/form/index.js
@@ -95,11 +95,11 @@ FormButtons.propTypes = {
 
 const AddEditQuestionForm = observer(({ ux }) => {
     useEffect(() => {
-      ux.enableAutosave()
+        ux.enableAutosave()
 
-      return () => {
-        ux.disableAutosave()
-      }
+        return () => {
+            ux.disableAutosave()
+        }
     }, [])
     return (
         <StyledAddEditQuestionModal

--- a/tutor/src/components/add-edit-question/form/index.js
+++ b/tutor/src/components/add-edit-question/form/index.js
@@ -1,4 +1,4 @@
-import { React, styled, observer, PropTypes } from 'vendor';
+import { React, styled, observer, PropTypes, useEffect } from 'vendor';
 import { Modal, Form, Button } from 'react-bootstrap';
 import AddEditQuestionModal from '../../course-modal';
 import AddEditQuestionFormTopic from './topic';
@@ -94,6 +94,13 @@ FormButtons.propTypes = {
 };
 
 const AddEditQuestionForm = observer(({ ux }) => {
+    useEffect(() => {
+      ux.enableAutosave()
+
+      return () => {
+        ux.disableAutosave()
+      }
+    }, [])
     return (
         <StyledAddEditQuestionModal
             data-test-id="add-edit-question"

--- a/tutor/src/components/add-edit-question/index.js
+++ b/tutor/src/components/add-edit-question/index.js
@@ -2,7 +2,7 @@ import { React, PropTypes, observer } from 'vendor';
 import AddEditQuestionUX from './ux';
 import AddEditQuestionForm from './form';
 import AddEditQuestionTermsOfUse from './terms-of-use';
-import { 
+import {
     FeedbackTipModal,
     ExitWarningModal,
     CoursePreviewOnlyModal,

--- a/tutor/src/components/add-edit-question/modals.js
+++ b/tutor/src/components/add-edit-question/modals.js
@@ -101,20 +101,21 @@ const ExitWarningModal = observer(({ ux }) => {
             backdrop="static"
         >
             <StyledHeader>
-        Exit without publishing?
+                Exit without publishing?
             </StyledHeader>
             <StyledBody>
                 <p>The question is not published yet and will not be saved. Are you sure you want to exit this form?</p>
                 <ControlsWrapper>
                     <Controls>
                         <Button variant="default" size="lg" onClick={() => {
+                            ux.clearAutosave();
                             ux.showExitWarningModal = false;
                             ux.onDisplayModal(false);
                         }}>
-                Yes, exit
+                            Yes, exit
                         </Button>
                         <Button variant="primary" size="lg" onClick={() => ux.showExitWarningModal = false}>
-                Cancel
+                            Cancel
                         </Button>
                     </Controls>
                 </ControlsWrapper>
@@ -136,7 +137,7 @@ const CoursePreviewOnlyModal = observer(({ onDisplayModal }) => {
         This is a demo course!
             </StyledHeader>
             <StyledBody>
-                <p>Adding or editing a question is <strong>not allowed</strong> in a demo course. 
+                <p>Adding or editing a question is <strong>not allowed</strong> in a demo course.
             You can create a live course to add or edit questions.</p>
                 <ControlsWrapper>
                     <Controls>
@@ -210,11 +211,11 @@ const QuestionPreviewModal = observer(({ ux }) => {
             </Button>
             </>
         }
-        
+
       </>;
     }
     else {
-        QuestionComponent = 
+        QuestionComponent =
       <>
         <Question question={question}/>
         <textarea

--- a/tutor/src/components/add-edit-question/ux.js
+++ b/tutor/src/components/add-edit-question/ux.js
@@ -126,6 +126,7 @@ export default class AddEditQuestionUX {
   }
 
   @action populateFromStorage() {
+      // No catch here needed because we check the parse a step up in autosaveIsValid
       const state = JSON.parse(localStorage['ql-editor-state'])
       Object.assign(this, state)
   }
@@ -210,8 +211,14 @@ export default class AddEditQuestionUX {
   }
 
   get autosaveIsValid() {
+      let state;
+      try {
+          state = JSON.parse(localStorage.getItem('ql-editor-state'))
+      } catch {
+          localStorage.removeItem('ql-editor-state')
+          return false
+      }
       const now = new Date().getTime()
-      const state = JSON.parse(localStorage.getItem('ql-editor-state'))
       const expiry = new Date(state?.autosave?.expiry)?.getTime()
       const version = state?.autosave?.version
 

--- a/tutor/src/components/add-edit-question/ux.js
+++ b/tutor/src/components/add-edit-question/ux.js
@@ -1,9 +1,10 @@
 import { action, observable, computed } from 'vendor';
-import { filter, some, find, forEach, pickBy, every, map, isEqual, omit } from 'lodash';
+import { filter, some, find, forEach, pickBy, every, map, isEqual, omit, pick } from 'lodash';
 import Toasts from '../../models/toasts';
 import { TAG_BLOOMS, TAG_DOKS } from './form/tags/constants';
 import User from '../../models/user';
 import S from '../../helpers/string';
+import { autorun, toJS } from 'mobx';
 
 const TERMS_NAME = 'exercise_editing';
 
@@ -65,6 +66,8 @@ export default class AddEditQuestionUX {
   @observable allowOthersCopyEdit = true;
   @observable anonymize = false;
   @observable excludeOriginal = false;
+  @observable changed = false;
+  autosaveDisposer;
 
   constructor(props = {}) {
       this.book = props.book;
@@ -77,17 +80,18 @@ export default class AddEditQuestionUX {
 
       //TODO: get from BE
       // edit or create
-      if(props.exercise) {
+      if (props.exercise) {
           this.populateExerciseContent(props.exercise);
+          this.clearAutosave();
+      }
+      else if (this.autosaveIsValid) {
+          this.populateFromStorage();
+          this.selectDefaultSectionAndChapter()
+          this.changed = true;
       }
       else {
-      // auto selected if there is only one chapter or selected pre-selected
-          if(this.preSelectedChapters.length === 1) {
-              this.selectedChapter = this.preSelectedChapters[0];
-              if(this.preSelectedChapterSections.length === 1) {
-                  this.selectedChapterSection = this.preSelectedChapterSections[0];
-              }
-          }
+          // auto selected if there is only one chapter or selected pre-selected
+          this.selectDefaultSectionAndChapter()
           // show 4 options by default
           for(let i = 1; i <= 4; i++) {
               this.options.push({
@@ -110,6 +114,20 @@ export default class AddEditQuestionUX {
       return this.from_exercise_id ? this.exercises.get(this.from_exercise_id) : null;
   }
 
+  @action selectDefaultSectionAndChapter() {
+      if(this.preSelectedChapters.length === 1) {
+          this.selectedChapter = this.preSelectedChapters[0];
+          if(this.preSelectedChapterSections.length === 1) {
+              this.selectedChapterSection = this.preSelectedChapterSections[0];
+          }
+      }
+  }
+
+  @action populateFromStorage() {
+      const state = JSON.parse(localStorage['ql-editor-state'])
+      Object.assign(this, state)
+  }
+
   @action populateExerciseContent(exercise) {
       // question - can only edit questions that are not MPQ
       const question = exercise.content.questions[0];
@@ -118,7 +136,7 @@ export default class AddEditQuestionUX {
       // chapter & section
       this.selectedChapter = find(this.preSelectedChapters, psc => some(psc.children, c => c.uuid === exercise.page_uuid));
       this.selectedChapterSection = find(this.preSelectedChapterSections, pscs => pscs.uuid === exercise.page_uuid);
-    
+
       this.questionText = question.stem_html;
       this.isTwoStep = question.isTwoStep;
       forEach(question.answers, a => {
@@ -131,7 +149,7 @@ export default class AddEditQuestionUX {
       });
       const detailedSolution = find(question.collaborator_solutions, cs => cs.solution_type === 'detailed');
       this.detailedSolution = detailedSolution ? detailedSolution.content_html : '';
-    
+
       // tags
       if(exercise.content.tags && exercise.tags.length > 0) {
           const exerciseTags = exercise.content.tags;
@@ -142,7 +160,7 @@ export default class AddEditQuestionUX {
           this.tagDok = this.populateExerciseTagLevel(exerciseTags, TAG_DOKS, 'dok');
           this.tagBloom = this.populateExerciseTagLevel(exerciseTags, TAG_BLOOMS, 'blooms');
       }
-    
+
       //general
       this.questionName = question.title;
   }
@@ -174,6 +192,80 @@ export default class AddEditQuestionUX {
       };
   }
 
+  @action.bound enableAutosave() {
+      this.autosaveDisposer = autorun(() => {
+          if (!this.hasAnyChanges) { return null; }
+          localStorage['ql-editor-state'] = JSON.stringify(toJS(this.toAutosaveData))
+      }, { delay: 300 })
+  }
+
+  @action.bound disableAutosave() {
+      this.autosaveDisposer()
+  }
+
+  @action clearAutosave() {
+      localStorage.removeItem('ql-editor-state')
+  }
+
+  get autosaveIsValid() {
+      const now = new Date().getTime()
+      const state = JSON.parse(localStorage.getItem('ql-editor-state'))
+      const expiry = new Date(state?.expiry)?.getTime()
+
+      if (state && now < expiry) {
+          return true;
+      } else {
+          localStorage.removeItem('ql-editor-state')
+          return false;
+      }
+  }
+
+  @computed get toFormData() {
+      return ({
+          course: this.course,
+          data: {
+              selectedChapterSection: this.selectedChapterSection?.id,
+              authorId: parseInt(this.author.id, 10),
+              derived_from_id: this.from_exercise_id,
+              questionText: this.questionText,
+              questionName: this.questionName,
+              options: this.isMCQ ? this.processOptions() : [],
+              detailedSolution: this.detailedSolution,
+              isTwoStep: this.isTwoStep,
+              tags: this.processTags(),
+              anonymize: this.anonymize,
+              copyable: this.allowOthersCopyEdit,
+              images: this.images.map(img => img.signed_id),
+          },
+          page_ids: this.selectedChapterSection ? [this.selectedChapterSection.id] : null,
+          book: this.course.referenceBook,
+      })
+  }
+
+  get toAutosaveData() {
+      const data = {
+          expiry: new Date().getTime() + 900000,
+          author: { id: parseInt(this.author.id, 10) },
+          from_exercise_id: this.from_exercise_id,
+          questionText: this.questionText,
+          questionName: this.questionName,
+          options: this.options,
+          detailedSolution: this.detailedSolution,
+          isTwoStep: this.isTwoStep,
+          tags: this.tags,
+          anonymize: this.anonymize,
+          allowOthersCopyEdit: this.allowOthersCopyEdit,
+          images: this.images,
+          isMCQ: this.isMCQ,
+          tagTime: this.tagTime,
+          tagDifficulty: this.tagDifficulty,
+          tagBloom: this.tagBloom,
+          tagDok: this.tagDok,
+      };
+
+      return data;
+  }
+
   @computed get didUserAgreeTermsOfUse() {
       return User.terms.hasAgreedTo(TERMS_NAME);
   }
@@ -181,8 +273,8 @@ export default class AddEditQuestionUX {
   // Chapters that the user has selected
   @computed get preSelectedChapters() {
       // return the chapters by checking the section pageIds
-      return filter(this.book.chapters, bc => 
-          some(bc.children, c => 
+      return filter(this.book.chapters, bc =>
+          some(bc.children, c =>
               some(this.pageIds, pi => pi === c.id)));
   }
 
@@ -191,7 +283,7 @@ export default class AddEditQuestionUX {
       if (!this.selectedChapter) {
           return null;
       }
-      return filter(this.selectedChapter.children, scc => 
+      return filter(this.selectedChapter.children, scc =>
           some(this.pageIds, pi => pi === scc.id) && scc.isAssignable);
   }
 
@@ -209,7 +301,7 @@ export default class AddEditQuestionUX {
       if(this.course.teacher_profiles.length > 0 && (!this.from_exercise_id || this.isUserGeneratedQuestion)) {
           return [...this.course.teacher_profiles];
       }
-      else 
+      else
           return [this.course.currentUser];
   }
 
@@ -260,14 +352,14 @@ export default class AddEditQuestionUX {
       // ignore check for chapter, section and author
       // after publish, we reset everything except this three fields
       const tempInitialStateForm = omit(this.initialStateForm, ['selectedChapter', 'selectedChapterSection', 'author']);
-      return some(
+      return this.changed || some(
           map(tempInitialStateForm, (f, key) => isEqual(this[key], f)),
           t => !t
       );
   }
 
   @computed get hasAnyChanges() {
-      return some(
+      return this.changed || some(
           map(this.initialStateForm, (f, key) => isEqual(this[key], f)),
           t => !t
       );
@@ -419,24 +511,11 @@ export default class AddEditQuestionUX {
       // store exericse since saving the new one it might remove old from map
       const exercise = this.from_exercise_id ? this.exercises.get(this.from_exercise_id) : null;
 
-      await this.exercises.createExercise({
-          course: this.course,
-          data: {
-              selectedChapterSection: this.selectedChapterSection.id,
-              authorId: parseInt(this.author.id, 10),
-              derived_from_id: this.from_exercise_id,
-              questionText: this.questionText,
-              questionName: this.questionName,
-              options: this.processOptions(),
-              detailedSolution: this.detailedSolution,
-              isTwoStep: this.isTwoStep,
-              tags: this.processTags(),
-              anonymize: this.anonymize,
-              copyable: this.allowOthersCopyEdit,
-              images: this.images.map(img => img.signed_id),
-          },
-          page_ids: this.selectedChapterSection ? [this.selectedChapterSection.id] : null,
-          book: this.course.referenceBook,
+      await this.exercises.createExercise(this.toFormData).then(() => {
+          this.clearAutosave();
+          this.disableAutosave();
+          this.changed = false;
+          this.enableAutosave();
       });
 
       // notify UI
@@ -518,7 +597,7 @@ export default class AddEditQuestionUX {
    * This method checks if the `fields` (fields in the form) are empty.
    * If so, set this.isEmpty[field] to true.
    * NOTE: Each `field` name should match the observable variable name so we can check the thruthy of `this[field]`.
-   * @param {*} fields - an array of `field` 
+   * @param {*} fields - an array of `field`
    */
   @action.bound checkValidityOfFields(fields = []) {
       let filterIsEmptyFields;

--- a/tutor/src/components/add-edit-question/ux.js
+++ b/tutor/src/components/add-edit-question/ux.js
@@ -199,7 +199,7 @@ export default class AddEditQuestionUX {
       this.autosaveDisposer = autorun(() => {
           if (!this.hasAnyChanges) { return null; }
           localStorage['ql-editor-state'] = JSON.stringify(toJS(this.toAutosaveData))
-      }, { delay: 300 })
+      })
   }
 
   @action.bound disableAutosave() {

--- a/tutor/src/screens/question-library/dashboard.jsx
+++ b/tutor/src/screens/question-library/dashboard.jsx
@@ -20,7 +20,7 @@ class QuestionsDashboard extends React.Component {
           open: PropTypes.func,
       }),
       history: PropTypes.shape({
-          push: PropTypes.func,
+          replace: PropTypes.func,
       }).isRequired,
   };
 
@@ -80,7 +80,7 @@ class QuestionsDashboard extends React.Component {
 
   @action.bound setPageIdsQuery(pageIds = []) {
       const query = extend(Router.currentQuery(this.windowImpl), { pageIds: pageIds.join(',') })
-      this.props.history.push(this.windowImpl.location.pathname + '?' + qs.stringify(query))
+      this.props.history.replace(this.windowImpl.location.pathname + '?' + qs.stringify(query))
   }
 
   render() {

--- a/tutor/src/screens/question-library/dashboard.jsx
+++ b/tutor/src/screens/question-library/dashboard.jsx
@@ -26,6 +26,23 @@ class QuestionsDashboard extends React.Component {
   @observable chapterIds;
   @observable pageIds = [];
 
+  constructor(props) {
+      super(props)
+
+      if (localStorage['ql-pageIds']) {
+          this.pageIds = JSON.parse(localStorage['ql-pageIds']);
+
+          if (!isEmpty(this.pageIds) && localStorage['ql-showing-exercises'] === 'true') {
+              this.isShowingExercises = true;
+              this.props.exercises.fetch({
+                  limit: false,
+                  course: this.props.course,
+                  page_ids: this.pageIds,
+              });
+          }
+      }
+  }
+
   @action.bound onShowDetailsViewClick() {
       this.showingDetails = true;
   }
@@ -37,11 +54,14 @@ class QuestionsDashboard extends React.Component {
   @action.bound onSelectionsChange(pageIds) {
       this.pageIds = pageIds;
       this.isShowingExercises = !isEmpty(pageIds);
+      localStorage['ql-pageIds'] = JSON.stringify(pageIds);
+      localStorage['ql-showing-exercises'] = !isEmpty(pageIds);
   }
 
   @action.bound onSelectSections() {
       this.showingDetails = false;
       this.isShowingExercises = false;
+      localStorage['ql-showing-exercises'] = false;
   }
 
   render() {

--- a/tutor/src/screens/question-library/index.jsx
+++ b/tutor/src/screens/question-library/index.jsx
@@ -12,6 +12,9 @@ export default
 class QuestionsDashboardShell extends React.Component {
   static propTypes = {
       exercises: PropTypes.object,
+      history: PropTypes.shape({
+          push: PropTypes.func,
+      }).isRequired,
   }
 
   static defaultProps = {
@@ -34,7 +37,7 @@ class QuestionsDashboardShell extends React.Component {
 
   render() {
       if (!this.course.referenceBook.api.hasBeenFetched) { return <Loading />; }
-      return <Dashboard exercises={this.props.exercises} course={this.course} />;
+      return <Dashboard exercises={this.props.exercises} course={this.course} history={this.props.history} />;
   }
 
 }

--- a/tutor/src/screens/question-library/sections-chooser.jsx
+++ b/tutor/src/screens/question-library/sections-chooser.jsx
@@ -102,7 +102,7 @@ class QLSectionsChooser extends React.Component {
       this.pageIds = pageIds;
   }
 
-  headerInfo = () => 
+  headerInfo = () =>
       <StyledHeaderInfo>The Question Library is a collection of peer-reviewed questions included with your course.</StyledHeaderInfo>
 
   render() {


### PR DESCRIPTION
- Store editor field state in localStorage. MobX's `autorun` handles firing the autosave when the observables change. A delay might be desirable in the future in case events need to debounce, but since it only occurs on blur or checking boxes, it seems to be performant.
- Set pageIds as a query param so that refreshing the page will put you on the same screen
- Fix a bug where if you started filling out MCQ options, but then switched the tab to Written-response and published, it would create the question as an MCQ, due to it still sending the `options` in the form.

AUTOSAVE_TTL is set to 15 minutes and used to help expired `signed_id`s from being used on uploaded images. AUTOSAVE_VERSION is used in case the form fields ever change significantly. In both cases, the validity (and parsability with a `try...catch`) will be checked before loading, and will clear the autosave if it doesn't match those conditions.