### PR TITLE
identify fetch failures and show message for them

### DIFF
--- a/tutor/specs/components/error-monitoring/server-error-message.spec.jsx
+++ b/tutor/specs/components/error-monitoring/server-error-message.spec.jsx
@@ -22,7 +22,7 @@ describe('Error monitoring: server-error message', function() {
     });
 
     it('shows interrupted message', function() {
-        props.apiResponse = undefined;
+        props.apiResponse = { statusText: 'Failed to fetch' }
         const wrapper = shallow(<ErrorMessage {...props} />);
         expect(wrapper.text()).toContain('It looks like your internet connection was interrupted');
     });

--- a/tutor/src/components/error-monitoring/server-error-message.jsx
+++ b/tutor/src/components/error-monitoring/server-error-message.jsx
@@ -10,7 +10,7 @@ const ServerErrorMessage = observer((props) => {
     const statusMessage = message || apiResponse?.statusText || 'No response was received'
     const status = apiResponse?.status || 0
 
-    const noRsponseMessage = apiResponse ? '' : <h4>It looks like your internet connection was interrupted,<br />please check your connection and retry</h4>;
+    const fetchFailure = apiResponse?.statusText?.match(/Failed to fetch/) && <h4>It looks like your internet connection was interrupted,<br />please check your connection and retry</h4>;
 
     if (data) {
         dataMessage = <span>Information returned was: <pre>{JSON.stringify(data, null, 2)}</pre></span>;
@@ -21,9 +21,9 @@ const ServerErrorMessage = observer((props) => {
     return (
         <div className="server-error">
             <h3>
-                An error with code {status} {statusMessage} has occured
+                {status} {statusMessage}
             </h3>
-            {noRsponseMessage}
+            {fetchFailure}
             <p>
                 Please <a href={mailTo}>contact us</a> to file a bug report.
             </p>


### PR DESCRIPTION
You can replicate by setting network offline, then switching months on the teacher calendar

<img width="460" alt="image" src="https://user-images.githubusercontent.com/79566/122804363-74fea800-d28d-11eb-8a85-842431be5718.png">


<img width="735" alt="image" src="https://user-images.githubusercontent.com/79566/122804410-81830080-d28d-11eb-81ad-417942127bf3.png">
