### PR TITLE
Lock icon on question header

### DIFF
--- a/tutor/specs/components/icons/lock.spec.js
+++ b/tutor/specs/components/icons/lock.spec.js
@@ -1,0 +1,18 @@
+import { StepLockIcon } from '../../../src/components/icons/lock';
+
+describe('StepLockIcon', () => {
+    it('does not render the lock icon when wasGraded and isClosed are both false', () => {
+        const stepLockIcon = mount(<StepLockIcon wasGraded={false} isClosed={false} />);
+        expect(stepLockIcon).not.toHaveRendered('.ox-icon-lock');
+    });
+
+    it('renders the lock icon when wasGraded is true', () => {
+        const stepLockIcon = mount(<StepLockIcon wasGraded={true} isClosed={false} />);
+        expect(stepLockIcon).toHaveRendered('.ox-icon-lock');
+    });
+
+    it('renders the lock icon when isClosed is true', () => {
+        const stepLockIcon = mount(<StepLockIcon wasGraded={false} isClosed={true} />);
+        expect(stepLockIcon).toHaveRendered('.ox-icon-lock');
+    });
+});

--- a/tutor/src/components/icons/lock.js
+++ b/tutor/src/components/icons/lock.js
@@ -22,7 +22,14 @@ const StyledTooltip = styled(Tooltip)`
   }
 `;
 
