### PR TITLE
tour - fix some visual glitches that can occur when the screen size is very large

### DIFF
--- a/tutor/src/components/tours/custom/drop-any.tsx
+++ b/tutor/src/components/tours/custom/drop-any.tsx
@@ -35,9 +35,6 @@ const StyledGreenTooltip = styled(GreenTooltip)`
     }
 
     &.drop-relocated {
-        margin-left: -8px;
-        margin-top: 15px;
-
         .header {
             padding: 10px 24px;
             font-weight: bold;
@@ -48,8 +45,6 @@ const StyledGreenTooltip = styled(GreenTooltip)`
         .header {
             padding: 9px 10px;
             min-width: 196px;
-            margin-top: -10px;
-            z-index: 1;
         }
     }
 `

--- a/tutor/src/components/tours/step.js
+++ b/tutor/src/components/tours/step.js
@@ -31,12 +31,16 @@ export default class TourStep extends React.Component {
         green: {
             arrow: {
                 color: colors.secondary,
+                spread: 16,
+                length: 10,
             },
         },
         greenNoBody: {
             arrow: {
                 color: colors.secondary,
-                margin: 14,
+                spread: 16,
+                length: 10,
+                margin: 20,
             },
             container: {
                 minHeight: 0,


### PR DESCRIPTION
Makes it so that when the screen size is very large, the arrows don't separate from the modal body.