### PR TITLE
improve humanized, show only most significant duration

### DIFF
--- a/shared/specs/model/time.spec.ts
+++ b/shared/specs/model/time.spec.ts
@@ -1,4 +1,4 @@
-import Time, { setNow, setResolution } from '../../src/model/time'
+import Time, { Interval, setNow, setResolution } from '../../src/model/time'
 import { autorun } from 'mobx'
 import moment from 'moment'
 
@@ -57,13 +57,40 @@ describe('time class', () => {
         expect(future.isAfter(past, 'hour')).toBe(false)
     })
 
-    it('converts to interval with human display', () => {
+    it('has a humanized representation', () => {
+        expect(new Interval({
+            start: '2020-01-14T03:00:00.000Z',
+            end: '2021-01-15T10:58:03.330Z',
+        }).humanized).toEqual('1 year')
+        expect(new Interval({
+            start: '2021-01-14T03:00:00.000Z',
+            end: '2021-04-15T10:58:03.330Z',
+        }).humanized).toEqual('3 months')
+        expect(new Interval({
+            start: '2021-01-14T03:00:00.000Z',
+            end: '2021-01-18T10:58:03.330Z',
+        }).humanized).toEqual('4 days')
+        expect(new Interval({
+            start: '2021-01-14T03:00:00.000Z',
+            end: '2021-01-14T10:58:03.330Z',
+        }).humanized).toEqual('7 hours')
+        expect(new Interval({
+            start: '2021-01-14T03:00:00.000Z',
+            end: '2021-01-14T03:58:03.330Z',
+        }).humanized).toEqual('58 minutes')
+        expect(new Interval({
+            start: '2021-01-14T03:00:00.000Z',
+            end: '2021-01-14T03:0:03.330Z',
+        }).humanized).toEqual('now')
+    })
+
+    it('converts to sentence', () => {
         const past = new Time('2021-01-14T03:00:00.000Z')
         const future = new Time('2021-01-15T10:58:03.330Z')
         const interval = future.intervalTo(past)
         // it flipped start/end so start always comes first
         expect(interval.start.isSame(past, 'millisecond')).toBe(true)
-        expect(interval.humanized).toEqual('1 day, 7 hours and 58 minutes')
+        expect(interval.asSentence).toEqual('1 day, 7 hours and 58 minutes')
     })
 
 })

--- a/shared/src/model/time.ts
+++ b/shared/src/model/time.ts
@@ -1,5 +1,5 @@
 import {
-    DateTime as LDT, DurationUnit, Interval as LDTInterval, DateObjectUnits, DurationObject, Zone, Settings,
+    DateTime as LDT, DurationUnit, Interval as LDTInterval, DateObjectUnits, DurationObject, Zone, Settings, DurationObjectUnits,
 } from 'luxon'
 import { map, compact, flatten, max, min, isString, isNumber, isDate } from 'lodash';
 import { readonly } from 'core-decorators'
@@ -184,6 +184,17 @@ export class Interval {
     }
 
     get humanized() {
+        const durations = ['years', 'months', 'days', 'hours', 'minutes', 'seconds'] as any as keyof DurationObjectUnits
+        const values = this.asLuxon.toDuration(durations)
+        for (let i = 0; i < durations.length - 1; i++) {
+            if (values[durations[i]]) {
+                return pluralize(durations[i], values[durations[i]], true)
+            }
+        }
+        return 'now'
+    }
+
+    get asSentence() {
         const { days, hours, minutes } = this.asLuxon.toDuration(['days', 'hours', 'minutes', 'seconds'])
         let str: string[] = []
         if (days)  str.push(pluralize('day', days, true))


### PR DESCRIPTION
Is more compact, most users won't care about the hours/minutes until it's less than 1 day left