### PR TITLE
remove best practices link from menu for OST subjects

### DIFF
--- a/tutor/src/models/course/information.js
+++ b/tutor/src/models/course/information.js
@@ -15,7 +15,6 @@ const BOOKS = {
     physics: {
         title:      'Physics',
         subject:    SUBJECTS.PHYSICS,
-        bp_doc:     'college-physics',
     },
     hs_physics: {
         title:      'High School Physics',
@@ -24,12 +23,10 @@ const BOOKS = {
     college_physics: {
         title:      'College Physics',
         subject:    SUBJECTS.PHYSICS,
-        bp_doc:     'college-physics',
     },
     biology: {
         title:      'Biology',
         subject:    SUBJECTS.BIOLOGY,
-        bp_doc:     'biology',
     },
     ap_biology: {
         title:      'Biology for AP® Courses',
@@ -46,7 +43,6 @@ const BOOKS = {
     college_biology: {
         title:      'College Biology',
         subject:    SUBJECTS.BIOLOGY,
-        bp_doc:     'biology',
     },
     principles_economics: {
         title:      'Principles of Economics',
@@ -63,7 +59,6 @@ const BOOKS = {
     intro_sociology: {
         title:      'Introduction to Sociology',
         subject:    SUBJECTS.SOCIOLOGY,
-        bp_doc:     'sociology',
     },
     anatomy_physiology: {
         title:      'Anatomy & Physiology',


### PR DESCRIPTION
Removes the Best Practices Guide link from the base Tutor subjects. I left the component and logic in place just in case we still want this ability on other subjects.

![image](https://user-images.githubusercontent.com/34174/114629766-0807da00-9c6e-11eb-9dff-fc12435ecf63.png)

![image](https://user-images.githubusercontent.com/34174/114629811-181fb980-9c6e-11eb-9e3d-d441d1c91200.png)