-const LockIcon = ({ className, wasGraded, isClosed, inline = false }) => {
+const LockIcon = ({ className }) => (
+    <Icon className={cn('lock-icon', className)} type="lock" />
+);
+LockIcon.propTypes = {
+    className: PropTypes.string,
+};
+
+const StepLockIcon = ({ className, wasGraded, isClosed, inline = false }) => {
     let msg;
     if (isClosed) {
         msg = 'This assignment is closed. You can no longer add or edit a response.';
@@ -37,7 +44,7 @@ const LockIcon = ({ className, wasGraded, isClosed, inline = false }) => {
     return (
         <OverlayTrigger
             placement="auto"
-            overlay={<StyledTooltip id="lock-icon">{msg}</StyledTooltip>}
+            overlay={<StyledTooltip id="step-lock-icon">{msg}</StyledTooltip>}
             popperConfig={{
                 modifiers: {
                     preventOverflow: { enabled: false },
@@ -45,17 +52,16 @@ const LockIcon = ({ className, wasGraded, isClosed, inline = false }) => {
             }}
         >
             <LockIconWrapper inline={inline}>
-                <Icon className={cn('lock-icon', className)} type="lock" />
+                <LockIcon className={className} />
             </LockIconWrapper>
         </OverlayTrigger>
     );
 };
-
-LockIcon.propTypes = {
+StepLockIcon.propTypes = {
     className: PropTypes.string,
     wasGraded: PropTypes.bool,
     isClosed: PropTypes.bool,
     inline: PropTypes.bool,
 };
 
-export default LockIcon;
+export { LockIcon, StepLockIcon };

--- a/tutor/src/components/icons/lock.js
+++ b/tutor/src/components/icons/lock.js
@@ -1,0 +1,61 @@
+import { React, PropTypes, styled, cn, css } from 'vendor';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { colors } from 'theme';
+import { Icon } from 'shared';
+
+const LockIconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+
+  ${props => props.inline && css`
+    display: inline-block;
+  `}
+`;
+
+const StyledTooltip = styled(Tooltip)`
+  pointer-events: none;
+  max-width: 214px;
+  color: ${colors.neutral.thin};
+  // Fix absolute positioning confusing where to place tooltip
+  &.bs-tooltip-right {
+    margin-left: 2.5rem;
+  }
+`;
+
+const LockIcon = ({ className, wasGraded, isClosed, inline = false }) => {
+    let msg;
+    if (isClosed) {
+        msg = 'This assignment is closed. You can no longer add or edit a response.';
+    }
+    else if (wasGraded) {
+        msg = 'Question has been graded already.';
+    }
+    else {
+        return null;
+    }
+
+    return (
+        <OverlayTrigger
+            placement="auto"
+            overlay={<StyledTooltip id="lock-icon">{msg}</StyledTooltip>}
+            popperConfig={{
+                modifiers: {
+                    preventOverflow: { enabled: false },
+                },
+            }}
+        >
+            <LockIconWrapper inline={inline}>
+                <Icon className={cn('lock-icon', className)} type="lock" />
+            </LockIconWrapper>
+        </OverlayTrigger>
+    );
+};
+
+LockIcon.propTypes = {
+    className: PropTypes.string,
+    wasGraded: PropTypes.bool,
+    isClosed: PropTypes.bool,
+    inline: PropTypes.bool,
+};
+
+export default LockIcon;

--- a/tutor/src/screens/task/step/card.js
+++ b/tutor/src/screens/task/step/card.js
@@ -2,6 +2,7 @@ import { React, PropTypes, cn, observer, styled } from 'vendor';
 import { colors, breakpoint } from 'theme';
 import { SpyInfo } from './spy-info';
 import { Icon } from 'shared';
+import LockIcon from '../../../components/icons/lock'
 import { StudentTaskStep } from '../../../models';
 import ScoresHelper from '../../../helpers/scores';
 
@@ -64,7 +65,7 @@ const StepCardHeader = styled.div`
     }
   }
 
-  svg {
+  button {
     margin-top: 3px;
     color: ${colors.neutral.gray};
     display: none;
@@ -78,7 +79,7 @@ const StepCardHeader = styled.div`
   ${({ theme }) => theme.breakpoint.tablet`
   font-size: 1.6rem;
     padding: 14px 26px 14px 8px;
-    svg {
+    button {
       display: inherit;
     }
     div:first-child {
@@ -142,6 +143,8 @@ const StepCard = ({
     numberOfQuestions,
     stepType,
     isHomework,
+    wasGraded,
+    isClosed,
     availablePoints,
     unpadded,
     className,
@@ -165,6 +168,7 @@ const StepCard = ({
                   onClick={goBackward}
               />
                 }
+                <LockIcon wasGraded={wasGraded} isClosed={isClosed}/>
                 <div>Question {questionNumber} <span>&nbsp;/ {numberOfQuestions}</span></div>
             </div>
             <div>
@@ -198,6 +202,8 @@ StepCard.propTypes = {
     canGoForward: PropTypes.bool,
     stepType: PropTypes.string,
     isHomework: PropTypes.string,
+    wasGraded: PropTypes.bool,
+    isClosed: PropTypes.bool,
     availablePoints: PropTypes.number,
 };
 
@@ -224,6 +230,8 @@ const TaskStepCard = observer(({
             canGoForward={canGoForward}
             stepType={step.type}
             isHomework={step.task.type}
+            wasGraded={step.was_manually_graded}
+            isClosed={step.task.isAssignmentClosed}
             data-task-step-id={step.id}
             availablePoints={step.available_points}
             className={cn(`${step.type}-step`, className)}

--- a/tutor/src/screens/task/step/card.js
+++ b/tutor/src/screens/task/step/card.js
@@ -2,7 +2,7 @@ import { React, PropTypes, cn, observer, styled } from 'vendor';
 import { colors, breakpoint } from 'theme';
 import { SpyInfo } from './spy-info';
 import { Icon } from 'shared';
-import LockIcon from '../../../components/icons/lock'
+import { StepLockIcon } from '../../../components/icons/lock'
 import { StudentTaskStep } from '../../../models';
 import ScoresHelper from '../../../helpers/scores';
 
@@ -168,7 +168,7 @@ const StepCard = ({
                   onClick={goBackward}
               />
                 }
-                <LockIcon wasGraded={wasGraded} isClosed={isClosed}/>
+                <StepLockIcon wasGraded={wasGraded} isClosed={isClosed}/>
                 <div>Question {questionNumber} <span>&nbsp;/ {numberOfQuestions}</span></div>
             </div>
             <div>


### PR DESCRIPTION
- Added a lock icon to questions that have been graded or whose assignment is closed
- Made mobile-only back and forward arrows in question header not clickable in tablet and desktop modes