### PR TITLE
set feedback font size to px

### DIFF
--- a/shared/resources/styles/components/exercise-preview/index.scss
+++ b/shared/resources/styles/components/exercise-preview/index.scss
@@ -215,7 +215,7 @@
         margin-bottom: 5px;
         color: $openstax-neutral;
         margin-left: 0;
-        font-size: 1.4rem;
+        font-size: 14px;
         line-height: 2rem;
       }
 


### PR DESCRIPTION
This fixes the font size of the preview text inside the exercises app. Using px here isn't ideal but refactoring the CSS is going to be a little more time intensive. The issue is that the base answer table font size in Exercises is set to 17px, so using rem here is an issue. I think longer term we should probably make Exercises use the same 10px font size so rems just work between shared components.

The Exercises preview is below. In Tutor there is no visual change due to 1.4rem == 14px.
![Screenshot_2021-04-23 OpenStax Exercises](https://user-images.githubusercontent.com/34174/115921382-405aa580-a430-11eb-813e-816a89684d79.png)