### PR TITLE
fix title text displaying span tags on add-edit form

### DIFF
--- a/tutor/src/models/reference-book/node.ts
+++ b/tutor/src/models/reference-book/node.ts
@@ -4,8 +4,9 @@ import {
     modelize, getParentOf, hydrateModel, array,
     action, computed, override,
 } from 'shared/model';
-import { currentMedia, ChapterSection }from '../../models'
+import { currentMedia, ChapterSection } from '../../models'
 import type { ReferenceBook } from '../reference-book'
+import S from 'shared/helpers/string'
 
 import urlFor from '../../api';
 
@@ -173,9 +174,9 @@ export class ReferenceBookNode extends BaseModel {
     }
 
     @computed get titleWithSection() {
-        if(!this.chapter_section || !this.chapter_section.chapter) {
+        if (!this.chapter_section || !this.chapter_section.chapter) {
             return this.titleText;
         }
-        return `${this.chapter_section.asString}. ${this.titleText}`;
+        return `${this.chapter_section.asString}. ${S.stripHTMLTags(this.titleText)}`;
     }
 }


### PR DESCRIPTION
Strip out the span tags that get rendered on the add-edit form.

Before:

![image](https://user-images.githubusercontent.com/34174/135497156-438db1cb-efda-4fcb-8158-2145edd4f244.png)


After:

![image](https://user-images.githubusercontent.com/34174/135497056-32c95e78-7188-41b6-9dfd-073f769821ce.png)
