### PR TITLE
When completing or cancelling assignment creation, send instructor back to selected month

### DIFF
--- a/tutor/specs/screens/assignment-edit/ux.spec.jsx
+++ b/tutor/specs/screens/assignment-edit/ux.spec.jsx
@@ -51,4 +51,14 @@ describe('AssignmentUX', function() {
             ecosystem_id: 142,
         }))
     });
+
+    it("sends the user back to the assignment's default dueAt month when complete", async () => {
+        const ux = new AssignmentUX()
+        attrs['course']['id'] = 42
+        attrs['due_at'] = '2021-06-12'
+        attrs['history'] = {push: jest.fn()}
+        await ux.initialize(attrs)
+        ux.onComplete()
+        expect(ux.history.push).toHaveBeenCalledWith('/course/42/t/month/2021-06-12')
+    });
 });

--- a/tutor/specs/screens/assignment-edit/ux.spec.jsx
+++ b/tutor/specs/screens/assignment-edit/ux.spec.jsx
@@ -52,11 +52,11 @@ describe('AssignmentUX', function() {
         }))
     });
 
-    it("sends the user back to the assignment's default dueAt month when complete", async () => {
+    it('sends the user back to the assignment\'s default dueAt month when complete', async () => {
         const ux = new AssignmentUX()
         attrs['course']['id'] = 42
         attrs['due_at'] = '2021-06-12'
-        attrs['history'] = {push: jest.fn()}
+        attrs['history'] = { push: jest.fn() }
         await ux.initialize(attrs)
         ux.onComplete()
         expect(ux.history.push).toHaveBeenCalledWith('/course/42/t/month/2021-06-12')

--- a/tutor/src/screens/assignment-edit/ux.js
+++ b/tutor/src/screens/assignment-edit/ux.js
@@ -254,7 +254,8 @@ export default class AssignmentUX {
     }
 
     @action.bound onComplete() {
-        this.history.push(`/course/${this.course.id}/t/month/${this.dueAt}`);
+        const month = this.dueAt || this.plan.tasking_plans[0]?.dueAt?.asISODateString;
+        this.history.push(`/course/${this.course.id}/t/month/${month}`);
     }
 
     @action.bound onCancel() {

--- a/tutor/src/screens/assignment-edit/ux.js
+++ b/tutor/src/screens/assignment-edit/ux.js
@@ -254,7 +254,7 @@ export default class AssignmentUX {
     }
 
     @action.bound onComplete() {
-        this.history.push(`/course/${this.course.id}`);
+        this.history.push(`/course/${this.course.id}/t/month/${this.dueAt}`);
     }
 
     @action.bound onCancel() {


### PR DESCRIPTION
When clicking the calendar to create an assignment, you should go back to that month.
Creating an assignment for the sidebar, however, seems to always default to the current month, so that won't work (but if we want that to change, we can pick a date for sidebar assignments based on the selected month).