### PR TITLE
Fix exercise edit URL

### DIFF
--- a/tutor/src/screens/qa-view/exercise-card.jsx
+++ b/tutor/src/screens/qa-view/exercise-card.jsx
@@ -52,7 +52,7 @@ export default class ExerciseCard extends React.Component {
                 <a
                     target="_blank"
                     className="edit-link"
-                    href={exercise.url.replace(/@\d+/, '@draft')}
+                    href={exercise.url.replace('/exercises/', '/exercise/')}
                 >
           edit
                 </a>


### PR DESCRIPTION
2 changes:

- Exercises FE doesn't like `@draft` so remove that
- Replace /exercises/ with /exercise/ to fix the URLs without having to reimport the book