### PR TITLE
remove outdated scroll fix

### DIFF
--- a/tutor/resources/styles/components/date-time-input.scss
+++ b/tutor/resources/styles/components/date-time-input.scss
@@ -886,10 +886,6 @@ tr > .oxdt-cell-in-view {
     display: flex;
     flex-direction: column-reverse;
 
-    @supports (-moz-appearance:none) {
-      justify-content: flex-end;
-    }
-
     // somehow the default order is 12, 1, 2, ... so keep the first item as order 1
     li:first-child {
       order: 1;

--- a/tutor/specs/e2e/teacher-gradebook.e2e.ts
+++ b/tutor/specs/e2e/teacher-gradebook.e2e.ts
@@ -42,8 +42,8 @@ describe('Teacher Gradebook', () => {
     it('sets preferences', async () => {
         await page.click('testEl=settings-btn')
         const settings = ['displayScoresAsPoints', 'arrangeColumnsByType','showDroppedStudents']
-        await page.click(`testEl=${settings[0]}-checkbox`, { timeout: 500, force: true })
-        await page.click(`testEl=${settings[1]}-checkbox`, { timeout: 500, force: true })
-        await page.click(`testEl=${settings[2]}-checkbox`, { timeout: 500, force: true })
+        await page.click(`testEl=${settings[0]}-checkbox`, { timeout: 1000, force: true })
+        await page.click(`testEl=${settings[1]}-checkbox`, { timeout: 1000, force: true })
+        await page.click(`testEl=${settings[2]}-checkbox`, { timeout: 1000, force: true })
     })
 })


### PR DESCRIPTION
It seems FireFox at some point in the last 6 months changed to match Chrome's behavior, so this scroll fix is no longer needed. Removing it fixes the scroll behavior.