### PR TITLE
only dasherize if tab is a string

### DIFF
--- a/tutor/specs/components/tabs.spec.js
+++ b/tutor/specs/components/tabs.spec.js
@@ -40,4 +40,14 @@ describe('Change Student ID', () => {
         expect(props.onSelect).toHaveBeenCalledWith(0, expect.anything());
         tabs.unmount();
     });
+
+    it('inserts already rendered content into the tab', () => {
+        props.tabs = [ <p>hello tab</p> ]
+        const tabs = mount(
+            <R><Tabs {...props}><Body /></Tabs></R>
+        );
+        expect(tabs.find('[data-test-id="tab-0"]')).toHaveLength(1)
+        expect(tabs.text()).toContain('hello tab')
+        tabs.unmount();
+    })
 });

--- a/tutor/src/components/tabs.jsx
+++ b/tutor/src/components/tabs.jsx
@@ -1,5 +1,5 @@
 import { React, cn, useState, useHistory, useEffect, useRef } from 'vendor';
-import { isNil, extend, partial } from 'lodash';
+import { isNil, extend, partial, isString } from 'lodash';
 import Router from '../helpers/router';
 import PropTypes from 'prop-types';
 import S from '../helpers/string';
@@ -93,7 +93,7 @@ const Tabs = ({
                         >
                             <a
                                 href="#"
-                                data-test-id={`${S.dasherize(tab.toLowerCase())}-tab`}
+                                data-test-id={isString(tab) ? `${S.dasherize(tab.toLowerCase())}-tab` : `tab-${index}`}
                                 onClick={partial(onTabClick, index)}
                             >
                                 <h2>


### PR DESCRIPTION
Tabs can also be already rendered content

fixes bug introduced by https://github.com/openstax/tutor-js/commit/5c84c681ea6b9691212a4facd6b0ea300a2acbe1#diff-3a83cdd9fa8c2b67379e55b77cd3d446398446926613b5a8c0f88cd693d17d14