### PR TITLE
Fix answer alignment

### DIFF
--- a/shared/resources/styles/components/exercise-preview/index.scss
+++ b/shared/resources/styles/components/exercise-preview/index.scss
@@ -187,6 +187,8 @@
         align-items: center;
         .correct-incorrect {
           min-width: 1em; // match font-awesome icon width
+          align-self: baseline;
+          margin-top: 4px;
         }
         .ox-icon {
           margin: 0;
@@ -194,7 +196,7 @@
         .answer-label {
           font-weight: 400;
           display: flex;
-          align-items: center;
+          align-items: baseline;
         }
 
         .answer-letter {

--- a/tutor/src/components/homework-questions.js
+++ b/tutor/src/components/homework-questions.js
@@ -121,6 +121,7 @@ const Body = styled.div`
       height: 2.5rem;
       width: 2.5rem;
       display: flex;
+      flex-shrink: 0;
       align-items: center;
       justify-content: center;
       background: #fff;


### PR DESCRIPTION
It's harder to see on the single line example, but the alignment is now on the baseline, so the answer letter baseline should match the answer text. For the checkmark alignment I just went with what felt right, easy to tweak.

This also fixes a FireFox-only bug in Submission Overview with the letter getting squashed when the adjacent text was long.

Before:
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/34174/115799550-97f40500-a38d-11eb-8bbf-7a4d79c2e5ea.png">
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/34174/115799744-f620e800-a38d-11eb-94cf-e4a9c1ff42f8.png">

After:
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/34174/115799492-7430bf00-a38d-11eb-862f-538ff39d9ce3.png">
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/34174/115799823-2072a580-a38e-11eb-80bb-67d455be08a0.png">


Before:
![image](https://user-images.githubusercontent.com/34174/115799596-b528d380-a38d-11eb-836b-7a1fed77e143.png)


After:
![image](https://user-images.githubusercontent.com/34174/115799579-a93d1180-a38d-11eb-86bb-36ca55a051f4.png)
