### PR TITLE
fix spacing of book name in validator response

### DIFF
--- a/tutor/src/screens/task/step/exercise-free-response.js
+++ b/tutor/src/screens/task/step/exercise-free-response.js
@@ -28,16 +28,23 @@ const InfoRow = styled.div`
   display: flex;
   justify-content: ${props => props.hasSubmitted ? 'space-between' : 'flex-end'};
   line-height: 1.6rem;
+
   .word-limit-error-info {
     color: ${colors.danger};
   }
-  span {
+
+  div > span {
     font-size: 12px;
     line-height: 16px;
     + span {
       margin-left: 1rem;
     }
-  };
+  }
+
+  .last-submitted + * {
+    margin-top: 0.8rem;
+  }
+
   color: ${colors.neutral.thin};
 `;
 
@@ -146,7 +153,7 @@ class FreeResponseInput extends React.Component {
                     />
                     <InfoRow hasSubmitted={!!ux.lastSubmitted}>
                         <div>
-                            {ux.lastSubmitted && <span>Last submitted on {ux.lastSubmitted.format('MMM DD [at] hh:mm A')}</span>}
+                            {ux.lastSubmitted && <span className="last-submitted">Last submitted on {ux.lastSubmitted.format('MMM DD [at] hh:mm A')}</span>}
                             {ux.isDisplayingNudge && <NudgeMessage course={course} step={step} ux={ux} />}
                         </div>
 


### PR DESCRIPTION
Fixes the spacing between the section number and title. Also adds a bit of vertical space between "last submitted at" and validator text.

| Old | New |
|--- | --- |
| ![image](https://user-images.githubusercontent.com/34174/133340696-643c7717-8660-4cb0-a079-948479917e76.png) | ![Screenshot 2021-09-14 at 15-00-06 OpenStax Tutor](https://user-images.githubusercontent.com/34174/133340550-fadcf0e5-6024-4c24-ac71-8f2fffd7aca4.png) |
