### PR TITLE
Add public solution subset

### DIFF
--- a/exercises/specs/components/__snapshots__/exercise.spec.js.snap
+++ b/exercises/specs/components/__snapshots__/exercise.spec.js.snap
@@ -7550,7 +7550,7 @@ exports[`Exercises component resets fields when model is new 1`] = `
                                     </TagWrapper>
                                   </SingleDropdown>
                                 </TimeTag>
-                                <PublicSolutions exercise={{...}}>
+                                <PublicSolutions exercise={{...}} onChange={[Function: onChange]}>
                                   <TagWrapper label=\\"Solution is public\\">
                                     <div className=\\"tag-type solutionIsPublic\\">
                                       <div className=\\"heading\\">

--- a/exercises/specs/components/exercise.spec.js
+++ b/exercises/specs/components/exercise.spec.js
@@ -87,6 +87,7 @@ describe('Exercises component', () => {
         const checkbox = ex.find('.tag-type.solutionIsPublic input').first();
 
         // WHEN: Solutions are private
+        checkbox.simulate('change', { target: { checked: false } });
         expect(props.exercises.get(data.uid).tags.withType(tag)).toBeFalsy();
         // THEN: The publicSolutionsSubset dropdown is not rendered
         expect(ex).not.toHaveRendered('.tag-type.publicSolutionsSubset');

--- a/exercises/specs/components/exercise.spec.js
+++ b/exercises/specs/components/exercise.spec.js
@@ -75,4 +75,38 @@ describe('Exercises component', () => {
         ex.find('.tag-type.book select').simulate('change', { target: { value: 'stax-apbio' } });
         expect(ex).toHaveRendered('.tag-type.sciencePractice');
     });
+
+    it('only includes public solution subset when question is multipart and solution is public', () => {
+        // GIVEN: a multi-part question
+        const data = Factory.data('Exercise', { multipart: true });
+        const tag = 'public-solutions-subset';
+
+        runInAction(() => props.exercises.onLoaded({ data: data })); // set(ex.uid, ex) );
+        props.match.params.uid = data.uid;
+        const ex = mount(<Router><Exercise {...props} /></Router>);
+        const checkbox = ex.find('.tag-type.solutionIsPublic input').first();
+
+        // WHEN: Solutions are private
+        expect(props.exercises.get(data.uid).tags.withType(tag)).toBeFalsy();
+        // THEN: The publicSolutionsSubset dropdown is not rendered
+        expect(ex).not.toHaveRendered('.tag-type.publicSolutionsSubset');
+
+        // WHEN: the solutions are made public
+        checkbox.simulate('change', { target: { checked: true } });
+        // THEN: The publicSolutionsSubset dropdown is rendered
+        expect(ex).toHaveRendered('.tag-type.publicSolutionsSubset');
+        
+        // WHEN: An option is selected
+        ex.find('.tag-type.publicSolutionsSubset .select__dropdown-indicator')
+            .first()
+            .simulate('mouseDown', { button: 0 });
+        ex.find('.tag-type.publicSolutionsSubset .select__option').last().simulate('click');
+        // THEN: The tag should be set
+        expect(props.exercises.get(data.uid).tags.withType(tag).raw).toMatch(new RegExp(`^${tag}:`));
+
+        // WHEN: Solution is Public is unchecked
+        checkbox.simulate('change', { target: { checked: false } });
+        // THEN: The tag should be unset
+        expect(props.exercises.get(data.uid).tags.withType(tag)).toBeFalsy();
+    });
 });

--- a/exercises/src/components/exercise/tags.jsx
+++ b/exercises/src/components/exercise/tags.jsx
@@ -18,6 +18,7 @@ import Nclex from '../tags/nclex';
 import SciencePractice from '../tags/science-practice';
 import PublicSolutions from '../tags/public-solutions';
 import Exercise from '../../models/exercises/exercise';
+import PublicSolutionsSubset from '../tags/public-solution-subset';
 
 function ExerciseTags({ exercise }) {
     const { validity } = exercise;
@@ -41,7 +42,16 @@ function ExerciseTags({ exercise }) {
                 <Dok {...tagProps} />
                 <Blooms {...tagProps} />
                 <Time {...tagProps} />
-                <PublicSolutions {...tagProps} />
+                <PublicSolutions {...tagProps} onChange={(value) => {
+                    if (exercise.isMultiPart && !value) {
+                        exercise.tags.removeType(
+                            Exercise.publicSolutionsSubsetType
+                        );
+                    }
+                }} />
+                {exercise.solutions_are_public && exercise.isMultiPart
+                    ? <PublicSolutionsSubset {...tagProps} />
+                    : null}
             </div>
         </div>
     );

--- a/exercises/src/components/tags/public-solution-subset.jsx
+++ b/exercises/src/components/tags/public-solution-subset.jsx
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { observer } from 'mobx-react';
+import Exercise from '../../models/exercises/exercise';
+import SingleDropdown from './single-dropdown';
+
+const CHOICES = {
+    even: 'Even-Numbered Solutions Are Public',
+    odd: 'Odd-Numbered Solutions Are Public',
+};
+
+function PublicSolutionsSubsetTag(props) {
+    return (
+        <SingleDropdown
+            {...props}
+            label="Public Solutions Subset"
+            type={Exercise.publicSolutionsSubsetType}
+            choices={CHOICES} 
+        />
+    );
+}
+
+PublicSolutionsSubsetTag.propTypes = {
+    exercise: PropTypes.instanceOf(Exercise).isRequired,
+};
+
+export default observer(PublicSolutionsSubsetTag);

--- a/exercises/src/components/tags/public-solutions.jsx
+++ b/exercises/src/components/tags/public-solutions.jsx
@@ -9,6 +9,7 @@ import Wrapper from './wrapper';
 class PublicSolutions extends React.Component {
     static propTypes = {
         exercise: PropTypes.instanceOf(Exercise).isRequired,
+        onChange: PropTypes.func,
     };
 
     constructor(props) {
@@ -17,7 +18,11 @@ class PublicSolutions extends React.Component {
     }
 
     @action.bound updateValue(ev) {
-        this.props.exercise.solutions_are_public = ev.target.checked;
+        const value = ev.target.checked;
+        this.props.exercise.solutions_are_public = value;
+        if (this.props.onChange !== undefined) {
+            this.props.onChange(value);
+        }
     }
 
     render() {

--- a/exercises/src/models/exercises/exercise.ts
+++ b/exercises/src/models/exercises/exercise.ts
@@ -1,4 +1,4 @@
-import { action } from 'mobx';
+import { action, override } from 'mobx';
 import { merge, find, isEmpty, isObject, map } from 'lodash';
 import { field, modelize, model, hydrateModel, observable, array } from 'shared/model';
 import Image from './image';
@@ -9,6 +9,7 @@ import CurrentUser from '../user';
 
 export default
 class Exercise extends SharedExercise {
+    public static readonly publicSolutionsSubsetType = 'public-solutions-subset';
     @field solutions_are_public = false
 
     static build(attrs: any) {
@@ -29,6 +30,15 @@ class Exercise extends SharedExercise {
 
     @action onError(message: any) {
         this.error = message;
+    }
+
+    @override toggleMultiPart(): void {
+        if (this.isMultiPart) {
+            // Remove tags that only apply to multi-part questions
+            const tagsForMultiPart = [Exercise.publicSolutionsSubsetType];
+            tagsForMultiPart.forEach((tag) => this.tags.removeType(tag));
+        }
+        super.toggleMultiPart();
     }
 
     get errorMessage() {


### PR DESCRIPTION
# Summary
- New tag with dropdown that supports values `even` and `odd`
- Dropdown is only visible when question is multi-part and solutions are public
- Tag is optional: when it is not set, that means all solutions are public
- When conditions for the dropdown appearing are not met, the value for the tag should be cleared