### PR TITLE
Use localeCompare in numeric mode for sorting course sections

### DIFF
--- a/tutor/specs/helpers/period.spec.js
+++ b/tutor/specs/helpers/period.spec.js
@@ -5,10 +5,13 @@ import PeriodHelper from '../../src/helpers/period';
 const sortPeriods = [
     [
         {
+            name: '0',
+        },
+        {
             name: '0th',
         },
         {
-            name: '0',
+            name: '1',
         },
         {
             name: '1st',
@@ -17,31 +20,22 @@ const sortPeriods = [
             name: '1th',
         },
         {
-            name: '1',
-        },
-        {
-            name: 'Period 2',
-        },
-        {
             name: '2',
         },
         {
             name: '9th',
         },
         {
-            name: 'Period 10',
-        },
-        {
-            name: '10th',
-        },
-        {
-            name: '10th',
+            name: '10.5th',
         },
         {
             name: '10.25',
         },
         {
-            name: '10.5th',
+            name: '10th',
+        },
+        {
+            name: '10th',
         },
         {
             name: '12.245th',
@@ -52,7 +46,6 @@ const sortPeriods = [
         {
             name: '90',
         },
-
         {
             name: 'Block B',
         },
@@ -64,6 +57,18 @@ const sortPeriods = [
         },
         {
             name: 'monkeys',
+        },
+        {
+            name: 'Period 2',
+        },
+        {
+            name: 'Period 2-1',
+        },
+        {
+            name: 'Period 2-2',
+        },
+        {
+            name: 'Period 10',
         },
         {
             name: 'th',
@@ -79,8 +84,9 @@ describe('Period helpers', () => {
             const randoedPeriods = shuffle(periods);
             const sortedByFunction = PeriodHelper.sort(randoedPeriods);
 
-            expect(map(sortedByFunction, 'name').join())
-                .toEqual(map(periods, 'name').join());
+            expect(map(map(sortedByFunction, 'name'), 'toLowerCase').join()).toEqual(
+                map(map(periods, 'name'), 'toLowerCase').join()
+            );
         });
     });
 

--- a/tutor/src/helpers/period.ts
+++ b/tutor/src/helpers/period.ts
@@ -1,5 +1,4 @@
 import type { CoursePeriod } from '../models'
-import { sortBy } from 'lodash';
 import S from './string';
 
 
@@ -9,21 +8,11 @@ const PeriodHelper = {
     },
 
     sort(periods: CoursePeriod[]) {
-        // sort first by non number values, then by numbers
-        periods = sortBy(periods, (period) => { // eslint-disable-line consistent-return
-            const name = period.name.match(/[^0-9]+/ig);
-            if (name) {
-                return name;
-            }
-            return undefined
-        });
-        return sortBy(periods, (period ) => { // eslint-disable-line consistent-return
-            const number = period.name.match(/[0-9.-]+/g);
-            if (number) {
-                return parseFloat(number[0]);
-            }
-            return undefined
-        });
+        return periods.slice(0).sort(
+            (firstPeriod, secondPeriod) => firstPeriod.name.toLowerCase().localeCompare(
+                secondPeriod.name.toLowerCase(), 'en', { numeric: true }
+            )
+        )
     },
 
 };


### PR DESCRIPTION
https://caniuse.com/localecompare

`localeCompare()` is only weird for the decimal parts of numbers, when the decimal parts have different lengths.
I don't think we care very much about that case though.