### PR TITLE
Fix exercises tag

### DIFF
--- a/exercises/src/models/exercises.ts
+++ b/exercises/src/models/exercises.ts
@@ -1,6 +1,6 @@
 import Map from 'shared/model/map';
 import { action, ID, hydrateModel, hydrateInstance } from 'shared/model';
-import { sortBy, last, get } from 'lodash';
+import { sortBy, last, get, merge } from 'lodash';
 import Exercise from './exercises/exercise';
 import urlFor  from '../api'
 
@@ -92,8 +92,9 @@ export class ExercisesMap extends Map<ID, Exercise | ExerciseVersions> {
         } else {
             url = urlFor('saveExistingDraft', { number: exercise.number })
         }
+        const data = merge(exercise.toJSON(), { "tags": exercise.tags.all.toJSON() })
         this.onSaved(
-            await this.api.request(url, { data: exercise.toJSON() }),
+            await this.api.request(url, { data: data }),
             exercise
         )
     }

--- a/exercises/src/models/exercises.ts
+++ b/exercises/src/models/exercises.ts
@@ -92,10 +92,9 @@ export class ExercisesMap extends Map<ID, Exercise | ExerciseVersions> {
         } else {
             url = urlFor('saveExistingDraft', { number: exercise.number })
         }
-        // Prevent method 'all' from TagsAssociation being serialized into tags array
-        const data = merge(exercise.toJSON(), { 'tags': exercise.tags.all.toJSON() })
+
         this.onSaved(
-            await this.api.request(url, { data: data }),
+            await this.api.request(url, { data: exercise.toJSON() }),
             exercise
         )
     }

--- a/exercises/src/models/exercises.ts
+++ b/exercises/src/models/exercises.ts
@@ -92,6 +92,7 @@ export class ExercisesMap extends Map<ID, Exercise | ExerciseVersions> {
         } else {
             url = urlFor('saveExistingDraft', { number: exercise.number })
         }
+        // Prevent method 'all' from TagsAssociation being serialized into tags array
         const data = merge(exercise.toJSON(), { 'tags': exercise.tags.all.toJSON() })
         this.onSaved(
             await this.api.request(url, { data: data }),

--- a/exercises/src/models/exercises.ts
+++ b/exercises/src/models/exercises.ts
@@ -92,7 +92,7 @@ export class ExercisesMap extends Map<ID, Exercise | ExerciseVersions> {
         } else {
             url = urlFor('saveExistingDraft', { number: exercise.number })
         }
-        const data = merge(exercise.toJSON(), { "tags": exercise.tags.all.toJSON() })
+        const data = merge(exercise.toJSON(), { 'tags': exercise.tags.all.toJSON() })
         this.onSaved(
             await this.api.request(url, { data: data }),
             exercise

--- a/exercises/src/models/exercises.ts
+++ b/exercises/src/models/exercises.ts
@@ -1,6 +1,6 @@
 import Map from 'shared/model/map';
 import { action, ID, hydrateModel, hydrateInstance } from 'shared/model';
-import { sortBy, last, get, merge } from 'lodash';
+import { sortBy, last, get } from 'lodash';
 import Exercise from './exercises/exercise';
 import urlFor  from '../api'
 

--- a/shared/src/model/exercise/tags-association.ts
+++ b/shared/src/model/exercise/tags-association.ts
@@ -49,6 +49,10 @@ export default class TagsAssociation {
     hydrate(tags: any[]) {
         this.all.splice(0, this.all.length, ...tags.map(t => hydrateModel(Tag, t)))
     }
+
+    serialize() {
+        return this.all.map(i => i.serialize())
+    }
 }
 
 export { Tag }


### PR DESCRIPTION
'all' was being created as a tag on exercises because of serialization of the `@model` tags object. This is a quick fix to grab the array instead.