### PR TITLE
find saved question by tasked_id not exercise_id

### DIFF
--- a/tutor/src/components/buttons/save-practice.js
+++ b/tutor/src/components/buttons/save-practice.js
@@ -77,7 +77,7 @@ const SavePracticeButton = observer(({
     };
 
     const getPracticeQuestion = () => {
-        return practiceQuestions.findByExerciseId(taskStep.exercise_id);
+        return practiceQuestions.findByTaskedId(taskStep.tasked_id);
     };
 
     const isSaved = () => {

--- a/tutor/src/models/practice-questions.ts
+++ b/tutor/src/models/practice-questions.ts
@@ -47,6 +47,10 @@ export class PracticeQuestions extends Map<ID, PracticeQuestion> {
         return this.array.find(prc => prc.exercise_id == exerciseId);
     }
 
+    findByTaskedId(taskedExerciseId: ID) {
+        return this.array.find(prc => prc.tasked_exercise_id == taskedExerciseId);
+    }
+
     getAllExerciseIds() {
         return map(this.array, a => a.exercise_id);
     }


### PR DESCRIPTION
Repro:

- Save a question to practice
- Update the course ecosystem
- Old assignment shows the question as unsaved, and throws an error when clicking save (PracticeQuestions have to be unique by tasked_exercise_id)

This is caused by `AddEcosystemToCourse` running `RemapPracticeQuestionExercises`, which changes the saved exercise id to the new one in the new ecosystem. This PR has a fix for this by looking for the tasked_id instead.