### PR TITLE
fix pageids not being set when clicking Show Questions

### DIFF
--- a/tutor/src/screens/question-library/dashboard.jsx
+++ b/tutor/src/screens/question-library/dashboard.jsx
@@ -69,6 +69,7 @@ class QuestionsDashboard extends React.Component {
     @action.bound onSelectionsChange(pageIds) {
         this.pageIds = pageIds;
         this.isShowingExercises = !isEmpty(pageIds);
+        this.setPageIdsQuery(this.pageIds);
     }
 
     @action.bound onSelectSections() {


### PR DESCRIPTION
I think I missed this during a merge conflict, this should fix the pageIds not being set in the url when changing Question Library screens (like `http://localhost:3000/course/37/questions?pageIds=224%2C225%2C226`)