### PR TITLE
Fix drag-n-drop past task plan onto calendar

### DIFF
--- a/shared/src/model/time.ts
+++ b/shared/src/model/time.ts
@@ -122,6 +122,12 @@ export default class Time {
     isSameOrBefore(other: ComparableValue, unit: DurationUnit = 'millisecond') { return this.isSame(other, unit) || this.diff(other, unit) <= 0 }
     isSameOrAfter(other: ComparableValue, unit: DurationUnit = 'seconds') { return this.isSame(other, unit) || this.diff(other, unit) >= 0 }
 
+    isBetween(start: ComparableValue, end: ComparableValue, unit: DurationUnit = 'millisecond') {
+        return Boolean(
+            this.isAfter(start, unit) && this.isBefore(end, unit)
+        )
+    }
+
     get isUnknown() { return this._value === Time.unknown._value }
     get isValid() { return Boolean(!this.isUnknown && this._value.isValid) }
 

--- a/tutor/src/models/task-plans/teacher/plan.ts
+++ b/tutor/src/models/task-plans/teacher/plan.ts
@@ -382,10 +382,10 @@ export class TeacherTaskPlan extends BaseModel {
     @computed get clonedAttributes() {
         return extend(pick(
             this,
-            'description', 'title', 'type', 'ecosystem_id', 'is_feedback_immediate', 'grading_template_id'
+            'description', 'title', 'type', 'ecosystem_id',
+            'is_feedback_immediate', 'grading_template_id', 'settings',
         ), {
             tasking_plans: map(this.tasking_plans, 'clonedAttributes'),
-            settings: this.canEdit ? this.settings : null,
         });
     }
 

--- a/tutor/src/screens/assignment-edit/ux.js
+++ b/tutor/src/screens/assignment-edit/ux.js
@@ -87,12 +87,14 @@ export default class AssignmentUX {
         if (this.canSelectTemplates) {
             // once templates is loaded, select ones of the correct type
             await gradingTemplates.ensureLoaded();
-            this.templates = gradingTemplates;
-            this.plan.grading_template_id =
-                // if cloning, set the grading_template_id to the current ones from copied course.
-        type === 'clone' || !this.plan.grading_template_id
-            ? get(this.gradingTemplates, '[0].id')
-            : this.plan.grading_template_id;
+            runInAction(() => {
+                this.templates = gradingTemplates;
+                this.plan.grading_template_id =
+                    // if cloning, set the grading_template_id to the current ones from copied course.
+                type === 'clone' || !this.plan.grading_template_id
+                    ? get(this.gradingTemplates, '[0].id')
+                    : this.plan.grading_template_id;
+            })
         }
         runInAction(() => {
             this.history = history;

--- a/tutor/src/screens/assignment-edit/ux.js
+++ b/tutor/src/screens/assignment-edit/ux.js
@@ -482,7 +482,7 @@ export default class AssignmentUX {
     @computed get showPreWRMCloneHelp() {
         if (!(this.plan.isClone && this.plan.isHomework)) { return false; }
         const clonedFrom = this.course.pastTaskPlans.get(this.plan.cloned_from_id);
-        return Boolean(clonedFrom && clonedFrom.duration.start.isBefore(WRM_START_DATE));
+        return Boolean(clonedFrom && clonedFrom.interval.start.isBefore(WRM_START_DATE));
     }
 
     @computed get canEditSettings() {

--- a/tutor/src/screens/teacher-dashboard/dashboard.js
+++ b/tutor/src/screens/teacher-dashboard/dashboard.js
@@ -91,8 +91,9 @@ export default class TeacherDashboard extends React.Component {
         const { course: { bounds: { start, end } } } = this.props;
 
         if (!this.hoveredDay ||
-      !this.hoveredDay.isBetween(start, end, 'day', '[]') ||
-      !this.hoveredDay.isSameOrAfter(Time.now, 'day')) { return; }
+            !this.hoveredDay.isBetween(start, end, 'day') ||
+            !this.hoveredDay.isSameOrAfter(Time.now, 'day')) { return; }
+
         if (item.pathname) { // is a link to create an assignment
             const url = item.pathname + '?' + qs.stringify({
                 due_at: this.hoveredDay.format(this.props.dateFormat),
@@ -110,13 +111,13 @@ export default class TeacherDashboard extends React.Component {
         return document.querySelector(`.day[data-date="${date}"]`);
     };
 
-    onDragHover = (day) => {
-        this.hoveredDay = day;
-    };
+    @action.bound onDragHover(day) {
+        this.hoveredDay = new Time(day);
+    }
 
-    onEditorHide = () => {
+    @action.bound onEditorHide() {
         this.editingPlan = null;
-    };
+    }
 
     @action.bound onDayClick(ev, date) {
         this.activeAddAssignment = {
@@ -162,6 +163,7 @@ export default class TeacherDashboard extends React.Component {
                             setDate={this.setDate}
                         />
                         <Month
+                            hoveredDay={this.hoveredDay}
                             onDayClick={this.onDayClick}
                             cloningPlan={this.cloningPlan}
                             course={course}

--- a/tutor/src/screens/teacher-dashboard/month.js
+++ b/tutor/src/screens/teacher-dashboard/month.js
@@ -14,6 +14,7 @@ import Plan from './plan';
 class Month extends React.Component {
     static propTypes = {
         date: TimeHelper.PropTypes.time,
+        hoveredDay: PropTypes.instanceOf(Time),
         course: PropTypes.instanceOf(Course).isRequired,
         onDrop: PropTypes.func.isRequired,
         onDrag: PropTypes.func.isRequired,
@@ -60,7 +61,7 @@ class Month extends React.Component {
 
     getClassNameForDate = (date) => {
         const classes = [];
-        const { course, cloningPlan } = this.props;
+        const { course, cloningPlan, hoveredDay } = this.props;
         const now = Time.now
         if (now.isSame(date, 'day')) {
             classes.push('today');
@@ -70,7 +71,9 @@ class Month extends React.Component {
         } else if (now.isBefore(date)) {
             classes.push('upcoming');
         }
-
+        if (hoveredDay?.isSame(date, 'day')) {
+            classes.push('hover')
+        }
         if (course.starts_at.isAfter(date)) {
             classes.push('before-term');
         } else if (course.ends_at.isBefore(date, 'day')) {
@@ -78,11 +81,9 @@ class Month extends React.Component {
         } else {
             classes.push('in-term');
         }
-
         if (cloningPlan && cloningPlan.due_at.isSame(date, 'day')) {
             classes.push('pending-clone');
         }
-
         return cn(...classes);
     };
 

--- a/tutor/src/screens/teacher-dashboard/past-assignments.jsx
+++ b/tutor/src/screens/teacher-dashboard/past-assignments.jsx
@@ -64,7 +64,7 @@ class PastAssignments extends React.Component {
         return (
             <div className={cn('past-assignments', this.props.className)}>
                 <div className="section-label">
-          Copied
+                    Copied
                 </div>
                 <div className="plans">
                     {plans.array.map((plan) =>

--- a/tutor/src/screens/teacher-dashboard/sidebar.js
+++ b/tutor/src/screens/teacher-dashboard/sidebar.js
@@ -25,10 +25,10 @@ const IntroPopover = ({ show, onClose }) => (
         <Popover id="drag-intro">
             <Popover.Content>
                 <p>
-          Click to add, or just drag to calendar.
+                    Click to add, or just drag to calendar.
                 </p>
                 <Button size="small" onClick={onClose}>
-          Got it
+                    Got it
                 </Button>
             </Popover.Content>
         </Popover>


### PR DESCRIPTION
I'm not sure why `clonedAttributes` was conditionally returning settings

It happened in this commit https://github.com/openstax/tutor-js/commit/6643bf8957e8df1b0f8932af4e012ba007acb6c2 which was part of the mass conversion. Doesn't seem like something that would have been automatically done though.