### PR TITLE
Fix saving multipart questions to practice 

### DIFF
--- a/tutor/src/components/buttons/save-practice.js
+++ b/tutor/src/components/buttons/save-practice.js
@@ -77,6 +77,17 @@ const SavePracticeButton = observer(({
     };
 
     const getPracticeQuestion = () => {
+        const multiPartGroup = taskStep.multiPartGroup
+
+        if (multiPartGroup) {
+            for (const tasked_id of multiPartGroup.steps.map((step) => step.tasked_id)) {
+                const practiceQuestion = practiceQuestions.findByTaskedId(tasked_id)
+                if (practiceQuestion) {
+                    return practiceQuestion;
+                }
+            }
+        }
+
         return practiceQuestions.findByTaskedId(taskStep.tasked_id);
     };
 


### PR DESCRIPTION
Fix saving multipart questions to practice by looking for any of the group's tasked ids being saved.