### PR TITLE
fix question emptiness check by stripping tags

### DIFF
--- a/tutor/specs/e2e/add-edit-question.e2e.ts
+++ b/tutor/specs/e2e/add-edit-question.e2e.ts
@@ -81,6 +81,20 @@ test.describe('Add/Edit Questions', () => {
         await page.click('.close')
     })
 
+    test('requires Question to be present', async ({ page }) => {
+        await page.click('testId=create-question')
+        await page.click('testId=switch-wrm')
+        const stemSel = 'testId=add-edit-question >> .question-text >> .editor'
+        await page.click(stemSel)
+        let editorSel = `${stemSel} >> .pw-prosemirror-editor`
+        await page.focus(editorSel)
+        await page.press(editorSel, 'Control+a')
+        await page.press(editorSel, 'Backspace')
+        await page.click('.tag-form button:first-child') // trigger focus blur for validation
+        await expect(page).toHaveText('Question field cannot be empty')
+        await page.click('.close')
+    })
+
     test('requires Answer Key to be present for WRMs', async ({ page }) => {
         await page.click('testId=create-question')
         await page.click('testId=switch-wrm')
@@ -97,5 +111,6 @@ test.describe('Add/Edit Questions', () => {
         await page.press(editorSel, 'Backspace')
         await page.click('.tag-form button:first-child') // trigger focus blur for validation
         await expect(page).toHaveText('Answer key field cannot be empty')
+        await page.click('.close')
     })
 })

--- a/tutor/src/components/add-edit-question/ux.js
+++ b/tutor/src/components/add-edit-question/ux.js
@@ -345,12 +345,13 @@ export default class AddEditQuestionUX {
         // check question section && detailed solution (labeled Answer Key on WRMs)
         let isQuestionFilled;
         let isDetailedSolutionFilled = true; // default to true because this field is optional in MCQs
+        const hasQuestionText = Boolean(S.stripHTMLTags(this.questionText))
 
         if (this.isMCQ) {
-            isQuestionFilled = Boolean(this.questionText && this.filledOptions.length >= 2 && some(this.filledOptions, fo => fo.isCorrect));
+            isQuestionFilled = Boolean(hasQuestionText && this.filledOptions.length >= 2 && some(this.filledOptions, fo => fo.isCorrect));
         }
         else {
-            isQuestionFilled = Boolean(this.questionText);
+            isQuestionFilled = hasQuestionText;
             isDetailedSolutionFilled = Boolean(S.stripHTMLTags(this.detailedSolution));
         }
         // check author
@@ -405,9 +406,7 @@ export default class AddEditQuestionUX {
     // actions for question form section
     @action.bound changeQuestionText(text) {
         this.questionText = text;
-        if(!S.isEmpty(S.stripHTMLTags(text))) {
-            this.isEmpty.questionText = false;
-        }
+        this.isEmpty.questionText = S.isEmpty(S.stripHTMLTags(text));
     }
 
     // called when an image is added to the HTML for question text


### PR DESCRIPTION
Fixes a bug that would allow for question text that contained the default editor html p tag to pass validation.