### PR TITLE
update task plan extensions with api response data

### DIFF
--- a/tutor/src/models/task-plans/teacher/plan.ts
+++ b/tutor/src/models/task-plans/teacher/plan.ts
@@ -2,7 +2,7 @@ import {
     BaseModel, field, action, computed, observable, model, lazyGetter,
     array, modelize, NEW_ID, ID, override, hydrateInstance, hydrateModel,
 } from 'shared/model';
-import { createAtom, IAtom, toJS } from 'mobx'
+import { createAtom, IAtom, runInAction, toJS } from 'mobx'
 import Time, { Interval, findEarliest, findLatest } from 'shared/model/time';
 import {
     first, last, map, flatMap, find, get, pick, extend, every, isEmpty,
@@ -466,11 +466,12 @@ export class TeacherTaskPlan extends BaseModel {
     async grantExtensions(extensions: TaskPlanExtensionData[]) {
         //if new extensions dates are selected for a student who has already an extension, this will update the student previous extended dates
         const grantedExtensions = unionBy(extensions, this.extensions, 'role_id');
-        const updatedExtensions = this.api.request<TaskPlanExtensionData[]>(
+        const updatedTaskPlan = await this.api.request<TeacherTaskPlanData>(
             urlFor('grantTaskExtensions', { taskPlanId: this.id }),
             { data: { extensions: grantedExtensions } },
         )
-        return updatedExtensions
+        runInAction(() => this.update(updatedTaskPlan))
+        return updatedTaskPlan.extensions
     }
 
 

--- a/tutor/src/screens/assignment-review/ux.ts
+++ b/tutor/src/screens/assignment-review/ux.ts
@@ -231,7 +231,6 @@ export default class AssignmentReviewUX {
             await this.taskPlan.grantExtensions(extensions);
         }
         await this.planScores.fetch();
-        runInAction(() => this.taskPlan.extensions.push(...extensions));
         this.cancelDisplayingGrantExtension();
     }
 

--- a/tutor/src/screens/assignment-review/ux.ts
+++ b/tutor/src/screens/assignment-review/ux.ts
@@ -231,6 +231,7 @@ export default class AssignmentReviewUX {
             await this.taskPlan.grantExtensions(extensions);
         }
         await this.planScores.fetch();
+        runInAction(() => this.taskPlan.extensions.push(...extensions));
         this.cancelDisplayingGrantExtension();
     }
 


### PR DESCRIPTION
Should make it so the "E" extension icon shows up immediately after saving the extensions, as the API gives us an update task plan in the response.