### PR TITLE
Fix grade book blowing up when dropped student had no work

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "mobx-react": "^7.1.0",
     "mobx-utils": "^6.0.3",
     "mockdate": "^2.0.5",
-    "modeled-mobx": "0.6.3",
+    "modeled-mobx": "0.6.4",
     "moment": "2.29.1",
     "moment-range": "^4.0.2",
     "moment-timezone": "0.5.23",

--- a/tutor/src/helpers/course-enrollment.tsx
+++ b/tutor/src/helpers/course-enrollment.tsx
@@ -13,6 +13,7 @@ import Enroll from '../components/enroll';
 import urlFor from '../api';
 import { ApiErrorData, isApiError } from 'shared/api/request';
 import type { User, CoursesMap } from '../models';
+import { CourseData } from '../models/types';
 
 export class CourseEnrollment extends BaseModel {
 
@@ -188,7 +189,7 @@ export class CourseEnrollment extends BaseModel {
     @action async create() {
         if (this.needsPeriodSelection) {
             this.courseToJoin = new Course()
-            const courseData = await this.api.request(
+            const courseData = await this.api.request<CourseData>(
                 urlFor('fetchEnrollmentChoices', { enrollmentCode: this.originalEnrollmentCode }),
             )
             this.courseToJoin = hydrateModel(Course, courseData)

--- a/tutor/src/models/course.ts
+++ b/tutor/src/models/course.ts
@@ -325,7 +325,7 @@ export class Course extends BaseModel {
 
     @action async saveExerciseExclusion({ exercise, is_excluded }: { exercise: Exercise, is_excluded: boolean }) {
         exercise.is_excluded = is_excluded; // eagerly set exclusion
-        const data = await this.api.request(
+        const data = await this.api.request<CourseData>(
             urlFor('saveExerciseExclusion', { courseId: this.id }),
             { data: [{ id: exercise.id, is_excluded }] },
         )

--- a/tutor/src/models/course/lms.ts
+++ b/tutor/src/models/course/lms.ts
@@ -5,6 +5,7 @@ import urlFor from '../../api'
 import type { Course } from '../../models'
 import Time from 'shared/model/time';
 import UiSettings from 'shared/model/ui-settings';
+import { CourseLMSData } from '../types';
 
 const LMS_VENDOR = 'lmsv';
 
@@ -36,7 +37,7 @@ export class CourseLMS extends BaseModel {
     }
 
     async fetch() {
-        const json = await this.api.request(urlFor('fetchCourseLMS', { courseId: this.course.id }))
+        const json = await this.api.request<CourseLMSData>(urlFor('fetchCourseLMS', { courseId: this.course.id }))
         hydrateInstance(this, json)
     }
 

--- a/tutor/src/models/types.ts
+++ b/tutor/src/models/types.ts
@@ -44,6 +44,17 @@ export interface TeacherProfileData {
     name: string
 }
 
+export interface CourseLMSData {
+    id: ID
+    key: string
+    secret: string
+    launch_url: string
+    configuration_url: string
+    xml: string
+    created_at: string
+    updated_at: string
+}
+
 export interface CoursePeriodData {
     id: ID
     enrollment_code: string

--- a/tutor/src/screens/teacher-gradebook/ux.js
+++ b/tutor/src/screens/teacher-gradebook/ux.js
@@ -124,11 +124,13 @@ export default class GradeBookUX {
         return this.scores.periods.get(this.coursePeriod.id);
     }
 
-    @computed get students() {
-        if(!this.currentPeriodScores) return [];
+    @computed get allStudents() {
+        return this.currentPeriodScores?.students || [];
+    }
 
+    @computed get students() {
         const students = sortBy(
-            filter(this.currentPeriodScores.students, s => !s.is_dropped),
+            filter(this.allStudents, s => !s.is_dropped),
             this.studentRowSorter,
         );
         if (!this.rowSort.asc) {
@@ -145,17 +147,17 @@ export default class GradeBookUX {
 
     @computed get droppedStudents() {
         return sortBy(
-            filter(this.currentPeriodScores.students, 'is_dropped'),
+            filter(this.allStudents, 'is_dropped'),
             this.studentRowSorter,
         );
     }
 
     @computed get hasDroppedStudents() {
-        return Boolean(find(this.currentPeriodScores.students, 'is_dropped'));
+        return Boolean(find(this.allStudents, 'is_dropped'));
     }
 
     @computed get hasAnyStudents() {
-        return some(this.currentPeriodScores.students, s => !s.is_dropped);
+        return some(this.allStudents, s => !s.is_dropped);
     }
 
     @computed get hasAnyAssignmentHeadings() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9442,10 +9442,10 @@ mockdate@^2.0.5:
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.5.tgz#70c6abf9ed4b2dae65c81dfc170dd1a5cec53620"
   integrity sha512-ST0PnThzWKcgSLyc+ugLVql45PvESt3Ul/wrdV/OPc/6Pr8dbLAIJsN1cIp41FLzbN+srVTNIRn+5Cju0nyV6A==
 
-modeled-mobx@0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/modeled-mobx/-/modeled-mobx-0.6.3.tgz#ab3f8f85080ad545753568de7c257700554f62a0"
-  integrity sha512-KzVXl5YkeSzTPihZd4tmhuGdWDdT/6NA3TAwmeGrO9dgAbn2QLRY6A0zqk0RyQ7I5CeGoT5GrdRpP9dtbRybAw==
+modeled-mobx@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/modeled-mobx/-/modeled-mobx-0.6.4.tgz#6a6220e7100f8c13eff93b90e4e3ef1010e73dd3"
+  integrity sha512-bC5ZAmBXmCLjrqwEq54RURx9mvz1b9VqxUHYDVRqlAmq6i7SoTcR6U8e4LqmtOCe4RV/LoeesVT281CCeYIXQg==
   dependencies:
     mobx "^6.1"
 


### PR DESCRIPTION
If a student's dropped before they do anything the `data` array on the student scores will be an array of null:

<img width="762" alt="image" src="https://user-images.githubusercontent.com/79566/122958171-3da10180-d348-11eb-9bd4-3cc92d2a0178.png">


this commit has the fix:
https://github.com/nathanstitt/modeled-mobx/commit/8d3ef74039c679f150a293ae928a800e985a94e0

