### PR TITLE
display interactives full-width in details view

### DIFF
--- a/shared/resources/styles/components/exercise-preview/index.scss
+++ b/shared/resources/styles/components/exercise-preview/index.scss
@@ -119,7 +119,7 @@
     $action-square-height: 75px;
     $size-scale: 0.5;
     .card-body, .card-body:hover {
-      padding: 2.8rem 2.8rem 2.8rem 90px;
+      padding: 2.8rem;
       position: relative;
       .controls-overlay {
         visibility: visible;

--- a/tutor/resources/styles/components/exercise-preview.scss
+++ b/tutor/resources/styles/components/exercise-preview.scss
@@ -153,10 +153,6 @@
   }
 }
 
-.openstax-exercise-preview {
-  @include book-content-interactives();
-}
-
 .is-college {
   // LO tags are hidden for college courses.
   .openstax-exercise-preview {


### PR DESCRIPTION
don't mind the failed to load iframe, that's due to it not trusting localhost

<img width="1150" alt="image" src="https://user-images.githubusercontent.com/79566/126376708-913de469-df9b-4ede-a07d-1a26724f3a71.png">
