### PR TITLE
update question cards to show tooltip and color when dropped

### DIFF
--- a/tutor/src/components/homework-questions.js
+++ b/tutor/src/components/homework-questions.js
@@ -1,6 +1,7 @@
 import { React, PropTypes, cn, styled, observer, css } from 'vendor';
 import { colors } from 'theme';
 import Question from 'shared/components/question';
+import { DroppedQuestionIndicator } from './dropped-question';
 
 const HomeworkQuestionsWrapper = styled.div`
 
@@ -31,9 +32,10 @@ const QuestionHeader = styled.div`
   background: ${colors.neutral.lighter};
   padding: 1rem;
   font-weight: bold;
-
   ${props => (props.variant === 'submission' || props.variant === 'reading') && css`
-    background: ${props.variant === 'reading' ? colors.templates.reading.background : colors.templates.homework.background};
+    ${!props.isDropped && css`
+        background: ${props.variant === 'reading' ? colors.templates.reading.background : colors.templates.homework.background};
+    `}
     font-size: 1.8rem;
     font-weight: normal;
     padding: 1.4rem 2.2rem;
@@ -186,9 +188,11 @@ const ReviewExerciseCard = observer(({
     questionType = 'teacher-preview',
     styleVariant = 'points',
 }) => {
+    const isDropped = !!info.droppedQuestion;
     return (
         <QuestionPreview className="openstax-exercise-preview">
-            <QuestionHeader variant={styleVariant} className="question-header">
+            <QuestionHeader variant={styleVariant} isDropped={isDropped} className="question-header">
+                {isDropped && <DroppedQuestionIndicator model={info.droppedQuestion} size={1.6} />}
                 <HeaderContent
                     styleVariant={styleVariant}
                     info={info}

--- a/tutor/src/models/task-plans/teacher/scores.ts
+++ b/tutor/src/models/task-plans/teacher/scores.ts
@@ -406,6 +406,9 @@ export class TaskPlanScoresTasking extends BaseModel {
                     if (!question) continue;
                     // while rare, heading will be null if this student received more exercises than others
                     const heading = studentQuestion.questionHeading;
+                    const droppedQuestion = heading && heading.droppedQuestions.find(
+                        dq => dq.question_id === question.id.toString()
+                    )
                     const questionInfo = info[question.id] || (info[question.id] = {
                         id: question.id,
                         key: question.id,
@@ -415,6 +418,7 @@ export class TaskPlanScoresTasking extends BaseModel {
                         remaining: heading ? heading.gradedStats.remaining : 0,
                         index: studentQuestion.index,
                         isCore: heading?.isCore,
+                        droppedQuestion: droppedQuestion,
                         exercise,
                         question,
                         responses: [],


### PR DESCRIPTION
Added gray background and blue triangle when the question is dropped. @nathanstitt Great idea to take size to factor the rem scale! Worked out really nicely 👍 

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/34174/118200246-8f7d7000-b409-11eb-9e42-341e70ad4aa3.png">
