### PR TITLE
Use $openstax-gray instead of $openstax-book-gray so exercises-js can compile

### DIFF
--- a/shared/resources/styles/components/exercise-badges/index.scss
+++ b/shared/resources/styles/components/exercise-badges/index.scss
@@ -4,7 +4,7 @@
   align-items: center;
   font-size: 1.4rem;
   margin: 1rem 0;
-  color: $openstax-book-gray;
+  color: $openstax-gray;
   .icon {
     height: 20px;
     margin-right: 0.6rem;


### PR DESCRIPTION
This style only exists on the Tutor side, but openstax-gray is exactly the same thing.