### PR TITLE
Limit node memory before GC to 512MB per process

### DIFF
--- a/bin/test-unit
+++ b/bin/test-unit
@@ -4,7 +4,11 @@ set -e
 
 args=${@:2}
 if [[ ! $args ]]; then
-   args='--watch'
+    args='--watch'
+fi
+
+if [[ -z "$NODE_OPTIONS" ]]; then
+    export NODE_OPTIONS="--max-old-space-size=512"
 fi
 
 $(npm bin)/jest --verbose false --config ./configs/test/jest.$1.js $args


### PR DESCRIPTION
You get 1 process per core on your machine when running tests (half of that in watch mode), so you could easily run out of memory and crash with node defaults (1.4GB per process).