### PR TITLE
Fixed "This Preview isn’t quite ready yet." spam

### DIFF
--- a/tutor/src/components/error-monitoring/handlers.jsx
+++ b/tutor/src/components/error-monitoring/handlers.jsx
@@ -114,6 +114,8 @@ const ERROR_HANDLERS = {
           OK
                 </Button>,
             ],
+            onOk: hideModal,
+            onCancel: hideModal,
         };
     },
 


### PR DESCRIPTION
This fixes the dialog triggering on every navigation (hideModal clears the errors array). A couple issues remain, however:
- The load animation for the preview course is not canceled (maybe that would be handled by the promise that ends up failing?)
- onOk doesn't seem to actually do anything, only onCancel seems to trigger. If the button's onClick is removed, then the dialog just stays open if you click OK