### PR TITLE
Removed num_questions_dropped and points_dropped

### DIFF
--- a/tutor/specs/factories/task-scores.js
+++ b/tutor/specs/factories/task-scores.js
@@ -51,8 +51,6 @@ Factory.define('TaskPlanPeriodScore')
         total_points: exercises.length,
         total_fraction: 1,
     }))
-    .num_questions_dropped(0)
-    .points_dropped(0)
     .question_headings(({ exercises }) => {
         return flatMap(exercises, (exercise, i) => (
             exercise.content.questions.map((question) => ({


### PR DESCRIPTION
These fields were incorrectly calculated and they are no longer sent by the backend.
We can fix the code and add them back if needed. 