### PR TITLE
bind onSelect to this so that props are in scope

### DIFF
--- a/tutor/src/screens/performance-forecast/teacher-student.js
+++ b/tutor/src/screens/performance-forecast/teacher-student.js
@@ -1,4 +1,4 @@
-import { React, PropTypes, withRouter, observer } from 'vendor';
+import { React, PropTypes, withRouter, action, observer, modelize } from 'vendor';
 import { Dropdown, Container } from 'react-bootstrap';
 import Router from '../../helpers/router';
 import { sortBy } from 'lodash';
@@ -21,13 +21,14 @@ class Display extends React.Component {
     constructor(props) {
         super(props)
         this.state = { ...props.match.params }
+        modelize(this)
     }
 
     componentDidMount() {
         this.props.course.roster.ensureLoaded();
     }
 
-    onSelectStudent(roleId) {
+    @action.bound onSelectStudent(roleId) {
         const { course } = this.props;
         course.performance.studentRoleId = roleId
         this.setState({ roleId });


### PR DESCRIPTION
fixes the bug with the student selector on the performance forecast 