### PR TITLE
allow two digits before final period in AP LO tag

### DIFF
--- a/exercises/specs/components/tags/aplo.spec.js
+++ b/exercises/specs/components/tags/aplo.spec.js
@@ -24,7 +24,7 @@ describe('ApLo tags component', () => {
         });
         const input = lo.find('Input input[type="text"]');
         expect(input.props()).toMatchObject({
-            placeholder: '[A-Z]{3}-#.[A-Z]',
+            placeholder: '[A-Z]{3}-#{1,2}.[A-Z]',
         });
 
         input.simulate('change', { target: { value: '1.11111' } });
@@ -39,11 +39,15 @@ describe('ApLo tags component', () => {
         input.simulate('blur');
         expect(lo.find('TagError').props().error).toBeNull();
 
+        input.simulate('change', { target: { value: 'EVO-12.C' } });
+        input.simulate('blur');
+        expect(lo.find('TagError').props().error).toBeNull();
+
         lo.find('BookSelection select').simulate('change', {
             target: { value: 'stax-apphys' },
         });
         expect(lo.find('Input input[type="text"]').props()).toMatchObject({
-            placeholder: '#.[A-Z].#.#',
+            placeholder: '#.[A-Z].#{1,2}.#',
         });
 
         lo.unmount();

--- a/exercises/src/components/tags/aplo.jsx
+++ b/exercises/src/components/tags/aplo.jsx
@@ -15,13 +15,13 @@ import BookSelection from './book-selection';
 
 const BOOKS = {
     'stax-apbio': {
-        r: /^[A-Z]{3}[-.]\d[-.][A-Z]$/,
-        pattern: '[A-Z]{3}-#.[A-Z]',
+        r: /^[A-Z]{3}[-.]\d{1,2}[-.][A-Z]$/,
+        pattern: '[A-Z]{3}-#{1,2}.[A-Z]',
         disallowed: /[^0-9A-Z.-]/g,
     },
     'stax-apphys': {
-        r: /^\d[-.][A-Z][-.]\d[-.]\d$/,
-        pattern: '#.[A-Z].#.#',
+        r: /^\d[-.][A-Z][-.]\d{1,2}[-.]\d$/,
+        pattern: '#.[A-Z].#{1,2}.#',
         disallowed: /[^0-9A-Z.-]/g,
     },
 };
@@ -42,7 +42,7 @@ class Input extends React.Component {
     }
 
     @computed get book() {
-        const { specifier } =  this.props.tag;
+        const { specifier } = this.props.tag;
         if (specifier && this.availableBooks.includes(specifier)) {
             return specifier;
         }
@@ -64,7 +64,7 @@ class Input extends React.Component {
 
     isLoValid(book, lo) {
         if (!lo || !this.validation) { return true; } // LO is not required
-        return lo.match( this.validation.r );
+        return lo.match(this.validation.r);
     }
 
     @action.bound validateAndSave(attrs) {
@@ -116,14 +116,14 @@ class Input extends React.Component {
                     limit={this.availableBooks}
                 />
                 {validation &&
-                 <input
-                     className="form-control"
-                     type="text"
-                     onChange={this.onTextChange}
-                     onBlur={this.onTextBlur}
-                     value={this.value}
-                     placeholder={validation.pattern}
-                 />}
+                    <input
+                        className="form-control"
+                        type="text"
+                        onChange={this.onTextChange}
+                        onBlur={this.onTextBlur}
+                        value={this.value}
+                        placeholder={validation.pattern}
+                    />}
                 <Error error={this.errorMsg} />
                 <span className="controls">
                     <Icon type="trash" onClick={this.onDelete} />


### PR DESCRIPTION
Allows tags for AP Biology and Physics to contain 2 digits before the final period instead of the current 1.

**Examples:**

AP Biology
![image](https://user-images.githubusercontent.com/34174/118542538-fe0f4600-b707-11eb-8fa6-7468f803aa2a.png)

AP Physics
![image](https://user-images.githubusercontent.com/34174/118542668-2b5bf400-b708-11eb-9598-04809bbae302.png)
