### PR TITLE
Always return to the calendar showing the assignment's due date

### DIFF
--- a/tutor/specs/screens/assignment-edit/ux.spec.jsx
+++ b/tutor/specs/screens/assignment-edit/ux.spec.jsx
@@ -52,9 +52,28 @@ describe('AssignmentUX', function() {
         }))
     });
 
-    it('sends the user back to the assignment\'s default dueAt month when complete', async () => {
+    it('sends the user to the assignment\'s first tasking_plan\'s dueAt when done', async () => {
         const ux = new AssignmentUX()
         attrs['course']['id'] = 42
+        attrs['plan'] = {
+            tasking_plans: [{ dueAt: { asISODateString: '2021-06-12' } }],
+            ensureLoaded: jest.fn(),
+            grading_template_id: 42,
+        }
+        attrs['history'] = { push: jest.fn() }
+        await ux.initialize(attrs)
+        ux.onComplete()
+        expect(ux.history.push).toHaveBeenCalledWith('/course/42/t/month/2021-06-12')
+    });
+
+    it('sends the user to the assignment\'s default dueAt month w/o tasking_plans', async () => {
+        const ux = new AssignmentUX()
+        attrs['course']['id'] = 42
+        attrs['plan'] = {
+            tasking_plans: [],
+            ensureLoaded: jest.fn(),
+            grading_template_id: 42,
+        }
         attrs['due_at'] = '2021-06-12'
         attrs['history'] = { push: jest.fn() }
         await ux.initialize(attrs)

--- a/tutor/src/screens/assignment-edit/ux.js
+++ b/tutor/src/screens/assignment-edit/ux.js
@@ -254,8 +254,8 @@ export default class AssignmentUX {
     }
 
     @action.bound onComplete() {
-        const month = this.dueAt || this.plan.tasking_plans[0]?.dueAt?.asISODateString;
-        this.history.push(`/course/${this.course.id}/t/month/${month}`);
+        const returnDate = this.plan.tasking_plans[0]?.dueAt?.asISODateString || this.dueAt || '';
+        this.history.push(`/course/${this.course.id}/t/month/${returnDate}`);
     }
 
     @action.bound onCancel() {

--- a/tutor/src/screens/assignment-edit/ux.js
+++ b/tutor/src/screens/assignment-edit/ux.js
@@ -254,7 +254,13 @@ export default class AssignmentUX {
     }
 
     @action.bound onComplete() {
-        const returnDate = this.plan.tasking_plans[0]?.dueAt?.asISODateString || this.dueAt || '';
+        let returnDate;
+        if (this.plan.tasking_plans.length > 0) {
+            returnDate = this.plan.tasking_plans[0].dueAt?.asISODateString;
+        }
+        else {
+            returnDate = this.dueAt;
+        }
         this.history.push(`/course/${this.course.id}/t/month/${returnDate}`);
     }
 


### PR DESCRIPTION
According to the card, we always want to return to the date that is currently set as the due date, regardless of the assignment's default date. I suppose we can still use the default date as a fallback though.