### PR TITLE
Fix notes/isNew

### DIFF
--- a/shared/specs/model/model.spec.ts
+++ b/shared/specs/model/model.spec.ts
@@ -1,5 +1,5 @@
 import { ObservableMap } from 'mobx';
-import { BaseModel, hydrateModel, modelize, observable, array, map, field, model } from 'shared/model'
+import { BaseModel, hydrateModel, modelize, observable, array, map, field, model, NEW_ID } from 'shared/model'
 
 describe('Model base class', () => {
 
@@ -8,6 +8,7 @@ describe('Model base class', () => {
     }
 
     class Foo extends BaseModel {
+        @field id = NEW_ID;
         @field foo = ''
         @model(Bar) bars = array((a: Bar[]) => ({
             eq(n: number) { return a.filter((b) => b.num == n) },
@@ -40,4 +41,11 @@ describe('Model base class', () => {
         }))
         expect(m.one).toEqual(1)
     });
+
+    it('checks if the model isNew', () => {
+        const foo = hydrateModel(Foo, {})
+        expect(foo.isNew).toEqual(true)
+        foo.id = 3
+        expect(foo.isNew).toEqual(false)
+    })
 })

--- a/shared/specs/model/model.spec.ts
+++ b/shared/specs/model/model.spec.ts
@@ -3,12 +3,17 @@ import { BaseModel, hydrateModel, modelize, observable, array, map, field, model
 
 describe('Model base class', () => {
 
-    class Bar {
+    class Bar extends BaseModel {
+        @field id = ''
         @observable num = 1
+        constructor() {
+            super();
+            modelize(this);
+        }
     }
 
     class Foo extends BaseModel {
-        @field id = NEW_ID;
+        @field id = NEW_ID
         @field foo = ''
         @model(Bar) bars = array((a: Bar[]) => ({
             eq(n: number) { return a.filter((b) => b.num == n) },
@@ -43,9 +48,13 @@ describe('Model base class', () => {
     });
 
     it('checks if the model isNew', () => {
-        const foo = hydrateModel(Foo, {})
+        const foo = hydrateModel(Foo, {}) // Initialized with 0
+        const bar = hydrateModel(Bar, {}) // Initialized with ''
         expect(foo.isNew).toEqual(true)
+        expect(bar.isNew).toEqual(true)
         foo.id = 3
         expect(foo.isNew).toEqual(false)
+        bar.id = '3'
+        expect(bar.isNew).toEqual(false)
     })
 })

--- a/shared/src/model.ts
+++ b/shared/src/model.ts
@@ -33,7 +33,7 @@ export class BaseModel {
 
     get isNew() {
         const id = this[(this.constructor as any).idField]
-        return isNil(id) || id === NEW_ID
+        return isNil(id) || id === NEW_ID || id === ''
     }
 
     @action async ensureLoaded(): Promise<void> {

--- a/shared/src/model.ts
+++ b/shared/src/model.ts
@@ -1,5 +1,5 @@
 import { action, ObservableMap } from 'mobx'
-import { isEmpty } from 'lodash'
+import { isNil } from 'lodash'
 import { readonly } from 'core-decorators';
 import { hydrateInstance, modelize, serialize } from 'modeled-mobx'
 import { LazyGetter } from 'lazy-get-decorator'
@@ -33,7 +33,7 @@ export class BaseModel {
 
     get isNew() {
         const id = this[(this.constructor as any).idField]
-        return isEmpty(id) || id === NEW_ID
+        return isNil(id) || id === NEW_ID
     }
 
     @action async ensureLoaded(): Promise<void> {

--- a/tutor/src/components/notes.js
+++ b/tutor/src/components/notes.js
@@ -1,4 +1,4 @@
-import { React, PropTypes, observer, cn, modelize } from 'vendor';
+import { React, PropTypes, observer, cn, modelize, runInAction } from 'vendor';
 import { observable, action, when } from 'shared/model'
 import { autobind } from 'core-decorators';
 import { Icon, Logging } from 'shared';
@@ -261,7 +261,7 @@ class NotesWidget extends React.Component {
 
     @autobind
     openAnnotator() {
-        return this.highlightAndClose().then(note => this.activeNote = note);
+        return this.highlightAndClose().then(note => runInAction(() => this.activeNote = note));
     }
 
     @autobind

--- a/tutor/src/components/notes/edit-box.jsx
+++ b/tutor/src/components/notes/edit-box.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { defer } from 'lodash';
 import { observer } from 'mobx-react';
-import { action, observable, computed, modelize } from 'shared/model'
+import { action, observable, computed, modelize, runInAction } from 'shared/model';
 import cn from 'classnames';
 import { Icon } from 'shared';
 import { Form } from 'react-bootstrap';
@@ -19,6 +19,7 @@ class EditBox extends React.Component {
         previous: PropTypes.instanceOf(Note),
         goToNote: PropTypes.func.isRequired,
         seeAll: PropTypes.func.isRequired,
+        textAreaDisabled: PropTypes.bool.isRequired,
     }
 
     constructor(props) {
@@ -37,14 +38,16 @@ class EditBox extends React.Component {
 
     UNSAFE_componentWillReceiveProps(nextProps) {
         if (nextProps.note !== this.props.note) {
-            this.annotation = nextProps.note ? nextProps.note.annotation : '';
+            runInAction(() => this.annotation = nextProps.note ? nextProps.note.annotation : '');
             defer(() => this.input.focus());
         }
     }
 
     componentWillUnmount() {
         if (!this.isDeleted && (this.annotation !== this.props.note.annotation)) {
-            this.props.note.annotation = this.annotation;
+            runInAction(() => {
+                this.props.note.annotation = this.annotation;
+            });
             this.props.note.save();
         }
     }
@@ -126,9 +129,6 @@ class EditBox extends React.Component {
         );
     }
 }
-EditBox.propTypes = {
-    textAreaDisabled: PropTypes.boolean,
-};
 
 const renderDesktop = (props) => {
     return <EditBox {...props} textAreaDisabled={false} />;
@@ -143,7 +143,7 @@ export default function EditBoxWrapper(props) {
     const show = !!props.note;
     return (
         <div className={cn('slide-out-edit-box', { open: show, closed: !show })}>
-            {props.note && 
+            {props.note &&
         <Responsive desktop={renderDesktop(props)} tablet={renderTablet(props)} mobile={renderTablet(props)}/>
             }
         </div>

--- a/tutor/src/components/notes/sidebar-buttons.jsx
+++ b/tutor/src/components/notes/sidebar-buttons.jsx
@@ -86,10 +86,10 @@ class SidebarButtons extends React.Component {
     }
 
     renderNotes() {
-        return this.props.notes.array.map(note =>
+        return this.props.notes.array.map((note, index) =>
             note.annotation && (
                 <NoteButton
-                    key={note.id}
+                    key={index}
                     isActive={this.props.activeNote === note}
                     containerTop={this.containerTop}
                     {...this.props}


### PR DESCRIPTION
Fixes updating existing notes that were returning true for `isNew` even though they had integer IDs, also fixes some MobX-related warnings.