### PR TITLE
Fixed the tooltip for dropped Tutor questions in scores

### DIFF
--- a/tutor/src/components/dropped-question.tsx
+++ b/tutor/src/components/dropped-question.tsx
@@ -1,6 +1,8 @@
 import { React, styled, css, observer } from 'vendor';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
-import { TaskPlanScoreHeading } from '../models/task-plans/teacher/scores'
+import {
+    TaskPlanScoreHeading, TaskPlanScoreStudentQuestion,
+} from '../models/task-plans/teacher/scores';
 import pluralize from 'pluralize';
 import { colors } from '../theme';
 
@@ -74,10 +76,10 @@ DroppedIndicator.displayName = 'DroppedIndicator'
 
 
 interface DroppedQuestionHeadingIndicatorProps {
+    heading: TaskPlanScoreHeading
     preventOverflow?: boolean
     size?: number
     responseCount?: number
-    heading: TaskPlanScoreHeading
 }
 
 const DroppedQuestionHeadingIndicator: React.FC<DroppedQuestionHeadingIndicatorProps> = observer(({
@@ -87,11 +89,12 @@ const DroppedQuestionHeadingIndicator: React.FC<DroppedQuestionHeadingIndicatorP
     size = 1,
 }) => {
     if (!heading.someQuestionsDropped) return null
+
     let tooltip
 
     const isHomework = heading.tasking.scores.type == 'homework'
 
-    if (isHomework && heading.isCore) {
+    if (isHomework) {
         if (heading.everyQuestionFullCredit) {
             tooltip = 'Full credit given to all students'
         } else {
@@ -109,9 +112,42 @@ const DroppedQuestionHeadingIndicator: React.FC<DroppedQuestionHeadingIndicatorP
             data-test-id="dropped-question-indicator"
             data-question-id={heading.title}
         />
-    );
+    )
 })
 DroppedQuestionHeadingIndicator.displayName = 'DroppedQuestionHeadingIndicator'
+
+
+interface DroppedTutorQuestionIndicatorProps {
+    result: TaskPlanScoreStudentQuestion
+    preventOverflow?: boolean
+    size?: number
+}
+
+const DroppedTutorQuestionIndicator: React.FC<DroppedTutorQuestionIndicatorProps> = observer(({
+    result,
+    preventOverflow = true,
+    size = 1,
+}) => {
+    if (!result.droppedQuestion) return null
+
+    let tooltip
+    if (result.droppedQuestion.drop_method == 'full_credit') {
+        tooltip = 'Full credit given'
+    } else {
+        tooltip = 'Points changed to 0'
+    }
+
+    return (
+        <DroppedIndicator
+            tooltip={tooltip}
+            preventOverflow={preventOverflow}
+            size={size}
+            data-test-id="dropped-question-indicator"
+            data-question-id={result.question_id}
+        />
+    )
+})
+DroppedTutorQuestionIndicator.displayName = 'DroppedTutorQuestionIndicator'
 
 
 interface DroppedReviewExerciseIndicatorProps {
@@ -167,5 +203,6 @@ export {
     TriangleCSS,
     DroppedIndicator,
     DroppedQuestionHeadingIndicator,
+    DroppedTutorQuestionIndicator,
     DroppedStepIndicator,
 };

--- a/tutor/src/models/task-plans/teacher/scores.ts
+++ b/tutor/src/models/task-plans/teacher/scores.ts
@@ -14,7 +14,7 @@ import {
     DroppedQuestion, GradingTemplate, CoursePeriod, currentExercises,
 } from '../../../models'
 
-class TaskPlanScoreStudentQuestion extends BaseModel {
+export class TaskPlanScoreStudentQuestion extends BaseModel {
     @field question_id = NEW_ID;
     @field exercise_id:ID = NEW_ID;
     @field is_completed = false;

--- a/tutor/src/screens/assignment-review/homework-scores.js
+++ b/tutor/src/screens/assignment-review/homework-scores.js
@@ -10,7 +10,9 @@ import InfoIcon from '../../components/icons/info';
 import SortIcon from '../../components/icons/sort';
 import SearchInput from '../../components/search-input';
 import TutorLink from '../../components/link';
-import { DroppedQuestionHeadingIndicator, DroppedIcon } from '../../components/dropped-question';
+import {
+    DroppedQuestionHeadingIndicator, DroppedTutorQuestionIndicator, DroppedIcon,
+} from '../../components/dropped-question';
 import GrantExtension from './grant-extension';
 import PublishScores from '../../components/buttons/publish-scores';
 import ResultTooltip from './result-tooltip';
@@ -235,7 +237,7 @@ const TaskResult = observer(({ heading, result, striped }) => {
             isTrouble={result && !result.isUnattemptedAutoZero && result.isTrouble}
             isUnattemptedAutoZero={result && result.isUnattemptedAutoZero}
         >
-            {!heading.isCore && <DroppedQuestionHeadingIndicator heading={heading} />}
+            {!heading.isCore && <DroppedTutorQuestionIndicator result={result} />}
             <ResultWrapper>
                 {body}
             </ResultWrapper>


### PR DESCRIPTION
Need to look at the result and not the heading in that case

![Screenshot from 2021-06-07 10-33-36](https://user-images.githubusercontent.com/1017808/121048010-034a3880-c77c-11eb-94f7-b991f4046f79.png)

![Screenshot from 2021-06-07 10-33-38](https://user-images.githubusercontent.com/1017808/121048014-05ac9280-c77c-11eb-9172-dc9dee260a89.png)