### PR TITLE
allow deleting feature and module tags in exercises

### DIFF
--- a/exercises/resources/styles/tags.scss
+++ b/exercises/resources/styles/tags.scss
@@ -20,7 +20,7 @@
         font-weight: bolder; font-size: 110%;
       }
     }
-    &.has-single-tag {
+    &:not(.cnxFeature):not(.cnxModule).has-single-tag {
       .tag .controls{ visibility: hidden; }
     }
     .tag {


### PR DESCRIPTION
The card 1624 was for only CNX Feature, but it seems like we should do this for the CNX Module tag as well.

![image](https://user-images.githubusercontent.com/34174/115931486-072a3180-a440-11eb-97ce-c8ceccaa6040.png)
