### PR TITLE
Make Upgrade to Sociology 3e message a link to creating a new Sociology 3e course

### DIFF
--- a/tutor/specs/screens/new-course/__snapshots__/sociology-3e-nudge.spec.js.snap
+++ b/tutor/specs/screens/new-course/__snapshots__/sociology-3e-nudge.spec.js.snap
@@ -22,6 +22,7 @@ exports[`Sociology 3e nudge matches snapshot 1`] = `
   Introduction to Sociology 2e is available until Summer 2022. 
   <a
     href="/new-course/offering/2"
+    onClick={[Function]}
   >
     Upgrade to 
     <cite>

--- a/tutor/specs/screens/new-course/__snapshots__/sociology-3e-nudge.spec.js.snap
+++ b/tutor/specs/screens/new-course/__snapshots__/sociology-3e-nudge.spec.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Sociology 3e nudge matches snapshot 1`] = `
+.c0 {
+  margin-top: 8px;
+  line-height: 2rem;
+  color: #6f6f6f;
+}
+
+.c0 a {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 cite {
+  font-weight: bold;
+}
+
+<div
+  className="c0"
+>
+  Introduction to Sociology 2e is available until Summer 2022. 
+  <a
+    href="/new-course/offering/2"
+  >
+    Upgrade to 
+    <cite>
+      Introduction to Sociology 3e
+    </cite>
+    .
+  </a>
+</div>
+`;

--- a/tutor/specs/screens/new-course/sociology-3e-nudge.spec.js
+++ b/tutor/specs/screens/new-course/sociology-3e-nudge.spec.js
@@ -1,4 +1,4 @@
-import { Factory } from '../../helpers';
+import { Factory, R } from '../../helpers';
 import BuilderUX from '../../../src/screens/new-course/ux';
 import Sociology3eNudge from '../../../src/screens/new-course/sociology-3e-nudge';
 
@@ -19,6 +19,6 @@ describe('Sociology 3e nudge', function() {
     });
 
     it('matches snapshot', function() {
-        expect.snapshot(<Sociology3eNudge ux={ux}/>).toMatchSnapshot();
+        expect.snapshot(<R><Sociology3eNudge ux={ux}/></R>).toMatchSnapshot();
     });
 });

--- a/tutor/specs/screens/new-course/sociology-3e-nudge.spec.js
+++ b/tutor/specs/screens/new-course/sociology-3e-nudge.spec.js
@@ -1,0 +1,24 @@
+import { ApiMock, React, Factory } from '../../helpers';
+import BuilderUX from '../../../src/screens/new-course/ux';
+import Sociology3eNudge from '../../../src/screens/new-course/sociology-3e-nudge';
+
+describe('Sociology 3e nudge', function() {
+    let ux;
+
+    beforeEach(() => {
+        ux = new BuilderUX({
+            router: { match: { params: {} } },
+            offerings: Factory.offeringsMap({ count: 2 }),
+        });
+
+        ux.router.match.params.offeringId = ux.offerings.array[0].id;
+        ux.offering.os_book_id = ux.offering.SOC2E_BOOK_ID;
+
+        const soc3eOffering = ux.offerings.array[1];
+        soc3eOffering.os_book_id = ux.offering.SOC3E_BOOK_ID;
+    });
+
+    it('matches snapshot', function() {
+        expect.snapshot(<Sociology3eNudge ux={ux}/>).toMatchSnapshot();
+    });
+});

--- a/tutor/specs/screens/new-course/sociology-3e-nudge.spec.js
+++ b/tutor/specs/screens/new-course/sociology-3e-nudge.spec.js
@@ -1,4 +1,4 @@
-import { ApiMock, React, Factory } from '../../helpers';
+import { Factory } from '../../helpers';
 import BuilderUX from '../../../src/screens/new-course/ux';
 import Sociology3eNudge from '../../../src/screens/new-course/sociology-3e-nudge';
 

--- a/tutor/src/screens/new-course/index.jsx
+++ b/tutor/src/screens/new-course/index.jsx
@@ -1,14 +1,19 @@
 import { React } from 'vendor';
+import { useParams } from 'react-router'
 import { ScrollToTop } from 'shared';
 import Wizard from './wizard';
 import './styles.scss';
 
-const NewCourse = () => (
-    <ScrollToTop>
-        <div className="new-course-wizard" data-test-id="new-course-wizard">
-            <Wizard />
-        </div>
-    </ScrollToTop>
-);
+const NewCourse = () => {
+    const params = useParams()
 
-export default NewCourse;
+    return (
+        <ScrollToTop>
+            <div className="new-course-wizard" data-test-id="new-course-wizard">
+                <Wizard key={params.offeringId} />
+            </div>
+        </ScrollToTop>
+    )
+}
+
+export default NewCourse

--- a/tutor/src/screens/new-course/sociology-3e-nudge.tsx
+++ b/tutor/src/screens/new-course/sociology-3e-nudge.tsx
@@ -1,5 +1,6 @@
 import { React, styled } from 'vendor'
 import { colors } from '../../theme'
+import TutorLink from '../../components/link';
 
 const Text = styled.div`
     margin-top: 8px;
@@ -26,9 +27,13 @@ const Sociology3eNudge = ({ ux }: { ux: any }) => {
     }
 
     if (ux.displaySoc3eAvailableNudge) {
+        const soc3eOfferingId = ux.offerings.sociology3e.array[0].id
+
         return (
             <Text>
-                Introduction to Sociology 2e is available until Summer 2022. <a href={`/new-course/offering/${ux.offerings.sociology3e.array[0].id}`}>Upgrade to <cite>Introduction to Sociology 3e</cite>.</a>
+                Introduction to Sociology 2e is available until Summer 2022. <TutorLink to="createNewCourseFromOffering" params={{ offeringId: soc3eOfferingId }}>
+                    Upgrade to <cite>Introduction to Sociology 3e</cite>.
+                </TutorLink>
             </Text>
         )
     }

--- a/tutor/src/screens/new-course/sociology-3e-nudge.tsx
+++ b/tutor/src/screens/new-course/sociology-3e-nudge.tsx
@@ -28,7 +28,7 @@ const Sociology3eNudge = ({ ux }: { ux: any }) => {
     if (ux.displaySoc3eAvailableNudge) {
         return (
             <Text>
-                Introduction to Sociology 2e is available until Summer 2022. Upgrade to <cite>Introduction to Sociology 3e</cite>.
+                Introduction to Sociology 2e is available until Summer 2022. <a href={`/new-course/offering/${ux.offerings.sociology3e.array[0].id}`}>Upgrade to <cite>Introduction to Sociology 3e</cite>.</a>
             </Text>
         )
     }

--- a/tutor/src/screens/new-course/ux.js
+++ b/tutor/src/screens/new-course/ux.js
@@ -188,12 +188,12 @@ export default class CourseBuilderUX extends BaseModel {
 
     @computed get displaySoc3eSoonNudge() {
         if (!this.offering) return false;
-        return this.offering.isSociology2e && currentOfferings.soc3eExists && !currentOfferings.soc3eAvailable;
+        return this.offering.isSociology2e && this.offerings.soc3eExists && !this.offerings.soc3eAvailable;
     }
 
     @computed get displaySoc3eAvailableNudge() {
         if (!this.offering) return false;
-        return this.offering.isSociology2e && currentOfferings.soc3eAvailable
+        return this.offering.isSociology2e && this.offerings.soc3eAvailable
     }
 
     @action.bound


### PR DESCRIPTION
Not sure if the message also shows up when cloning courses?
But we can't clone 2e into 3e so redirecting to a new course kind of makes sense in that case.